### PR TITLE
Filter Reactions during Enlarge Step in Flux Algorithm

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1959,7 +1959,7 @@ class ChemkinWriter(object):
     rmg.detach(listener)
     
     """
-    def __init__(self, outputDirectory):
+    def __init__(self, outputDirectory=''):
         super(ChemkinWriter, self).__init__()
         makeOutputSubdirectory(outputDirectory, 'chemkin')
     

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1225,7 +1225,7 @@ class KineticsFamily(Database):
                     # been formed in the first place.
                     tempObject = self.forbidden
                     self.forbidden = ForbiddenStructures()  # Initialize with empty one
-                    reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints)
+                    reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True)
                     if len(reactions) != 1:
                         logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                         raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1218,7 +1218,7 @@ class KineticsFamily(Database):
                     for product in rxn.products:
                         logging.info("Product")
                         logging.info(product.toAdjacencyList())
-                        logging.error("Debugging why no reaction was found...")
+                    logging.error("Debugging why no reaction was found...")
                     logging.error("Checking whether the family's forbidden species have affected reaction generation...")
                     # Set family's forbidden structures to empty for now to see if reaction gets generated...
                     # Note that it is not necessary to check global forbidden structures, because this reaction would not have

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1228,11 +1228,16 @@ class KineticsFamily(Database):
                     reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints)
                     if len(reactions) != 1:
                         logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
+                        raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
                     else:
                         logging.error("Error was fixed, the product is a forbidden structure when used as a reactant in the reverse direction.")
-                    
-                    raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
-                rxn.reverse = reactions[0]
+                        # Delete this reaction, since it should probably also be forbidden in the initial direction
+                        # Hack fix for now
+                        del rxn
+                else:
+                    rxn.reverse = reactions[0]
+
+
             
         else: # family is not ownReverse
             # Reverse direction (the direction in which kinetics is not defined)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -539,8 +539,14 @@ class RMG(util.Subject):
                         # We've shifted from not reacting to reacting
                         bimolecularReact[i,j] = True
                         
-        self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
+        forcedRecombinationProducts = self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
         logging.info('Completed initial enlarge edge step...')
+        
+        # Force any initial recombination products into the core
+        logging.info('Forcing recombination products into the core...')
+        for objectToEnlarge in forcedRecombinationProducts:
+            self.reactionModel.enlargeCore(objectToEnlarge)
+        logging.info('Done forcing recombination products into the core.')
         
         # Save react arrays into threshold arrays.  They are equivalent because this is the initial step
         unimolecularThreshold = unimolecularReact
@@ -675,8 +681,13 @@ class RMG(util.Subject):
 #                    for j in xrange(i,numCoreSpecies):
 #                        logging.info("{species_i}, {species_j}, {react}".format(species_i=str(self.reactionModel.core.species[i]),species_j=str(self.reactionModel.core.species[j]),react=bimolecularReact[i,j]))
 
-                self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
+                forcedRecombinationProducts = self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
 
+                # Force any generated recombination products into the core
+                logging.info('Forcing recombination products into the core...')
+                for objectToEnlarge in forcedRecombinationProducts:
+                    self.reactionModel.enlargeCore(objectToEnlarge)
+                logging.info('Done forcing recombination products into the core.')
 
             self.saveEverything()
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -627,14 +627,15 @@ class RMG(util.Subject):
                 
                 # Run a raw simulation to get concentrations
                 for index, reactionSystem in enumerate(self.reactionSystems):
+                    # Run with the same conditions as with pruning off
                     reactionSystem.simulate(
                         coreSpecies = self.reactionModel.core.species,
                         coreReactions = self.reactionModel.core.reactions,
                         edgeSpecies = [],
                         edgeReactions = [],
                         toleranceKeepInEdge = 0,
-                        toleranceMoveToCore = 1,
-                        toleranceInterruptSimulation = 1,
+                        toleranceMoveToCore = self.fluxToleranceMoveToCore,
+                        toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
                         pdepNetworks = self.reactionModel.networkList,
                         absoluteTolerance = self.absoluteTolerance,
                         relativeTolerance = self.relativeTolerance,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -606,8 +606,7 @@ class RMG(util.Subject):
                 
                 # If objects to enlarge are species rather than pdep networks, add them to core first
                 for objectToEnlarge in objectsToEnlarge:
-                    if isinstance(objectToEnlarge, Species):
-                        self.reactionModel.enlargeCore(objectToEnlarge)
+                    self.reactionModel.enlargeCore(objectToEnlarge)
                 
                 # Recalculate number of core species
                 numCoreSpecies = len(self.reactionModel.core.species)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -539,14 +539,8 @@ class RMG(util.Subject):
                         # We've shifted from not reacting to reacting
                         bimolecularReact[i,j] = True
                         
-        forcedRecombinationProducts = self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
+        self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
         logging.info('Completed initial enlarge edge step...')
-        
-        # Force any initial recombination products into the core
-        logging.info('Forcing recombination products into the core...')
-        for objectToEnlarge in forcedRecombinationProducts:
-            self.reactionModel.enlargeCore(objectToEnlarge)
-        logging.info('Done forcing recombination products into the core.')
         
         # Save react arrays into threshold arrays.  They are equivalent because this is the initial step
         unimolecularThreshold = unimolecularReact
@@ -681,13 +675,8 @@ class RMG(util.Subject):
 #                    for j in xrange(i,numCoreSpecies):
 #                        logging.info("{species_i}, {species_j}, {react}".format(species_i=str(self.reactionModel.core.species[i]),species_j=str(self.reactionModel.core.species[j]),react=bimolecularReact[i,j]))
 
-                forcedRecombinationProducts = self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
+                self.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
 
-                # Force any generated recombination products into the core
-                logging.info('Forcing recombination products into the core...')
-                for objectToEnlarge in forcedRecombinationProducts:
-                    self.reactionModel.enlargeCore(objectToEnlarge)
-                logging.info('Done forcing recombination products into the core.')
 
             self.saveEverything()
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -634,10 +634,12 @@ class CoreEdgeReactionModel:
         """
         reactionList = []
         if speciesB is None:
