### PR TITLE
Species revamp

### DIFF
--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -181,8 +181,8 @@ def reaction(label, reactants, products, transitionState, kinetics=None, tunneli
         if label in reactionDict:
             raise ValueError('Multiple occurrences of reaction with label {0!r}.'.format(label))
     logging.info('Loading reaction {0}...'.format(label))
-    reactants = sorted([speciesDict[spec] for spec in reactants])
-    products = sorted([speciesDict[spec] for spec in products])
+    reactants = sorted([speciesDict[spec] for spec in reactants], key= lambda x: id(x))
+    products = sorted([speciesDict[spec] for spec in products], key= lambda x: id(x))
     transitionState = transitionStateDict[transitionState]
     if tunneling.lower() == 'wigner':
         transitionState.tunneling = Wigner(frequency=None)
@@ -210,7 +210,7 @@ def network(label, isomers=None, reactants=None, products=None, pathReactions=No
     for reactant in reactants0:
         if not isinstance(reactant, (list,tuple)):
             reactant = [reactant]
-        reactants.append(sorted([speciesDict[spec] for spec in reactant]))
+        reactants.append(sorted([speciesDict[spec] for spec in reactant], key= lambda x: id(x)))
     
     if pathReactions is None:
         # If not explicitly given, use all reactions in input file
@@ -227,8 +227,8 @@ def network(label, isomers=None, reactants=None, products=None, pathReactions=No
             # Sort bimolecular configurations so that we always encounter them in the
             # same order
             # The actual order doesn't matter, as long as it is consistent
-            rxn.reactants.sort()
-            rxn.products.sort()
+            rxn.reactants.sort(key = lambda x: id(x))
+            rxn.products.sort(key = lambda x: id(x))
             # All reactant configurations not already defined as reactants or 
             # isomers are assumed to be product channels
             if len(rxn.reactants) == 1 and rxn.reactants[0] not in isomers and rxn.reactants not in products:
@@ -246,7 +246,7 @@ def network(label, isomers=None, reactants=None, products=None, pathReactions=No
         for product in products0:
             if not isinstance(product, (list,tuple)):
                 product = [product]
-            products.append(sorted([speciesDict[spec] for spec in product]))
+            products.append(sorted([speciesDict[spec] for spec in product], key= lambda x: id(x)))
 
     isomers = [Configuration(species) for species in isomers]
     reactants = [Configuration(*species) for species in reactants]

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -387,8 +387,8 @@ class CoreEdgeReactionModel:
         """
 
         # Make sure the reactant and product lists are sorted before performing the check
-        rxn.reactants.sort()
-        rxn.products.sort()
+        rxn.reactants.sort(key=lambda x: x.label)
+        rxn.products.sort(key=lambda x: x.label)
 
         # Get the short-list of reactions with the same family, reactant1 and reactant2
         r1 = rxn.reactants[0]
@@ -1396,8 +1396,8 @@ class CoreEdgeReactionModel:
         else:
             reactants = newReaction.products[:]
             products = newReaction.products[:]
-        reactants.sort()
-        products.sort()
+        reactants.sort(key=lambda x: x.label)
+        products.sort(key=lambda x: x.label)
         
         source = tuple(reactants)
 

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -403,8 +403,8 @@ class PDepNetwork(rmgpy.pdep.network.Network):
             # Sort bimolecular configurations so that we always encounter them in the
             # same order
             # The actual order doesn't matter, as long as it is consistent
-            rxn.reactants.sort()
-            rxn.products.sort()
+            rxn.reactants.sort(key=lambda x: x.label)
+            rxn.products.sort(key=lambda x: x.label)
             # Reactants of the path reaction
             if len(rxn.reactants) == 1 and rxn.reactants[0] not in isomers and rxn.reactants not in products:
                 # We've encountered a unimolecular reactant that is not classified

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -52,6 +52,8 @@ cdef class Species:
     
     cpdef generateResonanceIsomers(self)
     
+    cpdef __initialize(self)
+
     cpdef bint isIsomorphic(self, other)
     
     cpdef fromAdjacencyList(self, adjlist)

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -290,6 +290,13 @@ class Species(object):
         # Return a reference to itself so we can use e.g. Species().fromAdjacencyList()
         return self
     
+
+    def getInChI(self):
+        return self.molecule[0].toInChI() if self.molecule else ''
+    
+    def getAugmentedInChI(self):
+        return self.molecule[0].toAugmentedInChI() if self.molecule else ''
+
     def toAdjacencyList(self):
         """
         Return a string containing each of the molecules' adjacency lists.

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -44,6 +44,7 @@ transition states (first-order saddle points on a potential energy surface).
 
 import numpy
 import cython
+from copy import deepcopy
 from sets import Set
 
 import rmgpy.quantity as quantity
@@ -126,6 +127,8 @@ class Species(object):
         else:
             assert False
         
+    def copy(self):
+        return deepcopy(self)
 
     def is_equal(self,other):
         """Private method to test equality of two Species objects."""

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -108,13 +108,9 @@ class Species(object):
         self.Zrot = Zrot
         self.energyTransferModel = energyTransferModel        
         self.props = props or {}
+          
+        self.__initialize()
         
-        # Check multiplicity of each molecule is the same
-        if molecule is not None and len(molecule)>1:
-            mult = molecule[0].multiplicity
-            for m in molecule[1:]:
-                if mult != m.multiplicity:
-                    raise SpeciesError('Multiplicities of molecules in species {species} do not match.'.format(species=label))
 
     def __hash__(self):
         return hash(tuple([mol.getFingerprint() for mol in self.molecule]))
@@ -165,7 +161,38 @@ class Species(object):
         else: return False
     
     
+    def __generate_label(self):
+        """
+        Private method that generates a string and stores it in the attribute label.
+        Should only be called when the Species is constructed.
+        """
+        if self.label == '': 
+            mol = self.molecule[0]
+            # Use SMILES as default format for label
+            # However, SMILES can contain slashes (to describe the
+            # stereochemistry around double bonds); since RMG doesn't 
+            # distinguish cis and trans isomers, we'll just strip these out
+            # so that we can use the label in file paths
+            self.label = mol.toSMILES().replace('/','').replace('\\','')
+            
+    
+    def __initialize(self):
+        """Initializes the Species object."""
+        self.generateResonanceIsomers()
         
+        if self.molecule:
+            # Check multiplicity of each molecule is the same
+            if len(self.molecule)>1:
+                mult = self.molecule[0].multiplicity
+                for m in self.molecule[1:]:
+                    if mult != m.multiplicity:
+                        raise SpeciesError('Multiplicities of molecules in species {species} do not match.'.format(species=self.label))
+                    
+            self.__generate_label()
+            
+            self.molecularWeight = quantity.Quantity(self.molecule[0].getMolecularWeight()*1000.,"amu")
+            
+            self.props['formula'] = self.molecule[0].getFormula()
 
 
     def __repr__(self):


### PR DESCRIPTION
This PR adds some new functionalities to the Species object:
- equality comparison
- an (improved) constructor with label generation, and molecular weight/ formula caching.

This PR primarily implements an equality comparison of Species objects. By doing:

```python
spc1 == spc2
or
spc1 != spc2
```

it checks:
- are the two objects Species instances?
- are the two objects pointing to the same reference in memory?
- compare the 2 molecules (if necessary)

the comparison redirects to `Molecule` equality comparison.

I deliberately did not implement other rich comparison methods like < or >. Hence for `sorted(...)` or `.sort()` calls on Species arrays, I explicitly mentioned the sorting key in those cases.