### PR TITLE
ignore RuntimeWarning emitted by warnScoopStartedProperly wrapper

### DIFF
--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -52,6 +52,8 @@ def warnScoopStartedProperly(func):
         
         futures_not_loaded = 'scoop.futures' not in sys.modules
 
+        warnings.simplefilter('ignore', RuntimeWarning)
+
         try:
             controller_not_started = not (
                 sys.modules['scoop.futures'].__dict__.get("_controller", None)


### PR DESCRIPTION
RuntimeWarnings will not be printed to output.

fixes #510