### PR TITLE
Remove external references to Conformer._E0

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -765,10 +765,10 @@ class Reaction:
         for spec in self.reactants:
             logging.debug('    Calculating Partition function for ' + spec.label)
             Qreac *= spec.getPartitionFunction(T) / (constants.R * T / 101325.)
-            E0 -= spec.conformer._E0.value_si
+            E0 -= spec.conformer.E0.value_si
         logging.debug('    Calculating Partition function for ' + self.transitionState.label)
         Qts = self.transitionState.getPartitionFunction(T) / (constants.R * T / 101325.)
-        E0 += self.transitionState.conformer._E0.value_si
+        E0 += self.transitionState.conformer.E0.value_si
         k = (constants.kB * T / constants.h * Qts / Qreac) * math.exp(-E0 / constants.R / T)
         
         # Apply tunneling correction

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -285,7 +285,7 @@ class Species(object):
         if self.hasThermo():
             H = self.thermo.getEnthalpy(T)
         elif self.hasStatMech():
-            H = self.conformer.getEnthalpy(T) + self.conformer._E0.value_si
+            H = self.conformer.getEnthalpy(T) + self.conformer.E0.value_si
         else:
             raise Exception('Unable to calculate enthalpy for species {0!r}: no thermo or statmech data available.'.format(self.label))
         return H
@@ -315,7 +315,7 @@ class Species(object):
         if self.hasThermo():
             G = self.thermo.getFreeEnergy(T)
         elif self.hasStatMech():
-            G = self.conformer.getFreeEnergy(T) + self.conformer._E0.value_si
+            G = self.conformer.getFreeEnergy(T) + self.conformer.E0.value_si
         else:
             raise Exception('Unable to calculate free energy for species {0!r}: no thermo or statmech data available.'.format(self.label))
         return G


### PR DESCRIPTION
In rmgpy/statmech/conformer.pyx, _E0 is the private attribute backing the
public E0 property (to support an Energy cast on setting). Respect that
privacy and use the public interface.
