### PR TITLE
Avoid OverflowErrors for the connectivity value algorithm for large molecules

### DIFF
--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -29,7 +29,7 @@ cdef class Vertex(object):
     cdef public dict edges
 
     # These attributes are used in the VF2 graph isomorphism algorithm
-    cdef public int connectivity
+    cdef public long connectivity
     cdef public short sortingLabel
     cdef public bint terminal
     cdef public Vertex mapping
@@ -43,7 +43,7 @@ cdef class Vertex(object):
 
     cpdef resetConnectivityValues(self)
 
-cpdef int getVertexConnectivityValue(Vertex vertex) except 1 # all values should be negative
+cpdef long getVertexConnectivityValue(Vertex vertex) except 1 # all values should be negative
 
 cpdef short getVertexSortingLabel(Vertex vertex) except -1 # all values should be nonnegative
 

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -410,7 +410,7 @@ cdef class Graph:
         
         new_values = []
         
-        for vertex1, old_value in zip(self.vertices, old_values):
+        for vertex1 in self.vertices:
             count = 0
             for vertex2 in vertex1.edges: count += old_values[self.vertices.index(vertex2)]
             new_values.append(count)

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -113,7 +113,7 @@ cdef class Vertex(object):
         self.terminal = False
         self.mapping = None
 
-cpdef int getVertexConnectivityValue(Vertex vertex) except 1:
+cpdef long getVertexConnectivityValue(Vertex vertex) except 1:
     """
     Return a value used to sort vertices prior to poposing candidate pairs in
     :meth:`__VF2_pairs`. The value returned is based on the vertex's
@@ -286,12 +286,12 @@ cdef class Graph:
         used to accelerate the isomorphism checking.
         """
         cdef Vertex vertex
-        cdef int value
         cdef list connectivityValues
 
         connectivityValues = self.__update([len(vertex.edges) for vertex in self.vertices], 0)
         for vertex, value in zip(self.vertices, connectivityValues):
             vertex.connectivity = value
+            
 
 
     cpdef Graph copy(self, bint deep=False):
@@ -406,7 +406,6 @@ cdef class Graph:
         of different connectivity values does not increase anymore. 
         """
         cdef Vertex vertex1, vertex2
-        cdef int count
         cdef list new_values
         
         new_values = []
@@ -433,7 +432,7 @@ cdef class Graph:
         the isomorphism functions, much more efficient.
         """
         cdef Vertex vertex
-        cdef int index, value
+        cdef int index
         cdef list connectivityValues
 
         # Only need to conduct sort if there is an invalid sorting label on any vertex

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1562,6 +1562,108 @@ multiplicity 2
                     except RuntimeError:
                         self.fail("RDKit failed in finding the bond in the original atom!")
                         
