### PR TITLE
Reaction order

### DIFF
--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -41,7 +41,7 @@ import logging
 
 import rmgpy.constants as constants
 import rmgpy.quantity as quantity
-from rmgpy.kinetics import Chebyshev, PDepArrhenius, getRateCoefficientUnitsFromReactionOrder
+from rmgpy.kinetics import Chebyshev, PDepArrhenius
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics.tunneling import Wigner, Eckart
 

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -40,58 +40,6 @@ from rmgpy.species import Species
 
 ################################################################################
 
-# The names of all of the RMG reaction families that are bimolecular
-BIMOLECULAR_KINETICS_FAMILIES = [
-    'H_Abstraction',
-    'R_Addition_MultipleBond',
-    'R_Recombination',
-    'Disproportionation',
-    '1+2_Cycloaddition',
-    '2+2_cycloaddition_Cd',
-    '2+2_cycloaddition_CO',
-    '2+2_cycloaddition_CCO',
-    'Diels_alder_addition',
-    '1,2_Insertion',
-    '1,3_Insertion_CO2',
-    '1,3_Insertion_ROR',
-    'R_Addition_COm',
-    'Oa_R_Recombination',
-    'Substitution_O',
-    'SubstitutionS',
-    'R_Addition_CSm',
-    '1,3_Insertion_RSR',
-    'lone_electron_pair_bond',
-]
-
-# The names of all of the RMG reaction families that are unimolecular
-UNIMOLECULAR_KINETICS_FAMILIES = [
-    'intra_H_migration',
-    'Birad_recombination',
-    'intra_OH_migration',
-    'HO2_Elimination_from_PeroxyRadical',
-    'H_shift_cyclopentadiene',
-    'Cyclic_Ether_Formation',
-    'Intra_R_Add_Exocyclic',
-    'Intra_R_Add_Endocyclic',
-    '1,2-Birad_to_alkene',
-    'Intra_Disproportionation',
-    'Korcek_step1',
-    'Korcek_step2',
-    '1,2_shiftS',
-    'intra_substitutionCS_cyclization',
-    'intra_substitutionCS_isomerization',
-    'intra_substitutionS_cyclization',
-    'intra_substitutionS_isomerization',
-    'intra_NO2_ONO_conversion',
-    '1,4_Cyclic_birad_scission',
-    '1,4_Linear_birad_scission',
-    'Intra_Diels_alder',
-    'ketoenol',
-    'Retroen'
-]
-
-################################################################################
-
 class KineticsError(Exception):
     """
     An exception for problems with kinetics. Pass a string describing the problem.

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -44,8 +44,7 @@ from rmgpy.kinetics import Arrhenius, ArrheniusEP
 from rmgpy.molecule import Bond, GroupBond, Group, Molecule
 from rmgpy.species import Species
 
-from .common import KineticsError, UndeterminableKineticsError, saveEntry, \
-                    UNIMOLECULAR_KINETICS_FAMILIES, BIMOLECULAR_KINETICS_FAMILIES
+from .common import KineticsError, UndeterminableKineticsError, saveEntry
 from .depository import KineticsDepository
 from .groups import KineticsGroups
 from .rules import KineticsRules
@@ -1695,16 +1694,3 @@ class KineticsFamily(Database):
         kinetics, entry  = self.rules.estimateKinetics(template, degeneracy)
                 
         return kinetics, entry
-
-    def getRateCoefficientUnits(self):
-        """
-        Return the units of the forward kinetics generated for the family.
-        Raises a ValueError if this could not be determined (e.g. if the family
-        has not yet been added to the appropriate list).
-        """
-        if self.label in BIMOLECULAR_KINETICS_FAMILIES:
-            return 'm^3/(mol*s)'
-        elif self.label in UNIMOLECULAR_KINETICS_FAMILIES:
-            return 's^-1'
-        else:
-            raise ValueError('Unable to determine units of rate coefficient for reaction family "{0}".'.format(self.label))

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -45,8 +45,7 @@ from rmgpy.data.base import Database, Entry, DatabaseError, getAllCombinations
 from rmgpy.quantity import Quantity, ScalarQuantity
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics import ArrheniusEP
-from .common import KineticsError, saveEntry, \
-    BIMOLECULAR_KINETICS_FAMILIES, UNIMOLECULAR_KINETICS_FAMILIES
+from .common import KineticsError, saveEntry
 
 ################################################################################
 
@@ -103,6 +102,56 @@ class KineticsRules(Database):
         Process a list of parameters `data` as read from an old-style RMG
         thermo database, returning the corresponding kinetics object.
         """
+        
+        # The names of all of the RMG reaction families that are bimolecular
+        BIMOLECULAR_KINETICS_FAMILIES = [
+            'H_Abstraction',
+            'R_Addition_MultipleBond',
+            'R_Recombination',
+            'Disproportionation',
+            '1+2_Cycloaddition',
+            '2+2_cycloaddition_Cd',
+            '2+2_cycloaddition_CO',
+            '2+2_cycloaddition_CCO',
+            'Diels_alder_addition',
+            '1,2_Insertion',
+            '1,3_Insertion_CO2',
+            '1,3_Insertion_ROR',
+            'R_Addition_COm',
+            'Oa_R_Recombination',
+            'Substitution_O',
+            'SubstitutionS',
+            'R_Addition_CSm',
+            '1,3_Insertion_RSR',
+            'lone_electron_pair_bond',
+        ]
+        
+        # The names of all of the RMG reaction families that are unimolecular
+        UNIMOLECULAR_KINETICS_FAMILIES = [
+            'intra_H_migration',
+            'Birad_recombination',
+            'intra_OH_migration',
+            'HO2_Elimination_from_PeroxyRadical',
+            'H_shift_cyclopentadiene',
+            'Cyclic_Ether_Formation',
+            'Intra_R_Add_Exocyclic',
+            'Intra_R_Add_Endocyclic',
+            '1,2-Birad_to_alkene',
+            'Intra_Disproportionation',
+            'Korcek_step1',
+            'Korcek_step2',
+            '1,2_shiftS',
+            'intra_substitutionCS_cyclization',
+            'intra_substitutionCS_isomerization',
+            'intra_substitutionS_cyclization',
+            'intra_substitutionS_isomerization',
+            'intra_NO2_ONO_conversion',
+            '1,4_Cyclic_birad_scission',
+            '1,4_Linear_birad_scission',
+            'Intra_Diels_alder',
+            'ketoenol',
+            'Retroen'
+        ]
         # This is hardcoding of reaction families!
         label = os.path.split(self.label)[-2]
         if label in BIMOLECULAR_KINETICS_FAMILIES:
@@ -250,9 +299,10 @@ class KineticsRules(Database):
         
         # This is hardcoding of reaction families!
         label = os.path.split(self.label)[-2]
-        if label in BIMOLECULAR_KINETICS_FAMILIES:
+        reactionOrder = groups.groups.numReactants
+        if reactionOrder == 2:
             factor = 1.0e6
-        elif label in UNIMOLECULAR_KINETICS_FAMILIES:
+        elif reactionOrder == 1:
             factor = 1.0
         else:
             raise ValueError('Unable to determine preexponential units for old reaction family "{0}".'.format(self.label))


### PR DESCRIPTION
Addresses https://github.com/ReactionMechanismGenerator/RMG-Py/issues/237

Contrary to prior belief, we don't actually need to add the reaction family to the list of unimolecular and bimolecular families.  KineticsGroups.numReactants is capable of providing the reaction order.  However, I have migrated the hardcoded lists into the import old kinetics groups from RMG-Java function, since hardcoding in that function seems very reasonable.