### PR TITLE
Carry over reversibility of library reactions in reaction libraries and seed mechanisms

### DIFF
--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -236,7 +236,7 @@ class KineticsLibrary(Database):
             elif '=>' in rxn_string:
                 products = products[1:]
                 reversible = False
-            assert reversible == rxn.reversible
+            assert reversible == rxn.reversible, "Reaction string reversibility (=>) and entry attribute `reversible` (set to `False`) must agree if reaction is irreversible."
             for reactant in reactants.split('+'):
                 reactant = reactant.strip()
                 if reactant not in speciesDict:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1254,7 +1254,7 @@ class CoreEdgeReactionModel:
         seedMechanism = database.kinetics.libraries[seedMechanism]
 
         for entry in seedMechanism.entries.values():
-            rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:], library=seedMechanism, kinetics=entry.data, duplicate=entry.item.duplicate)
+            rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:], library=seedMechanism, kinetics=entry.data, duplicate=entry.item.duplicate, reversible=entry.item.reversible)
             r, isNew = self.makeNewReaction(rxn) # updates self.newSpeciesList and self.newReactionlist
             
         # Perform species constraints and forbidden species checks
@@ -1317,7 +1317,7 @@ class CoreEdgeReactionModel:
         reactionLibrary = database.kinetics.libraries[reactionLibrary]
 
         for entry in reactionLibrary.entries.values():
-            rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:], library=reactionLibrary, kinetics=entry.data, duplicate=entry.item.duplicate)
+            rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:], library=reactionLibrary, kinetics=entry.data, duplicate=entry.item.duplicate, reversible=entry.item.reversible)
             r, isNew = self.makeNewReaction(rxn) # updates self.newSpeciesList and self.newReactionlist
             if not isNew: logging.info("This library reaction was not new: {0}".format(rxn))
             


### PR DESCRIPTION
Addresses https://github.com/ReactionMechanismGenerator/RMG-Py/issues/345

Previously, irreversible reactions were not saved with the appropriate flag into RMG's model.  All reactions were converted to reversible.  This fixes the problem by carrying over the `reversible` as well as `degeneracy` attribute.  Note that the `degeneracy` attribute does not affect rates (kinetics already incorporates degeneracy).  

Checks performed:
- Chemkin files saves irreversible reaction
- Solver incorporates irreversibility and produces different output