### PR TITLE
Correct gaussian environment variable when g09 path is a list

### DIFF
--- a/rmgpy/qm/gaussian.py
+++ b/rmgpy/qm/gaussian.py
@@ -20,10 +20,15 @@ class Gaussian:
     outputFileExtension = '.log'
     
     gaussEnv = os.getenv('GAUSS_EXEDIR') or os.getenv('g09root') or os.getenv('g03root') or ""
-    if os.path.exists(os.path.join(gaussEnv , 'g09')):
-        executablePath = os.path.join(gaussEnv , 'g09')
-    elif os.path.exists(os.path.join(gaussEnv , 'g03')):
-        executablePath = os.path.join(gaussEnv , 'g03')
+    
+    # GAUSS_EXEDIR may be a list like "path1:path2:path3"
+    for possibleDir in gaussEnv.split(':'):
+        if os.path.exists(os.path.join(possibleDir , 'g09')):
+            executablePath = os.path.join(possibleDir , 'g09')
+            break
+        elif os.path.exists(os.path.join(possibleDir , 'g03')):
+            executablePath = os.path.join(possibleDir , 'g03')
+            break
     else:
         executablePath = os.path.join(gaussEnv , '(g03 or g09)')
 

--- a/rmgpy/qm/gaussianTest.py
+++ b/rmgpy/qm/gaussianTest.py
@@ -13,10 +13,14 @@ from rmgpy.qm.gaussian import GaussianMolPM3, GaussianMolPM6
 
 
 gaussEnv = os.getenv('GAUSS_EXEDIR') or os.getenv('g09root') or os.getenv('g03root') or ""
-if os.path.exists(os.path.join(gaussEnv , 'g09')):
-	executablePath = os.path.join(gaussEnv , 'g09')
-elif os.path.exists(os.path.join(gaussEnv , 'g03')):
-	executablePath = os.path.join(gaussEnv , 'g03')
+# GAUSS_EXEDIR may be a list like "path1:path2:path3"
+for possibleDir in gaussEnv.split(':'):
+	if os.path.exists(os.path.join(possibleDir , 'g09')):
+		executablePath = os.path.join(possibleDir , 'g09')
+		break
+	elif os.path.exists(os.path.join(possibleDir , 'g03')):
+		executablePath = os.path.join(possibleDir , 'g03')
+		break
 else:
 	executablePath = os.path.join(gaussEnv , '(g03 or g09)')
 

--- a/rmgpy/qm/mainTest.py
+++ b/rmgpy/qm/mainTest.py
@@ -57,10 +57,14 @@ class TestQMCalculator(unittest.TestCase):
 		mopExecutablePath = os.path.join(mopacEnv , '(MOPAC 2009 or 2012)')
 	
 	gaussEnv = os.getenv('GAUSS_EXEDIR') or os.getenv('g09root') or os.getenv('g03root') or ""
-	if os.path.exists(os.path.join(gaussEnv , 'g09')):
-		gaussExecutablePath = os.path.join(gaussEnv , 'g09')
-	elif os.path.exists(os.path.join(gaussEnv , 'g03')):
-		gaussExecutablePath = os.path.join(gaussEnv , 'g03')
+	# GAUSS_EXEDIR may be a list like "path1:path2:path3"
+	for possibleDir in gaussEnv.split(':'):
+		if os.path.exists(os.path.join(possibleDir , 'g09')):
+			gaussExecutablePath = os.path.join(possibleDir , 'g09')
+			break
+		elif os.path.exists(os.path.join(possibleDir , 'g03')):
+			gaussExecutablePath = os.path.join(possibleDir , 'g03')
+			break
 	else:
 		gaussExecutablePath = os.path.join(gaussEnv , '(g03 or g09)')
 	


### PR DESCRIPTION
This should not affect the environment variable that provides
a singe path to the g09 executable.

Some clusters have the environment variable set as a list
of paths. To correct this, the environment variable
`GAUSS_EXEDIR`, which should contains all these paths, is split 
at the `:`. Each path is then searched for the g09 executable.
