### PR TITLE
QM fix: Only use one rotational constant for linear molecules.

### DIFF
--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -367,8 +367,10 @@ class QMMolecule:
         
         trans = rmgpy.statmech.IdealGasTranslation( mass=self.qmData.molecularMass )
         if self.pointGroup.linear:
+            # there should only be one rotational constant for a linear rotor
+            rotationalConstant = rmgpy.quantity.Frequency(max(self.qmData.rotationalConstants.value), self.qmData.rotationalConstants.units)
             rot = rmgpy.statmech.LinearRotor(
-                                         rotationalConstant = self.qmData.rotationalConstants,
+                                         rotationalConstant = rotationalConstant,
                                          symmetry = self.pointGroup.symmetryNumber,
                                         )
         else:


### PR DESCRIPTION
The rmgpy.statmech.rotation.LinearRotor.rotationalConstant expects only a single value.
But MOPAC or similar (via cclib) returns a moments of inertial result in an array, like 
   B = ([0, 68.4, 68.4], "cm-1").

I assume (as had @keceli in his version of this fix 210ea35697c725594e96a9c56e019aa61a8256b8)
that we want to use the highest of the frequencies (as opposed to the sum or anything fancy?)

If this is right, it closes #250

Although similar, I think this fix is safer than @keceli's in 210ea35697c725594e96a9c56e019aa61a8256b8 simply because this is more explicit. 
The LinearRotor class _should_ expect only a single rotationalConstant and letting
it accept arrays without complaining opens up the potential for bugs elsewhere.
