### PR TITLE
Alter the way diffModels.py is called for easier calling by RMG-website

### DIFF
--- a/documentation/source/users/rmg/modules/diffModels.rst
+++ b/documentation/source/users/rmg/modules/diffModels.rst
@@ -8,12 +8,18 @@ The script ``diffModels`` compares two RMG generated models to determine their d
 To use this method you will need the chemkin and species dictionary outputs from RMG. These can be found in the 
 ``chemkin`` folder from the directory of the ``input.py`` file used for the RMG run.  The syntax is as follows::
 
-	python diffModels.py CHEMKIN1 SPECIESDICT1 THERMO1 CHEMKIN2 SPECIESDICT2 THERMO2
+	python diffModels.py CHEMKIN1 SPECIESDICT1 --thermo1 THERMO1 CHEMKIN2 SPECIESDICT2 --thermo2 THERMO2 --web
 
 where ``CHEMKIN`` represents the chemkin input file (``chem00XX.inp``), ``SPECIESDICT``
-is the species diectionary from RMG (``species_dictionary.txt``) and ``THERMO`` 
-is input as the chemkin file again (``chem00XX.inp``).  The numbers (``1`` and ``2``) represent 
-which model to each file is from.  
+is the species diectionary from RMG (``species_dictionary.txt``) and  the optional ``--thermo`` flag can be used
+to add separate thermo CHEMKIN files ``THERMO``.  The numbers (``1`` and ``2``) represent 
+which model to each file is from.  The optional ``--web`` flag is used for running this script through the
+RMG-website.  
+
+Running the script without any optional flags looks like::
+
+    python diffModels.py CHEMKIN1 SPECIESDICT1 CHEMKIN2 SPECIESDICT2
+
  
 Output of each comparison is printed, and the method then produces a html file (``diff.html``)
 for easy viewing of the comparison.  

--- a/scripts/diffModels.py
+++ b/scripts/diffModels.py
@@ -14,7 +14,7 @@ import os.path
 import logging
 
 from rmgpy.chemkin import loadChemkinFile
-from rmgpy.reaction import ReactionModel
+from rmgpy.rmg.model import ReactionModel
 from rmgpy.rmg.output import saveDiffHTML
 
 ################################################################################
@@ -208,22 +208,29 @@ if __name__ == '__main__':
         help='the Chemkin file of the first model')
     parser.add_argument('speciesDict1', metavar='SPECIESDICT1', type=str, nargs=1,
         help='the species dictionary file of the first model')