+            # React in a unimolecular reaction
             for moleculeA in speciesA.molecule:
                 reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA], products=None))
                 moleculeA.clearLabeledAtoms()
         else:
+            # React in a bimolecular reaction
             for moleculeA in speciesA.molecule:
                 for moleculeB in speciesB.molecule:
                     reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA, moleculeB], products=None))

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -696,6 +696,7 @@ class CoreEdgeReactionModel:
         # Generate kinetics of new reactions
         logging.info('Generating kinetics for new reactions...')
         for reaction in newReactionList:
+            family = getFamilyLibraryObject(reaction.family)
             # If the reaction already has kinetics (e.g. from a library),
             # assume the kinetics are satisfactory
             if reaction.kinetics is None:
@@ -706,7 +707,7 @@ class CoreEdgeReactionModel:
                 if not isForward:
                     reaction.reactants, reaction.products = reaction.products, reaction.reactants
                     reaction.pairs = [(p,r) for r,p in reaction.pairs]
-                if reaction.family.ownReverse and hasattr(reaction,'reverse'):
+                if family.ownReverse and hasattr(reaction,'reverse'):
                     if not isForward:
                         reaction.template = reaction.reverse.template
                     # We're done with the "reverse" attribute, so delete it to save a bit of memory

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -661,6 +661,7 @@ class CoreEdgeReactionModel:
         numCoreSpecies = len(self.core.species)
         reactionsMovedFromEdge = []
         newReactionList = []; newSpeciesList = []
+        forcedRecombinationProducts = []
         for i in xrange(numCoreSpecies):
             if unimolecularReact[i]:
                 # Find reactions involving the species that are unimolecular
@@ -678,8 +679,10 @@ class CoreEdgeReactionModel:
                     # these reactions are highly critical as sources and sinks of radicals and typically have low fluxes which are still important
                     # This is a bit of hardcoding based on intuitive understanding of radical chemistry
                     if self.core.species[i].molecule[0].isRadical() and self.core.species[j].molecule[0].isRadical():
+                        # Keep track of the number of new edge species resulting from R_Recombination.  These products are to be forced into the core later
+                        numPrevEdgeSpecies = len(self.edge.species)
                         self.processNewReactions(self.react(database, self.core.species[i], self.core.species[j], only_families=['R_Recombination']), self.core.species[j], None)
-        
+                        forcedRecombinationProducts.extend(self.edge.species[numPrevEdgeSpecies:])
             
         newSpeciesList.extend(self.newSpeciesList)
         newReactionList.extend(self.newReactionList)
@@ -753,6 +756,7 @@ class CoreEdgeReactionModel:
         )
 
         logging.info('')
+        return forcedRecombinationProducts
         
     def enlargeCore(self, newObject):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -659,19 +659,18 @@ class CoreEdgeReactionModel:
         numCoreSpecies = len(self.core.species)
         reactionsMovedFromEdge = []
         newReactionList = []; newSpeciesList = []
-        discoveredReactions = []
         for i in xrange(numCoreSpecies):
             if unimolecularReact[i]:
                 # Find reactions involving the species that are unimolecular
