### PR TITLE
Store the family/library name as a reaction attribute

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -47,8 +47,8 @@ from rmgpy.thermo import NASAPolynomial, NASA
 import rmgpy.constants as constants
 from rmgpy.quantity import Quantity
 from rmgpy.data.base import Entry 
-from rmgpy.data.kinetics.library import LibraryReaction, KineticsLibrary
-from rmgpy.data.kinetics.family import TemplateReaction, KineticsFamily
+from rmgpy.data.kinetics.library import LibraryReaction
+from rmgpy.data.kinetics.family import TemplateReaction
 from rmgpy.rmg.pdep import PDepNetwork
 from rmgpy.molecule import Molecule
 from rmgpy.transport import TransportData
@@ -543,7 +543,7 @@ def readReactionComments(reaction, comments, read = True):
             kinetics = reaction.kinetics,
             reversible = reaction.reversible,
             duplicate = reaction.duplicate,
-            library = KineticsLibrary(label='Unclassified'),
+            library = 'Unclassified',
         )        
         
         return reaction  
@@ -569,7 +569,7 @@ def readReactionComments(reaction, comments, read = True):
                 kinetics = reaction.kinetics,
                 reversible = reaction.reversible,
                 duplicate = reaction.duplicate,
-                family = KineticsFamily(label=label),
+                family = label,
                 template = [Entry(label=g) for g in template],
             )
             
@@ -582,7 +582,7 @@ def readReactionComments(reaction, comments, read = True):
                 kinetics = reaction.kinetics,
                 reversible = reaction.reversible,
                 duplicate = reaction.duplicate,
-                library = KineticsLibrary(label=label),
+                library = label,
             )   
             
         elif 'PDep reaction:' in line:
@@ -647,7 +647,7 @@ def readReactionComments(reaction, comments, read = True):
                 kinetics = reaction.kinetics,
                 reversible = reaction.reversible,
                 duplicate = reaction.duplicate,
-                library = KineticsLibrary(label=label),
+                library = label,
             )
             reaction.kinetics.comment = line
             
@@ -663,7 +663,7 @@ def readReactionComments(reaction, comments, read = True):
                 kinetics = reaction.kinetics,
                 reversible = reaction.reversible,
                 duplicate = reaction.duplicate,
-                family = KineticsFamily(label=label),
+                family = label,
                 template = [Entry(label=g) for g in template],
             )
             reaction.kinetics.comment = line
@@ -676,7 +676,7 @@ def readReactionComments(reaction, comments, read = True):
             kinetics = reaction.kinetics,
             reversible = reaction.reversible,
             duplicate = reaction.duplicate,
-            library = KineticsLibrary(label='Unclassified'),
+            library = 'Unclassified',
         )  
             
     return reaction
@@ -862,7 +862,7 @@ def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments 
                 if reaction1.duplicate and reaction2.duplicate:
                     
                     if isinstance(reaction1, LibraryReaction) and isinstance(reaction2, LibraryReaction):
