### PR TITLE
Added flux pairs info to chemkin file

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1531,6 +1531,17 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
                     else:
                         string += '! High-P limit: {0} (Template reaction: {1!s})\n'.format(rxn, rxn.family)   
     
+        # Next line of comment contains information about the pairs of reaction
+        pairs =[]
+        if reaction.pairs:
+            for pair in reaction.pairs:
+                pairs.append([getSpeciesIdentifier(spec) for spec in pair])
+            string += "! Flux pairs: "
+
+            for pair in pairs:
+                string += pair[0] + ", " + pair[1] + "; "
+            string += "\n"
+
         # Remaining lines of comments taken from reaction kinetics
         if reaction.kinetics.comment:
             for line in reaction.kinetics.comment.split("\n"):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -303,11 +303,19 @@ class ReactionModel:
             for i, reactant in enumerate(rxn.reactants):
                 try:
                     rxn.reactants[i] = commonSpecies[reactant]
+                    if rxn.pairs:
+                        for j, pair in enumerate(rxn.pairs):
+                            if reactant in pair:
+                                rxn.pairs[j] = (rxn.reactants[i],pair[1])
                 except KeyError:
                     pass
             for i, product in enumerate(rxn.products):
                 try:
                     rxn.products[i] = commonSpecies[product]
+                    if rxn.pairs:
+                        for j, pair in enumerate(rxn.pairs):
+                            if product in pair:
+                                rxn.pairs[j] = (pair[0], rxn.products[i])
                 except KeyError:
                     pass
         


### PR DESCRIPTION
This PR added

- flux pairs info to chemkin file when saving chemkin files. This info is particularly important for ROP analysis like aggregating flux by species

- when merging models, the pairs should be updated using the updated species 