### PR TITLE
Fix to gaussian implementation in QMTP

### DIFF
--- a/rmgpy/qm/gaussian.py
+++ b/rmgpy/qm/gaussian.py
@@ -103,9 +103,9 @@ class Gaussian:
                 if line.startswith("InChI="):
                     logFileInChI = line #output files should take up to 240 characters of the name in the input file
                     InChIFound = True
-                    if self.geometry.uniqueIDlong in logFileInChI:
+                    if self.uniqueIDlong in logFileInChI:
                         InChIMatch = True
-                    elif self.geometry.uniqueIDlong.startswith(logFileInChI):
+                    elif self.uniqueIDlong.startswith(logFileInChI):
                         logging.info("InChI too long to check, but beginning matches so assuming OK.")
                         InChIMatch = True
                     else:
@@ -212,7 +212,7 @@ class GaussianMol(QMMolecule, Gaussian):
                 
         if self.verifyOutputFile():
             logging.info("Found a successful output file already; using that.")
-            source = "QM {0} result file found from previous run.".format(self.__class__.__name__)
+            source = "QM {0} calculation found from previous run.".format(self.__class__.__name__)
         else:
             self.createGeometry()
             success = False

--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -104,17 +104,23 @@ class Mopac:
         with open(self.outputFilePath) as outputFile:
             for line in outputFile:
                 line = line.strip()
+                
                 for element in self.failureKeys: #search for failure keywords
                     if element in line:
                         logging.error("MOPAC output file contains the following error: {0}".format(element) )
                         return False
+                
                 for element in self.successKeys: #search for success keywords
                     if element in line:
                         successKeysFound[element] = True
+                
                 if "InChI=" in line:
                     logFileInChI = line #output files should take up to 240 characters of the name in the input file
                     InChIFound = True
                     if self.uniqueIDlong in logFileInChI:
+                        InChIMatch = True
+                    elif self.uniqueIDlong.startswith(logFileInChI):
+                        logging.info("InChI too long to check, but beginning matches so assuming OK.")
                         InChIMatch = True
                     else:
                         logging.warning("InChI in log file ({0}) didn't match that in geometry ({1}).".format(logFileInChI, self.uniqueIDlong))                    
@@ -131,23 +137,21 @@ class Mopac:
             logging.error("No InChI was found in the MOPAC output file {0}".format(self.outputFilePath))
             return False
         
-        if InChIMatch:
-            # Compare the optimized geometry to the original molecule
-            parser = cclib.parser.Mopac(self.outputFilePath)
-            parser.logger.setLevel(logging.ERROR) #cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
-            cclibData = parser.parse()
-            cclibMol = Molecule()
-            cclibMol.fromXYZ(cclibData.atomnos, cclibData.atomcoords[-1])
-            testMol = self.molecule.toSingleBonds()
-            
-            if cclibMol.isIsomorphic(testMol):
-                logging.info("Successful MOPAC quantum result found in {0}".format(self.outputFilePath))
-                # " + self.molfile.name + " ("+self.molfile.InChIAug+") has been found. This log file will be used.")
-                return True
-            else:
-                logging.info("Incorrect connectivity for optimized geometry in file {0}".format(self.outputFilePath))
-                # " + self.molfile.name + " ("+self.molfile.InChIAug+") has been found. This log file will be used.")
-                return False
+        if not InChIMatch:
+            #InChIs do not match (most likely due to limited name length mirrored in log file (240 characters), but possibly due to a collision)
+            return self.checkForInChiKeyCollision(logFileInChI) # Not yet implemented!
+
+        # Compare the optimized geometry to the original molecule
+        qmData = self.parse()
+        cclibMol = Molecule()
+        cclibMol.fromXYZ(qmData.atomicNumbers, qmData.atomCoords.value)
+        testMol = self.molecule.toSingleBonds()
+        if not cclibMol.isIsomorphic(testMol):
+            logging.info("Incorrect connectivity for optimized geometry in file {0}".format(self.outputFilePath))
+            return False
+
+        logging.info("Successful {1} quantum result in {0}".format(self.outputFilePath, self.__class__.__name__))
+        return True
         
         #InChIs do not match (most likely due to limited name length mirrored in log file (240 characters), but possibly due to a collision)
         return self.checkForInChiKeyCollision(logFileInChI) # Not yet implemented!


### PR DESCRIPTION
The output file verification was broken if gaussian was used.

The output file verification has also been made consistent for mopac and gaussian output files.