### PR TITLE
New style adjacency list

### DIFF
--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -456,10 +456,10 @@ def fromAdjacencyList(adjlist, group=False, saturateH=False):
         lines.pop()
         lastLine = lines[-1].strip()
     if re_IntermediateAdjList.match(lastLine):
-        logging.debug("Adjacency list line '{0}' looks like an intermediate style adjacency list".format(lastLine))
+        logging.debug("{1} adjacency list line '{0}' looks like an intermediate style adjacency list".format(lastLine, adjlist.splitlines()[0])
         return fromOldAdjacencyList(adjlist, group=group, saturateH=saturateH)
     if re_OldAdjList.match(lastLine):
-        logging.debug("Adjacency list line '{0}' looks like an old style adjacency list".format(lastLine))
+        logging.debug("{1} adjacency list line '{0}' looks like an old style adjacency list".format(lastLine, adjlist.splitlines()[0]))
         if not group:
             logging.debug("Will assume implicit H atoms")
         return fromOldAdjacencyList(adjlist, group=group, saturateH=(not group))


### PR DESCRIPTION
Small changes in the raise error which does not affect the code.

Just an improvement in the error message displayed by RMG when it fails to read adjacency list.
Now it displays the molecule label which led to fail instead of failing with just the reason why it failed.
The debug mode also print the label name in the message " it is look like an old adjacency list style".

Now if you load a big homemade chemkin file and fails, it displays which adjacency list is wrong in the error message.
