### PR TITLE
Fix bugs in readReactionComments

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -651,7 +651,7 @@ def readReactionComments(reaction, comments, read = True):
             )
             reaction.kinetics.comment = line
             
-        elif 'exact' in line or 'estimate' in line:
+        elif 'exact:' in line or 'estimate:' in line:
             index1 = line.find('[')
             index2 = line.find(']')
             template = [s.strip() for s in line[index1:index2].split(',')]

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -560,7 +560,7 @@ def readReactionComments(reaction, comments, read = True):
             pass
         
         elif 'Template reaction:' in line:
-            label = str(tokens[-2])
+            label = str(tokens[-1])
             template = tokens[-1][1:-1].split(',')
             reaction = TemplateReaction(
                 index = reaction.index,

--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -1,0 +1,47 @@
+import unittest
+import os
+from chemkin import *
+###################################################
+
+class ChemkinTest(unittest.TestCase):
+
+	def testReadTemplateReactionFamilyForMinimalExample(self):
+		"""
+		This example is mainly to test if family info can be correctly 
+		parsed from comments like '!Template reaction: R_Recombination'.
+		"""
+		folder = os.path.join(os.getcwd(),'rmgpy/tools/data/chemkin/chemkin_py')
+		
+		chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
+		dictionaryPath = os.path.join(folder,'minimal', 'species_dictionary.txt')
+
+		# loadChemkinFile
+		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath) 
+
+		reaction1 = reactions[0]
+		self.assertEqual(reaction1.family, "R_Recombination")
+
+		reaction2 = reactions[1]
+		self.assertEqual(reaction2.family, "H_Abstraction")
+	
+	def testReadTemplateReactionFamilyForPDDExample(self):
+		"""
+		This example is mainly to ensure comments like 
+		'! Kinetics were estimated in this direction instead 
+		of the reverse because:' or '! This direction matched 
+		an entry in H_Abstraction, the other was just an estimate.'
+		won't interfere reaction family info retrival.
+		"""
+		folder = os.path.join(os.getcwd(),'rmgpy/tools/data/chemkin/chemkin_py')
+		
+		chemkinPath = os.path.join(folder, 'pdd', 'chem.inp')
+		dictionaryPath = os.path.join(folder,'pdd', 'species_dictionary.txt')
+
+		# loadChemkinFile
+		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath) 
+
+		reaction1 = reactions[0]
+		self.assertEqual(reaction1.family, "H_Abstraction")
+
+		reaction2 = reactions[1]
+		self.assertEqual(reaction2.family, "H_Abstraction")

--- a/rmgpy/tools/data/chemkin/chemkin_py/minimal/chem.inp
+++ b/rmgpy/tools/data/chemkin/chemkin_py/minimal/chem.inp
@@ -1,0 +1,85 @@
+ELEMENTS H C O N Ne Ar He Si S Cl END
+
+SPECIES
+    Ar                  ! Ar
+    He                  ! He
+    Ne                  ! Ne
+    N2                  ! N2
+    ethane(1)           ! ethane(1)
+    CH3(2)              ! [CH3](2)
+    C2H5(3)             ! C[CH2](3)
+    C(6)                ! C(6)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+Ar                      Ar1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 4.37967000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 4.37967000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+He                      He1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 9.28724000E-01 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 9.28724000E-01                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+N2                      N 2                 G200.000   6000.000  1000.00       1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R)
+ethane(1)               C 2  H 6            G100.000   5000.000  954.51        1
+ 4.58979542E+00 1.41508364E-02-4.75965787E-06 8.60302924E-10-6.21723861E-14    2
+-1.27217507E+04-3.61718979E+00 3.78034578E+00-3.24276131E-03 5.52385395E-05    3
+-6.38587729E-08 2.28639990E-11-1.16203414E+04 5.21029728E+00                   4
+
+! Thermo library: primaryThermoLibrary + radical(CH3)
+CH3(2)                  C 1  H 3            G100.000   5000.000  1337.62       1
+ 3.54143640E+00 4.76790043E-03-1.82150130E-06 3.28880372E-10-2.22548587E-14    2
+ 1.62239681E+04 1.66047100E+00 3.91546905E+00 1.84152818E-03 3.48746163E-06    3
+-3.32752224E-09 8.49972445E-13 1.62856393E+04 3.51736167E-01                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + radical(CCJ)
+C2H5(3)                 C 2  H 5            G100.000   5000.000  900.30        1
+ 5.15612045E+00 9.43138098E-03-1.81955176E-06 2.21217842E-10-1.43499849E-14    2
+ 1.20641180E+04-2.91049253E+00 3.82186937E+00-3.43402515E-03 5.09273311E-05    3
+-6.20234394E-08 2.37084005E-11 1.30660115E+04 7.61631555E+00                   4
+
+! Thermo library: primaryThermoLibrary
+C(6)                    C 1  H 4            G100.000   5000.000  1084.12       1
+ 9.08263478E-01 1.14540895E-02-4.57174036E-06 8.29192155E-10-5.66315291E-14    2
+-9.71997345E+03 1.39931071E+01 4.20541563E+00-5.35557811E-03 2.51123416E-05    3
+-2.13763028E-08 5.97524682E-12-1.01619433E+04-9.21280686E-01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #1
+! Template reaction: R_Recombination
+! Exact match found for rate rule (C_methyl;C_methyl)
+CH3(2)+CH3(2)=ethane(1)                             8.260e+17 -1.400    1.000    
+
+! Reaction index: Chemkin #2; RMG #4
+! Template reaction: H_Abstraction
+! Estimated using template (C/H3/Cs;C_methyl) for rate rule (C/H3/Cs\H3;C_methyl)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+CH3(2)=C(6)+C2H5(3)                       4.488e-05 4.990     8.000    
+
+END
+

