### PR TITLE
Add test_kinetics_checkChildParentRelationship databaseTest

### DIFF
--- a/databaseTest.py
+++ b/databaseTest.py
@@ -8,6 +8,8 @@ from external.wip import work_in_progress
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase
 from copy import copy, deepcopy
+from rmgpy.data.base import LogicOr
+from rmgpy.molecule import Group
 
 class TestDatabase(unittest.TestCase):
     """
@@ -73,7 +75,7 @@ class TestDatabase(unittest.TestCase):
                 for nodeNameOther, nodeGroupOther in entriesCopy.iteritems():
                     self.assertFalse(family.matchNodeToNode(nodeGroup, nodeGroupOther), "Group {group} in {family} family was found to be identical to group {groupOther}".format(group=nodeName, family=family_name, groupOther=nodeNameOther))
     
-    @work_in_progress
+#     @work_in_progress
     def test_kinetics_checkChildParentRelationships(self):
         """
         This test checks that groups' parent-child relationships are correct in the database.
@@ -83,17 +85,25 @@ class TestDatabase(unittest.TestCase):
             family = Database()
             family.entries = originalFamily.groups.entries
             entriesCopy = copy(family.entries)
-            for nodeName, nodeGroup in family.entries.iteritems():
-                ascendParent = nodeGroup
+            for nodeName, childNode in family.entries.iteritems():
+                print childNode
+                #top nodes and product nodes don't have parents by definition, so they get an automatic pass:
+                if childNode in originalFamily.groups.top or childNode in originalFamily.forwardTemplate.products: continue
+                parentNode=childNode.parent
                 # Check whether the node has proper parents unless it is the top reactant or product node
-                while ascendParent not in originalFamily.groups.top and ascendParent not in originalFamily.forwardTemplate.products:
-                    child = ascendParent
-                    ascendParent = ascendParent.parent
-                    # The parent should be more general than the child
-                    self.assertTrue(family.matchNodeToChild(ascendParent,child), 
-                                    "In {family} family, group {parent} is not a proper parent of its child {child}.".format(family=family_name, parent=ascendParent, child=child))
-                    
-                    
+                # The parent should be more general than the child
+                self.assertTrue(family.matchNodeToChild(parentNode,childNode), 
+                                "In {family} family, group {parent} is not a proper parent of its child {child}.".format(family=family_name, parent=parentNode, child=nodeName))
+                
+                #check that parentNodes which are LogicOr do not have an ancestor that is a Group
+                #If it does, then the childNode must also be a child of the ancestor
+                if isinstance(parentNode, LogicOr):
+                    ancestorNode=childNode
+                    while ancestorNode not in originalFamily.groups.top and isinstance(ancestorNode, LogicOr):
+                        ancestorNode=ancestorNode.parent
+                    if isinstance(ancestorNode, Group):
+                        self.assertTrue(family.matchNodeToChild(ancestorNode, childNode),
+                                        "In {family} family, group {ancestor} is not a proper ancestor of its child {child}.".format(family=family_name, ancestor=ancestorNode, child=nodeName))     
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -915,7 +915,7 @@ class Database:
         if isinstance(node.item, Group) and isinstance(nodeOther.item, Group):
             return self.matchNodeToStructure(node,nodeOther.item, atoms=nodeOther.item.getLabeledAtoms()) and self.matchNodeToStructure(nodeOther,node.item,atoms=node.item.getLabeledAtoms())
         elif isinstance(node.item,LogicOr) and isinstance(nodeOther.item,LogicOr):
-            return node.item.matchToLogicOr(nodeOther.item)
+            return node.item.matchLogicOr(nodeOther.item)
         else:
             # Assume nonmatching
             return False
@@ -933,22 +933,14 @@ class Database:
                     return True                
             return False
         
