### PR TITLE
Fix input reading of interpolation model for ('PDepArrhenius')

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -243,6 +243,8 @@ def pressureDependence(
     rmg.pressureDependence.method = method
     
     # Process interpolation model
+    if isinstance(interpolation, str):
+        interpolation = (interpolation,)
     rmg.pressureDependence.interpolationModel = interpolation
 
     # Process temperatures


### PR DESCRIPTION
Closes https://github.com/ReactionMechanismGenerator/RMG-Py/pull/431, instead of using clunky input file tuple syntax.  See also: 
https://github.com/ReactionMechanismGenerator/RMG-Py/issues/432

This was already fixed in the Cantherm input reader, but
not for RMG's own input:
https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/cantherm/input.py#L305
