### PR TITLE
sort reactant and product lists in checkForExistingReaction

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -482,6 +482,10 @@ class CoreEdgeReactionModel:
         (a reaction with a different "family" key as the parameter reaction).
 
         """
+
+        # Make sure the reactant and product lists are sorted before performing the check
+        rxn.reactants.sort()
+        rxn.products.sort()
         
         familyObj = getFamilyLibraryObject(rxn.family)
         shortlist = self.searchRetrieveReactions(rxn)


### PR DESCRIPTION
this ensures that :

if (rxn0.reactants == rxn.reactants and rxn0.products == rxn.products) or \
   (rxn0.reactants == rxn.products and rxn0.products == rxn.reactants):

does not produce false negatives because of order differences of the
list elements