### PR TITLE
Change Process.get_memory_info() to Process.memory_info() in Cantherm.

### DIFF
--- a/cantherm.py
+++ b/cantherm.py
@@ -63,7 +63,7 @@ cantherm.execute()
 try:
     import psutil
     process = psutil.Process(os.getpid())
-    rss, vms = process.get_memory_info()
+    rss, vms = process.memory_info()
     logging.info('Memory used: %.2f MB' % (rss / 1024.0 / 1024.0))
 except ImportError:
     logging.info('Optional package dependency "psutil" not found; memory profiling information will not be saved.')


### PR DESCRIPTION
Newer version of psutil changed the function name.