### PR TITLE
code redesign of species constraints

### DIFF
--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2010 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import logging
+
+from rmgpy.species import Species
+
+def failsSpeciesConstraints(species):
+    """
+    Pass in either a `Species` or `Molecule` object and checks whether it passes 
+    the speciesConstraints set by the user.  If not, returns `True` for failing speciesConstraints.
+    """
+    
+    from rmgpy.rmg.input import getInput
+    speciesConstraints = getInput('speciesConstraints')
+
+    explicitlyAllowedMolecules = speciesConstraints.get('explicitlyAllowedMolecules', [])
+    maxCarbonAtoms = speciesConstraints.get('maximumCarbonAtoms', 1000000)
+    maxHydrogenAtoms = speciesConstraints.get('maximumHydrogenAtoms', 1000000)
+    maxOxygenAtoms = speciesConstraints.get('maximumOxygenAtoms', 1000000)
+    maxNitrogenAtoms = speciesConstraints.get('maximumNitrogenAtoms', 1000000)
+    maxSiliconAtoms = speciesConstraints.get('maximumSiliconAtoms', 1000000)
+    maxSulfurAtoms = speciesConstraints.get('maximumSulfurAtoms', 1000000)
+    maxHeavyAtoms = speciesConstraints.get('maximumHeavyAtoms', 1000000)
+    maxRadicals = speciesConstraints.get('maximumRadicalElectrons', 1000000)
+    
+    if isinstance(species, Species):
+        struct = species.molecule[0]
+    else:
+        # expects a molecule here
+        struct = species
+    for molecule in explicitlyAllowedMolecules:
+        if struct.isIsomorphic(molecule):
+            return False        
+    H = struct.getNumAtoms('H')
+    if struct.getNumAtoms('C') > maxCarbonAtoms:
+        return True
+    if H > maxHydrogenAtoms:
+        return True
+    if struct.getNumAtoms('O') > maxOxygenAtoms:
+        return True
+    if struct.getNumAtoms('N') > maxNitrogenAtoms:
+        return True
+    if struct.getNumAtoms('Si') > maxSiliconAtoms:
+        return True
+    if struct.getNumAtoms('S') > maxSulfurAtoms:
+        return True
+    if len(struct.atoms) - H > maxHeavyAtoms:
+        return True
+    if (struct.getNumberOfRadicalElectrons() > maxRadicals):
+        return True
+    return False

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -351,18 +351,18 @@ class KineticsDatabase(object):
                 onoff = 'on ' if self.recommendedFamilies[label] else 'off'
                 f.write("{num:<2d}    {onoff}     {label}\n".format(num=number, label=label, onoff=onoff))
     
-    def generateReactions(self, reactants, products=None, failsSpeciesConstraints=None):
+    def generateReactions(self, reactants, products=None):
         """
         Generate all reactions between the provided list of one or two
         `reactants`, which should be :class:`Molecule` objects. This method
         searches the depository, libraries, and groups, in that order.
         """
         reactionList = []
-        reactionList.extend(self.generateReactionsFromLibraries(reactants, products, failsSpeciesConstraints=failsSpeciesConstraints))
-        reactionList.extend(self.generateReactionsFromFamilies(reactants, products, failsSpeciesConstraints=failsSpeciesConstraints))
+        reactionList.extend(self.generateReactionsFromLibraries(reactants, products))
+        reactionList.extend(self.generateReactionsFromFamilies(reactants, products))
         return reactionList
 
-    def generateReactionsFromLibraries(self, reactants, products, failsSpeciesConstraints=None):
+    def generateReactionsFromLibraries(self, reactants, products):
         """
         Generate all reactions between the provided list of one or two
         `reactants`, which should be :class:`Molecule` objects. This method
@@ -372,10 +372,10 @@ class KineticsDatabase(object):
         for label, libraryType in self.libraryOrder:
             # Generate reactions from reaction libraries (no need to generate them from seeds)
             if libraryType == "Reaction Library":
-                reactionList.extend(self.generateReactionsFromLibrary(reactants, products, self.libraries[label], failsSpeciesConstraints=failsSpeciesConstraints))
+                reactionList.extend(self.generateReactionsFromLibrary(reactants, products, self.libraries[label]))
         return reactionList
 
-    def generateReactionsFromLibrary(self, reactants, products, library, failsSpeciesConstraints=None):
+    def generateReactionsFromLibrary(self, reactants, products, library):
         """
         Generate all reactions between the provided list of one or two
         `reactants`, which should be :class:`Molecule` objects. This method
