### PR TITLE
Tweak database path in input documentation

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -71,7 +71,7 @@ are to be used in addition to the Glarborg C3 library::
 	Location: Glarborg/C3
 	END 	
 
-The reaction libraries are stored in :file:`$RMG/databases/RMG_database/kinetics_libraries/`
+The reaction libraries are stored in :file:`RMG-database/input/kinetics/libraries/`
 and the `Location:` should be specified relative to this path.
 
 Please note that the keyword ``END`` must be placed at the end of the Reaction Library


### PR DESCRIPTION
This is still entirely wrong, in terms of how you enter the 
reaction libraries, but serves to show how easy it is
to update the documentation online :-)
