### PR TITLE
Fix xlwt import in stats module

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -41,10 +41,6 @@ import shutil
 import numpy
 import csv
 import gc
-try:
-    import xlwt
-except ImportError:
-    logging.warning('Optional package dependency "xlwt" not loaded; Some output features will not work.')
 
 from rmgpy.molecule import Molecule
 from rmgpy.solver.base import TerminationTime, TerminationConversion

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -634,9 +634,10 @@ class RMG(util.Subject):
         # file as well as the chemkin file
         self.reactionModel.outputSpeciesList = []
         self.reactionModel.outputReactionList = []
-        for library, option in self.reactionLibraries:
-            if option:
-                self.reactionModel.addReactionLibraryToOutput(library)
+        if self.reactionLibraries:
+            for library, option in self.reactionLibraries:
+                if option:
+                    self.reactionModel.addReactionLibraryToOutput(library)
         
         self.execTime.append(time.time() - self.initializationTime)
 

--- a/rmgpy/stats.py
+++ b/rmgpy/stats.py
@@ -30,6 +30,13 @@
 
 import os.path
 import logging
+try:
+    import xlwt
+except ImportError:
+    logging.warning(
+        'Optional package dependency "xlwt" not loaded;\
+         Some output features will not work.'
+         )
 
 import matplotlib.pyplot as plt
 

--- a/rmgpy/statsTest.py
+++ b/rmgpy/statsTest.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2009 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This script contains unit tests of the :mod:`rmgpy.stats` module.
+"""
+
+import unittest
+import os
+import os.path
+import shutil
+
+from rmgpy.rmg.main import RMG, CoreEdgeReactionModel
+
+from rmgpy.stats import *
+
+################################################################################
+
+class TestExecutionStatsWriter(unittest.TestCase):
+    """
+    Contains unit tests of the ExecutionStatsWriter.
+    """
+
+    def setUp(self):
+        """
+        Set up an RMG object
+        """
+
+        folder = os.path.join(os.getcwd(),'rmgpy/output')
+        if not os.path.isdir(folder):
+            os.mkdir(folder)
+
+        self.rmg = RMG(outputDirectory=folder)
+        self.rmg.reactionModel = CoreEdgeReactionModel()
+
+        self.rmg.saveEverything()
+
+    def test_save(self):
+        """
+        Tests if the statistics output file can be found.
+        """
+        
+        folder = self.rmg.outputDirectory
+        
+        writer = ExecutionStatsWriter(folder)
+        writer.update(self.rmg)
+
+        statsfile = os.path.join(folder,'statistics.xls')
+
+        self.assertTrue(os.path.isfile(statsfile))
+
+    def tearDown(self):
+        shutil.rmtree(self.rmg.outputDirectory)


### PR DESCRIPTION
This PR fixes importing the optional dependency xlwt to write a statistics file.
It also adds a unit test that verifies this.