@@ -399,7 +399,7 @@ class KineticsDatabase(object):
             reactionList = filterReactions(reactants, products, reactionList)
         return reactionList
 
-    def generateReactionsFromFamilies(self, reactants, products, only_families=None, failsSpeciesConstraints=None):
+    def generateReactionsFromFamilies(self, reactants, products, only_families=None):
         """
         Generate all reactions between the provided list of one or two
         `reactants`, which should be :class:`Molecule` objects. This method
@@ -416,7 +416,7 @@ class KineticsDatabase(object):
         reactionList = []
         for label, family in self.families.iteritems():
             if only_families is None or label in only_families:
-                reactionList.extend(family.generateReactions(reactants, failsSpeciesConstraints=failsSpeciesConstraints))
+                reactionList.extend(family.generateReactions(reactants))
         if products:
             reactionList = filterReactions(reactants, products, reactionList)
         return reactionList

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -37,6 +37,7 @@ import logging
 import codecs
 from copy import deepcopy
 
+from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.data.base import Database, Entry, LogicNode, LogicOr, ForbiddenStructures,\
                             ForbiddenStructureException, getAllCombinations
 from rmgpy.reaction import Reaction
@@ -1116,10 +1117,9 @@ class KineticsFamily(Database):
         # Apply the generated species constraints (if given)
         for struct in productStructures:
             if self.isMoleculeForbidden(struct):
-                raise ForbiddenStructureException()
-            if failsSpeciesConstraints:
-                if failsSpeciesConstraints(struct):
-                    raise ForbiddenStructureException() 
+                raise ForbiddenStructureException() 
+            if failsSpeciesConstraints(struct):
+                raise ForbiddenStructureException() 
                 
         return productStructures
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1067,7 +1067,7 @@ class KineticsFamily(Database):
         # Return the product structures
         return productStructures
 
-    def __generateProductStructures(self, reactantStructures, maps, forward, failsSpeciesConstraints=None):
+    def __generateProductStructures(self, reactantStructures, maps, forward):
         """
         For a given set of `reactantStructures` and a given set of `maps`,
         generate and return the corresponding product structures. The
@@ -1076,8 +1076,6 @@ class KineticsFamily(Database):
         parameter is a list of mappings of the top-level tree node of each
         *template* reactant to the corresponding *structure*. This function
         returns a list of the product structures.
-        `failsSpeciesConstraints` is a function that accepts a :class:`Molecule`
-        structure and returns `True` if it is forbidden.
         """
         
         productStructures = None
@@ -1191,7 +1189,7 @@ class KineticsFamily(Database):
         elif isinstance(struct, Group):
             return reactant.findSubgraphIsomorphisms(struct)
 
-    def generateReactions(self, reactants, failsSpeciesConstraints=None):
+    def generateReactions(self, reactants):
         """
         Generate all reactions between the provided list of one or two
         `reactants`, which should be either single :class:`Molecule` objects
@@ -1205,12 +1203,12 @@ class KineticsFamily(Database):
         reactionList = []
         
         # Forward direction (the direction in which kinetics is defined)
-        reactionList.extend(self.__generateReactions(reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints))
+        reactionList.extend(self.__generateReactions(reactants, forward=True))
         
         if self.ownReverse:
             # for each reaction, make its reverse reaction and store in a 'reverse' attribute
             for rxn in reactionList:
