### PR TITLE
Fix bug RMG-database #81

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -492,7 +492,8 @@ class CoreEdgeReactionModel:
         _, r1_rev, r2_rev = generateReactionKey(rxn, useProducts=True)
 
         for library in self.reactionDict:
-            if isinstance(library, KineticsLibrary) and library != family:
+            libObj = getFamilyLibraryObject(library)
+            if isinstance(libObj, KineticsLibrary) and library != rxn.family:
 
                 # First check seed short-list in forward direction                
                 shortlist = self.retrieve(library, r1_fwd, r2_fwd)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -509,8 +509,8 @@ class CoreEdgeReactionModel:
                 shortlist = self.retrieve(library, r1_rev, r2_rev)
                 
                 for rxn0 in shortlist:
-                    if (reactants0 == reactants and products0 == products) or \
-                        (reactants0 == products and products0 == reactants):
+                    if (rxn0.reactants == rxn.reactants and rxn0.products == rxn.products) or \
+                        (rxn0.reactants == rxn.products and rxn0.products == rxn.reactants):
                         return True, rxn0
 
         return False, None

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -462,7 +462,7 @@ class CoreEdgeReactionModel:
         reaction (if found).
         """
         
-        family = getFamily(rxn.family)
+        familyObj = getFamilyLibraryObject(rxn.family)
         shortlist = self.searchRetrieveReactions(rxn)
 
         # Now use short-list to check for matches. All should be in same forward direction.
@@ -474,14 +474,14 @@ class CoreEdgeReactionModel:
             rxn_id0 = generateReactionId(rxn0)
 
             if (rxn_id == rxn_id0):
-                if isinstance(family, KineticsLibrary):
+                if isinstance(familyObj, KineticsLibrary):
                     # If the reaction comes from a kinetics library, then we can retain duplicates if they are marked
                     if not rxn.duplicate:
                         return True, rxn0
                 else:
                     return True, rxn0
             
-            if isinstance(family,KineticsFamily) and family.ownReverse:
+            if isinstance(familyObj, KineticsFamily) and familyObj.ownReverse:
                 if (rxn_id == rxn_id0[::-1]):
                     return True, rxn0
 
@@ -727,7 +727,7 @@ class CoreEdgeReactionModel:
         # Generate kinetics of new reactions
         logging.info('Generating kinetics for new reactions...')
         for reaction in newReactionList:
-            family = getFamily(reaction.family)
+            family = getFamilyLibraryObject(reaction.family)
 
             # If the reaction already has kinetics (e.g. from a library),
             # assume the kinetics are satisfactory
@@ -872,7 +872,7 @@ class CoreEdgeReactionModel:
         # Only reactions from families should be missing kinetics
         assert isinstance(reaction, TemplateReaction)
         
-        family = getFamily(reaction.family)
+        family = getFamilyLibraryObject(reaction.family)
 
         # Get the kinetics for the reaction
         kinetics, source, entry, isForward = family.getKinetics(reaction, template=reaction.template, degeneracy=reaction.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
@@ -1697,7 +1697,7 @@ class CoreEdgeReactionModel:
         my_reactionList.extend(rxns)
             
             
-        family = getFamily(family_label)       
+        family = getFamilyLibraryObject(family_label)       
         # if the family is its own reverse (H-Abstraction) then check the other direction
         if isinstance(family,KineticsFamily) and family.ownReverse: # (family may be a KineticsLibrary)
 
@@ -1758,9 +1758,9 @@ def generateReactionId(rxn):
 
     return (reactants, products)
 
-def getFamily(label):
+def getFamilyLibraryObject(label):
     """
-    Returns the ReactionFamily object associated with the
+    Returns the KineticsFamily or KineticsLibrary object associated with the
     parameter string.
 
     First search through the reaction families, then 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -460,6 +460,19 @@ class CoreEdgeReactionModel:
         Check to see if an existing reaction has the same reactants, products, and
         family as `rxn`. Returns :data:`True` or :data:`False` and the matched
         reaction (if found).
+
+        First, a shortlist of reaction is retrieved that have the same reaction keys
+        as the parameter reaction.
+
+        Next, the reaction ID containing an identifier (e.g. label) of the reactants
+        and products is compared between the parameter reaction and the each of the
+        reactions in the shortlist. If a match is found, the discovered reaction is 
+        returned.
+
+        If a match is not yet found, the Library (seed mechs, reaction libs)
+        in the reaction database are iterated over to check if a reaction was overlooked
+        (a reaction with a different "family" key as the parameter reaction).
+
         """
         
         familyObj = getFamilyLibraryObject(rxn.family)
@@ -1657,6 +1670,15 @@ class CoreEdgeReactionModel:
         - reaction family
         - reactant(s) keys
 
+        First, the keys are generated for the parameter reaction.
+        
+        Next, it is checked whether the reaction database already 
+        contains similar keys. If not, a new container is created,
+        either a dictionary for the family key and first reactant key,
+        or a list for the second reactant key.
+
+        Finally, the reaction is inserted as the first element in the 
+        list.
         """
 
         key_family, key1, key2 = generateReactionKey(rxn)
