### PR TITLE
Make statmech depositories a dictionary.

### DIFF
--- a/rmgpy/data/statmech.py
+++ b/rmgpy/data/statmech.py
@@ -493,7 +493,8 @@ class StatmechDatabase(object):
         Load the statmech database from the given `path` on disk, where `path`
         points to the top-level folder of the thermo database.
         """
-        self.depository = StatmechDepository().load(os.path.join(path, 'depository.py'), self.local_context, self.global_context)
+        self.depository = {}
+        self.depository['depository']  = StatmechDepository().load(os.path.join(path, 'depository.py'), self.local_context, self.global_context)
 
     def loadLibraries(self, path, libraries=None):
         """
@@ -540,7 +541,8 @@ class StatmechDatabase(object):
         points to the top-level folder of the statmech depository.
         """
         if not os.path.exists(path): os.mkdir(path)
-        self.depository.save(os.path.join(path, 'depository.py'))
+        for name, depository in self.depository.iteritems():
+            depository.save(os.path.join(path, name + '.py'))
 
     def saveLibraries(self, path):
         """
@@ -565,7 +567,8 @@ class StatmechDatabase(object):
         `path` points to the top-level folder of the old RMG database.
         """
         # The old database does not have a depository, so create an empty one
-        self.depository = StatmechDepository(label='depository', name='Statmech Depository')
+        self.depository = {}
+        self.depository['depository'] = StatmechDepository(label='depository', name='Statmech Depository')
 
         for (root, dirs, files) in os.walk(os.path.join(path, 'frequencies_libraries')):
             if os.path.exists(os.path.join(root, 'Dictionary.txt')) and os.path.exists(os.path.join(root, 'Library.txt')):
@@ -638,11 +641,13 @@ class StatmechDatabase(object):
         """
         Return statmech data for the given :class:`Molecule` object `molecule`
         by searching the entries in the depository.
+        Returns a list of tuples  (statmechData, depository, entry).
         """
         items = []
-        for label, entry in self.depository.entries.iteritems():
-            if molecule.isIsomorphic(entry.item):
-                items.append((entry.data, self.depository['stable'], entry))
+        for name, depository in self.depository.iteritems():
+            for label, entry in depository.entries.iteritems():
+                if molecule.isIsomorphic(entry.item):
+                    items.append((entry.data, self.depository[name], entry))
         return items
 
     def getStatmechDataFromLibrary(self, molecule, library):


### PR DESCRIPTION
Now it is consistent with thermo depositories.  Otherwise
it does not make sense to store a default dictionary but then
replace with the StatmechDepository object.  Also this allows us
to add more depositories in the future as necessary.