-    parser.add_argument('thermo1', metavar = 'THERMO1', type=str, nargs = 1,
+    parser.add_argument('--thermo1', metavar = 'THERMO1', type=str, nargs = 1,
         help = 'the thermo file of the first model')
     parser.add_argument('chemkin2', metavar='CHEMKIN2', type=str, nargs=1,
         help='the Chemkin file of the second model')
     parser.add_argument('speciesDict2', metavar='SPECIESDICT2', type=str, nargs=1,
         help='the species dictionary file of the second model')
-    parser.add_argument('thermo2', metavar = 'THERMO2', type=str, nargs = 1,
+    parser.add_argument('--thermo2', metavar = 'THERMO2', type=str, nargs = 1,
         help = 'the thermo file of the second model')
+    parser.add_argument('--web', action='store_true', help='Running diff models through the RMG-website')
     
     args = parser.parse_args()
     chemkin1 = args.chemkin1[0]
     speciesDict1 = args.speciesDict1[0]
-    thermo1 = args.thermo1[0]
+    if args.thermo1: 
+        thermo1 = args.thermo1[0]
+    else:
+        thermo1 = None
     chemkin2 = args.chemkin2[0]
     speciesDict2 = args.speciesDict2[0]
-    thermo2 = args.thermo2[0]
+    if args.thermo2: 
+        thermo2 = args.thermo2[0]
+    else:
+        thermo2 = None
     
     model1 = ReactionModel()
     model1.species, model1.reactions = loadChemkinFile(chemkin1, speciesDict1, thermoPath = thermo1)
@@ -232,74 +239,72 @@ if __name__ == '__main__':
     
     commonSpecies, uniqueSpecies1, uniqueSpecies2 = compareModelSpecies(model1, model2)
     commonReactions, uniqueReactions1, uniqueReactions2 = compareModelReactions(model1, model2)
-
-    print '{0:d} species were found in both models:'.format(len(commonSpecies))
-    for spec1, spec2 in commonSpecies:
-        print '    {0!s}'.format(spec1)
-        if spec1.thermo and spec2.thermo:
-            spec1.molecule[0].getSymmetryNumber()
-            print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f} {8:7.2f}'.format( 
-                spec1.thermo.getEnthalpy(300) / 4184.,
-                spec1.thermo.getEntropy(300) / 4.184,
-                spec1.thermo.getHeatCapacity(300) / 4.184,
-                spec1.thermo.getHeatCapacity(400) / 4.184,
-                spec1.thermo.getHeatCapacity(500) / 4.184,
-                spec1.thermo.getHeatCapacity(600) / 4.184,
-                spec1.thermo.getHeatCapacity(800) / 4.184,
-                spec1.thermo.getHeatCapacity(1000) / 4.184,
-                spec1.thermo.getHeatCapacity(1500) / 4.184,
-            )
-            print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f} {8:7.2f}'.format( 
-                spec2.thermo.getEnthalpy(300) / 4184.,
-                spec2.thermo.getEntropy(300) / 4.184,
-                spec2.thermo.getHeatCapacity(300) / 4.184,
-                spec2.thermo.getHeatCapacity(400) / 4.184,
-                spec2.thermo.getHeatCapacity(500) / 4.184,
-                spec2.thermo.getHeatCapacity(600) / 4.184,
-                spec2.thermo.getHeatCapacity(800) / 4.184,
-                spec2.thermo.getHeatCapacity(1000) / 4.184,
-                spec2.thermo.getHeatCapacity(1500) / 4.184,
-            )
-    print '{0:d} species were only found in the first model:'.format(len(uniqueSpecies1))
-    for spec in uniqueSpecies1:
-        print '    {0!s}'.format(spec)
-    print '{0:d} species were only found in the second model:'.format(len(uniqueSpecies2))
-    for spec in uniqueSpecies2:
-        print '    {0!s}'.format(spec)
-
-    print '{0:d} reactions were found in both models:'.format(len(commonReactions))
-    for rxn1, rxn2 in commonReactions:
-        print '    {0!s}'.format(rxn1)
-        if rxn1.kinetics and rxn2.kinetics:
-            print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f}'.format(
-                math.log10(rxn1.kinetics.getRateCoefficient(300, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(400, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(500, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(600, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(800, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(1000, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(1500, 1e5)),
-                math.log10(rxn1.kinetics.getRateCoefficient(2000, 1e5)),
-            )
-            print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f}'.format(
-                math.log10(rxn2.kinetics.getRateCoefficient(300, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(400, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(500, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(600, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(800, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(1000, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(1500, 1e5)),
-                math.log10(rxn2.kinetics.getRateCoefficient(2000, 1e5)),
-            )
-    print '{0:d} reactions were only found in the first model:'.format(len(uniqueReactions1))
-    for rxn in uniqueReactions1:
-        print '    {0!s}'.format(rxn)
-    print '{0:d} reactions were only found in the second model:'.format(len(uniqueReactions2))
-    for rxn in uniqueReactions2:
-        print '    {0!s}'.format(rxn)
     
-    #commonSpecies.sort(key = enthalpyDiff)
-    #commonReactions.sort(key = kineticsDiff)
+    if not args.web:
+        print '{0:d} species were found in both models:'.format(len(commonSpecies))
+        for spec1, spec2 in commonSpecies:
+            print '    {0!s}'.format(spec1)
+            if spec1.thermo and spec2.thermo:
+                spec1.molecule[0].getSymmetryNumber()
+                print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f} {8:7.2f}'.format( 
+                    spec1.thermo.getEnthalpy(300) / 4184.,
+                    spec1.thermo.getEntropy(300) / 4.184,
+                    spec1.thermo.getHeatCapacity(300) / 4.184,
+                    spec1.thermo.getHeatCapacity(400) / 4.184,
+                    spec1.thermo.getHeatCapacity(500) / 4.184,
+                    spec1.thermo.getHeatCapacity(600) / 4.184,
+                    spec1.thermo.getHeatCapacity(800) / 4.184,
+                    spec1.thermo.getHeatCapacity(1000) / 4.184,
+                    spec1.thermo.getHeatCapacity(1500) / 4.184,
+                )
+                print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f} {8:7.2f}'.format( 
+                    spec2.thermo.getEnthalpy(300) / 4184.,
+                    spec2.thermo.getEntropy(300) / 4.184,
+                    spec2.thermo.getHeatCapacity(300) / 4.184,
+                    spec2.thermo.getHeatCapacity(400) / 4.184,
+                    spec2.thermo.getHeatCapacity(500) / 4.184,
+                    spec2.thermo.getHeatCapacity(600) / 4.184,
+                    spec2.thermo.getHeatCapacity(800) / 4.184,
+                    spec2.thermo.getHeatCapacity(1000) / 4.184,
+                    spec2.thermo.getHeatCapacity(1500) / 4.184,
+                )
+        print '{0:d} species were only found in the first model:'.format(len(uniqueSpecies1))
+        for spec in uniqueSpecies1:
+            print '    {0!s}'.format(spec)
+        print '{0:d} species were only found in the second model:'.format(len(uniqueSpecies2))
+        for spec in uniqueSpecies2:
+            print '    {0!s}'.format(spec)
+    
+        print '{0:d} reactions were found in both models:'.format(len(commonReactions))
+        for rxn1, rxn2 in commonReactions:
+            print '    {0!s}'.format(rxn1)
+            if rxn1.kinetics and rxn2.kinetics:
+                print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f}'.format(
+                    math.log10(rxn1.kinetics.getRateCoefficient(300, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(400, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(500, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(600, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(800, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(1000, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(1500, 1e5)),
+                    math.log10(rxn1.kinetics.getRateCoefficient(2000, 1e5)),
+                )
+                print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f}'.format(
+                    math.log10(rxn2.kinetics.getRateCoefficient(300, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(400, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(500, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(600, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(800, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(1000, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(1500, 1e5)),
+                    math.log10(rxn2.kinetics.getRateCoefficient(2000, 1e5)),
+                )
+        print '{0:d} reactions were only found in the first model:'.format(len(uniqueReactions1))
+        for rxn in uniqueReactions1:
+            print '    {0!s}'.format(rxn)
+        print '{0:d} reactions were only found in the second model:'.format(len(uniqueReactions2))
+        for rxn in uniqueReactions2:
+            print '    {0!s}'.format(rxn)
 
     print "Saving output in diff.html"
     outputPath = 'diff.html'


### PR DESCRIPTION
This is for allowing the script to be called easily through the RMG-website by adding a --web flag.
This also makes it less clunky for additional thermo dat files to be used, instead of putting in dummy filenames for thermo.  