### PR TITLE
Add MolePro files as energyLogs in cantherm

### DIFF
--- a/rmgpy/cantherm/molepro.py
+++ b/rmgpy/cantherm/molepro.py
@@ -43,7 +43,7 @@ class MoleProLog:
     def __init__(self, path):
         self.path = path
             
-    def loadCCSDEnergy(self):
+    def loadEnergy(self,frequencyScaleFactor=1.):
         """
         Return the f12 energy in J/mol from a MolePro Logfile of a CCSD(T)-f12 job. 
         This function determines which energy (f12a or f12b) to use based on the basis set,

--- a/rmgpy/cantherm/moleproTest.py
+++ b/rmgpy/cantherm/moleproTest.py
@@ -23,7 +23,7 @@ class MoleProTest(unittest.TestCase):
         """
         
         log=MoleProLog(os.path.join(os.path.dirname(__file__),'files','ethylene_f12_dz.out'))
-        E0=log.loadCCSDEnergy()
+        E0=log.loadEnergy()
         
         self.assertAlmostEqual(E0 / constants.Na / constants.E_h, -78.474353559604, 5)
     
@@ -34,7 +34,7 @@ class MoleProTest(unittest.TestCase):
         """
         
         log=MoleProLog(os.path.join(os.path.dirname(__file__),'files','ethylene_f12_qz.out'))
-        E0=log.loadCCSDEnergy()
+        E0=log.loadEnergy()
         
         self.assertAlmostEqual(E0 / constants.Na / constants.E_h, -78.472682755635, 5)
 
@@ -45,6 +45,6 @@ class MoleProTest(unittest.TestCase):
         """
         
         log=MoleProLog(os.path.join(os.path.dirname(__file__),'files','OH_f12.out'))
-        E0=log.loadCCSDEnergy()
+        E0=log.loadEnergy()
         
         self.assertAlmostEqual(E0 / constants.Na / constants.E_h, -75.663696424380, 5)

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -256,6 +256,9 @@ class StatMechJob:
         elif isinstance(energy, QchemLog):
             energyLog = energy; E0 = None
             energyLog.path = os.path.join(directory, energyLog.path)
+        elif isinstance(energy, MoleProLog):
+            energyLog = energy; E0 = None
+            energyLog.path = os.path.join(directory, energyLog.path)
         elif isinstance(energy, float):
             energyLog = None; E0 = energy
         


### PR DESCRIPTION
Enable a bare-bones commit that lets users use MolePro Files (only
CCSD(T)-f12-vtz and dtz) as inputs for cantherm energies.