-                reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints)
+                reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True)
                 if len(reactions) != 1:
                     logging.error("Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                     for reactant in rxn.reactants:
@@ -1224,7 +1222,7 @@ class KineticsFamily(Database):
             
         else: # family is not ownReverse
             # Reverse direction (the direction in which kinetics is not defined)
-            reactionList.extend(self.__generateReactions(reactants, forward=False, failsSpeciesConstraints=failsSpeciesConstraints))
+            reactionList.extend(self.__generateReactions(reactants, forward=False))
             
         # Return the reactions as containing Species objects, not Molecule objects
         for reaction in reactionList:
@@ -1255,7 +1253,7 @@ class KineticsFamily(Database):
                                  'but generated {2}').format(reaction, self.label, len(reactions)))
         return reactions[0].degeneracy
         
-    def __generateReactions(self, reactants, products=None, forward=True, failsSpeciesConstraints=None):
+    def __generateReactions(self, reactants, products=None, forward=True):
         """
         Generate a list of all of the possible reactions of this family between
         the list of `reactants`. The number of reactants provided must match
@@ -1263,8 +1261,6 @@ class KineticsFamily(Database):
         will return an empty list. Each item in the list of reactants should
         be a list of :class:`Molecule` objects, each representing a resonance
         isomer of the species of interest.
-        `failsSpeciesConstraints` is an optional function that accepts a :class:`Molecule`
-        structure and returns `True` if it is forbidden.
         """
 
         rxnList = []; speciesList = []
@@ -1300,7 +1296,7 @@ class KineticsFamily(Database):
                 for map in mappings:
                     reactantStructures = [molecule]
                     try:
-                        productStructures = self.__generateProductStructures(reactantStructures, [map], forward, failsSpeciesConstraints=failsSpeciesConstraints)
+                        productStructures = self.__generateProductStructures(reactantStructures, [map], forward)
                     except ForbiddenStructureException:
                         pass
                     else:
@@ -1327,7 +1323,7 @@ class KineticsFamily(Database):
                         for mapB in mappingsB:
                             reactantStructures = [moleculeA, moleculeB]
                             try:
-                                productStructures = self.__generateProductStructures(reactantStructures, [mapA, mapB], forward, failsSpeciesConstraints=failsSpeciesConstraints)
+                                productStructures = self.__generateProductStructures(reactantStructures, [mapA, mapB], forward)
                             except ForbiddenStructureException:
                                 pass
                             else:
@@ -1347,7 +1343,7 @@ class KineticsFamily(Database):
                             for mapB in mappingsB:
                                 reactantStructures = [moleculeA, moleculeB]
                                 try:
-                                    productStructures = self.__generateProductStructures(reactantStructures, [mapA, mapB], forward, failsSpeciesConstraints=failsSpeciesConstraints)
+                                    productStructures = self.__generateProductStructures(reactantStructures, [mapA, mapB], forward)
                                 except ForbiddenStructureException:
                                     pass
                                 else:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -366,9 +366,10 @@ def readInputFile(path, rmg0):
         raise
     finally:
         f.close()
-
-    broadcast(rmg.speciesConstraints, 'speciesConstraints')
     
+    rmg.speciesConstraints['explicitlyAllowedMolecules'] = []         
+    broadcast(rmg.speciesConstraints, 'speciesConstraints')
+
     # convert keys from species names into species objects.
     for reactionSystem in rmg.reactionSystems:
         reactionSystem.convertInitialKeysToSpeciesObjects(speciesDict)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -42,7 +42,7 @@ from rmgpy.solver.liquid import LiquidReactor
 
 from model import CoreEdgeReactionModel
 
-from rmgpy.scoop_framework.util import broadcast
+from rmgpy.scoop_framework.util import broadcast, get
 
 ################################################################################
 
@@ -584,3 +584,31 @@ def saveInputFile(path, rmg):
     f.write(')\n\n')
     
     f.close()
