### PR TITLE
Newly added Retroen family into RMG

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -86,7 +86,8 @@ UNIMOLECULAR_KINETICS_FAMILIES = [
     '1,4_Cyclic_birad_scission',
     '1,4_Linear_birad_scission',
     'Intra_Diels_alder',
-    'ketoenol'
+    'ketoenol',
+    'Retroen'
 ]
 
 ################################################################################


### PR DESCRIPTION
This PR is to allow Retroen family to be in the scope of RMG-Py.