-                discoveredReactions.extend(self.react(database, self.core.species[i]))
+                self.processNewReactions(self.react(database, self.core.species[i]), self.core.species[i], None)
         for i in xrange(numCoreSpecies):
             for j in xrange(i,numCoreSpecies):
                 # Find reactions involving the species that are bimolecular
                 # This includes a species reacting with itself (if its own concentration is high enough)
                 
                 if bimolecularReact[i,j]:
-                    discoveredReactions.extend(self.react(database, self.core.species[i], self.core.species[j]))
-        self.processNewReactions(discoveredReactions, None, None)
+                    # Consider the latest added core species as the 'new' species
+                    self.processNewReactions(self.react(database, self.core.species[i], self.core.species[j]), self.core.species[j], None)
         
             
         newSpeciesList.extend(self.newSpeciesList)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1579,7 +1579,7 @@ class CoreEdgeReactionModel:
             products = newReaction.products[:]
         else:
             reactants = newReaction.products[:]
-            products = newReaction.products[:]
+            products = newReaction.reactants[:] 
         reactants.sort()
         products.sort()
         

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1094,20 +1094,20 @@ class CoreEdgeReactionModel:
 
         logging.info('')
         if enlargeCore:
-            logging.info('Summary of Model Core Enlargement')
+            logging.info('Summary of Model Enlargement')
         else:
-            logging.info('Summary of Model Edge Enlargement')
+            logging.info('Summary of Secondary Model Edge Enlargement')
         logging.info('---------------------------------')
-        if enlargeCore:
-            logging.info('Added {0:d} new core species'.format(len(newCoreSpecies)))
-            for spec in newCoreSpecies:
-                display(spec)
-                logging.info('    {0}'.format(spec))
-        else:
-            logging.info('Created {0:d} new edge species'.format(len(newEdgeSpecies)))
-            for spec in newEdgeSpecies:
-                display(spec)
-                logging.info('    {0}'.format(spec))
+
+        logging.info('Added {0:d} new core species'.format(len(newCoreSpecies)))
+        for spec in newCoreSpecies:
+            display(spec)
+            logging.info('    {0}'.format(spec))
+
+        logging.info('Created {0:d} new edge species'.format(len(newEdgeSpecies)))
+        for spec in newEdgeSpecies:
+            display(spec)
+            logging.info('    {0}'.format(spec))
         
         if reactionsMovedFromEdge:
             logging.info('Moved {0:d} reactions from edge to core'.format(len(reactionsMovedFromEdge)))
@@ -1117,16 +1117,14 @@ class CoreEdgeReactionModel:
                         (r.products == rxn.reactants and r.reactants == rxn.products)):
                         logging.info('    {0}'.format(r))
                         newCoreReactions.remove(r)
-                        break
-        # Only enlarging edge can give new edge or core reactions (otherwise it is moving them from edge to core only)
-        if not enlargeCore:         
-            logging.info('Added {0:d} new core reactions'.format(len(newCoreReactions)))
-            for rxn in newCoreReactions:
-                logging.info('    {0}'.format(rxn))
-                
-            logging.info('Created {0:d} new edge reactions'.format(len(newEdgeReactions)))
-            for rxn in newEdgeReactions:
-                logging.info('    {0}'.format(rxn))
+                        break        
+        logging.info('Added {0:d} new core reactions'.format(len(newCoreReactions)))
+        for rxn in newCoreReactions:
+            logging.info('    {0}'.format(rxn))
+            
+        logging.info('Created {0:d} new edge reactions'.format(len(newEdgeReactions)))
+        for rxn in newEdgeReactions:
+            logging.info('    {0}'.format(rxn))
 
         coreSpeciesCount, coreReactionCount, edgeSpeciesCount, edgeReactionCount = self.getModelSize()
 

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -1323,7 +1323,7 @@ class OutputHTMLWriter(object):
     rmg.detach(listener)
 
     """
-    def __init__(self, outputDirectory):
+    def __init__(self, outputDirectory=''):
         super(OutputHTMLWriter, self).__init__()
         makeOutputSubdirectory(outputDirectory, 'species')
     

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -96,6 +96,10 @@ cdef class ReactionSystem(DASx):
     cdef public list snapshots
 
     cdef public list termination
+    
+    # reaction threshold settings
+    cdef public numpy.ndarray unimolecularThreshold
+    cdef public numpy.ndarray bimolecularThreshold
 
     # methods
     cpdef initializeModel(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions, list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?)

--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -225,6 +225,16 @@ cdef class SimpleReactor(ReactionSystem):
         self.V = constants.R * self.T.value_si * numpy.sum(self.y0[:self.numCoreSpecies]) / self.P.value_si# volume in m^3
         for j in xrange(self.numCoreSpecies):
             self.coreSpeciesConcentrations[j] = self.y0[j] / self.V
+        
+        # Set unimolecular and bimolecular thresholds as true for any concentrations greater than 0
+        numCoreSpecies = len(self.coreSpeciesConcentrations)
+        for i in xrange(numCoreSpecies):
+            if self.coreSpeciesConcentrations[i] > 0:
+                self.unimolecularThreshold[i] = True
+        for i in xrange(numCoreSpecies):
+            for j in xrange(i, numCoreSpecies):
+                if self.coreSpeciesConcentrations[i] > 0 and self.coreSpeciesConcentrations[j] > 0:
+                    self.bimolecularThreshold[i,j] = True
 
     @cython.boundscheck(False)
     def residual(self, double t, numpy.ndarray[numpy.float64_t, ndim=1] y, numpy.ndarray[numpy.float64_t, ndim=1] dydt, numpy.ndarray[numpy.float64_t, ndim=1] senpar = numpy.zeros(1, numpy.float64)):

--- a/rmgpy/stats.py
+++ b/rmgpy/stats.py
@@ -106,7 +106,8 @@ class ExecutionStatsWriter(object):
             rss, vms = process.memory_info()
             self.memoryUse.append(rss / 1.0e6)
             logging.info('    Memory used: %.2f MB' % (self.memoryUse[-1]))
-        except ImportError:
+        except:
+            logging.info('    Memory used: memory usage was unable to be logged')
             self.memoryUse.append(0.0)
         if os.path.exists(os.path.join(rmg.outputDirectory,'restart.pkl.gz')):
             self.restartSize.append(os.path.getsize(os.path.join(rmg.outputDirectory,'restart.pkl.gz')) / 1.0e6)

--- a/rmgpy/tools/generate_reactions.py
+++ b/rmgpy/tools/generate_reactions.py
@@ -136,9 +136,24 @@ def execute(rmg, inputFile, output_directory, **kwargs):
 
     Returns an RMG object.
     """   