@@ -1666,10 +1688,10 @@ class CoreEdgeReactionModel:
             self.reactionDict[key_family] = {}
 
         if not self.reactionDict[key_family].has_key(key1):
-            self.reactionDict[key_family][key1] = dict()
+            self.reactionDict[key_family][key1] = {}
 
         if not self.reactionDict[key_family][key1].has_key(key2):
-            self.reactionDict[key_family][key1][key2] = list()
+            self.reactionDict[key_family][key1][key2] = []
 
         # store this reaction at the top of the relevant short-list
         self.reactionDict[key_family][key1][key2].insert(0, rxn)
@@ -1683,12 +1705,8 @@ class CoreEdgeReactionModel:
 
         Both the reaction key based on the reactants as well as on the products
         is used to search for possible candidate reactions.
-
-        if the flag searchLibraries is set to True, then 
-        reactions will be returned that do not belong to the same reaction family
-        or reaction library necessarily, but do have the same reactant keys
-        as the parameter reaction.
         """
+
         # Get the short-list of reactions with the same family, reactant1 and reactant2
         family_label, r1_fwd, r2_fwd = generateReactionKey(rxn)
         

--- a/rmgpy/tools/data/generate/duplicates/input.py
+++ b/rmgpy/tools/data/generate/duplicates/input.py
@@ -1,0 +1,62 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    seedMechanisms = ['Methylformate'],
+    kineticsFamilies = ['R_Addition_MultipleBond'],
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+
+species(
+    label='HCjO',
+    reactive=True,
+    structure=adjacencyList(
+        """
+multiplicity 2
+1 C u1 p0 c0 {2,D} {3,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+        """),
+)
+
+species(
+    label='CH2O',
+    reactive=True,
+    structure=adjacencyList(
+        """
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+        """),
+)
+
+species(
+    label='Fmoml',
+    reactive=True,
+    structure=adjacencyList(
+        """
+multiplicity 2
+1 C u1 p0 c0 {3,S} {5,S} {6,S}
+2 C u0 p0 c0 {3,S} {4,D} {7,S}
+3 O u0 p2 c0 {1,S} {2,S}
+4 O u0 p2 c0 {2,D}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+        """),
+)
+
+
+simpleReactor(
+    temperature=(1399,'K'),
+    pressure=(1.93,'atm'),
+    initialMoleFractions={
+        "HCjO": 1,
+    },
+    terminationConversion={
+        'HCjO': 0.999,
+    },
+    terminationTime=(1e-3,'s'),
+)

--- a/rmgpy/tools/testGenerateReactions.py
+++ b/rmgpy/tools/testGenerateReactions.py
@@ -21,3 +21,30 @@ class GenerateReactionsTest(unittest.TestCase):
 
 
         shutil.rmtree(os.path.join(folder,'pdep'))
+
+    def testDuplicateReaction(self):
+        """
+        Test that the radical addition reaction
+
+        HCJ=O + CH2O = [CH2]OC=O
+
+        present in the reaction library "Methylformate",
+        only appears once in the model.
+
+        """
+        folder = os.path.join(os.getcwd(),'rmgpy/tools/data/generate/duplicates')
+        
+        inputFile = os.path.join(folder,'input.py')
+        
+        rmg = RMG()
+        rmg = execute(rmg, inputFile, folder)
+
+        self.assertIsNotNone(rmg)
+
+        """
+        13 reactions will be created,12 from the seed mechanism,
+        1 additional one through the reaction family.
+        """
+        self.assertEquals(13, len(rmg.reactionModel.core.reactions))
+
+        shutil.rmtree(os.path.join(folder,'pdep'))

--- a/rmgpy/tools/testGenerateReactions.py
+++ b/rmgpy/tools/testGenerateReactions.py
@@ -48,3 +48,10 @@ class GenerateReactionsTest(unittest.TestCase):
         self.assertEquals(13, len(rmg.reactionModel.core.reactions))
 
         shutil.rmtree(os.path.join(folder,'pdep'))
+
+    def tearDown(self):
+        """
+        Reset the loaded database
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None


### PR DESCRIPTION
This PR fixes the duplicated reactions that were erroneously not discovered as already existing reactions in the reaction database.

This issue was mentioned [here] (https://github.com/ReactionMechanismGenerator/RMG-database/issues/81) and in #513.

An attempt at creating a unit test that reproduces this is found in the testGenerateReactions module for lack of a better place.

The added unit test generates reactions for 3 input reactants (`HCJ=O, CH2O, and [CH2]OC=O`) through a single reaction family (radical addition to double bond). The one reaction 

`HCJ=O + CH2O <=> [CH2]OC=O`

that results from applying this reaction family, is also present in the seed mechanism (`methylformate`) that is imported. It is checked whether the total number of reactions in the final model is equal to the expected number.

Importing the library as a _reaction library_ rather than a seed mechanism and only generating 1 reaction is currently not working due to #515.