### PR TITLE
make cantherm alert user if reacting species is not lowest E conformer

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -132,7 +132,7 @@ In this section users can specify the particular reaction families that they wis
 
 	kineticsFamilies = ['Intra_RH_Add_Endocyclic']
 	
-Otherwise, by typing 'default', RMG will use recommended reaction families to generate the mechanism. The recommended reaction families can be found in :file:`RMG-database/input/families/recommended.py`.
+Otherwise, by typing 'default' (and excluding the brackets that are shown in the example above), RMG will use recommended reaction families to generate the mechanism. The recommended reaction families can be found in :file:`RMG-database/input/families/recommended.py`.
 
 	
 Kinetics Estimator

--- a/examples/cantherm/reactions/methoxy/README
+++ b/examples/cantherm/reactions/methoxy/README
@@ -1,0 +1,2 @@
+to run, execute 'run-cantherm' 
+(if not executable and if you are using linux, use the command: chmod +x run-cantherm)

--- a/examples/cantherm/reactions/methoxy/input.py
+++ b/examples/cantherm/reactions/methoxy/input.py
@@ -1,0 +1,223 @@
+
+title = 'methoxy decomposition to H + CH2O'
+
+description = \
+"""
+This example illustrates how to manually set up a CanTherm input file for a small P-dep reaction system [using only the
+RRHO assumption, and without tunneling, although this can be easily implemented]. Such a calculation is desireable if the user 
+wishes to supply experimentally determined freqeuncies, for example. Althgou some coommented notes below may be useful, 
+see http://greengroup.github.io/RMG-Py/users/cantherm/index.html for more documented information about CanTherm and 
+creating input files. (information pertaining this file is adopted by Dames and Golden, 2013, JPCA 117 (33) 7686-96.)
+"""
+transitionState(
+    label = 'TS3',
+    E0 = (34.1,'kcal/mol'),  # this INCLUDES the ZPE. Note that other energy units are also possible (e.g., kJ/mol)
+    spinMultiplicity = 2,
+    opticalIsomers = 1, 
+    frequency = (-967,'cm^-1'),
+    modes = [   # these modes are used to compute the partition functions
+        HarmonicOscillator(frequencies=([466,581,1169,1242,1499,1659,2933,3000],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.970, 1.029, 3.717],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")) #this must be included for every species/ts
+    ],
+
+)
+
+transitionState(
+    label = 'TS2',
+    E0 = (38.9,'kcal/mol'),
+    spinMultiplicity = 2,
+    opticalIsomers = 1, 
+    frequency = (-1934,'cm^-1'),
+    modes = [
+        HarmonicOscillator(frequencies=([792, 987 ,1136, 1142, 1482 ,2441 ,3096, 3183],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.928,0.962,5.807],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")) 
+    ],
+
+)
+transitionState(
+    label = 'TS1',
+    E0 = (39.95,'kcal/mol'), 
+    spinMultiplicity = 2,
+    opticalIsomers = 1, 
+    frequency = (-1756,'cm^-1'),
+    modes = [
+        HarmonicOscillator(frequencies=([186 ,626 ,1068, 1234, 1474, 1617, 2994 ,3087],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.966,0.986,5.253],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")) 
+    ],
+
+)
+
+species(
+    label = 'methoxy',
+    structure = SMILES('C[O]'),
+    E0 = (9.44,'kcal/mol'),
+    modes = [
+        HarmonicOscillator(frequencies=([758,960,1106 ,1393,1403,1518,2940,3019,3065],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.916, 0.921, 5.251],"cm^-1"),symmetry=3, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")),
+    ],
+    spinMultiplicity = 3.88, # 3+exp(-89/T)
+    opticalIsomers = 1,
+    molecularWeight = (31.01843,'amu'),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+)
+
+
+species(
+    label = 'CH2O',
+    E0 = (28.69,'kcal/mol'),
+    molecularWeight = (30.0106,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    spinMultiplicity = 1, 
+    opticalIsomers = 1,
+    modes = [
+        HarmonicOscillator(frequencies=([1180,1261,1529,1764,2931,2999],'cm^-1')), 
+        NonlinearRotor(rotationalConstant=([1.15498821005263, 1.3156969584727, 9.45570474524524],"cm^-1"),symmetry=2, quantum=False),
+        IdealGasTranslation(mass=(30.0106,"g/mol")),
+    ],
+)
+
+species(
+    label = 'H',
+    E0 = (0.000,'kcal/mol'),
+	molecularWeight = (1.00783,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    modes = [
+        IdealGasTranslation(mass=(1.00783,"g/mol")),
+    ],
+	spinMultiplicity = 2, 
+    opticalIsomers = 1,
+
+)
+
+species(
+    label = 'CH2Ob',  #this is a special system with two chemically equivalent product channels. Thus, different labels are used.
+    E0 = (28.69,'kcal/mol'),
+    molecularWeight = (30.0106,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    spinMultiplicity = 1, 
+    opticalIsomers = 1,
+    modes = [
+        HarmonicOscillator(frequencies=([1180,1261,1529,1764,2931,2999],'cm^-1')), 
+        NonlinearRotor(rotationalConstant=([1.15498821005263, 1.3156969584727, 9.45570474524524],"cm^-1"),symmetry=2, quantum=False),
+        IdealGasTranslation(mass=(30.0106,"g/mol")),
+    ],
+)
+
+species(
+    label = 'Hb',
+    E0 = (0.0001,'kcal/mol'),
+    molecularWeight = (1.00783,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    modes = [
+        IdealGasTranslation(mass=(1.00783,"g/mol")),
+    ],
+    spinMultiplicity = 2, 
+    opticalIsomers = 1,
+
+)
+species(
+    label = 'CH2OH',
+    E0 = (0.00,'kcal/mol'),
+    molecularWeight = (31.01843,"g/mol"),	
+    modes = [
+        HarmonicOscillator(frequencies=([418,595, 1055, 1198, 1368, 1488, 3138, 3279, 3840],'cm^-1')),
+        # below is an example of how to include hindered rotors
+		#HinderedRotor(inertia=(5.75522e-47,'kg*m^2'), symmetry=1, barrier=(22427.8,'J/mol'), semiclassical=False),
+        NonlinearRotor(rotationalConstant=([0.868,0.993,6.419],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")),
+    ],
+    spinMultiplicity = 2, 
+    opticalIsomers = 2,
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+)
+
+species(
+    label = 'He',
+#    freqScaleFactor = 1, # TypeError: species() got an unexpected keyword argument 'freqScaleFactor'.
+    structure = SMILES('[He]'),
+    molecularWeight = (4.003,'amu'),
+    collisionModel = TransportData(sigma=(2.55e-10,'m'), epsilon=(0.0831,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+)
+
+reaction(
+    label = 'CH2O+H=Methoxy',
+#    label = 'Methoxy = CH2O+H',
+    reactants = ['CH2O','H'],
+    products = ['methoxy'],
+#    reactants = ['methoxy'],
+#    products = ['CH2O', 'H'],
+    transitionState = 'TS3',
+    #tunneling='Eckart',
+)
+
+reaction(
+ #   label = 'CH2Ob+Hb=CH2OH',
+   label = 'CH2OH = CH2Ob+Hb',
+#    products = ['CH2OH'],
+    reactants = ['CH2OH'],
+#   reactants = ['CH2Ob','Hb'],
+   products = ['CH2Ob', 'Hb'],
+    transitionState = 'TS1',
+    #tunneling='Eckart',
+)
+
+reaction(
+    label = 'CH2OH = Methoxy',
+#    reactants = ['methoxy'],
+#    products = ['CH2OH'],
+#    label = 'Methoxy = CH2OH',
+    products = ['methoxy'],
+    reactants = ['CH2OH'],
+    transitionState = 'TS2',
+    #tunneling='Eckart',
+)
+
+kinetics('CH2O+H=Methoxy')
+#kinetics('Methoxy = CH2O+H' )
+#kinetics('Methoxy = CH2OH' )
+kinetics('CH2OH = Methoxy')
+kinetics('CH2OH = CH2Ob+Hb' )
+#kinetics('CH2Ob+Hb=CH2OH')
+network(
+    label = 'methoxy',
+    isomers = [
+        'methoxy',
+		'CH2OH',
+    ],
+
+    reactants = [
+	('CH2O','H'),
+#        ('CH2Ob','Hb'),
+	],
+
+    bathGas = {
+        'He': 1,
+    },
+)
+
+pressureDependence(
+    label = 'methoxy',
+    Tmin = (450,'K'), Tmax = (1200,'K'), Tcount = 4, 
+    Tlist = ([450,500,678,700],'K'),
+    Pmin = (0.01,'atm'), Pmax = (1000,'atm'), Pcount = 7,
+    Plist = ([0.01,0.1,1,3,10,100,1000],'atm'), 
+    maximumGrainSize = (0.5,'kcal/mol'), 
+    minimumGrainCount = 500, 
+    method = 'modified strong collision',
+    #Other methods include: 'reservoir state', 'chemically-significant eigenvalues', 
+    interpolationModel = ('pdeparrhenius'), 
+    activeKRotor = True,
+#    activeJRotor = False, #causes cantherm to crash
+    rmgmode = False, 
+)

--- a/examples/cantherm/reactions/methoxy/run-cantherm
+++ b/examples/cantherm/reactions/methoxy/run-cantherm
@@ -1,0 +1,3 @@
+#!/bin/bash                                                                                                                                    
+
+python ../../../../cantherm.py input.py

--- a/rmgpy/cantherm/common.py
+++ b/rmgpy/cantherm/common.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2009 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import numpy
+import os.path
+import logging
+import rmgpy.constants as constants
+################################################################################
+
+def checkConformerEnergy(Vlist,path):
+    """
+    Check to see that the starting energy of the species in the potential energy scan calculation
+    is not 0.5 kcal/mol (or more) higher than any other energies in the scan. If so, print and 
+    log a warning message.  
+    """    
+    Vlist = numpy.array(Vlist, numpy.float64)
+    Vdiff = (Vlist[0] - numpy.min(Vlist))*constants.E_h*constants.Na/1000
+    if Vdiff >= 2: #we choose 2 kJ/mol to be the critical energy
+        logging.warning('the species corresponding to ' + str(os.path.basename(path)) + ' is different in energy from the lowest energy conformer by ' + "%0.2f" % Vdiff + ' kJ/mol. This can cause significant errors in your computed rate constants. ')
+
+

--- a/rmgpy/cantherm/commonTest.py
+++ b/rmgpy/cantherm/commonTest.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2009 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This script contains unit tests of the :mod:`rmgpy.quantity` module.
+"""
+import unittest
+import numpy
+from rmgpy.cantherm import CanTherm 
+import rmgpy.constants as constants
+################################################################################
+
+class CommonTest(unittest.TestCase):
+    """
+    Contains unit tests of the Cantherm common functions.
+    """
+    
+    def test_checkConformerEnergy(self):
+        """
+        test the checkConformerEnergy function with an list of energies.
+        """    
+        Vlist = [-272.2779012225, -272.2774933703, -272.2768397635, -272.2778432059, -272.278645477, -272.2789602654, -272.2788749196, -272.278496709, -272.2779350675, -272.2777008843, -272.2777167286, -272.2780937643, -272.2784838846, -272.2788050464, -272.2787865352, -272.2785091607, -272.2779977452, -272.2777957743, -272.2779134906, -272.2781827547, -272.278443339, -272.2788244214, -272.2787748749]
+        Vlist = numpy.array(Vlist, numpy.float64)
+        Vdiff = (Vlist[0] - numpy.min(Vlist))*constants.E_h*constants.Na/1000
+        self.assertAlmostEqual(Vdiff / 2.7805169838282797, 1, 5)
+
+
+class testCanthermJob(unittest.TestCase):
+    """
+    Contains unit tests of the Cantherm module and its interactions with other RMG modules.
+    """    
+    def setUp(self):
+        
+        cantherm = CanTherm()
+        jobList = cantherm.loadInputFile(r'./test/methoxy.py')
+        pdepjob = jobList[-1]
+        self.kineticsjob = jobList[0]
+        pdepjob.activeJRotor = True
+        network = pdepjob.network
+        self.Nisom = len(network.isomers) 
+        self.Nreac = len(network.reactants)
+        self.Nprod = len(network.products)
+        self.Npath = len(network.pathReactions)
+        self.PathReaction2 =  network.pathReactions[2]
+        self.TminValue = pdepjob.Tmin.value
+        self.Tmaxvalue = pdepjob.Tmax.value
+        self.TmaxUnits = pdepjob.Tmax.units
+        self.TlistValue = pdepjob.Tlist.value
+        self.PminValue = pdepjob.Pmin.value
+        self.Pcount = pdepjob.Pcount
+        self.Tcount = pdepjob.Tcount
+        self.GenTlist = pdepjob.generateTemperatureList()
+        self.PlistValue = pdepjob.Plist.value
+        self.maximumGrainSizeValue = pdepjob.maximumGrainSize.value
+        self.method = pdepjob.method
+        self.rmgmode = pdepjob.rmgmode
+        
+# test Cantherm's interactions with the network module
+    def testNisom(self):
+        """
+        Test the number of isomers identified.
+        """        
+        self.assertEqual(self.Nisom, 2, msg=None)
+        
+    def testNreac(self):
+        """
+        Test the number of reactants identified.
+        """        
+        self.assertEqual(self.Nreac, 1, msg=None)
+
+    def testNprod(self):
+        """
+        Test the number of products identified.
+        """        
+        self.assertEqual(self.Nprod, 1, msg=None)
+        
+    def testNpathReactions(self):
+        """
+        Test the whether or not RMG mode is turned on.
+        """    
+        self.assertEqual(self.Npath, 3, msg=None)    
+
+    def testPathReactions(self):
+        """
+        Test a path reaction label
+        """    
+        self.assertEqual(str(self.PathReaction2), 'CH2OH <=> methoxy', msg=None)     
+              
+# test Cantherm's interactions with the pdep module      
+    def testTemperaturesUnits(self):
+        """
+        Test the Temperature Units.
+        """           
+        self.assertEqual(str(self.TmaxUnits), 'K', msg=None)     
+        
+    def testTemperaturesValue(self):
+        """
+        Test the temperature value.
+        """    
+        self.assertEqual(self.TminValue, 450.0, msg=None)
+
+    def testTemperaturesList(self):
+        """
+        Test the temperature list.
+        """        
+        self.assertEqual(numpy.array_equal(self.TlistValue, numpy.array([450,500,678,700])), True, msg=None)  
+              
+    def testPminValue(self):
+        """
+        Test the minimum pressure value.
+        """    
+        self.assertEqual("%0.7f" % self.PminValue, str(0.0101325), msg=None)   
+    
+    def testPcount(self):
+        """
+        Test the number pressures specified.
+        """    
+        self.assertEqual(self.Pcount, 7, msg=None) 
+          
+    def testTcount(self):
+        """
+        Test the number temperatures specified.
+        """    
+        self.assertEqual(self.Tcount, 4, msg=None) 
+                          
+    def testPressureList(self):
+        """
+        Test the pressure list.
+        """     
+        self.assertEqual(numpy.array_equal(self.PlistValue, numpy.array([0.01,0.1,1,3,10,100,1000])), True, msg=None)    
+    
+    def testGenerateTemperatureList(self):
+        """
+        Test the generated temperature list.
+        """      
+        self.assertEqual(list(self.GenTlist), [450.0, 500.0, 678.0, 700.0], msg=None)    
+              
+    def testmaximumGrainSizeValue(self):
+        """
+        Test the max grain size value.
+        """    
+        self.assertEqual(self.maximumGrainSizeValue, 0.5, msg=None)  
+
+    def testMethod(self):
+        """
+        Test the master equation solution method chosen.
+        """    
+        self.assertEqual(self.method, 'modified strong collision', msg=None)   
+        
+    def testRmgmode(self):
+        """
+        Test the whether or not RMG mode is turned on.
+        """    
+        self.assertEqual(self.rmgmode, False, msg=None)       
+                  
+# Test cantherms interactions with the kinetics module         
+    def testCalculateTSTRateCoefficient(self):
+        """
+        Test the calculation of the high-pressure limit rate coef for one of the kinetics jobs at Tmin and Tmax.
+        """
+        self.assertEqual("%0.7f" % self.kineticsjob.reaction.calculateTSTRateCoefficient(self.TminValue), str(46608.5904933), msg=None)               
+        self.assertEqual("%0.5f" % self.kineticsjob.reaction.calculateTSTRateCoefficient(self.Tmaxvalue), str(498796.64535), msg=None)      
+    
+    def testTunneling(self):
+        """
+        Test the whether or not tunneling has been included in a specific kinetics job.
+        """
+        self.assertEqual(self.kineticsjob.reaction.transitionState.tunneling, None, msg=None)               
+    
+if __name__ == '__main__':
+    unittest.main( testRunner = unittest.TextTestRunner(verbosity=2) )

--- a/rmgpy/cantherm/gaussian.py
+++ b/rmgpy/cantherm/gaussian.py
@@ -31,7 +31,7 @@
 import math
 import numpy
 import os.path
-
+from rmgpy.cantherm.common import checkConformerEnergy
 import rmgpy.constants as constants
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 
@@ -380,9 +380,12 @@ class GaussianLog:
         if rigidScan==True:
             print '   Assuming', os.path.basename(self.path), 'is the output from a rigid scan...'
         
+        Vlist = numpy.array(Vlist, numpy.float64)
+        # check to see if the scanlog indicates that a one of your reacting species may not be the lowest energy conformer
+        checkConformerEnergy(Vlist, self.path)
+        
         # Adjust energies to be relative to minimum energy conformer
         # Also convert units from Hartree/particle to kJ/mol
-        Vlist = numpy.array(Vlist, numpy.float64)
         Vlist -= numpy.min(Vlist)
         Vlist *= constants.E_h * constants.Na
 

--- a/rmgpy/cantherm/qchem.py
+++ b/rmgpy/cantherm/qchem.py
@@ -32,6 +32,7 @@ import math
 import numpy
 import os.path
 import rmgpy.constants as constants
+from rmgpy.cantherm.common import checkConformerEnergy
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 ################################################################################
 class QchemLog:
@@ -373,9 +374,13 @@ class QchemLog:
         print '   Assuming', os.path.basename(self.path), 'is the output from a Qchem PES scan...'
         f.close()  
                     
+
+        Vlist = numpy.array(Vlist, numpy.float64)
+        # check to see if the scanlog indicates that one of your reacting species may not be the lowest energy conformer
+        checkConformerEnergy(Vlist, self.path)
+        
         # Adjust energies to be relative to minimum energy conformer
         # Also convert units from Hartree/particle to J/mol
-        Vlist = numpy.array(Vlist, numpy.float64)
         Vlist -= numpy.min(Vlist)
         Vlist *= constants.E_h * constants.Na      
         angle = numpy.arange(0.0, 2*math.pi+0.00001, 2*math.pi/(len(Vlist)-1), numpy.float64)

--- a/rmgpy/cantherm/test/methoxy.py
+++ b/rmgpy/cantherm/test/methoxy.py
@@ -1,0 +1,224 @@
+
+title = 'methoxy decomposition to H + CH2O'
+
+description = \
+frequencyScaleFactor = 1.0
+"""
+This example illustrates how to manually set up a CanTherm input file for a small P-dep reaction system [using only the
+RRHO assumption, and without tunneling, although this can be easily implemented]. Such a calculation is desireable if the user 
+wishes to supply experimentally determined freqeuncies, for example. Althgou some coommented notes below may be useful, 
+see http://greengroup.github.io/RMG-Py/users/cantherm/index.html for more documented information about CanTherm and 
+creating input files. (information pertaining this file is adopted by Dames and Golden, 2013, JPCA 117 (33) 7686-96.)
+"""
+transitionState(
+    label = 'TS3',
+    E0 = (34.1,'kcal/mol'),  # this INCLUDES the ZPE. Note that other energy units are also possible (e.g., kJ/mol)
+    spinMultiplicity = 2,
+    opticalIsomers = 1, 
+    frequency = (-967,'cm^-1'),
+    modes = [   # these modes are used to compute the partition functions
+        HarmonicOscillator(frequencies=([466,581,1169,1242,1499,1659,2933,3000],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.970, 1.029, 3.717],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")) #this must be included for every species/ts
+    ],
+
+)
+
+transitionState(
+    label = 'TS2',
+    E0 = (38.9,'kcal/mol'),
+    spinMultiplicity = 2,
+    opticalIsomers = 1, 
+    frequency = (-1934,'cm^-1'),
+    modes = [
+        HarmonicOscillator(frequencies=([792, 987 ,1136, 1142, 1482 ,2441 ,3096, 3183],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.928,0.962,5.807],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")) 
+    ],
+
+)
+transitionState(
+    label = 'TS1',
+    E0 = (39.95,'kcal/mol'), 
+    spinMultiplicity = 2,
+    opticalIsomers = 1, 
+    frequency = (-1756,'cm^-1'),
+    modes = [
+        HarmonicOscillator(frequencies=([186 ,626 ,1068, 1234, 1474, 1617, 2994 ,3087],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.966,0.986,5.253],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")) 
+    ],
+
+)
+
+species(
+    label = 'methoxy',
+    structure = SMILES('C[O]'),
+    E0 = (9.44,'kcal/mol'),
+    modes = [
+        HarmonicOscillator(frequencies=([758,960,1106 ,1393,1403,1518,2940,3019,3065],'cm^-1')),
+        NonlinearRotor(rotationalConstant=([0.916, 0.921, 5.251],"cm^-1"),symmetry=3, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")),
+    ],
+    spinMultiplicity = 3.88, # 3+exp(-89/T)
+    opticalIsomers = 1,
+    molecularWeight = (31.01843,'amu'),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+)
+
+
+species(
+    label = 'CH2O',
+    E0 = (28.69,'kcal/mol'),
+    molecularWeight = (30.0106,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    spinMultiplicity = 1, 
+    opticalIsomers = 1,
+    modes = [
+        HarmonicOscillator(frequencies=([1180,1261,1529,1764,2931,2999],'cm^-1')), 
+        NonlinearRotor(rotationalConstant=([1.15498821005263, 1.3156969584727, 9.45570474524524],"cm^-1"),symmetry=2, quantum=False),
+        IdealGasTranslation(mass=(30.0106,"g/mol")),
+    ],
+)
+
+species(
+    label = 'H',
+    E0 = (0.000,'kcal/mol'),
+	molecularWeight = (1.00783,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    modes = [
+        IdealGasTranslation(mass=(1.00783,"g/mol")),
+    ],
+	spinMultiplicity = 2, 
+    opticalIsomers = 1,
+
+)
+
+species(
+    label = 'CH2Ob',  #this is a special system with two chemically equivalent product channels. Thus, different labels are used.
+    E0 = (28.69,'kcal/mol'),
+    molecularWeight = (30.0106,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    spinMultiplicity = 1, 
+    opticalIsomers = 1,
+    modes = [
+        HarmonicOscillator(frequencies=([1180,1261,1529,1764,2931,2999],'cm^-1')), 
+        NonlinearRotor(rotationalConstant=([1.15498821005263, 1.3156969584727, 9.45570474524524],"cm^-1"),symmetry=2, quantum=False),
+        IdealGasTranslation(mass=(30.0106,"g/mol")),
+    ],
+)
+
+species(
+    label = 'Hb',
+    E0 = (0.0001,'kcal/mol'),
+    molecularWeight = (1.00783,"g/mol"),
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+    modes = [
+        IdealGasTranslation(mass=(1.00783,"g/mol")),
+    ],
+    spinMultiplicity = 2, 
+    opticalIsomers = 1,
+
+)
+species(
+    label = 'CH2OH',
+    E0 = (0.00,'kcal/mol'),
+    molecularWeight = (31.01843,"g/mol"),	
+    modes = [
+        HarmonicOscillator(frequencies=([418,595, 1055, 1198, 1368, 1488, 3138, 3279, 3840],'cm^-1')),
+        # below is an example of how to include hindered rotors
+		#HinderedRotor(inertia=(5.75522e-47,'kg*m^2'), symmetry=1, barrier=(22427.8,'J/mol'), semiclassical=False),
+        NonlinearRotor(rotationalConstant=([0.868,0.993,6.419],"cm^-1"),symmetry=1, quantum=False),
+        IdealGasTranslation(mass=(31.01843,"g/mol")),
+    ],
+    spinMultiplicity = 2, 
+    opticalIsomers = 2,
+    collisionModel = TransportData(sigma=(3.69e-10,'m'), epsilon=(4.0,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+)
+
+species(
+    label = 'He',
+#    freqScaleFactor = 1, # TypeError: species() got an unexpected keyword argument 'freqScaleFactor'.
+    structure = SMILES('[He]'),
+    molecularWeight = (4.003,'amu'),
+    collisionModel = TransportData(sigma=(2.55e-10,'m'), epsilon=(0.0831,'kJ/mol')),
+    energyTransferModel = SingleExponentialDown(alpha0=(0.956,'kJ/mol'), T0=(300,'K'), n=0.95),
+)
+
+reaction(
+    label = 'CH2O+H=Methoxy',
+#    label = 'Methoxy = CH2O+H',
+    reactants = ['CH2O','H'],
+    products = ['methoxy'],
+#    reactants = ['methoxy'],
+#    products = ['CH2O', 'H'],
+    transitionState = 'TS3',
+    #tunneling='Eckart',
+)
+
+reaction(
+ #   label = 'CH2Ob+Hb=CH2OH',
+   label = 'CH2OH = CH2Ob+Hb',
+#    products = ['CH2OH'],
+    reactants = ['CH2OH'],
+#   reactants = ['CH2Ob','Hb'],
+   products = ['CH2Ob', 'Hb'],
+    transitionState = 'TS1',
+    #tunneling='Eckart',
+)
+
+reaction(
+    label = 'CH2OH = Methoxy',
+#    reactants = ['methoxy'],
+#    products = ['CH2OH'],
+#    label = 'Methoxy = CH2OH',
+    products = ['methoxy'],
+    reactants = ['CH2OH'],
+    transitionState = 'TS2',
+    #tunneling='Eckart',
+)
+
+kinetics('CH2O+H=Methoxy')
+#kinetics('Methoxy = CH2O+H' )
+#kinetics('Methoxy = CH2OH' )
+kinetics('CH2OH = Methoxy')
+kinetics('CH2OH = CH2Ob+Hb' )
+#kinetics('CH2Ob+Hb=CH2OH')
+network(
+    label = 'methoxy',
+    isomers = [
+        'methoxy',
+		'CH2OH',
+    ],
+
+    reactants = [
+	('CH2O','H'),
+#        ('CH2Ob','Hb'),
+	],
+
+    bathGas = {
+        'He': 1,
+    },
+)
+
+pressureDependence(
+    label = 'methoxy',
+    Tmin = (450,'K'), Tmax = (1200,'K'), Tcount = 4, 
+    Tlist = ([450,500,678,700],'K'),
+    Pmin = (0.01,'atm'), Pmax = (1000,'atm'), Pcount = 7,
+    Plist = ([0.01,0.1,1,3,10,100,1000],'atm'), 
+    maximumGrainSize = (0.5,'kcal/mol'), 
+    minimumGrainCount = 500, 
+    method = 'modified strong collision',
+    #Other methods include: 'reservoir state', 'chemically-significant eigenvalues', 
+    interpolationModel = ('pdeparrhenius'), 
+    activeKRotor = True,
+#    activeJRotor = False, #causes cantherm to crash
+    rmgmode = False, 
+)

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -726,14 +726,15 @@ def loadTransportFile(path, speciesDict):
 
 def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments = True, thermoPath = None):
     """
-    Load a Chemkin input file to `path` on disk, returning lists of the species
-    and reactions in the Chemkin file.
+    Load a Chemkin input file located at `path` on disk to `path`, returning lists of the species
+    and reactions in the Chemkin file. The 'thermoPath' point to a separate thermo file, or, if 'None' is 
+    specified, the function will look for the thermo database within the chemkin mechanism file
     """
     
     speciesList = []; speciesDict = {}; speciesAliases = {}
     reactionList = []
 
-    # If the dictionary path is given, the read it and generate Molecule objects
+    # If the dictionary path is given, then read it and generate Molecule objects
     # You need to append an additional adjacency list for nonreactive species, such
     # as N2, or else the species objects will not store any structures for the final
     # HTML output.


### PR DESCRIPTION
For large molecules, it's not always easy to know that the species you
use during a reaction is at it's lowest energy conformation. However,
the scan calculations that are used for inclusion of hindered rotors can
be used to alert a user if this is potentially the case, since most/all
users utilize the geometry from one of their reacting species to
initiate a scan calculation. This will help prevent incorrect calculations in the future for gaussian and qchem users.
