### PR TITLE
Check RDKit version during 'make' so that people update to 2015+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@
 
 DASPK=$(shell python -c 'import pydas.daspk; print pydas.daspk.__file__')
 DASSL=$(shell python -c 'import pydas.dassl; print pydas.dassl.__file__')
-RDKIT_YEAR=$(shell python -c 'import rdkit; print rdkit.__version__.split(".")[0]')
-
 
 .PHONY : all minimal main solver cantherm clean decython documentation QM mopac_travis
 
@@ -48,11 +46,9 @@ QM: bin/symmetry
 	@ echo "Checking you have rdkit..."
 	@ python -c 'import rdkit; print rdkit.__file__'
 	@ echo "Checking rdkit version..."
-ifeq ($(shell test $(RDKIT_YEAR) -lt 2015; echo $$?),0)
-	$(error rdkit version out of date, please install rdkit version 2015.03.1 or later);
-endif
+	@ python -c 'import rdkit; assert float(rdkit.__version__[:7])>=2015, "RDKit version is out of date. Please upgrade to 2015.03.1 or later"'
 	@ echo "Checking rdkit has InChI support..."
-	@ python -c 'from rdkit import Chem; assert Chem.inchi.INCHI_AVAILABLE, "RDKit installed without InChI Support"'
+	@ python -c 'from rdkit import Chem; assert Chem.inchi.INCHI_AVAILABLE, "RDKit installed without InChI Support. Please install with InChI."'
 
 documentation:
 	$(MAKE) -C documentation html

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 
 DASPK=$(shell python -c 'import pydas.daspk; print pydas.daspk.__file__')
 DASSL=$(shell python -c 'import pydas.dassl; print pydas.dassl.__file__')
+RDKIT_YEAR=$(shell python -c 'import rdkit; print rdkit.__version__.split(".")[0]')
+
 
 .PHONY : all minimal main solver cantherm clean decython documentation QM mopac_travis
 
@@ -45,6 +47,10 @@ bin/symmetry:
 QM: bin/symmetry
 	@ echo "Checking you have rdkit..."
 	@ python -c 'import rdkit; print rdkit.__file__'
+	@ echo "Checking rdkit version..."
+ifeq ($(shell test $(RDKIT_YEAR) -lt 2015; echo $$?),0)
+	$(error rdkit version out of date, please install rdkit version 2015.03.1 or later);
+endif
 	@ echo "Checking rdkit has InChI support..."
 	@ python -c 'from rdkit import Chem; assert Chem.inchi.INCHI_AVAILABLE, "RDKit installed without InChI Support"'
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ QM: bin/symmetry
 	@ echo "Checking you have rdkit..."
 	@ python -c 'import rdkit; print rdkit.__file__'
 	@ echo "Checking rdkit version..."
-	@ python -c 'import rdkit; assert float(rdkit.__version__[:7])>=2015, "RDKit version is out of date. Please upgrade to 2015.03.1 or later"'
+	@ python -c 'import rdkit; assert float(rdkit.__version__[:7])>=2016, "RDKit version is out of date. Please upgrade to 2015.03.1 or later with InChI support."'
 	@ echo "Checking rdkit has InChI support..."
 	@ python -c 'from rdkit import Chem; assert Chem.inchi.INCHI_AVAILABLE, "RDKit installed without InChI Support. Please install with InChI."'
 


### PR DESCRIPTION
This pull request tries to address https://github.com/ReactionMechanismGenerator/RMG-Py/issues/416

Not sure when the feature was actually updated in RDKit, but let's assume 2015 to be safe.

One thing to be cautious of is when building from Github source for RDKit.  Not sure if version is given from that. But for now assume that most people have a stable release.