### PR TITLE
cantherm examples input files fixed

### DIFF
--- a/examples/cantherm/networks/acetyl+O2/input.py
+++ b/examples/cantherm/networks/acetyl+O2/input.py
@@ -28,7 +28,7 @@ species(
     spinMultiplicity = 2,
     opticalIsomers = 1,
     molecularWeight = (75.04,"g/mol"),
-    collisionModel = LennardJones(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
+    collisionModel = TransportData(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
     energyTransferModel = SingleExponentialDown(
         alpha0 = (0.5718,'kcal/mol'),
         T0 = (300,'K'),
@@ -51,7 +51,7 @@ species(
     spinMultiplicity = 2,
     opticalIsomers = 1,
     molecularWeight = (75.04,"g/mol"),
-    collisionModel = LennardJones(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
+    collisionModel = TransportData(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
     energyTransferModel = SingleExponentialDown(
         alpha0 = (0.5718,'kcal/mol'),
         T0 = (300,'K'),
@@ -144,7 +144,7 @@ species(
     label = 'nitrogen',
     structure = SMILES('N#N'),
     molecularWeight = (28.04,"g/mol"),
-    collisionModel = LennardJones(sigma=(3.70,'angstrom'), epsilon=(94.9,'K')),
+    collisionModel = TransportData(sigma=(3.70,'angstrom'), epsilon=(94.9,'K')),
 )
 
 ################################################################################

--- a/examples/cantherm/networks/n-butanol/input.py
+++ b/examples/cantherm/networks/n-butanol/input.py
@@ -29,7 +29,7 @@ species(
     spinMultiplicity = 1,
     opticalIsomers = 1,
     molecularWeight = (74.07,"g/mol"),
-    collisionModel = LennardJones(sigma=(5.94,'angstrom'), epsilon=(559,'K')),
+    collisionModel = TransportData(sigma=(5.94,'angstrom'), epsilon=(559,'K')),
     energyTransferModel = SingleExponentialDown(alpha0=(447.5*0.011962,"kJ/mol"), T0=(300,"K"), n=0.85),
 )
 
@@ -65,7 +65,7 @@ species(
     label = "bath_gas",
     E0 = (0,'kJ/mol'),
     molecularWeight = (28.04,"g/mol"),
-    collisionModel = LennardJones(sigma=(3.41,"angstrom"), epsilon=(124,"K")),
+    collisionModel = TransportData(sigma=(3.41,"angstrom"), epsilon=(124,"K")),
     energyTransferModel = None,
 )
 

--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -113,7 +113,7 @@ def species(label, *args, **kwargs):
         if structure: spec.molecule = [structure]
         spec.conformer = Conformer(E0=E0, modes=modes, spinMultiplicity=spinMultiplicity, opticalIsomers=opticalIsomers)  
         spec.molecularWeight = molecularWeight
-        spec.transportData = collisionModel
+        spec.TransportData = collisionModel
         spec.energyTransferModel = energyTransferModel
         spec.thermo = thermo
         


### PR DESCRIPTION
input files had old LennardJones tranport attribute which now crashes
cantherm. also fixed typo in cantherm/input.py