+
+def getInput(name):
+    """
+    Returns the RMG input object that corresponds
+    to the parameter name.
+
+    First, the module level is queried. If this variable
+    is empty, the broadcasted variables are queried.
+    """
+    global rmg
+
+    if rmg:
+        if name == 'speciesConstraints':
+            return rmg.speciesConstraints
+        else:
+            raise Exception('Unrecognized keyword: {}'.format(name))
+    else:
+        try:
+            obj = get(name)
+            if obj:
+                return obj
+            else:
+                raise Exception
+        except Exception, e:
+            logging.error("Did not find a way to obtain the broadcasted variable for {}.".format(name))
+            raise e
+
+    raise Exception('Could not get variable with name: {}'.format(name))

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -42,6 +42,8 @@ from rmgpy.solver.liquid import LiquidReactor
 
 from model import CoreEdgeReactionModel
 
+from rmgpy.scoop_framework.util import broadcast
+
 ################################################################################
 
 class InputError(Exception): pass
@@ -287,6 +289,7 @@ def options(units='si', saveRestartPeriod=None, generateOutputHTML=False, genera
     rmg.saveEdgeSpecies = saveEdgeSpecies
 
 def generatedSpeciesConstraints(**kwargs):
+
     validConstraints = [
         'allowed',
         'maximumCarbonAtoms',
@@ -299,9 +302,11 @@ def generatedSpeciesConstraints(**kwargs):
         'maximumRadicalElectrons',
         'allowSingletO2',
     ]
+
     for key, value in kwargs.items():
         if key not in validConstraints:
             raise InputError('Invalid generated species constraint {0!r}.'.format(key))
+        
         rmg.speciesConstraints[key] = value
 
 ################################################################################
@@ -362,6 +367,8 @@ def readInputFile(path, rmg0):
     finally:
         f.close()
 
+    broadcast(rmg.speciesConstraints, 'speciesConstraints')
+    
     # convert keys from species names into species objects.
     for reactionSystem in rmg.reactionSystems:
         reactionSystem.convertInitialKeysToSpeciesObjects(speciesDict)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -200,7 +200,7 @@ class RMG(util.Subject):
         if self.pressureDependence:
             self.pressureDependence.outputFile = self.outputDirectory
             self.reactionModel.pressureDependence = self.pressureDependence
-        self.reactionModel.speciesConstraints = self.speciesConstraints
+
         self.reactionModel.verboseComments = self.verboseComments
         
         if self.quantumMechanics:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -192,7 +192,6 @@ class RMG(util.Subject):
         from input import readInputFile
         if path is None: path = self.inputFile
         readInputFile(path, self)
-        self.speciesConstraints['explicitlyAllowedMolecules'] = [] 
         self.reactionModel.kineticsEstimator = self.kineticsEstimator
         # If the output directory is not yet set, then set it to the same
         # directory as the input file by default

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -42,6 +42,7 @@ import numpy
 import csv
 import gc
 
+from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.molecule import Molecule
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 from rmgpy.solver.simple import SimpleReactor
@@ -426,7 +427,7 @@ class RMG(util.Subject):
                         logging.warning('Input species {0} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.'.format(spec.label))
                     else:
                         raise ForbiddenStructureException("Input species {0} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label))
-                if self.reactionModel.failsSpeciesConstraints(spec):
+                if failsSpeciesConstraints(spec):
                     if 'allowed' in self.speciesConstraints and 'input species' in self.speciesConstraints['allowed']:
                         self.speciesConstraints['explicitlyAllowedMolecules'].append(spec.molecule[0])
                         pass

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -631,12 +631,12 @@ class CoreEdgeReactionModel:
         reactionList = []
         if speciesB is None:
             for moleculeA in speciesA.molecule:
-                reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA], products=None, failsSpeciesConstraints=self.failsSpeciesConstraints))
+                reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA], products=None))
                 moleculeA.clearLabeledAtoms()
         else:
             for moleculeA in speciesA.molecule:
                 for moleculeB in speciesB.molecule:
