### PR TITLE
Free up the memory of pruned species by deleting hidden references from TemplateReaction objects

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1182,6 +1182,14 @@ class CoreEdgeReactionModel:
             for reactant1 in self.reactionDict[family]:
                 if spec in self.reactionDict[family][reactant1]:
                     del self.reactionDict[family][reactant1][spec]
+            for reactant1 in self.reactionDict[family]:
+                for reactant2 in self.reactionDict[family][reactant1]:
+                    tempRxnDeleteList = []
+                    for templateReaction in self.reactionDict[family][reactant1][reactant2]:
+                        if spec in templateReaction.reactants or spec in templateReaction.products:
+                            tempRxnDeleteList.append(templateReaction)
+                    for tempRxnToBeDeleted in tempRxnDeleteList:
+                        self.reactionDict[family][reactant1][reactant2].remove(tempRxnToBeDeleted)
 
         # remove from the global list of species, to free memory
         formula = spec.molecule[0].getFormula()


### PR DESCRIPTION
Objgraph shows after pruning, the pruned species are still in the memory so not too much memory is retrieved. And it is because there're still some objects (mainly from TemplateReaction objects in reactionDict, see the pic below) referring to them. After deleting those objects, memory was eventually released.
![in function prune prunedspecies-7-objgraph-aftfpruned](https://cloud.githubusercontent.com/assets/2739496/4940825/2072c762-65de-11e4-94cf-c13d097bfeaa.jpg)
