### PR TITLE
Fix bug91 website & ensure heavy atoms appear first in adj lists

### DIFF
--- a/rmgpy/molecule/adjlistTest.py
+++ b/rmgpy/molecule/adjlistTest.py
@@ -670,12 +670,12 @@ class TestMoleculeAdjLists(unittest.TestCase):
         adjlist: Check that we can convert back to old style adjacency list
         """
         molecule2 = Molecule().fromSMILES('C=CC=C[CH]C')
-        string = """1 C 0 {3,D} {4,S}
-2 C 0 {4,S}
-3 C 0 {1,D} {5,S}
-4 C 1 {1,S} {2,S}
-5 C 0 {3,S} {6,D}
-6 C 0 {5,D}"""
+        string = """1 C 0 {2,D}
+2 C 0 {1,D} {4,S}
+3 C 1 {5,S} {6,S}
+4 C 0 {2,S} {6,D}
+5 C 0 {3,S}
+6 C 0 {3,S} {4,D}"""
         self.assertEqual(molecule2.toAdjacencyList(removeH=True,oldStyle=True).strip(),string.strip())
 ################################################################################
 class TestConsistencyChecker(unittest.TestCase):

--- a/rmgpy/molecule/atomtypeTest.py
+++ b/rmgpy/molecule/atomtypeTest.py
@@ -201,11 +201,11 @@ class TestGetAtomType(unittest.TestCase):
         """
         Test that getAtomType() returns appropriate carbon atom types.
         """
-        self.assertEqual(self.atomType(self.mol1, 0), 'Cs')
-        self.assertEqual(self.atomType(self.mol1, 6), 'Cd')
-        self.assertEqual(self.atomType(self.mol1, 4), 'Cdd')
-        self.assertEqual(self.atomType(self.mol1, 9), 'Ct')
-        self.assertEqual(self.atomType(self.mol1, 1), 'CO')
+        self.assertEqual(self.atomType(self.mol1, 5), 'Cs')
+        self.assertEqual(self.atomType(self.mol1, 4), 'Cd')
+        self.assertEqual(self.atomType(self.mol1, 6), 'Cdd')
+        self.assertEqual(self.atomType(self.mol1, 3), 'Ct')
+        self.assertEqual(self.atomType(self.mol1, 7), 'CO')
         self.assertEqual(self.atomType(self.mol2, 0), 'Cb')
     
     def testNitrogenTypes(self):
@@ -230,25 +230,26 @@ class TestGetAtomType(unittest.TestCase):
         """
         Test that getAtomType() returns appropriate oxygen atom types.
         """
-        self.assertEqual(self.atomType(self.mol1, 3), 'Os')
-        self.assertEqual(self.atomType(self.mol1, 8), 'Od')
+        self.assertEqual(self.atomType(self.mol1, 1), 'Os')
+        self.assertEqual(self.atomType(self.mol1, 0), 'Od')
     
     def testSiliconTypes(self):
         """
         Test that getAtomType() returns appropriate silicon atom types.
         """
-        self.assertEqual(self.atomType(self.mol4, 6), 'Sis')
-        self.assertEqual(self.atomType(self.mol4, 0), 'Sid')
-        self.assertEqual(self.atomType(self.mol4, 1), 'Sidd')
-        self.assertEqual(self.atomType(self.mol4, 4), 'Sit')
-        self.assertEqual(self.atomType(self.mol4, 8), 'SiO')
+        print self.mol4.toAdjacencyList()
+        self.assertEqual(self.atomType(self.mol4, 4), 'Sis')
+        self.assertEqual(self.atomType(self.mol4, 6), 'Sid')
+        self.assertEqual(self.atomType(self.mol4, 8), 'Sidd')
+        self.assertEqual(self.atomType(self.mol4, 5), 'Sit')
+        self.assertEqual(self.atomType(self.mol4, 3), 'SiO')
     
     def testSulfurTypes(self):
         """
         Test that getAtomType() returns appropriate sulfur atom types.
         """
-        self.assertEqual(self.atomType(self.mol4, 5), 'Ss')
-        self.assertEqual(self.atomType(self.mol4, 10), 'Sd')
+        self.assertEqual(self.atomType(self.mol4, 2), 'Ss')
+        self.assertEqual(self.atomType(self.mol4, 0), 'Sd')
     
     def testOtherTypes(self):
         """

