### PR TITLE
Add checks on toleranceMoveToCore and toleranceInterruptSimulation

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -172,7 +172,7 @@ def solvation(solvent):
 	assert isinstance(solvent,str), "solvent should be a string like 'water'"
 	rmg.solvent = solvent
 
-def model(toleranceMoveToCore, toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, maximumEdgeSpecies=None):
+def model(toleranceMoveToCore=None, toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, maximumEdgeSpecies=None):
     rmg.fluxToleranceKeepInEdge = toleranceKeepInEdge
     rmg.fluxToleranceMoveToCore = toleranceMoveToCore
     rmg.fluxToleranceInterrupt = toleranceInterruptSimulation


### PR DESCRIPTION
This pull request is related to #299. I just add another check if the line toleranceMoveToCore was missing in the input file (this case should never happen but just in case, it costs only 2 more lines) and raise a better error than the previous one.

I checked it on my branch and it is working:
-if no line toleranceMoveToCore -->raise error
-if toleranceMoveToCore > toleranceInterruptSimulaiton --> raise error
-Minimals completed.
