### PR TITLE
RMG Output via observer pattern

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1925,10 +1925,10 @@ def saveChemkinFiles(rmg):
                 os.unlink(latest_chemkin_path)
             shutil.copy2(this_chemkin_path,latest_chemkin_path)
 
-class ChemkinListener(object):
-    """docstring for ChemkinListener"""
+class ChemkinWriter(object):
+    """docstring for ChemkinWriter"""
     def __init__(self):
-        super(ChemkinListener, self).__init__()
+        super(ChemkinWriter, self).__init__()
     
     def update(self, rmg):
         saveChemkinFiles(rmg)

--- a/rmgpy/qm/main.py
+++ b/rmgpy/qm/main.py
@@ -204,4 +204,20 @@ class QMCalculator():
             raise Exception("Unknown QM software '{0}'".format(self.settings.software))
         return thermo0
     
+
+def save(rmg):
+    # Save the QM thermo to a library if QM was turned on
+    if rmg.quantumMechanics:
+        logging.info('Saving the QM generated thermo to qmThermoLibrary.py ...')
+        rmg.quantumMechanics.database.save(os.path.join(rmg.outputDirectory,'qmThermoLibrary.py'))    
+
+class QMDatabaseWriter(object):
+    """docstring for QMDatabaseWriter"""
+    def __init__(self):
+        super(QMDatabaseWriter, self).__init__()
+    
+    def update(self, rmg):
+        save(rmg)
+
         
+    

--- a/rmgpy/restart.py
+++ b/rmgpy/restart.py
@@ -32,11 +32,12 @@
 import os.path
 import logging
 import cPickle
+import time
 
 def save(rmg):
     # Save the restart file if desired
     if rmg.saveRestartPeriod or rmg.done:
-        rmg.saveRestartFile( os.path.join(rmg.outputDirectory,'restart.pkl'),
+        saveRestartFile( os.path.join(rmg.outputDirectory,'restart.pkl'),
                               rmg.reactionModel,
                               delay=0 if rmg.done else rmg.saveRestartPeriod.value_si
                             )

--- a/rmgpy/restart.py
+++ b/rmgpy/restart.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2010 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+
+import os.path
+import logging
+import cPickle
+
+def save(rmg):
+    # Save the restart file if desired
+    if rmg.saveRestartPeriod or rmg.done:
+        rmg.saveRestartFile( os.path.join(rmg.outputDirectory,'restart.pkl'),
+                              rmg.reactionModel,
+                              delay=0 if rmg.done else rmg.saveRestartPeriod.value_si
+                            )
+
+        
+        
+def saveRestartFile(path, reactionModel, delay=0):
+    """
+    Save a restart file to `path` on disk containing the contents of the
+    provided `reactionModel`. The `delay` parameter is a time in seconds; if
+    the restart file is not at least that old, the save is aborted. (Use the
+    default value of 0 to force the restart file to be saved.)
+    """
+    
+    # Saving of a restart file is very slow (likely due to all the Quantity objects)
+    # Therefore, to save it less frequently, don't bother if the restart file is less than an hour old
+    if os.path.exists(path) and time.time() - os.path.getmtime(path) < delay:
+        logging.info('Not saving restart file in this iteration.')
+        return
+    
+    # Pickle the reaction model to the specified file
+    # We also compress the restart file to save space (and lower the disk read/write time)
+    logging.info('Saving restart file...')
+    f = open(path, 'wb')
+    cPickle.dump(reactionModel, f, cPickle.HIGHEST_PROTOCOL)
+    f.close()
+
+class RestartWriter(object):
+    """docstring for RestartWriter"""
+    def __init__(self):
+        super(RestartWriter, self).__init__()
+    
+    def update(self, rmg):
+      	save(rmg)
+
+        
+    

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -60,7 +60,7 @@ from model import Species, CoreEdgeReactionModel
 from pdep import PDepNetwork
 from pydas.observer import Subject
 
-from rmgpy.chemkin import ChemkinListener
+from rmgpy.chemkin import ChemkinWriter
 ################################################################################
 
 solvent = None
@@ -130,7 +130,7 @@ class RMG(Subject):
         self.outputDirectory = outputDirectory
         self.scratchDirectory = scratchDirectory
         self.clear()
-        self.attach(ChemkinListener())
+        self.attach(ChemkinWriter())
     
     def clear(self):
         """

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -61,6 +61,7 @@ from pdep import PDepNetwork
 from pydas.observer import Subject
 
 from rmgpy.chemkin import ChemkinWriter
+from rmgpy.rmg.output import OutputHTMLWriter
 ################################################################################
 
 solvent = None
@@ -400,11 +401,6 @@ class RMG(Subject):
             else:
                 raise ValueError('Invalid format for wall time; should be HH:MM:SS.')
     
-        # Delete previous HTML file if that option was on
-        if self.generateOutputHTML:
-            from rmgpy.rmg.output import saveOutputHTML
-            saveOutputHTML(os.path.join(self.outputDirectory, 'output.html'), self.reactionModel, 'core')
-        
         # Initialize reaction model
         if restart:
             self.loadRestartFile(os.path.join(self.outputDirectory,'restart.pkl'))
@@ -485,6 +481,9 @@ class RMG(Subject):
         """
 
         self.attach(ChemkinWriter())
+
+        if self.generateOutputHTML:
+            self.attach(OutputHTMLWriter())
 
 
     def execute(self, inputFile, output_directory, **kwargs):
@@ -700,10 +699,6 @@ class RMG(Subject):
             if option:
                 self.reactionModel.addReactionLibraryToOutput(library)
                 
-        # Save the current state of the model to HTML files
-        if self.generateOutputHTML:
-            self.saveOutputHTML()
-
         # Notify registered listeners:
         self.notify()
 
@@ -844,19 +839,6 @@ class RMG(Subject):
                             reactionDict[family][reactant1][reactant2].append(rxn)
         
         self.reactionModel.reactionDict = reactionDict
-    
-    def saveOutputHTML(self):
-        """
-        Save the current reaction model to a pretty HTML file.
-        """
-        logging.info('Saving current model core to HTML file...')
-        from rmgpy.rmg.output import saveOutputHTML
-        saveOutputHTML(os.path.join(self.outputDirectory, 'output.html'), self.reactionModel, 'core')
-        
-        if self.saveEdgeSpecies ==True:
-            logging.info('Saving current model edge to HTML file...')
-            from rmgpy.rmg.output import saveOutputHTML
-            saveOutputHTML(os.path.join(self.outputDirectory, 'output_edge.html'), self.reactionModel, 'edge')
         
         
     def saveRestartFile(self, path, reactionModel, delay=0):

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -63,6 +63,7 @@ from pydas.observer import Subject
 from rmgpy.chemkin import ChemkinWriter
 from rmgpy.rmg.output import OutputHTMLWriter
 from rmgpy.restart import RestartWriter
+from rmgpy.qm.main import QMDatabaseWriter
 
 ################################################################################
 
@@ -486,6 +487,8 @@ class RMG(Subject):
         if self.saveRestartPeriod:
             self.attach(RestartWriter()) 
 
+        if self.quantumMechanics:
+            self.attach(QMDatabaseWriter())             
 
     def execute(self, inputFile, output_directory, **kwargs):
         """
@@ -702,11 +705,6 @@ class RMG(Subject):
                 
         # Notify registered listeners:
         self.notify()
-
-        # Save the QM thermo to a library if QM was turned on
-        if self.quantumMechanics:
-            logging.info('Saving the QM generated thermo to qmThermoLibrary.py ...')
-            self.quantumMechanics.database.save(os.path.join(self.outputDirectory,'qmThermoLibrary.py'))            
             
     def finish(self):
         """

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -183,6 +183,8 @@ class RMG(Subject):
         self.speciesConstraints = {}
         self.wallTime = 0
         self.initializationTime = 0
+
+        self.execTime = []
     
     def loadInput(self, path=None):
         """
@@ -500,8 +502,6 @@ class RMG(Subject):
         """
     
         self.initialize(inputFile, output_directory, **kwargs)
-        
-        self.execTime = []
 
         self.done = False
         self.saveEverything()
@@ -574,11 +574,12 @@ class RMG(Subject):
 
             self.saveEverything()
 
+
             # Consider stopping gracefully if the next iteration might take us
             # past the wall time
-            if self.wallTime > 0 and len(execTime) > 1:
-                t = execTime[-1]
-                dt = execTime[-1] - execTime[-2]
+            if self.wallTime > 0 and len(self.execTime) > 1:
+                t = self.execTime[-1]
+                dt = self.execTime[-1] - self.execTime[-2]
                 if t + 3 * dt > self.wallTime:
                     logging.info('MODEL GENERATION TERMINATED')
                     logging.info('')
@@ -644,7 +645,9 @@ class RMG(Subject):
         for library, option in self.reactionLibraries:
             if option:
                 self.reactionModel.addReactionLibraryToOutput(library)
-                
+        
+        self.execTime.append(time.time() - self.initializationTime)
+
         # Notify registered listeners:
         self.notify()
             

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -58,12 +58,14 @@ from rmgpy.kinetics.diffusionLimited import diffusionLimiter
 
 from model import Species, CoreEdgeReactionModel
 from pdep import PDepNetwork
+from pydas.observer import Subject
+
 
 ################################################################################
 
 solvent = None
 
-class RMG:
+class RMG(Subject):
     """
     A representation of a Reaction Mechanism Generator (RMG) job. The 
     attributes are:
@@ -122,6 +124,7 @@ class RMG:
     """
     
     def __init__(self, inputFile=None, logFile=None, outputDirectory=None, scratchDirectory=None):
+        super(RMG, self).__init__()
         self.inputFile = inputFile
         self.logFile = logFile
         self.outputDirectory = outputDirectory

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -130,7 +130,6 @@ class RMG(Subject):
         self.outputDirectory = outputDirectory
         self.scratchDirectory = scratchDirectory
         self.clear()
-        self.attach(ChemkinWriter())
     
     def clear(self):
         """
@@ -344,6 +343,9 @@ class RMG(Subject):
         # Read input file
         self.loadInput(inputFile)
         
+        # register listeners
+        self.register_listeners()
+
         # Check input file 
         self.checkInput()
     
@@ -476,6 +478,15 @@ class RMG(Subject):
             if self.saveRestartPeriod:
                 self.saveRestartFile(os.path.join(self.outputDirectory,'restart.pkl'), self.reactionModel)
     
+    def register_listeners(self):
+        """
+        Attaches listener classes depending on the options 
+        found in the RMG input file.
+        """
+
+        self.attach(ChemkinWriter())
+
+
     def execute(self, inputFile, output_directory, **kwargs):
         """
         Execute an RMG job using the command-line arguments `args` as returned

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1624,37 +1624,6 @@ class CoreEdgeReactionModel:
         rxnList = self.core.reactions + self.outputReactionList
         markDuplicateReactions(rxnList)
         
-        
-    def saveChemkinFile(self, path, verbose_path, dictionaryPath=None, transportPath=None, saveEdgeSpecies=False):
-        """
-        Save a Chemkin file for the current model as well as any desired output
-        species and reactions to `path`. If `saveEdgeSpecies` is True, then 
-        a chemkin file and dictionary file for the core and edge species and reactions
-        will be saved.  
-        """
-        from rmgpy.chemkin import saveChemkinFile, saveSpeciesDictionary, saveTransportFile
-        
-        if saveEdgeSpecies == False:
-            speciesList = self.core.species + self.outputSpeciesList
-            rxnList = self.core.reactions + self.outputReactionList
-            saveChemkinFile(path, speciesList, rxnList, verbose = False, checkForDuplicates=False) # We should already have marked everything as duplicates by now        
-            logging.info('Saving current model to verbose Chemkin file...')
-            saveChemkinFile(verbose_path, speciesList, rxnList, verbose = True, checkForDuplicates=False)
-            if dictionaryPath:
-                saveSpeciesDictionary(dictionaryPath, speciesList)
-            if transportPath:
-                saveTransportFile(transportPath, speciesList)
-            
-        else:
-            speciesList = self.core.species + self.edge.species + self.outputSpeciesList
-            rxnList = self.core.reactions + self.edge.reactions + self.outputReactionList
-            saveChemkinFile(path, speciesList, rxnList, verbose = False, checkForDuplicates=False)        
-            logging.info('Saving current core and edge to verbose Chemkin file...')
-            saveChemkinFile(verbose_path, speciesList, rxnList, verbose = True, checkForDuplicates=False)
-            if dictionaryPath:
-                saveSpeciesDictionary(dictionaryPath, speciesList)
-            if transportPath:
-                saveTransportFile(transportPath, speciesList)
                 
     def failsSpeciesConstraints(self, species):
         """

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -954,3 +954,23 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
     f = open(path, 'w')
     f.write(template.render(title=title, commonSpecies=commonSpeciesList, speciesList1=speciesList1, speciesList2 = speciesList2, commonReactions=commonReactions, uniqueReactions1=uniqueReactions1, uniqueReactions2=uniqueReactions2, families1=families1, families2=families2, familyCount1=familyCount1,familyCount2=familyCount2, speciesList=speciesList))
     f.close()
+
+
+def saveOutput(rmg):
+    """
+    Save the current reaction model to a pretty HTML file.
+    """
+    logging.info('Saving current model core to HTML file...')
+    saveOutputHTML(os.path.join(rmg.outputDirectory, 'output.html'), rmg.reactionModel, 'core')
+    
+    if rmg.saveEdgeSpecies == True:
+        logging.info('Saving current model edge to HTML file...')
+        saveOutputHTML(os.path.join(rmg.outputDirectory, 'output_edge.html'), rmg.reactionModel, 'edge')
+
+class OutputHTMLWriter(object):
+    """docstring for OutputHTMLWriter"""
+    def __init__(self):
+        super(OutputHTMLWriter, self).__init__()
+    
+    def update(self, rmg):
+        saveOutput(rmg)

--- a/rmgpy/stats.py
+++ b/rmgpy/stats.py
@@ -42,7 +42,6 @@ class ExecutionStatsWriter(object):
         self.coreReactionCount = []
         self.edgeSpeciesCount = []
         self.edgeReactionCount = []
-        self.execTime = []
         self.restartSize = []
         self.memoryUse = []
     
@@ -58,8 +57,7 @@ class ExecutionStatsWriter(object):
         self.coreReactionCount.append(coreReac)
         self.edgeSpeciesCount.append(edgeSpec)
         self.edgeReactionCount.append(edgeReac)
-        self.execTime.append(time.time() - rmg.initializationTime)
-        elapsed = self.execTime[-1]
+        elapsed = rmg.execTime[-1]
         seconds = elapsed % 60
         minutes = (elapsed - seconds) % 3600 / 60
         hours = (elapsed - seconds - minutes * 60) % (3600 * 24) / 3600
@@ -107,7 +105,7 @@ class ExecutionStatsWriter(object):
 
         # First column is execution time
         sheet.write(0,0,'Execution time (s)')
-        for i, etime in enumerate(self.execTime):
+        for i, etime in enumerate(rmg.execTime):
             sheet.write(i+1,0,etime)
 
         # Second column is number of core species
@@ -156,30 +154,30 @@ class ExecutionStatsWriter(object):
 
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
-        ax1.semilogx(self.execTime, self.coreSpeciesCount, 'o-b')
+        ax1.semilogx(rmg.execTime, self.coreSpeciesCount, 'o-b')
         ax1.set_xlabel('Execution time (s)')
         ax1.set_ylabel('Number of core species')
         ax2 = ax1.twinx()
-        ax2.semilogx(self.execTime, self.coreReactionCount, 'o-r')
+        ax2.semilogx(rmg.execTime, self.coreReactionCount, 'o-r')
         ax2.set_ylabel('Number of core reactions')
         plt.savefig(os.path.join(rmg.outputDirectory, 'plot/coreSize.svg'))
         plt.clf()
 
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
-        ax1.loglog(self.execTime, self.edgeSpeciesCount, 'o-b')
+        ax1.loglog(rmg.execTime, self.edgeSpeciesCount, 'o-b')
         ax1.set_xlabel('Execution time (s)')
         ax1.set_ylabel('Number of edge species')
         ax2 = ax1.twinx()
-        ax2.loglog(self.execTime, self.edgeReactionCount, 'o-r')
+        ax2.loglog(rmg.execTime, self.edgeReactionCount, 'o-r')
         ax2.set_ylabel('Number of edge reactions')
         plt.savefig(os.path.join(rmg.outputDirectory, 'plot/edgeSize.svg'))
         plt.clf()
 
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
-        ax1.semilogx(self.execTime, self.memoryUse, 'o-k')
-        ax1.semilogx(self.execTime, self.restartSize, 'o-g')
+        ax1.semilogx(rmg.execTime, self.memoryUse, 'o-k')
+        ax1.semilogx(rmg.execTime, self.restartSize, 'o-g')
         ax1.set_xlabel('Execution time (s)')
         ax1.set_ylabel('Memory (MB)')
         ax1.legend(['RAM', 'Restart file'], loc=2)

--- a/rmgpy/stats.py
+++ b/rmgpy/stats.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2012 Prof. Richard H. West (r.west@neu.edu),
+#                           Prof. William H. Green (whgreen@mit.edu)
+#                           and the RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import os.path
+import logging
+
+import matplotlib.pyplot as plt
+
+class ExecutionStatsWriter(object):
+    """docstring for ExecutionStatsWriter"""
+    def __init__(self):
+        super(ExecutionStatsWriter, self).__init__()
+        # RMG execution statistics
+        self.coreSpeciesCount = []
+        self.coreReactionCount = []
+        self.edgeSpeciesCount = []
+        self.edgeReactionCount = []
+        self.execTime = []
+        self.restartSize = []
+        self.memoryUse = []
+    
+    def update(self, rmg):
+        self.update_execution(rmg)
+
+    def update_execution(self, rmg):
+
+        # Update RMG execution statistics
+        logging.info('Updating RMG execution statistics...')
+        coreSpec, coreReac, edgeSpec, edgeReac = rmg.reactionModel.getModelSize()
+        self.coreSpeciesCount.append(coreSpec)
+        self.coreReactionCount.append(coreReac)
+        self.edgeSpeciesCount.append(edgeSpec)
+        self.edgeReactionCount.append(edgeReac)
+        self.execTime.append(time.time() - rmg.initializationTime)
+        elapsed = self.execTime[-1]
+        seconds = elapsed % 60
+        minutes = (elapsed - seconds) % 3600 / 60
+        hours = (elapsed - seconds - minutes * 60) % (3600 * 24) / 3600
+        days = (elapsed - seconds - minutes * 60 - hours * 3600) / (3600 * 24)
+        logging.info('    Execution time (DD:HH:MM:SS): '
+            '{0:02}:{1:02}:{2:02}:{3:02}'.format(int(days), int(hours), int(minutes), int(seconds)))
+        try:
+            import psutil
+            process = psutil.Process(os.getpid())
+            rss, vms = process.memory_info()
+            self.memoryUse.append(rss / 1.0e6)
+            logging.info('    Memory used: %.2f MB' % (self.memoryUse[-1]))
+        except ImportError:
+            self.memoryUse.append(0.0)
+        if os.path.exists(os.path.join(rmg.outputDirectory,'restart.pkl.gz')):
+            self.restartSize.append(os.path.getsize(os.path.join(rmg.outputDirectory,'restart.pkl.gz')) / 1.0e6)
+            logging.info('    Restart file size: %.2f MB' % (self.restartSize[-1]))
+        else:
+            self.restartSize.append(0.0)
+        self.saveExecutionStatistics(rmg)
+        if rmg.generatePlots:
+            self.generateExecutionPlots(rmg)
+
+        logging.info('')
+
+    def saveExecutionStatistics(self, rmg):
+        """
+        Save the statistics of the RMG job to an Excel spreadsheet for easy viewing
+        after the run is complete. The statistics are saved to the file
+        `statistics.xls` in the output directory. The ``xlwt`` package is used to
+        create the spreadsheet file; if this package is not installed, no file is
+        saved.
+        """
+
+        # Attempt to import the xlwt package; return if not installed
+        try:
+            xlwt
+        except NameError:
+            logging.warning('Package xlwt not loaded. Unable to save execution statistics.')
+            return
+
+        # Create workbook and sheet for statistics to be places
+        workbook = xlwt.Workbook()
+        sheet = workbook.add_sheet('Statistics')
+
+        # First column is execution time
+        sheet.write(0,0,'Execution time (s)')
+        for i, etime in enumerate(self.execTime):
+            sheet.write(i+1,0,etime)
+
+        # Second column is number of core species
+        sheet.write(0,1,'Core species')
+        for i, count in enumerate(self.coreSpeciesCount):
+            sheet.write(i+1,1,count)
+
+        # Third column is number of core reactions
+        sheet.write(0,2,'Core reactions')
+        for i, count in enumerate(self.coreReactionCount):
+            sheet.write(i+1,2,count)
+
+        # Fourth column is number of edge species
+        sheet.write(0,3,'Edge species')
+        for i, count in enumerate(self.edgeSpeciesCount):
+            sheet.write(i+1,3,count)
+
+        # Fifth column is number of edge reactions
+        sheet.write(0,4,'Edge reactions')
+        for i, count in enumerate(self.edgeReactionCount):
+            sheet.write(i+1,4,count)
+
+        # Sixth column is memory used
+        sheet.write(0,5,'Memory used (MB)')
+        for i, memory in enumerate(self.memoryUse):
+            sheet.write(i+1,5,memory)
+
+        # Seventh column is restart file size
+        sheet.write(0,6,'Restart file size (MB)')
+        for i, memory in enumerate(self.restartSize):
+            sheet.write(i+1,6,memory)
+
+        # Save workbook to file
+        fstr = os.path.join(rmg.outputDirectory, 'statistics.xls')
+        workbook.save(fstr)
+
+    def generateExecutionPlots(self, rmg):
+        """
+        Generate a number of plots describing the statistics of the RMG job,
+        including the reaction model core and edge size and memory use versus
+        execution time. These will be placed in the output directory in the plot/
+        folder.
+        """
+
+        logging.info('Generating plots of execution statistics...')
+
+        fig = plt.figure()
+        ax1 = fig.add_subplot(111)
+        ax1.semilogx(self.execTime, self.coreSpeciesCount, 'o-b')
+        ax1.set_xlabel('Execution time (s)')
+        ax1.set_ylabel('Number of core species')
+        ax2 = ax1.twinx()
+        ax2.semilogx(self.execTime, self.coreReactionCount, 'o-r')
+        ax2.set_ylabel('Number of core reactions')
+        plt.savefig(os.path.join(rmg.outputDirectory, 'plot/coreSize.svg'))
+        plt.clf()
+
+        fig = plt.figure()
+        ax1 = fig.add_subplot(111)
+        ax1.loglog(self.execTime, self.edgeSpeciesCount, 'o-b')
+        ax1.set_xlabel('Execution time (s)')
+        ax1.set_ylabel('Number of edge species')
+        ax2 = ax1.twinx()
+        ax2.loglog(self.execTime, self.edgeReactionCount, 'o-r')
+        ax2.set_ylabel('Number of edge reactions')
+        plt.savefig(os.path.join(rmg.outputDirectory, 'plot/edgeSize.svg'))
+        plt.clf()
+
+        fig = plt.figure()
+        ax1 = fig.add_subplot(111)
+        ax1.semilogx(self.execTime, self.memoryUse, 'o-k')
+        ax1.semilogx(self.execTime, self.restartSize, 'o-g')
+        ax1.set_xlabel('Execution time (s)')
+        ax1.set_ylabel('Memory (MB)')
+        ax1.legend(['RAM', 'Restart file'], loc=2)
+        plt.savefig(os.path.join(rmg.outputDirectory, 'plot/memoryUse.svg'))
+        plt.clf()


### PR DESCRIPTION
The idea is that we will eventually have an RMG simulation class (`rmgpy.rmg.RMG`) that is unaware (and doesn't care) of what is done with its state (reaction model, reaction system, ...).

For example: 
the chemkin file, and HTML output writers are moved to the corresponding modules that contain the code that writes the stuff. 

The idea is to decouple everything related to writing information to the user from the actual simulation. It's an easier design to extend in the future, and it could potentially be used as well to (asynchronously) offload these time consuming parts in the future.