--- a/rmgpy/molecule/atomtypeTest.py
+++ b/rmgpy/molecule/atomtypeTest.py
@@ -204,7 +204,7 @@ class TestGetAtomType(unittest.TestCase):
         self.assertEqual(self.atomType(self.mol1, 0), 'Cs')
         self.assertEqual(self.atomType(self.mol1, 6), 'Cd')
         self.assertEqual(self.atomType(self.mol1, 4), 'Cdd')
-        self.assertEqual(self.atomType(self.mol1, 16), 'Ct')
+        self.assertEqual(self.atomType(self.mol1, 9), 'Ct')
         self.assertEqual(self.atomType(self.mol1, 1), 'CO')
         self.assertEqual(self.atomType(self.mol2, 0), 'Cb')
     
@@ -231,7 +231,7 @@ class TestGetAtomType(unittest.TestCase):
         Test that getAtomType() returns appropriate oxygen atom types.
         """
         self.assertEqual(self.atomType(self.mol1, 3), 'Os')
-        self.assertEqual(self.atomType(self.mol1, 13), 'Od')
+        self.assertEqual(self.atomType(self.mol1, 8), 'Od')
     
     def testSiliconTypes(self):
         """

--- a/rmgpy/molecule/inchiparsingTest.py
+++ b/rmgpy/molecule/inchiparsingTest.py
@@ -111,7 +111,6 @@ class InChITest(unittest.TestCase):
         mult = 5
         u_indices = [3, 5, 7, 8]
         mol = self.compare(inchi, mult, u_indices)
-        print mol.toAdjacencyList()
 
     def testQuadri2DoubleBondMult5(self):
         inchi = 'C8H14/c1-5-7(3)8(4)6-2/h5-8H,1-2H2,3-4H3'
@@ -152,10 +151,10 @@ class InChITest(unittest.TestCase):
         mult = 1
         mol = self.compare(inchi, mult)
 
-        assert mol.atoms[1].lonePairs == 1 # Oxygen
+        self.assertEqual(mol.atoms[1].lonePairs, 1) # Oxygen
 
-        assert mol.atoms[0].charge == -1
-        assert mol.atoms[1].charge == +1
+        self.assertEqual(mol.atoms[0].charge, -1)
+        self.assertEqual(mol.atoms[1].charge, 1)
 
     def testMethylene(self):
         inchi = 'CH2/h1H2'
@@ -173,14 +172,13 @@ class InChITest(unittest.TestCase):
         mol = self.compare(inchi, mult)
         for at in mol.atoms:
             if at.isOxygen():
-                assert at.lonePairs == 2
+                self.assertEqual(at.lonePairs, 2)
     
     def testC6H6(self):
         inchi = 'C6H6/c1-3-5-6-4-2/h1,6H,2,5H2'
         mult = 3
         u_indices = [4,6]
         mol = self.compare(inchi, mult, u_indices)
