### PR TITLE
Adapting kinetics for with multiple transition states

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -903,8 +903,8 @@ class KineticsFamily(Database):
             item.kinetics = data
             data = item.generateReverseRateCoefficient()
             
-            item = Reaction(reactants=[m.molecule[0].copy(deep=True) for m in entry.item.products], products=[m.molecule[0].copy(deep=True) for m in entry.item.reactants])
-            template = self.getReactionTemplate(item)
+            item = TemplateReaction(reactants=[m.molecule[0].copy(deep=True) for m in entry.item.products], products=[m.molecule[0].copy(deep=True) for m in entry.item.reactants])
+            item.template = self.getReactionTemplate(item)
             item.degeneracy = self.calculateDegeneracy(item)
             
             new_entry = Entry(
@@ -1271,15 +1271,8 @@ class KineticsFamily(Database):
                 reaction.pairs = self.getReactionPairs(reaction)
             for possibleReaction in reactions:
                 # Match the correct reaction if there are multiple reaction pathways
-                if possibleReaction.pairs[0][0].isIsomorphic(reaction.pairs[0][0]) and possibleReaction.pairs[0][1].isIsomorphic(reaction.pairs[0][1]):
-                    return possibleReaction.degeneracy
-                if possibleReaction.pairs[0][0].isIsomorphic(reaction.pairs[0][1]) and possibleReaction.pairs[0][1].isIsomorphic(reaction.pairs[0][0]):
-                    return possibleReaction.degeneracy
-                if possibleReaction.pairs[0][0].isIsomorphic(reaction.pairs[1][0]) and possibleReaction.pairs[0][1].isIsomorphic(reaction.pairs[1][1]):
-                    return possibleReaction.degeneracy
-                if possibleReaction.pairs[0][0].isIsomorphic(reaction.pairs[1][1]) and possibleReaction.pairs[0][1].isIsomorphic(reaction.pairs[1][0]):
-                    return possibleReaction.degeneracy
-                        
+                if set(possibleReaction.template) == set(reaction.template): return possibleReaction.degeneracy 
+            
             raise Exception('Unable to calculate degeneracy for reaction {0} in reaction family {1}.'.format(reaction, self.label))
         
         else:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1222,25 +1222,11 @@ class KineticsFamily(Database):
             for rxn in reactionList:
                 reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints)
                 #assert len(reactions) == 1, "Expecting one matching reverse reaction, not {0}. Forward reaction {1!s} : {1!r}".format(len(reactions), rxn)
-                if len(reactions) != 1:
-                    for possibleReaction in reactions:   
-                        if possibleReaction.pairs[0][0].isIsomorphic(rxn.pairs[0][0]) and possibleReaction.pairs[0][1].isIsomorphic(rxn.pairs[0][1]):
-                            rxn.reverse = possibleReaction
-                            break
-                        if possibleReaction.pairs[0][0].isIsomorphic(rxn.pairs[0][1]) and possibleReaction.pairs[0][1].isIsomorphic(rxn.pairs[0][0]):
-                            rxn.reverse = possibleReaction
-                            break
-                        if possibleReaction.pairs[0][0].isIsomorphic(rxn.pairs[1][0]) and possibleReaction.pairs[0][1].isIsomorphic(rxn.pairs[1][1]):
-                            rxn.reverse = possibleReaction
-                            break
-                        if possibleReaction.pairs[0][0].isIsomorphic(rxn.pairs[1][1]) and possibleReaction.pairs[0][1].isIsomorphic(rxn.pairs[1][0]):
-                            rxn.reverse = possibleReaction
-                            break
-                    else:
-                        raise Exception("Could not match to reverse reaction due to no matching pairs. Forward reaction {1!s} : {1!r}".format(len(reactions), rxn))
+                if len(reactions) == 0:
+                    raise Exception("Could not match to reverse reaction due to no matching pairs. Forward reaction {1!s} : {1!r}".format(len(reactions), rxn))
                    
                 else:
-                    # Only one matching reverse reaction
+                    # Use one of the matching reverse reactions
                     rxn.reverse = reactions[0]
             
         else: # family is not ownReverse

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1478,7 +1478,7 @@ class KineticsFamily(Database):
                 # If we found a match, remove it from the list
                 # Also increment the reaction path degeneracy of the remaining reaction
                 if match:
-                    if reaction0.template == reaction.template:
+                    if set(reaction0.template) == set(reaction.template):
                         # template must match, otherwise we may have found an alternate transition state
                         reaction0.degeneracy += 1
                         rxnList.remove(reaction)
@@ -1498,9 +1498,6 @@ class KineticsFamily(Database):
         # what it should be, so divide those by two
         if sameReactants or self.label.lower().startswith('r_recombination'):
             for rxn in rxnList:
-                print rxn
-                print rxn.template
-                print rxn.degeneracy
                 assert(rxn.degeneracy % 2 == 0)
                 rxn.degeneracy /= 2
                 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -483,14 +483,13 @@ class CoreEdgeReactionModel:
                     if not rxn.duplicate:
                         return True, rxn0
                 else:
-                    if rxn0.template == rxn.template:
-                        print 'here'
+                    if set(rxn0.template) == set(rxn.template):
                         return True, rxn0
-            
+                    
+            # Do not add reverse reaction if it already exists.            
             if isinstance(family,KineticsFamily) and family.ownReverse:
                 if (rxn0.reactants == rxn.products and rxn0.products == rxn.reactants):
-                    if rxn0.template == rxn.template:
-                        return True, rxn0
+                    return True, rxn0
 
         # Now check seed mechanisms
         # We want to check for duplicates in *other* seed mechanisms, but allow

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -483,11 +483,14 @@ class CoreEdgeReactionModel:
                     if not rxn.duplicate:
                         return True, rxn0
                 else:
-                    return True, rxn0
+                    if rxn0.template == rxn.template:
+                        print 'here'
+                        return True, rxn0
             
             if isinstance(family,KineticsFamily) and family.ownReverse:
                 if (rxn0.reactants == rxn.products and rxn0.products == rxn.reactants):
-                    return True, rxn0
+                    if rxn0.template == rxn.template:
+                        return True, rxn0
 
         # Now check seed mechanisms
         # We want to check for duplicates in *other* seed mechanisms, but allow


### PR DESCRIPTION
Putting up this pull request so that we don't forget about this issue: https://github.com/GreenGroup/RMG-Py/issues/142

In certain families, there are multiple reaction paths that can occur, sometimes with different kinetics.  The example found in the issue is that of isobutyl radical + tertbutyl radical reacting to form isobutane and isobutene.  There are two possible paths in the Disproportionation family: (C_rad/H2/Cs,Cmethyl_Csrad) or (C_rad/Cs3,C/H/NdNd_Csrad).  What is currently found in Java is a randomly chosen version of the kinetics (Sometimes the first template appears, other times the 2nd template appears).

What these commits attempt to do is to calculate degeneracy by allowing identical reactions IF their reaction templates are different (https://github.com/GreenGroup/RMG-Py/commit/3aea3e5a5fe228f23166ec12e50cc4fbace2f847).  Then degeneracy is calculated separately for each 'transition state' based on bookkeeping of the reaction pairs.  

Remaining issues:
- Is matching reaction pairs sufficient?  It works in the case of bimolecular reactions, but unimolecular reactions or recombination reactions  (these probably don't have multiple TS's to begin with) won't really be distinguished (see https://github.com/GreenGroup/RMG-Py/issues/140).  
- If kinetics are identical, they should probably be combined through degeneracy for simplicity's sake in the chemkin file and then have their diff templates written as comments. In this commit they remain as duplicates.
