### PR TITLE
anticipate situation in which species constraints are not loaded.

### DIFF
--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -39,7 +39,13 @@ def failsSpeciesConstraints(species):
     """
     
     from rmgpy.rmg.input import getInput
-    speciesConstraints = getInput('speciesConstraints')
+
+    try:
+        speciesConstraints = getInput('speciesConstraints')
+    except Exception, e:
+        logging.debug('Species constraints could not be found.')
+        speciesConstraints = {}
+    
 
     explicitlyAllowedMolecules = speciesConstraints.get('explicitlyAllowedMolecules', [])
     maxCarbonAtoms = speciesConstraints.get('maximumCarbonAtoms', 1000000)

--- a/rmgpy/constraintsTest.py
+++ b/rmgpy/constraintsTest.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2009 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This script contains unit tests of the :mod:`rmgpy.constraints` module.
+"""
+
+import unittest
+
+from rmgpy.constraints import *
+
+################################################################################
+
+class TestFailsSpeciesConstraints(unittest.TestCase):
+    """
+    Contains unit tests of the failsSpeciesConstraints function.
+    """
+            
+    def testConstraintsNotLoaded(self):
+        """
+        Test what happens when constraints are not loaded.
+        """
+        from rmgpy.species import Species
+
+        spc = Species().fromSMILES('C')
+
+        fails = failsSpeciesConstraints(spc)
+        self.assertFalse(fails)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -609,7 +609,7 @@ def getInput(name):
             else:
                 raise Exception
         except Exception, e:
-            logging.error("Did not find a way to obtain the broadcasted variable for {}.".format(name))
+            logging.debug("Did not find a way to obtain the variable for {}.".format(name))
             raise e
 
     raise Exception('Could not get variable with name: {}'.format(name))


### PR DESCRIPTION
fix RMG-website bug #104

cf. https://github.com/ReactionMechanismGenerator/RMG-website/issues/104