--- a/rmgpy/tools/data/chemkin/chemkin_py/minimal/species_dictionary.txt
+++ b/rmgpy/tools/data/chemkin/chemkin_py/minimal/species_dictionary.txt
@@ -1,0 +1,47 @@
+Ar
+1 Ar u0 p4 c0
+
+He
+1 He u0 p1 c0
+
+Ne
+1 Ne u0 p4 c0
+
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+ethane(1)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+
+CH3(2)
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+C2H5(3)
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+
+C(6)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+

--- a/rmgpy/tools/data/chemkin/chemkin_py/pdd/chem.inp
+++ b/rmgpy/tools/data/chemkin/chemkin_py/pdd/chem.inp
@@ -1,0 +1,113 @@
+ELEMENTS H C O N Ne Ar He Si S Cl END
+
+SPECIES
+    Ar                  ! Ar
+    He                  ! He
+    Ne                  ! Ne
+    N2                  ! N2
+    C4J(1)              ! C4J(1)
+    C11H22(2)           ! C11H22(2)
+    CCCC(5)             ! CCCC(5)
+    C11H21(6)           ! C=CCCCC[CH]CCCC(6)
+    C11H21(7)           ! C=CCCC[CH]CCCCC(7)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+Ar                      Ar1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 4.37967000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 4.37967000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+He                      He1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 9.28724000E-01 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 9.28724000E-01                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+N2                      N 2                 G200.000   6000.000  1000.00       1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) +
+! group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + radical(RCCJ)
+C4J(1)                  C 4  H 9            G100.000   5000.000  1048.11       1
+ 7.21574891E+00 2.70036507E-02-1.06547116E-05 1.95471782E-09-1.35977653E-13    2
+ 5.47162388E+03-1.06997328E+01 2.34847953E+00 2.91324214E-02 9.83641575E-06    3
+-2.60505989E-08 1.01150985E-11 7.39526561E+03 1.73201945E+01                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) +
+! other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-
+! CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-CsCsHH) +
+! gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-(Cds-Cds)CsHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) +
+! other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R)
+C11H22(2)               C 11 H 22           G100.000   5000.000  1687.46       1
+ 2.40183437E+01 6.63233942E-02-2.68542330E-05 4.78759141E-09-3.18671908E-13    2
+-3.06597483E+04-9.23478682E+01-2.31376357E+00 1.28742717E-01-8.23402763E-05    3
+ 2.67088731E-08-3.56639802E-12-2.17730146E+04 4.84665094E+01                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) +
+! group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R)
+CCCC(5)                 C 4  H 10           G100.000   5000.000  1025.38       1
+ 7.36804605E+00 2.93849568E-02-1.14713947E-05 2.10841164E-09-1.47486526E-13    2
+-1.94135365E+04-1.48586318E+01 2.31394819E+00 2.83758835E-02 2.03227705E-05    3
+-3.82747116E-08 1.45043264E-11-1.72875368E+04 1.49639199E+01                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) +
+! other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-
+! CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-CsCsHH) +
+! gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-(Cds-Cds)CsHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) +
+! other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + radical(RCCJCC)
+C11H21(6)               C 11 H 21           G100.000   5000.000  1517.06       1
+ 1.41237789E+01 7.88982983E-02-3.39282828E-05 6.26591707E-09-4.27728998E-13    2
+-3.07728703E+03-3.32559805E+01-1.15790060E+00 1.19190852E-01-7.37674054E-05    3
+ 2.37729367E-08-3.31272981E-12 1.55939561E+03 4.68384245E+01                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) +
+! other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-
+! CsCsHH) + gauche(Cs(Cs(CsRR)Cs(CsRR)RR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-CsCsHH) +
+! gauche(Cs(Cs(CsRR)CsRR)) + other(R) + group(Cs-(Cds-Cds)CsHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) +
+! other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + radical(RCCJCC)
+C11H21(7)               C 11 H 21           G100.000   5000.000  1517.06       1
+ 1.41237789E+01 7.88982983E-02-3.39282828E-05 6.26591707E-09-4.27728998E-13    2
+-3.07728703E+03-3.32559805E+01-1.15790060E+00 1.19190852E-01-7.37674054E-05    3
+ 2.37729367E-08-3.31272981E-12 1.55939561E+03 4.68384245E+01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #1
+! Template reaction: H_Abstraction
+! Exact match found for rate rule (C/H2/NonDeC;C_rad/H2/Cs)
+! Multiplied by reaction path degeneracy 2
+! Kinetics were estimated in this direction instead of the reverse because:
+! This direction matched an entry in H_Abstraction, the other was just an estimate.
+! dHrxn(298 K) = -11.09 kJ/mol, dGrxn(298 K) = -11.22 kJ/mol
+C4J(1)+C11H22(2)=CCCC(5)+C11H21(6)                  1.840e-03 4.340     7.000    
+
+! Reaction index: Chemkin #2; RMG #2
+! Template reaction: H_Abstraction
+! Exact match found for rate rule (C/H2/NonDeC;C_rad/H2/Cs)
+! Multiplied by reaction path degeneracy 2
+! Kinetics were estimated in this direction instead of the reverse because:
+! This direction matched an entry in H_Abstraction, the other was just an estimate.
+! dHrxn(298 K) = -11.09 kJ/mol, dGrxn(298 K) = -11.22 kJ/mol
+C4J(1)+C11H22(2)=CCCC(5)+C11H21(7)                  1.840e-03 4.340     7.000    
+
+END
+

--- a/rmgpy/tools/data/chemkin/chemkin_py/pdd/species_dictionary.txt
+++ b/rmgpy/tools/data/chemkin/chemkin_py/pdd/species_dictionary.txt
@@ -1,0 +1,150 @@
+Ar
+1 Ar u0 p4 c0
+
+He
+1 He u0 p1 c0
+
+Ne
+1 Ne u0 p4 c0
+
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+C4J(1)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u1 p0 c0 {2,S} {12,S} {13,S}
+5  H u0 p0 c0 {2,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+
+C11H22(2)
+1  C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+2  C u0 p0 c0 {1,S} {3,S} {11,S} {12,S}
+3  C u0 p0 c0 {2,S} {6,S} {17,S} {18,S}
+4  C u0 p0 c0 {1,S} {5,S} {15,S} {16,S}
+5  C u0 p0 c0 {4,S} {7,S} {21,S} {22,S}
+6  C u0 p0 c0 {3,S} {8,S} {19,S} {20,S}
+7  C u0 p0 c0 {5,S} {9,S} {23,S} {24,S}
+8  C u0 p0 c0 {6,S} {10,S} {25,S} {26,S}
+9  C u0 p0 c0 {7,S} {28,S} {29,S} {30,S}
+10 C u0 p0 c0 {8,S} {27,D} {31,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {1,S}
+14 H u0 p0 c0 {1,S}
+15 H u0 p0 c0 {4,S}
+16 H u0 p0 c0 {4,S}
+17 H u0 p0 c0 {3,S}
+18 H u0 p0 c0 {3,S}
+19 H u0 p0 c0 {6,S}
+20 H u0 p0 c0 {6,S}
+21 H u0 p0 c0 {5,S}
+22 H u0 p0 c0 {5,S}
+23 H u0 p0 c0 {7,S}
+24 H u0 p0 c0 {7,S}
+25 H u0 p0 c0 {8,S}
+26 H u0 p0 c0 {8,S}
+27 C u0 p0 c0 {10,D} {32,S} {33,S}
+28 H u0 p0 c0 {9,S}
+29 H u0 p0 c0 {9,S}
+30 H u0 p0 c0 {9,S}
+31 H u0 p0 c0 {10,S}
+32 H u0 p0 c0 {27,S}
+33 H u0 p0 c0 {27,S}
+
+CCCC(5)
+1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+
+C11H21(6)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+2  C u0 p0 c0 {1,S} {8,S} {15,S} {16,S}
+3  C u0 p0 c0 {1,S} {6,S} {13,S} {14,S}
+4  C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+5  C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  C u1 p0 c0 {3,S} {5,S} {21,S}
+7  C u0 p0 c0 {4,S} {9,S} {22,S} {23,S}
+8  C u0 p0 c0 {2,S} {10,S} {24,S} {25,S}
+9  C u0 p0 c0 {7,S} {27,S} {28,S} {29,S}
+10 C u0 p0 c0 {8,S} {26,D} {30,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {1,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {2,S}
+16 H u0 p0 c0 {2,S}
+17 H u0 p0 c0 {5,S}
+18 H u0 p0 c0 {5,S}
+19 H u0 p0 c0 {4,S}
+20 H u0 p0 c0 {4,S}
+21 H u0 p0 c0 {6,S}
+22 H u0 p0 c0 {7,S}
+23 H u0 p0 c0 {7,S}
+24 H u0 p0 c0 {8,S}
+25 H u0 p0 c0 {8,S}
+26 C u0 p0 c0 {10,D} {31,S} {32,S}
+27 H u0 p0 c0 {9,S}
+28 H u0 p0 c0 {9,S}
+29 H u0 p0 c0 {9,S}
+30 H u0 p0 c0 {10,S}
+31 H u0 p0 c0 {26,S}
+32 H u0 p0 c0 {26,S}
+
+C11H21(7)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {15,S} {16,S}
+2  C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
+3  C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4  C u0 p0 c0 {5,S} {8,S} {19,S} {20,S}
+5  C u0 p0 c0 {4,S} {7,S} {17,S} {18,S}
+6  C u0 p0 c0 {2,S} {9,S} {21,S} {22,S}
+7  C u1 p0 c0 {3,S} {5,S} {23,S}
+8  C u0 p0 c0 {4,S} {10,S} {24,S} {25,S}
+9  C u0 p0 c0 {6,S} {27,S} {28,S} {29,S}
+10 C u0 p0 c0 {8,S} {26,D} {30,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {1,S}
+16 H u0 p0 c0 {1,S}
+17 H u0 p0 c0 {5,S}
+18 H u0 p0 c0 {5,S}
+19 H u0 p0 c0 {4,S}
+20 H u0 p0 c0 {4,S}
+21 H u0 p0 c0 {6,S}
+22 H u0 p0 c0 {6,S}
+23 H u0 p0 c0 {7,S}
+24 H u0 p0 c0 {8,S}
+25 H u0 p0 c0 {8,S}
+26 C u0 p0 c0 {10,D} {31,S} {32,S}
+27 H u0 p0 c0 {9,S}
+28 H u0 p0 c0 {9,S}
+29 H u0 p0 c0 {9,S}
+30 H u0 p0 c0 {10,S}
+31 H u0 p0 c0 {26,S}
+32 H u0 p0 c0 {26,S}
+


### PR DESCRIPTION
This PR mainly fixed two bugs

- parse comment like "! Template reaction: Disproportionation", where family info is in last token

- parse comment like "Disproportionation estimate: (Average:)". where family info is relied on checking whether the line has "estimate:" or "exact:"