-        print mol.toAdjacencyList()
 
     def testC4H6O_2(self):
         """
@@ -190,7 +188,6 @@ class InChITest(unittest.TestCase):
         mult = 3
         u_indices = [3,5]
         mol = self.compare(inchi, mult, u_indices)
-        print mol.toAdjacencyList()
 
         
 

--- a/rmgpy/molecule/inchiparsingTest.py
+++ b/rmgpy/molecule/inchiparsingTest.py
@@ -97,25 +97,25 @@ class InChITest(unittest.TestCase):
     def testTriRadicalDoubleBondMult4(self):
         inchi = 'C4H7/c1-3-4-2/h3H,1-2,4H2'
         mult = 4
-        u_indices = [2,4]
+        u_indices = [1, 2, 3]
         self.compare(inchi, mult, u_indices)
 
     def testTriRadical2DoubleBondMult4(self):
         inchi = 'C6H9/c1-4-6(3)5-2/h1,4-6H,2H2,3H3'
         mult = 4
-        u_indices = [3, 5]
+        u_indices = [1, 2, 4]
         self.compare(inchi, mult, u_indices)
 
     def testQuadriRadicalDoubleBondZwitterMult5(self):
         inchi = 'C8H14/c1-4-6-7-8(3)5-2/h5-6,8H,1-2,4,7H2,3H3'
         mult = 5
-        u_indices = [3, 5, 7, 8]
+        u_indices = [1, 2, 4, 6]
         mol = self.compare(inchi, mult, u_indices)
 
     def testQuadri2DoubleBondMult5(self):
         inchi = 'C8H14/c1-5-7(3)8(4)6-2/h5-8H,1-2H2,3-4H3'
         mult = 5
-        u_indices = [5, 6, 7, 8]
+        u_indices = [1, 2, 3, 4]
         self.compare(inchi, mult, u_indices)
 
     def testC2H3O3(self):
@@ -151,10 +151,10 @@ class InChITest(unittest.TestCase):
         mult = 1
         mol = self.compare(inchi, mult)
 
-        self.assertEqual(mol.atoms[1].lonePairs, 1) # Oxygen
+        self.assertEqual(mol.atoms[0].lonePairs, 1) # Oxygen
 
-        self.assertEqual(mol.atoms[0].charge, -1)
-        self.assertEqual(mol.atoms[1].charge, 1)
+        self.assertEqual(mol.atoms[1].charge, -1)
+        self.assertEqual(mol.atoms[0].charge, 1)
 
     def testMethylene(self):
         inchi = 'CH2/h1H2'
@@ -177,7 +177,7 @@ class InChITest(unittest.TestCase):
     def testC6H6(self):
         inchi = 'C6H6/c1-3-5-6-4-2/h1,6H,2,5H2'
         mult = 3
-        u_indices = [4,6]
+        u_indices = [4,5]
         mol = self.compare(inchi, mult, u_indices)
 
     def testC4H6O_2(self):
@@ -186,7 +186,7 @@ class InChITest(unittest.TestCase):
         """
         inchi = 'C4H6O/c1-2-3-4-5/h2,4H,1,3H2'
         mult = 3
-        u_indices = [3,5]
+        u_indices = [3,1]
         mol = self.compare(inchi, mult, u_indices)
 
         

--- a/rmgpy/molecule/inchiparsingTest.py
+++ b/rmgpy/molecule/inchiparsingTest.py
@@ -103,20 +103,20 @@ class InChITest(unittest.TestCase):
     def testTriRadical2DoubleBondMult4(self):
         inchi = 'C6H9/c1-4-6(3)5-2/h1,4-6H,2H2,3H3'
         mult = 4
-        u_indices = [3,6]
+        u_indices = [3, 5]
         self.compare(inchi, mult, u_indices)
 
     def testQuadriRadicalDoubleBondZwitterMult5(self):
         inchi = 'C8H14/c1-4-6-7-8(3)5-2/h5-6,8H,1-2,4,7H2,3H3'
         mult = 5
-        u_indices = [3, 5,10, 11]
+        u_indices = [3, 5, 7, 8]
         mol = self.compare(inchi, mult, u_indices)
         print mol.toAdjacencyList()
 
     def testQuadri2DoubleBondMult5(self):
         inchi = 'C8H14/c1-5-7(3)8(4)6-2/h5-8H,1-2H2,3-4H3'
         mult = 5
-        u_indices = [5, 6, 9, 10]
+        u_indices = [5, 6, 7, 8]
         self.compare(inchi, mult, u_indices)
 
     def testC2H3O3(self):
@@ -178,14 +178,17 @@ class InChITest(unittest.TestCase):
     def testC6H6(self):
         inchi = 'C6H6/c1-3-5-6-4-2/h1,6H,2,5H2'
         mult = 3
-        u_indices = [4,9]
+        u_indices = [4,6]
         mol = self.compare(inchi, mult, u_indices)
         print mol.toAdjacencyList()
 
     def testC4H6O_2(self):
+        """
+        .O-HC.-CH2CH=CH2
+        """
         inchi = 'C4H6O/c1-2-3-4-5/h2,4H,1,3H2'
         mult = 3
