### PR TITLE
Mopac PM6 and PM7 now inherit from the correct class.

### DIFF
--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -285,7 +285,7 @@ class MopacMolPM3(MopacMolPMn):
     """
     pm_method = 'pm3'
 
-class MopacMolPM6(MopacMol):
+class MopacMolPM6(MopacMolPMn):
     """
     Mopac PM6 calculations for molecules
     
@@ -294,7 +294,7 @@ class MopacMolPM6(MopacMol):
     """
     pm_method = 'pm6'
 
-class MopacMolPM7(MopacMol):
+class MopacMolPM7(MopacMolPMn):
     """
     Mopac PM7 calculations for molecules
     


### PR DESCRIPTION
Came across this while writing the unit test.

The original setup had the individual MOPAC methods inheriting
from a base class MopacMol. However this was altered to avoid
code repetition. The PM3 method was correctly defined, but the
PM6 and PM7 methods are now correct.
