### PR TITLE
add missing method argument in thermoEstimator example input file

### DIFF
--- a/examples/thermoEstimator/input.py
+++ b/examples/thermoEstimator/input.py
@@ -25,6 +25,7 @@ species(
 
 quantumMechanics(
     software='mopac',
+    method='pm3',
     fileStore='QMfiles', # relative to where you run it? defaults to inside the output folder.
     scratchDirectory = None, # not currently used
     onlyCyclics = True,


### PR DESCRIPTION
this pull request adds the keyword "method" and sets it to the value "PM3". It was missing and crashed the thermoEstimator example in the examples folder of RMG-Py.