+    def testLargeMolUpdate(self):
+        adjlist = """
+1  C u0 p0 c0 {7,S} {33,S} {34,S} {35,S}
+2  C u0 p0 c0 {8,S} {36,S} {37,S} {38,S}
+3  C u0 p0 c0 {5,S} {9,D} {39,S}
+4  C u0 p0 c0 {6,S} {10,D} {40,S}
+5  C u0 p0 c0 {3,S} {17,S} {41,S} {85,S}
+6  C u0 p0 c0 {4,S} {18,D} {42,S}
+7  C u0 p0 c0 {1,S} {11,S} {43,S} {44,S}
+8  C u0 p0 c0 {2,S} {12,S} {45,S} {46,S}
+9  C u0 p0 c0 {3,D} {31,S} {47,S}
+10 C u0 p0 c0 {4,D} {32,S} {48,S}
+11 C u0 p0 c0 {7,S} {19,S} {51,S} {52,S}
+12 C u0 p0 c0 {8,S} {20,S} {53,S} {54,S}
+13 C u0 p0 c0 {18,S} {32,S} {50,S} {86,S}
+14 C u0 p0 c0 {17,D} {31,S} {49,S}
+15 C u0 p0 c0 {17,S} {25,S} {63,S} {64,S}
+16 C u0 p0 c0 {18,S} {26,S} {65,S} {66,S}
+17 C u0 p0 c0 {5,S} {14,D} {15,S}
+18 C u0 p0 c0 {6,D} {13,S} {16,S}
+19 C u0 p0 c0 {11,S} {23,S} {55,S} {56,S}
+20 C u0 p0 c0 {12,S} {24,S} {57,S} {58,S}
+21 C u0 p0 c0 {25,S} {29,S} {75,S} {76,S}
+22 C u0 p0 c0 {26,S} {30,S} {77,S} {78,S}
+23 C u0 p0 c0 {19,S} {27,S} {71,S} {72,S}
+24 C u0 p0 c0 {20,S} {28,S} {73,S} {74,S}
+25 C u0 p0 c0 {15,S} {21,S} {59,S} {60,S}
+26 C u0 p0 c0 {16,S} {22,S} {61,S} {62,S}
+27 C u0 p0 c0 {23,S} {29,S} {79,S} {80,S}
+28 C u0 p0 c0 {24,S} {30,S} {81,S} {82,S}
+29 C u0 p0 c0 {21,S} {27,S} {67,S} {68,S}
+30 C u0 p0 c0 {22,S} {28,S} {69,S} {70,S}
+31 C u0 p0 c0 {9,S} {14,S} {32,S} {83,S}
+32 C u0 p0 c0 {10,S} {13,S} {31,S} {84,S}
+33 H u0 p0 c0 {1,S}
+34 H u0 p0 c0 {1,S}
+35 H u0 p0 c0 {1,S}
+36 H u0 p0 c0 {2,S}
+37 H u0 p0 c0 {2,S}
+38 H u0 p0 c0 {2,S}
+39 H u0 p0 c0 {3,S}
+40 H u0 p0 c0 {4,S}
+41 H u0 p0 c0 {5,S}
+42 H u0 p0 c0 {6,S}
+43 H u0 p0 c0 {7,S}
+44 H u0 p0 c0 {7,S}
+45 H u0 p0 c0 {8,S}
+46 H u0 p0 c0 {8,S}
+47 H u0 p0 c0 {9,S}
+48 H u0 p0 c0 {10,S}
+49 H u0 p0 c0 {14,S}
+50 H u0 p0 c0 {13,S}
+51 H u0 p0 c0 {11,S}
+52 H u0 p0 c0 {11,S}
+53 H u0 p0 c0 {12,S}
+54 H u0 p0 c0 {12,S}
+55 H u0 p0 c0 {19,S}
+56 H u0 p0 c0 {19,S}
+57 H u0 p0 c0 {20,S}
+58 H u0 p0 c0 {20,S}
+59 H u0 p0 c0 {25,S}
+60 H u0 p0 c0 {25,S}
+61 H u0 p0 c0 {26,S}
+62 H u0 p0 c0 {26,S}
+63 H u0 p0 c0 {15,S}
+64 H u0 p0 c0 {15,S}
+65 H u0 p0 c0 {16,S}
+66 H u0 p0 c0 {16,S}
+67 H u0 p0 c0 {29,S}
+68 H u0 p0 c0 {29,S}
+69 H u0 p0 c0 {30,S}
+70 H u0 p0 c0 {30,S}
+71 H u0 p0 c0 {23,S}
+72 H u0 p0 c0 {23,S}
+73 H u0 p0 c0 {24,S}
+74 H u0 p0 c0 {24,S}
+75 H u0 p0 c0 {21,S}
+76 H u0 p0 c0 {21,S}
+77 H u0 p0 c0 {22,S}
+78 H u0 p0 c0 {22,S}
+79 H u0 p0 c0 {27,S}
+80 H u0 p0 c0 {27,S}
+81 H u0 p0 c0 {28,S}
+82 H u0 p0 c0 {28,S}
+83 H u0 p0 c0 {31,S}
+84 H u0 p0 c0 {32,S}
+85 H u0 p0 c0 {5,S}
+86 H u0 p0 c0 {13,S}
+        """
+        mol = Molecule().fromAdjacencyList(adjlist)
+
+        mol.resetConnectivityValues()
+
+        try:
+            mol.updateConnectivityValues()
+        except OverflowError:
+            self.fail("updateConnectivityValues() raised OverflowError unexpectedly!")
+
+        
+
+
+
 
 ################################################################################
 


### PR DESCRIPTION
The connectivity values may grow to numbers that do not fit in an C integer anymore, which was statically typed in `graph.pyx`. this resulted in an `OverflowError`.