### PR TITLE
remove " is rxn present in self.edge.reactions"

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1252,8 +1252,7 @@ class CoreEdgeReactionModel:
         list of core species, and the others are in either the core or the
         edge).
         """
-        if rxn not in self.edge.reactions:
-            self.edge.reactions.append(rxn)
+        self.edge.reactions.append(rxn)
 
     def getModelSize(self):
         """


### PR DESCRIPTION
Based on @KEHANG CPU profiling, this was eating away a lot of our CPU time, for no good reason.

this is always true since we already know that
- the reaction is new
- at least one species is not in the core yet