### PR TITLE
Fixed updateConfiguations call when pruning prep network

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1162,7 +1162,7 @@ class CoreEdgeReactionModel:
                         network.netReactions.remove(rxn)
                         
                     # Recompute the isomers, reactants, and products for this network
-                    network.updateConfigurations()
+                    network.updateConfigurations(self)
 
         # Remove from the global list of reactions
         # also remove it from the global list of reactions


### PR DESCRIPTION
Discussed in #58. @jwallen made the change in 4ef7e32, just missed this case.

Leads to a crash when pDep and pruning is used. The crash occurs when a molecule in a pDep network is designated fro pruning.
