### PR TITLE
Change sidebar icon width in documentation website

### DIFF
--- a/documentation/source/_templates/customsidebar.html
+++ b/documentation/source/_templates/customsidebar.html
@@ -4,7 +4,7 @@
 <table cellpadding="3">
 
 <tr><td>
-        <a href="http://reactionmechanismgenerator.github.io/RMG-Py"><img src="{{ pathto('_static/documentation-icon.png', 1) }}" class="icon_sidebar" width="75px" alt="Documentation"/></a>
+        <a href="http://reactionmechanismgenerator.github.io/RMG-Py"><img src="{{ pathto('_static/documentation-icon.png', 1) }}" class="icon_sidebar" width="25px" alt="Documentation"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://reactionmechanismgenerator.github.io/RMG-Py">Documentation</a></div>
@@ -12,7 +12,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/database/"><img src="{{ pathto('_static/database-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Database"/></a>
+        <a href="http://rmg.mit.edu/database/"><img src="{{ pathto('_static/database-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Database"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/database/">Database</a></div>
@@ -20,7 +20,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/simulate/input"><img src="{{ pathto('_static/input-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Create Input File"/></a>
+        <a href="http://rmg.mit.edu/simulate/input"><img src="{{ pathto('_static/input-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Create Input File"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/simulate/input">Create Input File</a></div>
@@ -28,7 +28,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/group_draw"><img src="{{ pathto('_static/groupdraw-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Draw Group"/></a>
+        <a href="http://rmg.mit.edu/group_draw"><img src="{{ pathto('_static/groupdraw-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Draw Group"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/group_draw">Draw Group</a></div>
@@ -36,7 +36,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/molecule_search"><img src="{{ pathto('_static/moleculedraw-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Molecule Search"/></a>
+        <a href="http://rmg.mit.edu/molecule_search"><img src="{{ pathto('_static/moleculedraw-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Molecule Search"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/molecule_search">Molecule Search</a></div>
@@ -44,7 +44,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/kinetics/search/"><img src="{{ pathto('_static/kinetics-search-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Kinetics Search"/></a>
+        <a href="http://rmg.mit.edu/kinetics/search/"><img src="{{ pathto('_static/kinetics-search-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Kinetics Search"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/kinetics/search/">Kinetics Search</a></div>
@@ -52,7 +52,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/solvation_search"><img src="{{ pathto('_static/solvation-search-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Solvation Search"/></a>
+        <a href="http://rmg.mit.edu/solvation_search"><img src="{{ pathto('_static/solvation-search-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Solvation Search"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/solvation_search">Solvation Search</a></div>
@@ -61,7 +61,7 @@
 
 
 <tr><td>
-        <a href="http://rmg.mit.edu/pdep/"><img src="{{ pathto('_static/pdep-logo-small.png', 1) }}" class="icon_sidebar" width="75px" alt="Pressure Dependent Networks"/></a>
+        <a href="http://rmg.mit.edu/pdep/"><img src="{{ pathto('_static/pdep-logo-small.png', 1) }}" class="icon_sidebar" width="25px" alt="Pressure Dependent Networks"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/pdep/">Pressure Dependent Networks</a></div>
@@ -69,7 +69,7 @@
 </td></tr>
 
 <tr><td>
-        <a href="http://rmg.mit.edu/simulate/"><img src="{{ pathto('_static/tools-icon.png', 1) }}" class="icon_sidebar" width="75px" alt="Simulation & Tools"/></a>
+        <a href="http://rmg.mit.edu/simulate/"><img src="{{ pathto('_static/tools-icon.png', 1) }}" class="icon_sidebar" width="25px" alt="Simulation & Tools"/></a>
 </td>
 <td>
         <div class="biglink_sidebar"><a href="http://rmg.mit.edu/simulate/">Simulation & Tools</a></div>


### PR DESCRIPTION
Reduced size to improve appearance in Firefox and IE.

I couldn't figure out the reason, but Chrome reduces the size of the icons to 25 px, while Firefox and IE were using the set width of 75 px. I changed the setting to 25 px, which fixes the display in Firefox and IE, but doesn't affect Chrome.