### PR TITLE
Parallel generation of reactions in `enlarge`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,14 @@ eg7: all
 	@ echo "Running gri_mech_rxn_lib example."
 	python rmg.py testing/gri_mech_rxn_lib/input.py
 	
+scoop: noQM
+	mkdir -p testing/scoop
+	rm -rf testing/scoop/*
+	cp examples/rmg/minimal/input.py testing/scoop/input.py
+	coverage erase
+	@ echo "Running minimal example with SCOOP"
+	python -m scoop -n 2 rmg.py -v testing/scoop/input.py
+
 ######### 
 # Section for setting up MOPAC calculations on the Travis-CI.org server
 ifeq ($(TRAVIS),true)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1128,10 +1128,13 @@ class KineticsFamily(Database):
         Return ``True`` if the molecule is forbidden in this family, or
         ``False`` otherwise. 
         """
-        from rmgpy.data.rmg import database
+        from rmgpy.data.rmg import getDB
+        
+        forbidden_structures = getDB('forbidden')
+
         if self.forbidden is not None and self.forbidden.isMoleculeForbidden(molecule):
             return True
-        if database.forbiddenStructures.isMoleculeForbidden(molecule):
+        if forbidden_structures.isMoleculeForbidden(molecule):
             return True
         return False
 

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -34,6 +34,7 @@ for working with the RMG database.
 """
 
 import os.path
+import logging
 
 from base import ForbiddenStructures
 from thermo import ThermoDatabase
@@ -68,7 +69,6 @@ class RMGDatabase:
         if database is None:
             database = self
         else:
-            import logging
             logging.warning("Should only make one instance of RMGDatabase because it's stored as a module-level variable!")
             logging.warning("Unexpected behaviour may result!")
 

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -42,7 +42,7 @@ from rmgpy.data.kinetics.database import KineticsDatabase
 from statmech import StatmechDatabase
 from solvation import SolvationDatabase
 
-from rmgpy.scoop_framework.util import broadcast
+from rmgpy.scoop_framework.util import get, broadcast
 
 # Module-level variable to store the (only) instance of RMGDatabase in use.
 database = None
@@ -226,3 +226,41 @@ class RMGDatabase:
         self.forbiddenStructures.saveOld(os.path.join(path, 'ForbiddenStructures.txt'))
         self.kinetics.saveOld(path)
         self.statmech.saveOld(path)
+
+def getDB(name):
+    """
+    Returns the RMG database object that corresponds
+    to the parameter name.
+
+    First, the module level is queried. If this variable
+    is empty, the broadcasted variables are queried.
+    """
+    global database
+
+    if database:
+        if name == 'kinetics':
+            return database.kinetics
+        elif name == 'thermo':
+            return database.thermo
+        elif name == 'transport':
+            return database.transport
+        elif name == 'solvation':
+            return database.solvation
+        elif name == 'statmech':
+            return database.statmech
+        elif name == 'forbidden':
+            return database.forbiddenStructures
+        else:
+            raise Exception('Unrecognized database keyword: {}'.format(name))
+    else:
+        try:
+            db = get(name)
+            if db:
+                return db
+            else:
+                raise Exception
+        except Exception, e:
+            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
+            raise e
+
+    raise Exception('Could not get database with name: {}'.format(name))

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -684,16 +684,24 @@ class CoreEdgeReactionModel:
                     logging.info('Adding species {0} to model core'.format(newSpecies))
                     display(newSpecies) # if running in IPython --pylab mode, draws the picture!
                     
+                    familyKeys = database.kinetics.families.keys()
+                    familieCount = len(familyKeys)
+
                     # Find reactions involving the new species as unimolecular reactant
                     # or product (e.g. A <---> products)
-                    newReactions.extend(self.react(database, newSpecies))
+
+                    results_A = map_(
+                                    WorkerWrapper(react_family),
+                                    familyKeys,
+                                    [newSpecies] * familieCount,
+                                    [[]] * familieCount
+                                )
+
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with other core species (e.g. A + B <---> products)
 
-                    familyKeys = database.kinetics.families.keys()
                     corespeciesList = self.core.species
 
-                    familieCount = len(familyKeys)
                     results_AB = map_(
                                     WorkerWrapper(react_family),
                                     familyKeys,
@@ -711,7 +719,7 @@ class CoreEdgeReactionModel:
                                     [[newSpecies.copy(deep=True)]] * familieCount
                                 )
 
-                    for result in itertools.chain(results_AA, results_AB):
+                    for result in itertools.chain(results_A, results_AA, results_AB):
                         newReactions.extend(result)
     
                 # Add new species
@@ -1803,7 +1811,7 @@ def getKey(spc):
         
 def react_family(familyKey, spcA, speciesList):
     """
-    Generate bimolecular reactions for one specific family.
+    Generate uni and bimolecular reactions for one specific family.
     :return: a list of new reactions
     """
 
@@ -1812,14 +1820,31 @@ def react_family(familyKey, spcA, speciesList):
     families = getDB('kinetics').families
     family = families[familyKey]
 
-    for spcB in speciesList:
-        if spcB.reactive:
-            for molA in spcA.molecule:
-                for molB in spcB.molecule:
-                    reactionList.extend(family.generateReactions(
-                        [molA, molB]))
-                    molA.clearLabeledAtoms()
-                    molB.clearLabeledAtoms()
+    unimolecular = not speciesList
+
+    for molA in spcA.molecule:
+        if unimolecular:
+            reactants = [molA]
+                        
+            reactionList.extend(
+                family.generateReactions(reactants)
+                )
+
+            for reactant in reactants:
+                reactant.clearLabeledAtoms()
+
+        else:#bimolecular
+            for spcB in speciesList:
+                if spcB.reactive:
+                    for molB in spcB.molecule:
+                        reactants = [molA, molB]
+                        
+                        reactionList.extend(
+                            family.generateReactions(reactants)
+                            )
+
+                        for reactant in reactants:
+                            reactant.clearLabeledAtoms()
 
     logging.debug("{} reactions are generated from {}"
              .format(len(reactionList), familyKey)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -694,17 +694,25 @@ class CoreEdgeReactionModel:
                     corespeciesList = self.core.species
 
                     familieCount = len(familyKeys)
-                    results = map_(WorkerWrapper(react_family), familyKeys,
-                                    [newSpecies]*familieCount,
-                                    [corespeciesList]*familieCount
+                    results_AB = map_(
+                                    WorkerWrapper(react_family),
+                                    familyKeys,
+                                    [newSpecies] * familieCount,
+                                    [corespeciesList] * familieCount
                                 )
-                            
-  
-                    [newReactions.extend(result) for result in results]
+                    
 
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with itself (e.g. A + A <---> products)
-                    newReactions.extend(self.react(database, newSpecies, newSpecies))
+                    results_AA = map_(
+                                    WorkerWrapper(react_family),
+                                    familyKeys,
+                                    [newSpecies] * familieCount,
+                                    [[newSpecies.copy(deep=True)]] * familieCount
+                                )
+
+                    for result in itertools.chain(results_AA, results_AB):
+                        newReactions.extend(result)
     
                 # Add new species
                 reactionsMovedFromEdge = self.addSpeciesToCore(newSpecies)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -691,7 +691,7 @@ class CoreEdgeReactionModel:
                     # or product (e.g. A <---> products)
 
                     results_A = map_(
-                                    WorkerWrapper(react_family),
+                                    WorkerWrapper(reactFamily),
                                     familyKeys,
                                     [newSpecies] * familieCount,
                                     [[]] * familieCount
@@ -703,7 +703,7 @@ class CoreEdgeReactionModel:
                     corespeciesList = self.core.species
 
                     results_AB = map_(
-                                    WorkerWrapper(react_family),
+                                    WorkerWrapper(reactFamily),
                                     familyKeys,
                                     [newSpecies] * familieCount,
                                     [corespeciesList] * familieCount
@@ -713,7 +713,7 @@ class CoreEdgeReactionModel:
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with itself (e.g. A + A <---> products)
                     results_AA = map_(
-                                    WorkerWrapper(react_family),
+                                    WorkerWrapper(reactFamily),
                                     familyKeys,
                                     [newSpecies] * familieCount,
                                     [[newSpecies.copy(deep=True)]] * familieCount
@@ -1809,72 +1809,65 @@ def getKey(spc):
     return spc.label
 
         
-def react_family(familyKey, spcA, speciesList):
+def reactFamily(familyKey, spcA, speciesList):
     """
     Generate uni and bimolecular reactions for one specific family.
     :return: a list of new reactions
     """
 
-    reactionList = []
-
-    families = getDB('kinetics').families
-    family = families[familyKey]
-
-    unimolecular = not speciesList
-    if unimolecular:
-        for molA in spcA.molecule:
-            reactants = [molA]
-                        
-            reactionList.extend(
-                family.generateReactions(reactants)
-                )
-
-            for reactant in reactants:
-                reactant.clearLabeledAtoms()
-
+    if not speciesList:
+        combos = [[spcA]]
     else:
-
         reactive_species = [spc for spc in speciesList if spc.reactive]
-        speciesCount = len(reactive_species)
-        
         if reactive_species:
-            results = map_(
-                        WorkerWrapper(reactSpecies),
-                        reactive_species,
-                        [spcA] * speciesCount,
-                        [familyKey] * speciesCount,
-                        )
+            combos = list(itertools.product(reactive_species, [spcA]))
+        else:
+            return []
 
-            for result in results:
-                reactionList.extend(result)
+    results = map_(
+                WorkerWrapper(reactSpecies),
+                combos,
+                [familyKey] * len(combos),
+                )
 
-    logging.debug("{} reactions are generated from {}"
-             .format(len(reactionList), familyKey)
-            )
+    # flatten list of lists:
+    reactionList = list(itertools.chain.from_iterable(results))
+    
+    return reactionList
+
+def reactSpecies(speciesList, familyKey):
+    """
+    Performs a reaction between the
+    species in the list for the given family key.
+    """
+
+    molList = [spc.molecule for spc in speciesList]
+
+    combos = list(itertools.product(*molList))
+
+    results = map_(
+                WorkerWrapper(reactMolecules),
+                combos,
+                [familyKey] * len(combos),
+                )
+
+    # flatten list of lists:
+    reactionList = list(itertools.chain.from_iterable(results))
 
     return reactionList
 
-def reactSpecies(spcA, spcB, familyKey):
+def reactMolecules(molecules, familyKey):
     """
-    Performs a bimolecular reaction between
-    species A and B for the given family key.
+    Performs a reaction between
+    the resonance isomers for the given family key.
     """
-    reactionList = []
 
     families = getDB('kinetics').families
     family = families[familyKey]
 
-    for molA in spcA.molecule:
-        for molB in spcB.molecule:
+    reactionList = family.generateReactions(list(molecules))
 
-            reactants = [molA, molB]
-            
-            reactionList.extend(
-                family.generateReactions(reactants)
-                )
-
-            for reactant in reactants:
-                reactant.clearLabeledAtoms()
+    for reactant in molecules:
+        reactant.clearLabeledAtoms()
 
     return reactionList
-

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1793,21 +1793,21 @@ def getKey(spc):
     return spc.label
 
         
-def react_family(familyKey, newSpecies, coreSpecies):
+def react_family(familyKey, spcA, speciesList):
     """
-    Generate bimolecular reactions for one specific family
-    and species A is different than species B where B is one of old core species
-    :param family: in database.kinetics.families
-    :param newSpecies: new core species
+    Generate bimolecular reactions for one specific family.
     :return: a list of new reactions
     """
+
     reactionList = []
+
     families = getDB('kinetics').families
     family = families[familyKey]
-    for oldCoreSpecies in coreSpecies:
-        if oldCoreSpecies.reactive:
-            for molA in newSpecies.molecule:
-                for molB in oldCoreSpecies.molecule:
+
+    for spcB in speciesList:
+        if spcB.reactive:
+            for molA in spcA.molecule:
+                for molB in spcB.molecule:
                     reactionList.extend(family.generateReactions(
                         [molA, molB]))
                     molA.clearLabeledAtoms()

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -58,7 +58,7 @@ import rmgpy.data.rmg
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
 
-from rmgpy.scoop_framework.util import get, map_
+from rmgpy.scoop_framework.util import get, map_, WorkerWrapper
 
 ################################################################################
 
@@ -719,7 +719,7 @@ class CoreEdgeReactionModel:
 
                     familieCount = len(familyKeys)
                     results = list(
-                                map_(self.react_family, familyKeys,
+                                map_(WorkerWrapper(self.react_family), familyKeys,
                                     [newSpecies]*familieCount,
                                     [corespeciesList]*familieCount
                                     )

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -58,7 +58,7 @@ import rmgpy.data.rmg
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
 
-
+from rmgpy.scoop_framework.util import get, map_
 
 ################################################################################
 
@@ -641,23 +641,30 @@ class CoreEdgeReactionModel:
                     moleculeB.clearLabeledAtoms()
         return reactionList
 
-    def react_family(self, family, speciesA):
+    def react_family(self, familyKey, newSpecies, coreSpecies):
         """
         Generate bimolecular reactions for one specific family
         and species A is different than species B where B is one of old core species
         :param family: in database.kinetics.families
-        :param speciesA: new core species
+        :param newSpecies: new core species
         :return: a list of new reactions
         """
         reactionList = []
-        for oldCoreSpecies in self.core.species:
+        families = get('kinetics').families
+        family = families[familyKey]
+        for oldCoreSpecies in coreSpecies:
             if oldCoreSpecies.reactive:
-                for molA in speciesA.molecule:
+                for molA in newSpecies.molecule:
                     for molB in oldCoreSpecies.molecule:
                         reactionList.extend(family.generateReactions(
                             [molA, molB], failsSpeciesConstraints=self.failsSpeciesConstraints))
                         molA.clearLabeledAtoms()
                         molB.clearLabeledAtoms()
+
+        logging.info("{} reactions are generated from {}"
+                 .format(len(reactionList), familyKey)
+                )
+
         return reactionList
 
 
@@ -706,9 +713,19 @@ class CoreEdgeReactionModel:
                     newReactions.extend(self.react(database, newSpecies))
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with other core species (e.g. A + B <---> products)
-                    # generate all the reactions family by family which is helpful to parallelism
-                    for label, family in database.kinetics.families.iteritems():
-                        newReactions.extend(self.react_family(family, newSpecies))
+
+                    familyKeys = database.kinetics.families.keys()
+                    corespeciesList = self.core.species
+
+                    familieCount = len(familyKeys)
+                    results = list(
+                                map_(self.react_family, familyKeys,
+                                    [newSpecies]*familieCount,
+                                    [corespeciesList]*familieCount
+                                    )
+                                )
+  
+                    [newReactions.extend(result) for result in results]
 
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with itself (e.g. A + A <---> products)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -51,14 +51,16 @@ from rmgpy.data.base import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
+from rmgpy.data.rmg import getDB
 from rmgpy.kinetics import KineticsData
 import rmgpy.data.rmg
+
 
 
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
 
-from rmgpy.scoop_framework.util import get, map_, WorkerWrapper
+from rmgpy.scoop_framework.util import map_, WorkerWrapper
 
 ################################################################################
 
@@ -1790,40 +1792,6 @@ def getKey(spc):
     """
 
     return spc.label
-
-
-def getDB(name):
-    """
-    Returns the RMG database object that corresponds
-    to the parameter name.
-
-    First, the module level is queried. If this variable
-    is empty, the broadcasted variables are queried.
-    """
-
-    database = rmgpy.data.rmg.database
-
-    if database:
-        if name == 'kinetics':
-            return database.kinetics
-        elif name == 'thermo':
-            return database.thermo
-        elif name == 'transport':
-            return database.transport
-        elif name == 'solvation':
-            return database.solvation
-        elif name == 'statmech':
-            return database.statmech
-        elif name == 'forbidden':
-            return database.forbiddenStructures
-        else:
-            raise Exception('Unrecognized database keyword: {}'.format(name))
-    else:
-        try:
-            db = get(name)
-        except Exception, e:
-            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
-            raise e
 
         
 def react_family(familyKey, newSpecies, coreSpecies):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -694,12 +694,11 @@ class CoreEdgeReactionModel:
                     corespeciesList = self.core.species
 
                     familieCount = len(familyKeys)
-                    results = list(
-                                map_(WorkerWrapper(react_family), familyKeys,
+                    results = map_(WorkerWrapper(react_family), familyKeys,
                                     [newSpecies]*familieCount,
                                     [corespeciesList]*familieCount
-                                    )
                                 )
+                            
   
                     [newReactions.extend(result) for result in results]
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -650,7 +650,7 @@ class CoreEdgeReactionModel:
         :return: a list of new reactions
         """
         reactionList = []
-        families = get('kinetics').families
+        families = getDB('kinetics').families
         family = families[familyKey]
         for oldCoreSpecies in coreSpecies:
             if oldCoreSpecies.reactive:
@@ -1816,3 +1816,38 @@ def getKey(spc):
     """
 
     return spc.label
+
+
+def getDB(name):
+    """
+    Returns the RMG database object that corresponds
+    to the parameter name.
+
+    First, the module level is queried. If this variable
+    is empty, the broadcasted variables are queried.
+    """
+
+    database = rmgpy.data.rmg.database
+
+    if database:
+        if name == 'kinetics':
+            return database.kinetics
+        elif name == 'thermo':
+            return database.thermo
+        elif name == 'transport':
+            return database.transport
+        elif name == 'solvation':
+            return database.solvation
+        elif name == 'statmech':
+            return database.statmech
+        elif name == 'forbidden':
+            return database.forbiddenStructures
+        else:
+            raise Exception('Unrecognized database keyword: {}'.format(name))
+    else:
+        try:
+            db = get(name)
+        except Exception, e:
+            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
+            raise e
+        

--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -39,6 +39,7 @@ from functools import wraps
 
 try:
     from scoop import futures
+    from scoop.futures import map
     from scoop import shared
     from scoop import logger as logging
 
@@ -147,3 +148,6 @@ def get(key):
         Name error will be caught when the SCOOP library is not imported properly.
         """
         logging.debug('SCOOP not loaded. Not retrieving the shared object with key {}'.format(key))
+
+def map_(*args, **kwargs):
+    return map(*args, **kwargs)


### PR DESCRIPTION
This PR introduces a new design for the generation of reactions in parallel.

In the `rmgpy.rmg.model.CoreEdgeReactionModel.enlarge` method, reactions between a new core species and the existing list of core species, for the given list of available reaction families. This process is parallelized across the reaction families, across the list of core species and across the list of resonance isomers of a specific species both for uni- and bimolecular reaction families to minimize worker load imbalances due to the _heterogeneity_ of reaction families, species, and molecules. 

A lazy evaluation scheme of the tasks is chosen to maximize the number of tasks being run at the same time.

- A uniform `rmgpy.scoop_framework.util.map_` interface is introduced that either uses the parallel `map` function of SCOOP, or the serial map of python if scoop is not loaded.
- A new test target `make scoop` in Makefile is created to illustrate the launch of the parallel version using the minimal example.
- A uniform `rmgpy.data.rmg.getDB` interface allows retrieving RMG-database info, either from the global `rmgpy.data.rmg.database` variable, or from broadcasted variables when that global variable is not available (e.g. on remote workers).