### PR TITLE
Added Exception for user input of double bonded O2

### DIFF
--- a/examples/rmg/ch3no2/input.py
+++ b/examples/rmg/ch3no2/input.py
@@ -19,6 +19,7 @@ generatedSpeciesConstraints(
     #maximumSulfurAtoms = 0,
     #maximumHeavyAtoms = 3,
     maximumRadicalElectrons = 2,
+	allowSingletO2=False
 )
 
 # List of species

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -289,6 +289,7 @@ def generatedSpeciesConstraints(**kwargs):
         'maximumSulfurAtoms',
         'maximumHeavyAtoms',
         'maximumRadicalElectrons',
+        'allowSingletO2',
     ]
     for key, value in kwargs.items():
         if key not in validConstraints:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -289,7 +289,7 @@ def generatedSpeciesConstraints(**kwargs):
         'maximumSulfurAtoms',
         'maximumHeavyAtoms',
         'maximumRadicalElectrons',
-        'allowSingletO2',
+        'allowsSingletO2',
     ]
     for key, value in kwargs.items():
         if key not in validConstraints:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -43,6 +43,7 @@ import rmgpy.constants as constants
 from rmgpy.quantity import Quantity
 import rmgpy.species
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
+from rmgpy.molecule import Molecule
 from rmgpy.pdep import SingleExponentialDown
 from rmgpy.statmech import  Conformer
 
@@ -1605,15 +1606,27 @@ class CoreEdgeReactionModel:
         maxSulfurAtoms = self.speciesConstraints.get('maximumSulfurAtoms', 1000000)
         maxHeavyAtoms = self.speciesConstraints.get('maximumHeavyAtoms', 1000000)
         maxRadicals = self.speciesConstraints.get('maximumRadicalElectrons', 1000000)
-        
+        allowSingletO2= self.speciesConstraints.get('allowSingletO2', False)
+             
         if isinstance(species, rmgpy.species.Species):
             struct = species.molecule[0]
         else:
             # expects a molecule here
             struct = species
+        #This is checked first by design, it actually ignores the allowed list because most often a user will accidently include O2 without knowing it
+        #We want the user to very explicitly allowSingletO2 (not implicitly by having it as part of the allowed list)
+        if not allowSingletO2:
+            O2Singlet=Molecule().fromSMILES('O=O')
+            if struct.isIsomorphic(O2Singlet):
+                logging.error("""
+                RMG expects the triplet form of oxygen for correct usage in reaction families. Please change your input to SMILES='[O][O]'
+                If you actually want to use the singlet state, set the allowSingletO2=True inside of the Species Constraints block in your input file.
+                """)
+                return True
+            
         for molecule in explicitlyAllowedMolecules:
             if struct.isIsomorphic(molecule):
-                return False        
+                return False
         H = struct.getNumAtoms('H')
         if struct.getNumAtoms('C') > maxCarbonAtoms:
             return True

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1606,23 +1606,12 @@ class CoreEdgeReactionModel:
         maxSulfurAtoms = self.speciesConstraints.get('maximumSulfurAtoms', 1000000)
         maxHeavyAtoms = self.speciesConstraints.get('maximumHeavyAtoms', 1000000)
         maxRadicals = self.speciesConstraints.get('maximumRadicalElectrons', 1000000)
-        allowSingletO2= self.speciesConstraints.get('allowSingletO2', False)
              
         if isinstance(species, rmgpy.species.Species):
             struct = species.molecule[0]
         else:
             # expects a molecule here
             struct = species
-        #This is checked first by design, it actually ignores the allowed list because most often a user will accidently include O2 without knowing it
-        #We want the user to very explicitly allowSingletO2 (not implicitly by having it as part of the allowed list)
-        if not allowSingletO2:
-            O2Singlet=Molecule().fromSMILES('O=O')
-            if struct.isIsomorphic(O2Singlet):
-                logging.error("""
-                RMG expects the triplet form of oxygen for correct usage in reaction families. Please change your input to SMILES='[O][O]'
-                If you actually want to use the singlet state, set the allowSingletO2=True inside of the Species Constraints block in your input file.
-                """)
-                return True
             
         for molecule in explicitlyAllowedMolecules:
             if struct.isIsomorphic(molecule):


### PR DESCRIPTION
Many users erroneously use the double bonded singlet version for O2, which
does not react with most reaction families. Now RMG will throw an error
giving an explaination for why the user should use triplet O2.

If the user actually wants singlet O2, I have included a new option
"allowSingletO2" to the generatedSpeciesConstraints. Note that this
constraint is a little more restrictive by design. It will ignore
the allowed list, which usually lets users circumvent species
constraints for inputs such starting species and reaction libraries. The
only way to have singlet O2 is to set allowSingletO2=True. The point is
that we never want singlet O2 to fly under the radar.