-        u_indices = [3,9]
+        u_indices = [3,5]
         mol = self.compare(inchi, mult, u_indices)
         print mol.toAdjacencyList()
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -210,4 +210,3 @@ cdef class Molecule(Graph):
     cpdef findAllDelocalizationPathsN5dd_N5ts(self, Atom atom1)
 
     cpdef int calculateSymmetryNumber(self) except -1
-    

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1692,7 +1692,7 @@ class Molecule(Graph):
         if self.isCyclic():
             molecule = self.copy(deep=True)
             try:
-                rdkitmol, rdAtomIndices = parser.toRDKitMol(molecule, removeHs=True, returnMapping=True)
+                rdkitmol, rdAtomIndices = parser.toRDKitMol(molecule, removeHs=False, returnMapping=True)
             except:
                 return []
             aromatic = False

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1693,7 +1693,7 @@ class Molecule(Graph):
         if self.isCyclic():
             molecule = self.copy(deep=True)
             try:
-                rdkitmol, rdAtomIndices = parser.toRDKitMol(molecule, removeHs=False, returnMapping=True)
+                rdkitmol, rdAtomIndices = parser.toRDKitMol(molecule, removeHs=True, returnMapping=True)
             except:
                 return []
             aromatic = False

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -184,7 +184,7 @@ class Atom(Vertex):
             return True
     
     def getDescriptor(self):
-        return (self.getAtomConnectivityValue(), self.symbol, self.radicalElectrons, self.lonePairs, self.charge)
+        return (self.number, self.getAtomConnectivityValue(), self.radicalElectrons, self.lonePairs, self.charge)
 
     def getAtomConnectivityValue(self):
         return getVertexConnectivityValue(self)
@@ -706,7 +706,8 @@ class Molecule(Graph):
             if vertex.sortingLabel < 0:
                 self.updateConnectivityValues()
                 break
-        self.atoms.sort(key=lambda a: a.getDescriptor())
+        self.atoms.sort(key=lambda a: a.getDescriptor(), reverse=True)
+        # self.moveHs()
         for index, vertex in enumerate(self.vertices):
             vertex.sortingLabel = index
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -700,6 +700,11 @@ class Molecule(Graph):
         """
         Sort the atoms in the graph. This can make certain operations, e.g.
         the isomorphism functions, much more efficient.
+        
+        This function orders atoms using several attributes in atom.getDescriptor().
+        Currently it sorts by placing heaviest atoms first and hydrogen atoms last.
+        Placing hydrogens last during sorting ensures that functions with hydrogen
+        removal work properly.
         """
         cython.declare(vertex=Vertex, a=Atom, index=int)
         for vertex in self.vertices:

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1534,6 +1534,35 @@ multiplicity 2
         with self.assertRaises(Exception):
             mol = Molecule().fromAugmentedInChI(malform_aug_inchi)
 
+    def testRDKitMolAtomMapping(self):
+        """
+        Test that the atom mapping returned by toRDKitMol contains the correct
+        atom indices of the atoms of the molecule when hydrogens are removed.
+        """
+        from rmgpy.molecule.parser import toRDKitMol
+
+        adjlist = '''
+1 H u0 p0 c0 {2,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 O u0 p2 c0 {2,S} {6,S}
+6 H u0 p0 c0 {5,S}
+        '''
+
+        mol = Molecule().fromAdjacencyList(adjlist)
+        rdkitmol, rdAtomIndices = toRDKitMol(mol, removeHs=True, returnMapping=True)
+
+        heavy_atoms = [at for at in mol.atoms if at.number != 1]
+        for at1 in heavy_atoms:
+            for at2 in heavy_atoms:
+                if mol.hasBond(at1, at2):
+                    try:
+                        rdkitmol.GetBondBetweenAtoms(rdAtomIndices[at1],rdAtomIndices[at2])
+                    except RuntimeError:
+                        self.fail("RDKit failed in finding the bond in the original atom!")
+                        
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -892,7 +892,7 @@ class TestMolecule(unittest.TestCase):
         test_strings = ['[C-]#[O+]', '[C]', '[CH]', 'OO', '[H][H]', '[H]',
                        '[He]', '[O]', 'O', '[CH3]', 'C', '[OH]', 'CCC',
                        'CC', 'N#N', '[O]O', 'C[CH2]', '[Ar]', 'CCCC',
-                       'O=C=O', '[C]#N',
+                       'O=C=O', 'N#[C]',
                        ]
         for s in test_strings:
             molecule = Molecule(SMILES=s)
