### PR TITLE
Cantherm fix, doc update, more bondE corrections

### DIFF
--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -17,11 +17,21 @@ Model Chemistry
 ===============
 
 The first item in the input file should be a ``modelChemistry()`` function,
-which accepts a string describing the model chemistry. Currently the only
-allowed model chemistries are ``'CBS-QB3'`` and ``'G3'``. CanTherm uses this
-information to adjust the computed energies to the usual gas-phase reference
-states. For example, below demonstrates how to specify CBS-QB3 as a model 
-chemistry::
+which accepts a string describing the model chemistry. Currently the 
+allowed model chemistries are:
+``'CBS-QB3'``
+``'G3'``
+``'M08SO/MG3S*'`` * indicates that the grid size used in the [QChem] electronic structure calculation utilized 75 radial points and 434 angular points
+``'CCSD(T)-F12/cc-pVnZ-F12'``  n = D, T, Q
+``'CCSD(T)-F12/aug-cc-pVnZ-F12'``  n = D, T, Q
+``'MP2_rmp2_pVnZ'``  n = D, T, Q
+``'FCI/cc-pVnZ'``  n = D, T, Q
+``'DFT_G03_b3lyp'``  a B3LYP calculation with a moderately large basis set
+``'BMK/cbsb7'`` or  ``'BMK/6-311G(2d,d,p)'``
+
+CanTherm uses this information to adjust the computed energies to the usual gas-phase reference
+states by applying atom, bond and spin-orbit coupling energy corrections. This is particularly important for ``thermo()`` calculations (see below). The example below 
+demonstrates how to specify CBS-QB3 as a model chemistry::
 
     modelChemistry("CBS-QB3")
 
@@ -58,7 +68,7 @@ Each :class:`HinderedRotor()` object requires the following parameters:
 ====================== =========================================================
 Parameter              Description
 ====================== =========================================================
-``scanLog``            The path to the Gaussian log file containing the scan
+``scanLog``            The path to the Gaussian/Qchem log file containing the scan
 ``pivots``             The indices of the atoms in the hindered rotor torsional bond
 ``top``                The indices of all atoms on one side of the torsional bond (including the pivot atom)
 ``symmetry``           The symmetry number for the torsional rotation
@@ -79,6 +89,9 @@ The following is an example of a typical species item, based on ethane::
         atoms = {'C': 2, 'H': 6},
         bonds = {'C-C': 1, 'C-H': 6},
     )
+
+Note that the atoms identified within the rotor section should correspond to the geometry indicated by
+``geomLog``. 
 
 Transition State
 ================
@@ -138,12 +151,12 @@ Use a ``thermo()`` function to compute the thermodynamic parameters for a
 species. Pass the string label of the species you wish to compute the 
 thermodynamic parameters for and the type of thermodynamics model to
 generate (either ``'Wilhoit'`` or ''`NASA`'' for a Wilhoit polynomial
-model or NASA polynomial model). If you would like to see a plot of the
-fitted thermodynamics, set the `plot` parameter to ``True``.
+model or NASA polynomial model). A table of thermodynamic parameters will
+also be displayed in the output file. 
 
 Below is a typical ``thermo()`` function::
 
-    thermo('ethane', model='Wilhoit', plot=True)
+    thermo('ethane', model='Wilhoit')
 
 Kinetics Computations
 =====================

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -608,7 +608,7 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
     elif modelChemistry == 'FCI/cc-pVQZ':
         atomEnergies = {'C':-37.787052110598+ SOC['C']}
         
-    elif modelChemistry == 'BMK/cbsb7':
+    elif modelChemistry == 'BMK/cbsb7' or 'BMK/6-311G(2d,d,p)':
         atomEnergies = {'H':-0.498618853119+ SOC['H'], 'N':-54.5697851544+ SOC['N'], 'O':-75.0515210278+ SOC['O'], 'C':-37.8287310027+ SOC['C'], 'P':-341.167615941+ SOC['P'], 'S': -398.001619915+ SOC['S']}
         
     else:
@@ -637,6 +637,7 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
         if symbol in atomEnergies: E0 += count * atomEnergies[symbol] * 4184.
     
     # Step 3: Bond energy corrections
+    bondEnergies = {}
     if modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
         bondEnergies = { 'C-H': -0.46, 'C-C': -0.68, 'C=C': -1.90, 'C#C': -3.13,
             'O-H': -0.51, 'C-O': -0.23, 'C=O': -0.69, 'O-O': -0.02, 'N-C': -0.67,
@@ -659,7 +660,12 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
         bondEnergies = { 'C-H': -0.11, 'C-C': -0.3, 'C=C': -0.08, 'C#C': -0.64,
             'O-H': 0.02, 'C-O': 0.33, 'C=O': 0.55, 'N#N': -2.0, 'O=O': -0.2, 
             'H-H': 1.1, 'C#N': -0.89, 'C-S': 0.43, 'S=O': -0.78, 'S-H': 0.0, }
+    elif modelChemistry == 'B3LYP/cbsb7' or 'B3LYP/6-311G(2d,d,p)' or 'DFT_G03_b3lyp' or 'B3LYP/6-311+G(3df,2p)':
+        bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
+            'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44, 
+            'C#N': 0.22, 'C-S': -2.35, 'S=O': -5.19, 'S-H': -0.52, }    
     else:
+        
         logging.warning('No bond energy correction found for  model chemistry: {0}'.format(modelChemistry))
 
     for symbol, count in bonds.items():


### PR DESCRIPTION
Cantherm was crashing if the input file did not use a model chemistry
with a bond energy correction in Cantherm's database. Creation of an initial empty
dictionary fixes this. Also added B3LYP bond energy corrections  from
the same table and source as the CBS-QB3 corrections. Made some small
updates to the doc.
