### PR TITLE
PAH bug checking valencies when reading adjacancy lists

### DIFF
--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -109,8 +109,15 @@ class ConsistencyChecker(object):
             theoretical = valence - order - atom.radicalElectrons - 2*atom.lonePairs
 
             if atom.charge != theoretical:
-                raise InvalidAdjacencyListError('Invalid valency for atom {symbol} with {radicals} unpaired electrons, {lonePairs} pairs of electrons, and {charge} charge.'
-                                                .format(symbol=atom.symbol, radicals=atom.radicalElectrons, lonePairs=atom.lonePairs, charge=atom.charge))
+                raise InvalidAdjacencyListError(
+                    ('Invalid valency for atom {symbol} with {radicals} unpaired electrons, '
+                    '{lonePairs} pairs of electrons, {charge} charge, and bonds [{bonds}].'
+                    ).format(symbol=atom.symbol,
+                             radicals=atom.radicalElectrons,
+                             lonePairs=atom.lonePairs,
+                             charge=atom.charge,
+                             bonds=','.join([bond.order for bond in atom.bonds.values()])
+                            ))
 
     @staticmethod
     def check_multiplicity(nRad, multiplicity):

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -33,7 +33,7 @@ adjacency list format used by Reaction Mechanism Generator (RMG).
 """
 import logging
 import re
-from .molecule import Atom, Bond
+from .molecule import Atom, Bond, getAtomType
 from .group import GroupAtom, GroupBond
 #import chempy.molecule.atomtype as atomtypes
 
@@ -100,6 +100,9 @@ class ConsistencyChecker(object):
             the theoretical one:
             
             '''
+            if getAtomType(atom, atom.edges).label == 'Cbf':
+                logging.warning("Skipping consistency check for fused benzene atom type")
+                return True
             global bond_orders
             valence = PeriodicSystem.valence_electrons[atom.symbol]
             order = 0
@@ -110,9 +113,10 @@ class ConsistencyChecker(object):
 
             if atom.charge != theoretical:
                 raise InvalidAdjacencyListError(
-                    ('Invalid valency for atom {symbol} with {radicals} unpaired electrons, '
+                    ('Invalid valency for atom {symbol} ({type}) with {radicals} unpaired electrons, '
                     '{lonePairs} pairs of electrons, {charge} charge, and bonds [{bonds}].'
                     ).format(symbol=atom.symbol,
+                             type=getAtomType(atom, atom.edges).label,
                              radicals=atom.radicalElectrons,
                              lonePairs=atom.lonePairs,
                              charge=atom.charge,

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1510,6 +1510,44 @@ multiplicity 2
         saturated_molecule.saturate()
         self.assertTrue(saturated_molecule.isIsomorphic(indene))
         
+    def testFusedAromatic(self):
+        """Test we can make aromatic perylene from both adjlist and SMILES"""
+        perylene = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {3,B} {6,B} {7,B}
+2  C u0 p0 c0 {4,B} {5,B} {8,B}
+3  C u0 p0 c0 {1,B} {4,B} {11,B}
+4  C u0 p0 c0 {2,B} {3,B} {12,B}
+5  C u0 p0 c0 {2,B} {6,B} {15,B}
+6  C u0 p0 c0 {1,B} {5,B} {16,B}
+7  C u0 p0 c0 {1,B} {9,B} {10,B}
+8  C u0 p0 c0 {2,B} {13,B} {14,B}
+9  C u0 p0 c0 {7,B} {17,B} {22,S}
+10 C u0 p0 c0 {7,B} {18,B} {23,S}
+11 C u0 p0 c0 {3,B} {18,B} {25,S}
+12 C u0 p0 c0 {4,B} {19,B} {26,S}
+13 C u0 p0 c0 {8,B} {19,B} {28,S}
+14 C u0 p0 c0 {8,B} {20,B} {29,S}
+15 C u0 p0 c0 {5,B} {20,B} {31,S}
+16 C u0 p0 c0 {6,B} {17,B} {32,S}
+17 C u0 p0 c0 {9,B} {16,B} {21,S}
+18 C u0 p0 c0 {10,B} {11,B} {24,S}
+19 C u0 p0 c0 {12,B} {13,B} {27,S}
+20 C u0 p0 c0 {14,B} {15,B} {30,S}
+21 H u0 p0 c0 {17,S}
+22 H u0 p0 c0 {9,S}
+23 H u0 p0 c0 {10,S}
+24 H u0 p0 c0 {18,S}
+25 H u0 p0 c0 {11,S}
+26 H u0 p0 c0 {12,S}
+27 H u0 p0 c0 {19,S}
+28 H u0 p0 c0 {13,S}
+29 H u0 p0 c0 {14,S}
+30 H u0 p0 c0 {20,S}
+31 H u0 p0 c0 {15,S}
+32 H u0 p0 c0 {16,S}
+""")
+        perylene2 = Molecule().fromSMILES('c1cc2cccc3c4cccc5cccc(c(c1)c23)c54')
+        self.assertTrue(perylene.isIsomorphic(perylene2))
 
 ################################################################################
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+
 from external.wip import work_in_progress
-from rmgpy.molecule.molecule import Atom, Bond, Molecule, ActionError
-from rmgpy.molecule.group import Group
 from rmgpy.molecule.element import getElement, elementList
+from rmgpy.molecule.group import Group
+from rmgpy.molecule.molecule import Atom, Bond, Molecule, ActionError
+
 
 ################################################################################
-
 class TestAtom(unittest.TestCase):
     """
     Contains unit tests of the Atom class.
@@ -1547,7 +1548,14 @@ multiplicity 2
 32 H u0 p0 c0 {16,S}
 """)
         perylene2 = Molecule().fromSMILES('c1cc2cccc3c4cccc5cccc(c(c1)c23)c54')
-        self.assertTrue(perylene.isIsomorphic(perylene2))
+        for isomer in perylene2.getAromaticResonanceIsomers():
+            if perylene.isIsomorphic(isomer):
+                break
+        else:  # didn't break
+            self.fail("{} isn't isomorphic with any aromatic forms of {}".format(
+                            perylene.toSMILES(),
+                            perylene2.toSMILES()
+                        ))
 
 ################################################################################
 


### PR DESCRIPTION
Trying to read the adjacency list for a polyaromatic hydrocarbon leads to this `InvalidAdjacencyListError: Invalid valency for atom C with 0 unpaired electrons, 0 pairs of electrons, 0 charge, and bonds [B,B,B].`

I guess the problem is those benzene bonds don't have an "order" of 1.5, because if they did then the atom would need a valence of 4.5.
e.g. http://chemistry.stackexchange.com/questions/1302/bond-order-for-carbonate-ion-for-resonance

Here's a failing unit test to get things started...
(do not merge this PR yet - at least until it's marked as "work in progress" (WIP))

Any ideas @nickvandewiele