@@ -1530,7 +1530,7 @@ multiplicity 2
 
     def testMalformedAugmentedInChI_Wrong_Indices(self):
         """Test that augmented inchi with wrong layer is caught."""
-        malform_aug_inchi = 'InChI=1S/C6H6/c1-3-5-6-4-2/h1,6H,2,5H2/mult3/u4,5'# should be 6
+        malform_aug_inchi = 'InChI=1S/C6H6/c1-3-5-6-4-2/h1,6H,2,5H2/mult3/u4,1'
         with self.assertRaises(Exception):
             mol = Molecule().fromAugmentedInChI(malform_aug_inchi)
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1508,6 +1508,32 @@ multiplicity 2
         self.assertTrue(saturated_molecule.isIsomorphic(indene))
         
 
+    def testMalformedAugmentedInChI(self):
+        """Test that augmented inchi without InChI layer raises Exception."""
+        from rmgpy.molecule.inchi import InchiException
+
+        malform_aug_inchi = 'foo'
+        with self.assertRaises(InchiException):
+            mol = Molecule().fromAugmentedInChI(malform_aug_inchi)
+
+    def testMalformedAugmentedInChI_Wrong_InChI_Layer(self):
+        """Test that augmented inchi with wrong layer is caught."""
+        malform_aug_inchi = 'InChI=1S/CH3/h1H2'
+        with self.assertRaises(Exception):
+            mol = Molecule().fromAugmentedInChI(malform_aug_inchi)
+
+    def testMalformedAugmentedInChI_Wrong_Mult(self):
+        """Test that augmented inchi with wrong layer is caught."""
+        malform_aug_inchi = 'InChI=1S/CH3/h1H3/mult3'
+        with self.assertRaises(Exception):
+            mol = Molecule().fromAugmentedInChI(malform_aug_inchi)
+
+    def testMalformedAugmentedInChI_Wrong_Indices(self):
+        """Test that augmented inchi with wrong layer is caught."""
+        malform_aug_inchi = 'InChI=1S/C6H6/c1-3-5-6-4-2/h1,6H,2,5H2/mult3/u4,5'# should be 6
+        with self.assertRaises(Exception):
+            mol = Molecule().fromAugmentedInChI(malform_aug_inchi)
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -120,6 +120,7 @@ def convert_unsaturated_bond_to_biradical(mol, u_indices):
                 u_indices.remove(u1)
                 u_indices.remove(u2)
                 return mol        