-                        assert reaction1.library.label == reaction2.library.label
+                        assert reaction1.library == reaction2.library
                         if reaction1 not in duplicateReactionsToRemove:
                             # already created duplicate reaction, move on to appending any additional duplicate kinetics
                             if isinstance(reaction1.kinetics,
@@ -1518,18 +1518,18 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
         
         # Next line of comment contains information about the type of reaction
         if isinstance(reaction, TemplateReaction):
-            string += '! Template reaction: {0!s}\n'.format(reaction.family.label)
+            string += '! Template reaction: {0!s}\n'.format(reaction.family)
         elif isinstance(reaction, LibraryReaction):
-            string += '! Library reaction: {0!s}\n'.format(reaction.library.label)
+            string += '! Library reaction: {0!s}\n'.format(reaction.library)
         elif isinstance(reaction, PDepReaction):
             string += '! PDep reaction: {0!s}\n'.format(reaction.network)          
             if logging.getLogger().getEffectiveLevel() == logging.DEBUG:
                 # Print additional information about the pdep network's high-P limit reactions if in debug mode.
                 for rxn in reaction.network.pathReactions:
                     if isinstance(rxn, LibraryReaction):
-                        string += '! High-P limit: {0} (Library reaction: {1!s})\n'.format(rxn, rxn.library.label)
+                        string += '! High-P limit: {0} (Library reaction: {1!s})\n'.format(rxn, rxn.library)
                     else:
-                        string += '! High-P limit: {0} (Template reaction: {1!s})\n'.format(rxn, rxn.family.label)   
+                        string += '! High-P limit: {0} (Template reaction: {1!s})\n'.format(rxn, rxn.family)   
     
         # Remaining lines of comments taken from reaction kinetics
         if reaction.kinetics.comment:

--- a/rmgpy/data/kinetics/depository.py
+++ b/rmgpy/data/kinetics/depository.py
@@ -98,7 +98,7 @@ class DepositoryReaction(Reaction):
         Return the database that was the source of this reaction. For a
         DepositoryReaction this should be a KineticsDepository object.
         """
-        return self.depository
+        return self.depository.label
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1161,7 +1161,7 @@ class KineticsFamily(Database):
             products = products if isForward else reactants,
             degeneracy = 1,
             reversible = True,
-            family = self,
+            family = self.label,
         )
         
         # Store the labeled atoms so we can recover them later

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -751,12 +751,12 @@ class RMG(util.Subject):
                     if isinstance(family0, KineticsLibrary):
                         for rxn in self.reactionModel.reactionDict[family0][reactant1][reactant2]:
                             assert isinstance(rxn, LibraryReaction)
-                            rxn.library = family
+                            rxn.library = family.label
                             reactionDict[family][reactant1][reactant2].append(rxn)
                     elif isinstance(family0, KineticsFamily):
                         for rxn in self.reactionModel.reactionDict[family0][reactant1][reactant2]:
                             assert isinstance(rxn, TemplateReaction)
-                            rxn.family = family
+                            rxn.family = family.label
                             reactionDict[family][reactant1][reactant2].append(rxn)
         
         self.reactionModel.reactionDict = reactionDict

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1666,3 +1666,28 @@ class CoreEdgeReactionModel:
         if (struct.getNumberOfRadicalElectrons() > maxRadicals):
             return True
         return False
+
+def getFamily(label):
+    """
+    Returns the ReactionFamily object associated with the
+    parameter string.
+
+    First search through the reaction families, then 
+    through the libraries.
+    """
+
+    kinetics = rmgpy.data.rmg.database.kinetics
+
+    try:
+        fam = kinetics.families[label]
+        return fam
+    except KeyError, e:
+        pass
+
+    try:
+        lib = kinetics.libraries[label]
+        return lib
+    except KeyError, e:
+        pass
+
+    raise Exception('Could not retrieve the family/library: {}'.format(label))

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -123,7 +123,7 @@ def saveOutputHTML(path, reactionModel, partCoreEdge='core'):
         if isinstance(rxn, PDepReaction):
             family = "PDepNetwork"
         else:
-            family = rxn.getSource().label
+            family = rxn.getSource()
         if family in familyCount:
             familyCount[family] += 1
         else:
@@ -331,22 +331,22 @@ $(document).ready(function() {
 <table class="reactionList hide_comment hide_kinetics hide_chemkin">
 <tr><th>Index</th><th colspan="3" style="text-align: center;">Reaction</th><th>Family</th></tr>
 {% for rxn in reactions %}
-<tr class="reaction {{ rxn.getSource().label|csssafe }}">
+<tr class="reaction {{ rxn.getSource()|csssafe }}">
     <td class="index"><a href="{{ rxn.getURL() }}" title="Search on RMG website" class="searchlink">{{ rxn.index }}.</a></td>
     <td class="reactants">{% for reactant in rxn.reactants %}<a href="{{ reactant.molecule[0].getURL() }}"><img src="species/{{ reactant|replace('#','%23') }}.png" alt="{{ reactant }}" title="{{ reactant }}, MW = {{ "%.2f g/mol"|format(reactant.molecule[0].getMolecularWeight() * 1000) }}"></a>{% if not loop.last %} + {% endif %}{% endfor %}</td>
     <td class="reactionArrow">{% if rxn.reversible %}&hArr;{% else %}&rarr;{% endif %}</td>
     <td class="products">{% for product in rxn.products %}<a href="{{ product.molecule[0].getURL() }}"><img src="species/{{ product|replace('#','%23') }}.png" alt="{{ product }}" title="{{ product }}, MW = {{ "%.2f g/mol"|format(product.molecule[0].getMolecularWeight() * 1000) }}"></a>{% if not loop.last %} + {% endif %}{% endfor %}</td>
-    <td class="family">{{ rxn.getSource().label }}</td>
+    <td class="family">{{ rxn.getSource() }}</td>
 </tr>
-<tr class="kinetics {{ rxn.getSource().label|csssafe }}">
+<tr class="kinetics {{ rxn.getSource()|csssafe }}">
     <td></td>
     <td colspan="4">{{ rxn.kinetics.toHTML() }}</td>
 </tr>
-<tr class="chemkin {{ rxn.getSource().label|csssafe }}">
+<tr class="chemkin {{ rxn.getSource()|csssafe }}">
     <td></td>
     <td colspan="4">{{ rxn.toChemkin(species) }}</td>
 </tr>
-<tr class="comment {{ rxn.getSource().label|csssafe }}">
+<tr class="comment {{ rxn.getSource()|csssafe }}">
     <td></td>
     <td colspan="4">{{ rxn.kinetics.comment }}</td>
 </tr>
@@ -463,7 +463,7 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
         if isinstance(rxn1, PDepReaction):
             family = "PDepNetwork"
         else:
-            family = rxn1.getSource().label
+            family = rxn1.getSource()
         if family in familyCount1:
             familyCount1[family] += 1
             familyCount2[family] += 1
@@ -475,7 +475,7 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
         if isinstance(rxn, PDepReaction):
             family = "PDepNetwork"
         else:
-            family = rxn.getSource().label
+            family = rxn.getSource()
         if family in familyCount1:
             familyCount1[family] += 1
         else:
@@ -485,7 +485,7 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
         if isinstance(rxn, PDepReaction):
             family = "PDepNetwork"
         else:
-            family = rxn.getSource().label
+            family = rxn.getSource()
         if family in familyCount2:
             familyCount2[family] += 1
         else:
@@ -838,10 +838,10 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
 
 <tr width=100%>
      <td class="index" width=10%><a href="{{ rxn1.getURL() }}" title="Search on RMG website" class="searchlink">{{ rxn1.index }}.</a></td>
-     <td class="family" width=40%>{{ rxn1.getSource().label }}</td>
+     <td class="family" width=40%>{{ rxn1.getSource() }}</td>
 
      <td class="index" width=10%><a href="{{ rxn2.getURL() }}" title="Search on RMG website" class="searchlink">{{ rxn2.index }}.</a></td>
-     <td class="family" width=40%>{{ rxn2.getSource().label }}</td>
+     <td class="family" width=40%>{{ rxn2.getSource() }}</td>
  </tr>
 
 <tr width=100%>{% if not rxn1.isIsomorphic(rxn2, eitherDirection=False) %} 
@@ -891,22 +891,22 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
 <table class="reactionList hide_comment hide_kinetics hide_chemkin">
     <tr><th>Index</th><th colspan="3" style="text-align: center;">Reaction</th><th>Family</th></tr>
     {% for rxn in uniqueReactions1 %}
-    <tr class="reaction {{ rxn.getSource().label|csssafe }}">
+    <tr class="reaction {{ rxn.getSource()|csssafe }}">
         <td class="index"><a href="{{ rxn.getURL() }}" title="Search on RMG website" class="searchlink">{{ rxn.index }}.</a></td>
         <td class="reactants">{% for reactant in rxn.reactants %}<a href="{{ reactant.molecule[0].getURL() }}"><img src="species1/{{ reactant|replace('#','%23') }}.png" alt="{{ reactant }}" title="{{ reactant }}, MW = {{ "%.2f"|format(reactant.molecule[0].getMolecularWeight() * 1000) }}"></a>{% if not loop.last %} + {% endif %}{% endfor %}</td>
         <td class="reactionArrow">{% if rxn.reversible %}&hArr;{% else %}&rarr;{% endif %}</td>
         <td class="products">{% for product in rxn.products %}<a href="{{ product.molecule[0].getURL() }}"><img src="species1/{{ product|replace('#','%23') }}.png" alt="{{ product }}" title="{{ product }}, MW = {{ "%.2f"|format(product.molecule[0].getMolecularWeight() * 1000) }}"></a>{% if not loop.last %} + {% endif %}{% endfor %}</td>
-        <td class="family">{{ rxn.getSource().label }}</td>
+        <td class="family">{{ rxn.getSource() }}</td>
     </tr>
-    <tr class="kinetics {{ rxn.getSource().label|csssafe }}">
+    <tr class="kinetics {{ rxn.getSource()|csssafe }}">
         <td></td>
         <td colspan="4">{{ rxn.kinetics.toHTML() }}</td>
     </tr>
-    <tr class="chemkin {{ rxn.getSource().label|csssafe }}">
+    <tr class="chemkin {{ rxn.getSource()|csssafe }}">
         <td></td>
         <td colspan="4">{{ rxn.toChemkin(species) }}</td>
     </tr>
-    <tr class="comment {{ rxn.getSource().label|csssafe }}">
+    <tr class="comment {{ rxn.getSource()|csssafe }}">
         <td></td>
         <td colspan="4">{{ rxn.kinetics.comment }}</td>
     </tr>
@@ -921,22 +921,22 @@ def saveDiffHTML(path, commonSpeciesList, speciesList1, speciesList2, commonReac
 <table class="reactionList hide_comment hide_kinetics hide_chemkin">
     <tr><th>Index</th><th colspan="3" style="text-align: center;">Reaction</th><th>Family</th></tr>
     {% for rxn in uniqueReactions2 %}
-    <tr class="reaction {{ rxn.getSource().label|csssafe }}">
+    <tr class="reaction {{ rxn.getSource()|csssafe }}">
         <td class="index"><a href="{{ rxn.getURL() }}" title="Search on RMG website" class="searchlink">{{ rxn.index }}.</a></td>
         <td class="reactants">{% for reactant in rxn.reactants %}<a href="{{ reactant.molecule[0].getURL() }}"><img src="species2/{{ reactant|replace('#','%23') }}.png" alt="{{ reactant }}" title="{{ reactant }}, MW = {{ "%.2f"|format(reactant.molecule[0].getMolecularWeight() * 1000) }}"></a>{% if not loop.last %} + {% endif %}{% endfor %}</td>
         <td class="reactionArrow">{% if rxn.reversible %}&hArr;{% else %}&rarr;{% endif %}</td>
         <td class="products">{% for product in rxn.products %}<a href="{{ product.molecule[0].getURL() }}"><img src="species2/{{ product|replace('#','%23') }}.png" alt="{{ product }}" title="{{ product }}, MW = {{ "%.2f"|format(product.molecule[0].getMolecularWeight() * 1000) }}"></a>{% if not loop.last %} + {% endif %}{% endfor %}</td>
-        <td class="family">{{ rxn.getSource().label }}</td>
+        <td class="family">{{ rxn.getSource() }}</td>
     </tr>
-    <tr class="kinetics {{ rxn.getSource().label|csssafe }}">
+    <tr class="kinetics {{ rxn.getSource()|csssafe }}">
         <td></td>
         <td colspan="4">{{ rxn.kinetics.toHTML() }}</td>
     </tr>
-    <tr class="chemkin {{ rxn.getSource().label|csssafe }}">
+    <tr class="chemkin {{ rxn.getSource()|csssafe }}">
         <td></td>
         <td colspan="4">{{ rxn.toChemkin(species) }}</td>
     </tr>
-    <tr class="comment {{ rxn.getSource().label|csssafe }}">
+    <tr class="comment {{ rxn.getSource()|csssafe }}">
         <td></td>
         <td colspan="4">{{ rxn.kinetics.comment }}</td>
     </tr>


### PR DESCRIPTION
Instead of storing (referencing) the entire reaction family in each reaction instance, this PR changes this.

Instead, we only store the name of the family/library as an attribute, and redirect to the family/library object through a function called `getFamily`. The latter is located in `rmgpy.rmg.model` as this is the only module that needs access to the objects, rather than just the names. The other modules like `chemkin` only require the name of the family/library.

The advantage of this design is:
- we need less space when we serialize a reaction object (this reduces transfer costs across memories)
- we don't get in trouble when a reaction object is created on a remote computer where the references to the reaction family object is different.