### PR TITLE
Corrects default molecule coordinates to an empty numpy array

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -50,6 +50,8 @@ from .group import GroupAtom, GroupBond, Group, ActionError
 from .atomtype import AtomType, atomTypes, getAtomType
 import rmgpy.constants as constants
 
+import numpy
+
 #: This dictionary is used to shortcut lookups of a molecule's SMILES string from its chemical formula.
 _known_smiles_molecules = {
                  'N2': 'N#N',
@@ -107,7 +109,7 @@ class Atom(Vertex):
     e.g. ``atom.symbol`` instead of ``atom.element.symbol``.
     """
 
-    def __init__(self, element=None, radicalElectrons=0, spinMultiplicity=1, charge=0, label='', lonePairs=0, coords=None):
+    def __init__(self, element=None, radicalElectrons=0, spinMultiplicity=1, charge=0, label='', lonePairs=0, coords=numpy.array([])):
         Vertex.__init__(self)
         if isinstance(element, str):
             self.element = elements.__dict__[element]


### PR DESCRIPTION
Originally set as `None`, however this is incorrect and leads to other issues. The default should be an empty numpy array, as it is later filled in QMTP with a numpy array with x, y, and z coordinates.