+    raise Exception('The indices {} did not refer to atoms that are connected in the molecule {}.'.format(u_indices, mol))    
 
 def isUnsaturated(mol):
     """Does the molecule have a bond that's not single?

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -676,7 +676,10 @@ def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
         rdAtom.SetNumRadicalElectrons(atom.radicalElectrons)
         if atom.element.symbol == 'C' and atom.lonePairs == 1 and mol.multiplicity == 1: rdAtom.SetNumRadicalElectrons(2)
         rdkitmol.AddAtom(rdAtom)
-        rdAtomIndices[atom] = index
+        if removeHs and atom.symbol == 'H':
+            pass
+        else:
+            rdAtomIndices[atom] = index
     
     rdBonds = Chem.rdchem.BondType
     orders = {'S': rdBonds.SINGLE, 'D': rdBonds.DOUBLE, 'T': rdBonds.TRIPLE, 'B': rdBonds.AROMATIC}

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -289,9 +289,8 @@ def check(mol, aug_inchi) :
 
     conditions.append(condition_electrons)
 
-    assert all(conditions), 'Molecule \n {0} does not correspond to aug. inchi {1}'.format(mol.toAdjacencyList(), aug_inchi)
     if not all(conditions):
-        raise Exception
+        raise Exception('Molecule \n {0} does not correspond to aug. inchi {1}'.format(mol.toAdjacencyList(), aug_inchi))
 
 
 def correct_O_triple_bond(mol):
@@ -410,9 +409,8 @@ def fromAugmentedInChI(mol, aug_inchi):
     indices = aug_inchi.u_indices[:] if aug_inchi.u_indices is not None else None    
     
     if not correct and not indices:
-        logging.error('Cannot correct {} based on {} by converting unsaturated bonds into unpaired electrons...'\
+        raise Exception('Cannot correct {} based on {} by converting unsaturated bonds into unpaired electrons...'\
             .format(mol.toAdjacencyList(), aug_inchi))
-        raise Exception
 
     while not correct and unsaturated and len(indices) > 1:
         mol = convert_unsaturated_bond_to_biradical(mol, indices)

--- a/rmgpy/molecule/parserTest.py
+++ b/rmgpy/molecule/parserTest.py
@@ -6,42 +6,44 @@ from rmgpy.molecule.molecule import Molecule
 
 class parserTest(unittest.TestCase):
 
-   def test_fromAugmentedInChI(self):
-      aug_inchi = 'InChI=1S/CH4/h1H4'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(not mol.InChI == '')
+    def test_fromAugmentedInChI(self):
+        aug_inchi = 'InChI=1S/CH4/h1H4'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(not mol.InChI == '')
 
-      aug_inchi = 'InChI=1/CH4/h1H4'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(not mol.InChI == '')
+        aug_inchi = 'InChI=1/CH4/h1H4'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(not mol.InChI == '')
+ 
+    def test_OptionalMultLayer(self):
+        """
+        Test that multiplicity layer be optional in cases where the layer is not needed.
+        """
 
-   def test_OptionalMultLayer(self):
-      """Test that multiplicity layer be optional in cases where the layer is not needed."""
-
-      aug_inchi = 'InChI=1S/CH3/h1H3'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 2)
-
-      aug_inchi = 'InChI=1S/CH3/h1H3/mult2'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 2)
-
-      aug_inchi = 'InChI=1S/CH3/h1H3/mult2/u0'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 2)
-
-      aug_inchi = 'InChI=1S/CH2/h1H2/mult3'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 3)
-
-      aug_inchi = 'InChI=1S/CH2/h1H2/mult1'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 1)
-
-      aug_inchi = 'InChI=1S/CH2/h1H2/mult3/u0'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 3)
-
-      aug_inchi = 'InChI=1S/CH2/h1H2/mult1/u0'
-      mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
-      self.assertTrue(mol.multiplicity == 1)
+        aug_inchi = 'InChI=1S/CH3/h1H3'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 2)
+        
+        aug_inchi = 'InChI=1S/CH3/h1H3/mult2'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 2)
+        
+        aug_inchi = 'InChI=1S/CH3/h1H3/mult2/u0'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 2)
+        
+        aug_inchi = 'InChI=1S/CH2/h1H2/mult3'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 3)
+        
+        aug_inchi = 'InChI=1S/CH2/h1H2/mult1'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 1)
+        
+        aug_inchi = 'InChI=1S/CH2/h1H2/mult3/u0'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 3)
+        
+        aug_inchi = 'InChI=1S/CH2/h1H2/mult1/u0'
+        mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
+        self.assertTrue(mol.multiplicity == 1)

--- a/rmgpy/molecule/parserTest.py
+++ b/rmgpy/molecule/parserTest.py
@@ -47,3 +47,33 @@ class parserTest(unittest.TestCase):
         aug_inchi = 'InChI=1S/CH2/h1H2/mult1/u0'
         mol = parser.fromAugmentedInChI(Molecule(), aug_inchi)
         self.assertTrue(mol.multiplicity == 1)
+
+    def test_toRDKitMol(self):
+        """
+        Test that toRDKitMol returns correct indices and atom mappings.
+        """
+        bondOrderDict = {'SINGLE':'S','DOUBLE':'D','TRIPLE':'T','AROMATIC':'B'}
+        mol = parser.fromSMILES(Molecule(), 'C1CCC=C1C=O')
+        rdkitmol, rdAtomIndices = mol.toRDKitMol(removeHs=False, returnMapping=True, sanitize=True)
+        for atom in mol.atoms:
+            # Check that all atoms are found in mapping
+            self.assertTrue(atom in rdAtomIndices)
+            # Check that all bonds are in rdkitmol with correct mapping and order
+            for connectedAtom, bond in atom.bonds.iteritems():
+                bondType = str(rdkitmol.GetBondBetweenAtoms(rdAtomIndices[atom],rdAtomIndices[connectedAtom]).GetBondType())
+                rdkitBondOrder = bondOrderDict[bondType]
+                self.assertEqual(bond.order, rdkitBondOrder)
+        
+        # Test for removeHs = True        
+        rdkitmol2, rdAtomIndices2 = mol.toRDKitMol(removeHs=True, returnMapping=True, sanitize=True)
+        
+        for atom in mol.atoms:
+            # Check that all non-hydrogen atoms are found in mapping
+            if atom.symbol != 'H':
+                self.assertTrue(atom in rdAtomIndices)
+                # Check that all bonds connected to non-hydrogen have the correct mapping and order
+                for connectedAtom, bond in atom.bonds.iteritems():
+                    if connectedAtom.symbol != 'H':
+                        bondType = str(rdkitmol.GetBondBetweenAtoms(rdAtomIndices[atom],rdAtomIndices[connectedAtom]).GetBondType())
+                        rdkitBondOrder = bondOrderDict[bondType]
+                        self.assertEqual(bond.order, rdkitBondOrder)   

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -1,0 +1,48 @@
+import unittest
+
+from rmgpy.molecule.molecule import Molecule
+
+class ResonanceTest(unittest.TestCase):
+
+    def test_C9H9_aro(self):
+        """CyclopropylBenzene-radical, aromatic bonds"""
+        mol = Molecule(SMILES="[CH]1CC1c1ccccc1")
+        mol.generateResonanceIsomers()
+    
+    def test_C9H9_kek(self):
+        """CyclopropylBenzene-radical, kekulized bonds"""
+        mol = Molecule(SMILES="[CH]1CC1C1C=CC=CC=1")
+        mol.generateResonanceIsomers()
+
+    def test_Benzene_aro(self):
+        mol = Molecule(SMILES="c1ccccc1")
+        mol.generateResonanceIsomers()
+    
+    def test_Benzene_kek(self):
+        mol = Molecule(SMILES="C1C=CC=CC=1")
+        mol.generateResonanceIsomers()
+
+    def test_C9H11_aro(self):
+        """PropylBenzene-radical"""
+        mol = Molecule(SMILES="[CH2]CCc1ccccc1")
+        mol.generateResonanceIsomers()
+
+    def test_C10H11_aro(self):
+        """CyclobutylBenzene-radical"""
+        mol = Molecule(SMILES="[CH]1CCC1c1ccccc1")
+        mol.generateResonanceIsomers()
+
+    def test_C9H10_aro(self):
+        """CyclopropylBenzene, aromatic bonds"""
+        mol = Molecule(SMILES="C1CC1c1ccccc1")
+        mol.generateResonanceIsomers()
+
+    def test_C10H12_aro(self):
+        """CyclopropylMethylBenzene"""
+        mol = Molecule(SMILES="C1CC1c1c(C)cccc1")
+        mol.generateResonanceIsomers()
+
+    def test_C9H10_aro(self):
+        """CyclopropylBenzene, generate aro resonance isomers"""
+        mol = Molecule(SMILES="C1CC1c1ccccc1")
+        mol.getAromaticResonanceIsomers()


### PR DESCRIPTION
This PR addresses https://github.com/ReactionMechanismGenerator/RMG-website/issues/91 and ensures that heavy atoms appear first in the adjacency list.

bf72770 is a unit test contains a number of aromatic species that include the molecule mentioned in the issue.

794eb1a ensure that the risky combo of `.toRDKitMol(molecule, removeHs=True, returnMapping=True)` is not used anymore.

ab4d579 is an improvement of `toRDKitMol` to only add atoms to the index list that will actually exist in the generated rdkit molecule.

a625972 ensures that heavy atoms always preceed H-atoms, when `molecule.sortAtoms()` is called.