### PR TITLE
TemplateReaction's template are stored as a list of strings

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1694,3 +1694,31 @@ class KineticsFamily(Database):
         kinetics, entry  = self.rules.estimateKinetics(template, degeneracy)
                 
         return kinetics, entry
+
+
+    def getReactionTemplateLabels(self, reaction):
+        """
+        Retrieve the template for the reaction and 
+        return the corresponding labels for each of the 
+        groups in the template.
+        """
+        template = self.getReactionTemplate(reaction)
+        
+        templateLabels = []
+        for entry in template:
+            templateLabels.append(entry.label)
+
+        return templateLabels
+
+    def retrieveTemplate(self, templateLabels):
+        """
+        Reconstruct the groups associated with the 
+        labels of the reaction template and 
+        return a list.
+        """
+        template = []
+        for label in templateLabels:
+            template.append(self.groups.entries[label])
+
+        return template
+

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1454,7 +1454,7 @@ class KineticsFamily(Database):
             
             # Generate metadata about the reaction that we will need later
             reaction.pairs = self.getReactionPairs(reaction)
-            reaction.template = self.getReactionTemplate(reaction)
+            reaction.template = self.getReactionTemplateLabels(reaction)
             if not forward:
                 reaction.degeneracy = self.calculateDegeneracy(reaction)
 
@@ -1621,6 +1621,8 @@ class KineticsFamily(Database):
         kineticsList = []
         
         depositories = self.depositories[:]
+
+        template = self.retrieveTemplate(template)
         
         # Check the various depositories for kinetics
         for depository in depositories:


### PR DESCRIPTION
The template attribute of a TemplateReaction is obtained [during the generation of the reaction] (https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/data/kinetics/family.py#L1457).

It is used to compute a rate coefficient object, [much more downstream] (https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/rmg/model.py#L882) in the `CERM.generateKinetics(...)` method.

This PR goes from a design in which `templaterxn.template` stores a list of group objects to a design in that stores a list of strings, corresponding to the labels of the groups.

Only, when the group objects are needed again are the group objects retrieved again. The result is that the template attribute contains a much smaller objects (strings), which don't need to go through the delicate procedure of de/serialization when the reaction is sent/received to/from remote workers.