-
+    import numpy
     rmg.initialize(inputFile, output_directory, **kwargs)
     
+    numCoreSpecies = len(rmg.reactionModel.core.species)
+    # In the enlarge reaction filter modified algorithm, you must explicitly set all the react matrices to true
+    unimolecularReact = numpy.zeros((numCoreSpecies),bool)
+    bimolecularReact = numpy.zeros((numCoreSpecies, numCoreSpecies),bool)
+    
+    for i in xrange(numCoreSpecies):
+        if rmg.reactionModel.core.species[i].reactive: 
+            unimolecularReact[i] = True
+                
+    for i in xrange(numCoreSpecies):
+        for j in xrange(i, numCoreSpecies):
+            if rmg.reactionModel.core.species[i].reactive and rmg.reactionModel.core.species[j].reactive: 
+                bimolecularReact[i,j] = True
+    
+    rmg.reactionModel.enlargeEdge(unimolecularReact, bimolecularReact)
     # Show all core and edge species and reactions in the output
     rmg.reactionModel.outputSpeciesList.extend(rmg.reactionModel.edge.species)
     rmg.reactionModel.outputReactionList.extend(rmg.reactionModel.edge.reactions)


### PR DESCRIPTION
These commits change our flux algorithm such that it prevents species from reacting when their concentrations are deemed too low at reaction conditions.  

<img width="624" alt="screenshot 2016-01-22 11 13 43" src="https://cloud.githubusercontent.com/assets/583115/12516036/50d09bd8-c0f9-11e5-8731-d966da827271.png">

<img width="630" alt="screenshot 2016-01-22 11 13 59" src="https://cloud.githubusercontent.com/assets/583115/12516042/5cda0bee-c0f9-11e5-8903-4b55a4766b26.png">

**Key Variables**
`unimolecularThreshold` and `bimolecularThreshold`
- Binary arrays storing flag for whether a species or a pair of species are above a reaction threshold
- Threshold is set to True if rate = k_max*CA > toleranceMoveToCore*ratechar at any given time t in the reaction system
- Unimolecular k_max = kB*T/h
- Bimolecular k_max = k_diffusion = 1e13 cm^3/mol*s

`unimolecularReact` and `bimolecularReact`
- Binary arrays storing flags for when the unimolecularThreshold or bimolecularThreshold flag shifts from False to True 
- RMG should then react those species together

**Other considerations**
The `R_Recombination` reaction family is treated as an exception.  These reactions are now always added to core by default, because filtering method tends to omit them due to being the only case where 2 radicals combine.  They generally appear in a converged model, but may not enter the core until later, and may affect models with larger compounds or models that are not converged. This class of reactions are very important in models as a radical source and sink.  

- Bill also suggests that potentially other radical sources and sinks such as disproportionation may have to be treated differently as well.. which is for later consideration.

two radicals 
Note: Do not pull yet, still making some changes and need to perform tests.