### PR TITLE
Prepare for updated version of RDKit (2015.03)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ bin/symmetry:
 QM: bin/symmetry
 	@ echo "Checking you have rdkit..."
 	@ python -c 'import rdkit; print rdkit.__file__'
+	@ echo "Checking rdkit version..."
+	@ python -c 'import rdkit.rdBase; print rdkit.rdBase.rdkitVersion; assert rdkit.rdBase.rdkitVersion > "2015.03"'
 	@ echo "Checking rdkit has InChI support..."
 	@ python -c 'from rdkit import Chem; assert Chem.inchi.INCHI_AVAILABLE, "RDKit installed without InChI Support"'
 


### PR DESCRIPTION
There's a new release of RDKit on its way. See the release notes at 
https://github.com/rdkit/rdkit/releases/tag/Release_2015_03_1beta1

This release has a new (faster and more robust) algorithm for canonical atom ordering. This means that canonical SMILES generated with the new version will be different from those generated with previous versions. 

Also, they have re-written their drawing routines, and deprecated (but not yet removed) the old methods.

Some things we should do in preparation for, or soon after, the release:

 * [ ] Check that it still works
 * [ ] Update any Unit Tests that were checking against an expected SMILES string
 * [ ] See if our drawing algorithms (some of which use RDKit to generate the 2d coordinates, eg. cyclic compounds) depend on the now deprecated (but not yet removed) drawing methods, and update to the new methods if needed.
 * [ ] Update RDKit running on various web servers
 * [ ] Remind developers/users to upgrade their RDKits

This pull request is to collect necessary changes (maybe none) and track comments on the above.