### PR TITLE
.travis.yml: Configure Travis CI for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install git build-essential gfortran python-dev liblapack-dev python-openbabel python-setuptools python-pip
+  - sudo apt-get install python-rdkit librdkit-dev librdkit1 rdkit-data
+  - git clone git@github.com:GreenGroup/RMG-database.git
+install:
+  - pip install numpy --use-mirrors
+  - pip install -r requirements.txt --use-mirrors
+  - make
+  - pip install .
+script: make test


### PR DESCRIPTION
The installation is based on the [Ubuntu 12.04 instructions](http://greengroup.github.io/RMG-Py/users/rmg/installation/linux.html).  Conveniently for us, [Travis uses Ubuntu 12.04][2] as its Linux environment as well.  I made a few changes to the suggested installation procedure:
- [build-essential](http://packages.ubuntu.com/precise/build-essential) instead of g++ (so we get Make too)
- [Non-Python][4] RDKit from packages ([5](http://www.rdkit.org/docs/Install.html#ubuntu-12-04-and-later),[6](http://packages.ubuntu.com/precise/python-rdkit),[7](http://packages.ubuntu.com/precise/librdkit-dev),[8](http://packages.ubuntu.com/precise/librdkit1),[9](http://packages.ubuntu.com/precise/rdkit-data)) instead of from
  source, although this installs RDKit v201106, which may be too old?
  I haven't checked any of the [InChl stuff](http://code.google.com/p/rdkit/wiki/BuildingWithCmake#Getting_Ready) for building from
  source, so this might be completely broken at the moment.
  Unfortunately, the version of RDKit on PyPI is [2009.Q1b1](https://pypi.python.org/pypi/rdkit), which is
  too old for the libraries we've installed from packages.
- Travis [doesn't support Python 2.5][12], so I only test on 2.6 and
  2.7.

I also don't understand how RMG-Py finds RMG-database, so that might be broken
as well.

For an intro to Travis, see:
- http://docs.travis-ci.com/
- http://docs.travis-ci.com/user/getting-started/

[2]:
http://docs.travis-ci.com/user/installing-dependencies/#Installing-Ubuntu-packages

[4]:
http://docs.travis-ci.com/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs

[12]:
http://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against