-        elif isinstance(parentNode.item,LogicOr) and isinstance(childNode.item,Group):
-            if self.matchNodeToStructure(parentNode,childNode.item, atoms=childNode.item.getLabeledAtoms()) is True:
-                return True
-            else:
-                return False
-        elif isinstance(parentNode.item,LogicOr) and isinstance(childNode.item,LogicOr):
-            if parentNode.item.matchToLogicOr(childNode.item):
-                # the two LogicOrs are identical
-                return False 
-            else:
-                for group in parentNode.item.components:
-                    if group not in childNode.item.components:
-                        return False
-                return True
-        else:
-            return False
+        #If the parentNode is a Group and the childNode is a LogicOr there is nothing to check,
+        #so it gets an automatic pass. However, we do need to check that everything down this
+        #family line is consistent, which is done in the databaseTest unitTest
+        elif isinstance(parentNode.item, Group) and isinstance(childNode.item, LogicOr):
+            return True
+        
+        elif isinstance(parentNode.item,LogicOr):
+            return childNode.label in parentNode.item.components
 
     def matchNodeToStructure(self, node, structure, atoms):
         """
@@ -1108,7 +1100,7 @@ class LogicOr(LogicNode):
                 return True != self.invert
         return False != self.invert
 
-    def matchToLogicOr(self, other):
+    def matchLogicOr(self, other):
         """
         Is other the same LogicOr group as self?
         """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1986,7 +1986,7 @@ class KineticsFamily(Database):
                                 if not (isinstance(expectedNode, Group) and expectedNode.isIdentical(actualNode)):
                                     raise DatabaseError("Group definition doesn't match label '{label}'".format(label=expectedNodeName))
                             elif isinstance(actualNode, LogicOr):
-                                if not (isinstance(expectedNode, LogicOr) and expectedNode.matchToLogicOr(actualNode)):
+                                if not (isinstance(expectedNode, LogicOr) and expectedNode.matchLogicOr(actualNode)):
                                     raise DatabaseError("Group definition doesn't match label '{label}'".format(label=expectedNodeName, node=expectedNode))
                     except DatabaseError, e:
                         "Didn't pass"
@@ -2003,7 +2003,7 @@ class KineticsFamily(Database):
                             potentialGroup = groupEntry.item
                             if isinstance(actualGroup, Group) and isinstance(potentialGroup, Group) and potentialGroup.isIdentical(actualGroup):
                                 break
-                            elif isinstance(actualGroup, LogicOr) and isinstance(potentialGroup, LogicOr) and potentialGroup.matchToLogicOr(actualGroup):
+                            elif isinstance(actualGroup, LogicOr) and isinstance(potentialGroup, LogicOr) and potentialGroup.matchLogicOr(actualGroup):
                                 break
                         else:
                             "We didn't break, so we didn't find a match"
@@ -2043,7 +2043,7 @@ class KineticsFamily(Database):
                         if nodeGroupItem.isIdentical(nodeGroup2Item):
                             databaseLog.error("{0} is not unique. It shares its definition with {1}".format(nodeName, nodeName2))
                     if isinstance(nodeGroup2Item, LogicOr) and isinstance(nodeGroupItem, LogicOr):
-                        if nodeGroupItem.matchToLogicOr(nodeGroup2Item):
+                        if nodeGroupItem.matchLogicOr(nodeGroup2Item):
                             databaseLog.error("{0} is not unique. It shares its definition with {1}".format(nodeName, nodeName2))
                     
                 #For a correct child-parent relationship, each atom in the parent should have a corresponding child atom in the child.


### PR DESCRIPTION
Implemented parent/child checking for nodes. I changed the way
matchNodeToChild in base.py worked:

-For the case where the parent is a LogicOr, it simply checks if the child
is in the components of the LogicOr

-There is also the interesting case where we have intermediate LogicOr
nodes e.g:

L3: GroupA
  L4: LogicOr
    L5: GroupB

In this case, we also need to check that GroupB is subgroup of GroupA. I
have implemented some extra lines for this in
test_kinetics_checkChildParentRelationship.

Also, we must ignore a check between the L4 LogicOr and L3 GroupA because
there is actually nothing to check. This was added to matchNodeToChild
to automatically pass this case.

I'm not convinced that we should have intermediate LogicOr groups like
this, but I've left the flexibility to do so for now.

Finally, I also changed the name of the function matchtoLogicOr to just
matchLogicOr as I thought it sounded more concise.
