### PR TITLE
use try..except statement to reduce verbosity of parametrized tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ pydot
 
 # For running the unit tests
 nose
-nose-parameterized
 coverage
 
 # for generating the documentation


### PR DESCRIPTION
The output of the parametrized tests is reduced by wrapping the parametrized tests with a method, and using a try..except mechanism to print assertion errors and others.

With help from @wolever (thanks!), ironically enough, we don't need nose-parametrized anymore.