-                    reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA, moleculeB], products=None, failsSpeciesConstraints=self.failsSpeciesConstraints))
+                    reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA, moleculeB], products=None))
                     moleculeA.clearLabeledAtoms()
                     moleculeB.clearLabeledAtoms()
         return reactionList

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -375,7 +375,6 @@ class CoreEdgeReactionModel:
         self.quantumMechanics = None
         self.verboseComments = False
         self.kineticsEstimator = 'group additivity'
-        self.speciesConstraints = {}
 
     def checkForExistingSpecies(self, molecule):
         """
@@ -1301,6 +1300,8 @@ class CoreEdgeReactionModel:
 
         if react: raise NotImplementedError("react=True doesn't work yet")
         database = rmgpy.data.rmg.database
+
+        from rmgpy.rmg.input import rmg
         
         self.newReactionList = []; self.newSpeciesList = []
 
@@ -1322,13 +1323,13 @@ class CoreEdgeReactionModel:
         
         for spec in self.newSpeciesList:
             if database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0]):
-                if 'allowed' in self.speciesConstraints and 'seed mechanisms' in self.speciesConstraints['allowed']:
+                if 'allowed' in rmg.speciesConstraints and 'seed mechanisms' in rmg.speciesConstraints['allowed']:
                     logging.warning("Species {0} from seed mechanism {1} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.".format(spec.label, seedMechanism.label))
                 else:
                     raise ForbiddenStructureException("Species {0} from seed mechanism {1} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label, seedMechanism.label))
             if self.failsSpeciesConstraints(spec):
-                if 'allowed' in self.speciesConstraints and 'seed mechanisms' in self.speciesConstraints['allowed']:
-                    self.speciesConstraints['explicitlyAllowedMolecules'].extend(spec.molecule)
+                if 'allowed' in rmg.speciesConstraints and 'seed mechanisms' in rmg.speciesConstraints['allowed']:
+                    rmg.speciesConstraints['explicitlyAllowedMolecules'].extend(spec.molecule)
                 else:
                     raise ForbiddenStructureException("Species constraints forbids species {0} from seed mechanism {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, seedMechanism.label))
 
@@ -1368,6 +1369,8 @@ class CoreEdgeReactionModel:
 
         database = rmgpy.data.rmg.database
 
+        from rmgpy.rmg.input import rmg
+
         self.newReactionList = []
         self.newSpeciesList = []
 
@@ -1388,13 +1391,13 @@ class CoreEdgeReactionModel:
         # Perform species constraints and forbidden species checks
         for spec in self.newSpeciesList:
             if database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0]):
-                if 'allowed' in self.speciesConstraints and 'reaction libraries' in self.speciesConstraints['allowed']:
+                if 'allowed' in rmg.speciesConstraints and 'reaction libraries' in rmg.speciesConstraints['allowed']:
                     logging.warning("Species {0} from reaction library {1} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.".format(spec.label, reactionLibrary.label))
                 else:
                     raise ForbiddenStructureException("Species {0} from reaction library {1} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label, reactionLibrary.label))
             if self.failsSpeciesConstraints(spec):
-                if 'allowed' in self.speciesConstraints and 'reaction libraries' in self.speciesConstraints['allowed']:
-                    self.speciesConstraints['explicitlyAllowedMolecules'].extend(spec.molecule)
+                if 'allowed' in rmg.speciesConstraints and 'reaction libraries' in rmg.speciesConstraints['allowed']:
+                    rmg.speciesConstraints['explicitlyAllowedMolecules'].extend(spec.molecule)
                 else:
                     raise ForbiddenStructureException("Species constraints forbids species {0} from reaction library {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, reactionLibrary.label))
        


### PR DESCRIPTION
This PR addresses some of the concerns vented in #521 regarding the manipulation of static user input information like species constraints.

In the current design:
- the `failsSpeciesConstraints` method is moved to the constraints module since it was called in various places; 
- passing the function name to various methods is deprecated: when a method needs the species constraints, it simply calls the global rmg variable that already stored that info
- the species constraints are broadcasted when the info is needed on a remote worker instead of the root worker, and a convenience function `getInput` is created that searches for that info in the global rmg variable or the broadcasted variable.