### PR TITLE
Parallel generation of reactions in RMG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,14 @@ eg7: all
 	@ echo "Running eg7: gri_mech_rxn_lib example"
 	python rmg.py testing/eg7/input.py
 	
+scoop: noQM
+	mkdir -p testing/scoop
+	rm -rf testing/scoop/*
+	cp examples/rmg/minimal/input.py testing/scoop/input.py
+	coverage erase
+	@ echo "Running minimal example with SCOOP"
+	python -m scoop -n 2 rmg.py -v testing/scoop/input.py
+
 ######### 
 # Section for setting up MOPAC calculations on the Travis-CI.org server
 ifeq ($(TRAVIS),true)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1128,10 +1128,13 @@ class KineticsFamily(Database):
         Return ``True`` if the molecule is forbidden in this family, or
         ``False`` otherwise. 
         """
-        from rmgpy.data.rmg import database
+        from rmgpy.data.rmg import getDB
+        
+        forbidden_structures = getDB('forbidden')
+
         if self.forbidden is not None and self.forbidden.isMoleculeForbidden(molecule):
             return True
-        if database.forbiddenStructures.isMoleculeForbidden(molecule):
+        if forbidden_structures.isMoleculeForbidden(molecule):
             return True
         return False
 

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -34,6 +34,7 @@ for working with the RMG database.
 """
 
 import os.path
+import logging
 
 from base import ForbiddenStructures
 from thermo import ThermoDatabase
@@ -68,7 +69,6 @@ class RMGDatabase:
         if database is None:
             database = self
         else:
-            import logging
             logging.warning("Should only make one instance of RMGDatabase because it's stored as a module-level variable!")
             logging.warning("Unexpected behaviour may result!")
 

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -42,7 +42,7 @@ from rmgpy.data.kinetics.database import KineticsDatabase
 from statmech import StatmechDatabase
 from solvation import SolvationDatabase
 
-from rmgpy.scoop_framework.util import broadcast
+from rmgpy.scoop_framework.util import get, broadcast
 
 # Module-level variable to store the (only) instance of RMGDatabase in use.
 database = None
@@ -226,3 +226,41 @@ class RMGDatabase:
         self.forbiddenStructures.saveOld(os.path.join(path, 'ForbiddenStructures.txt'))
         self.kinetics.saveOld(path)
         self.statmech.saveOld(path)
+
+def getDB(name):
+    """
+    Returns the RMG database object that corresponds
+    to the parameter name.
+
+    First, the module level is queried. If this variable
+    is empty, the broadcasted variables are queried.
+    """
+    global database
+
+    if database:
+        if name == 'kinetics':
+            return database.kinetics
+        elif name == 'thermo':
+            return database.thermo
+        elif name == 'transport':
+            return database.transport
+        elif name == 'solvation':
+            return database.solvation
+        elif name == 'statmech':
+            return database.statmech
+        elif name == 'forbidden':
+            return database.forbiddenStructures
+        else:
+            raise Exception('Unrecognized database keyword: {}'.format(name))
+    else:
+        try:
+            db = get(name)
+            if db:
+                return db
+            else:
+                raise Exception
+        except Exception, e:
+            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
+            raise e
+
+    raise Exception('Could not get database with name: {}'.format(name))

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -691,8 +691,9 @@ class CoreEdgeReactionModel:
                     # or products with itself (e.g. A + A <---> products)
                     results_AA = reactFamilies(newSpecies.copy(deep=True), [newSpecies.copy(deep=True)])
                             
-                    for result in itertools.chain(results_A, results_AA, results_AB):
-                        newReactions.extend(result)
+                    newReactions.extend(results_A)
+                    newReactions.extend(results_AB)
+                    newReactions.extend(results_AA)
     
                 # Add new species
                 reactionsMovedFromEdge = self.addSpeciesToCore(newSpecies)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -635,32 +635,6 @@ class CoreEdgeReactionModel:
 
         return forward
 
-    def react(self, database, speciesA, speciesB=None, only_families=None):
-        """
-        Generates reactions involving :class:`rmgpy.species.Species` speciesA and speciesB.
-        The optional only_families flag allows the user to input a list of familylabels which then
-        allow the reactions to only be generated from those families.
-        """
-        if not speciesA.reactive:
-            return []
-        reactionList = []
-        if speciesB is None:
-            # React in a unimolecular reaction
-            for moleculeA in speciesA.molecule:
-                reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA], products=None, only_families=only_families))
-                moleculeA.clearLabeledAtoms()
-        else:
-            if not speciesB.reactive:
-                return []
-            # React in a bimolecular reaction
-            for moleculeA in speciesA.molecule:
-                for moleculeB in speciesB.molecule:
-                    reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA, moleculeB], products=None, only_families=only_families))
-                    moleculeA.clearLabeledAtoms()
-                    moleculeB.clearLabeledAtoms()
-        return reactionList
-
-
     def enlarge(self, newObject=None, reactEdge=False, unimolecularReact=None, bimolecularReact=None):
         """
         Enlarge a reaction model by processing the objects in the list `newObject`. 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1832,21 +1832,21 @@ def getKey(spc):
     return spc.label
 
         
-def react_family(familyKey, newSpecies, coreSpecies):
+def react_family(familyKey, spcA, speciesList):
     """
-    Generate bimolecular reactions for one specific family
-    and species A is different than species B where B is one of old core species
-    :param family: in database.kinetics.families
-    :param newSpecies: new core species
+    Generate bimolecular reactions for one specific family.
     :return: a list of new reactions
     """
+
     reactionList = []
+
     families = getDB('kinetics').families
     family = families[familyKey]
-    for oldCoreSpecies in coreSpecies:
-        if oldCoreSpecies.reactive:
-            for molA in newSpecies.molecule:
-                for molB in oldCoreSpecies.molecule:
+
+    for spcB in speciesList:
+        if spcB.reactive:
+            for molA in spcA.molecule:
+                for molB in spcB.molecule:
                     reactionList.extend(family.generateReactions(
                         [molA, molB]))
                     molA.clearLabeledAtoms()

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -685,6 +685,8 @@ class CoreEdgeReactionModel:
         reactionsMovedFromEdge = []
         self.newReactionList = []; self.newSpeciesList = []
 
+        familyKeys = database.kinetics.families.keys()
+
         if reactEdge is False:
             # We are adding core species 
             newReactions = []
@@ -702,7 +704,6 @@ class CoreEdgeReactionModel:
                     logging.info('Adding species {0} to model core'.format(newSpecies))
                     display(newSpecies) # if running in IPython --pylab mode, draws the picture!
        
-                    familyKeys = database.kinetics.families.keys()
                     familieCount = len(familyKeys)
 
                     # Find reactions involving the new species as unimolecular reactant
@@ -746,7 +747,7 @@ class CoreEdgeReactionModel:
             elif isinstance(newObject, tuple) and isinstance(newObject[0], PDepNetwork) and self.pressureDependence:
 
                 pdepNetwork, newSpecies = newObject
-                newReactions.extend(pdepNetwork.exploreIsomer(newSpecies, self, database))
+                newReactions.extend(pdepNetwork.exploreIsomer(newSpecies, familyKeys))
                 self.processNewReactions(newReactions, newSpecies, pdepNetwork)
 
             else:
@@ -766,7 +767,7 @@ class CoreEdgeReactionModel:
                     for products in network.products:
                         products = products.species
                         if len(products) == 1 and products[0] == species:
-                            newReactions = network.exploreIsomer(species, self, database)
+                            newReactions = network.exploreIsomer(species, familyKeys)
                             self.processNewReactions(newReactions, species, network)
                             network.updateConfigurations(self)
                             index = 0

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -712,12 +712,11 @@ class CoreEdgeReactionModel:
                     corespeciesList = self.core.species
 
                     familieCount = len(familyKeys)
-                    results = list(
-                                map_(WorkerWrapper(react_family), familyKeys,
+                    results = map_(WorkerWrapper(react_family), familyKeys,
                                     [newSpecies]*familieCount,
                                     [corespeciesList]*familieCount
-                                    )
                                 )
+                            
   
                     [newReactions.extend(result) for result in results]
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -54,7 +54,7 @@ from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 
 from rmgpy.kinetics import KineticsData
 import rmgpy.data.rmg
-from .react import reactFamilies
+from .react import react
 
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
@@ -678,18 +678,18 @@ class CoreEdgeReactionModel:
                     # Find reactions involving the new species as unimolecular reactant
                     # or product (e.g. A <---> products)
 
-                    results_A = reactFamilies(newSpecies.copy(deep=True))
+                    results_A = react(newSpecies.copy(deep=True))
 
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with other core species (e.g. A + B <---> products)
 
                     corespeciesList = self.core.species
 
-                    results_AB = reactFamilies(newSpecies.copy(deep=True), corespeciesList)                    
+                    results_AB = react(newSpecies.copy(deep=True), corespeciesList)                    
 
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with itself (e.g. A + A <---> products)
-                    results_AA = reactFamilies(newSpecies.copy(deep=True), [newSpecies.copy(deep=True)])
+                    results_AA = react(newSpecies.copy(deep=True), [newSpecies.copy(deep=True)])
                             
                     newReactions.extend(results_A)
                     newReactions.extend(results_AB)
@@ -741,7 +741,7 @@ class CoreEdgeReactionModel:
             for i in xrange(numOldCoreSpecies):
                 if unimolecularReact[i]:
                     # Find reactions involving the species that are unimolecular
-                    reactions = reactFamilies(self.core.species[i].copy(deep=True)) 
+                    reactions = react(self.core.species[i].copy(deep=True)) 
                     self.processNewReactions(reactions, self.core.species[i], None)
 
             for i in xrange(numOldCoreSpecies):
@@ -750,7 +750,7 @@ class CoreEdgeReactionModel:
                     # This includes a species reacting with itself (if its own concentration is high enough)
                     
                     if bimolecularReact[i,j]:
-                        reactions = reactFamilies(self.core.species[i].copy(deep=True), [self.core.species[j]]) 
+                        reactions = react(self.core.species[i].copy(deep=True), [self.core.species[j]]) 
                         # Consider the latest added core species as the 'new' species
                         self.processNewReactions(reactions, self.core.species[j], None)
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -58,7 +58,7 @@ import rmgpy.data.rmg
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
 
-from rmgpy.scoop_framework.util import get, map_
+from rmgpy.scoop_framework.util import get, map_, WorkerWrapper
 
 ################################################################################
 
@@ -737,7 +737,7 @@ class CoreEdgeReactionModel:
 
                     familieCount = len(familyKeys)
                     results = list(
-                                map_(self.react_family, familyKeys,
+                                map_(WorkerWrapper(self.react_family), familyKeys,
                                     [newSpecies]*familieCount,
                                     [corespeciesList]*familieCount
                                     )

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -659,32 +659,6 @@ class CoreEdgeReactionModel:
                     moleculeB.clearLabeledAtoms()
         return reactionList
 
-    def react_family(self, familyKey, newSpecies, coreSpecies):
-        """
-        Generate bimolecular reactions for one specific family
-        and species A is different than species B where B is one of old core species
-        :param family: in database.kinetics.families
-        :param newSpecies: new core species
-        :return: a list of new reactions
-        """
-        reactionList = []
-        families = getDB('kinetics').families
-        family = families[familyKey]
-        for oldCoreSpecies in coreSpecies:
-            if oldCoreSpecies.reactive:
-                for molA in newSpecies.molecule:
-                    for molB in oldCoreSpecies.molecule:
-                        reactionList.extend(family.generateReactions(
-                            [molA, molB], failsSpeciesConstraints=self.failsSpeciesConstraints))
-                        molA.clearLabeledAtoms()
-                        molB.clearLabeledAtoms()
-
-        logging.info("{} reactions are generated from {}"
-                 .format(len(reactionList), familyKey)
-                )
-
-        return reactionList
-
 
     def enlarge(self, newObject=None, reactEdge=False, unimolecularReact=None, bimolecularReact=None):
         """
@@ -737,7 +711,7 @@ class CoreEdgeReactionModel:
 
                     familieCount = len(familyKeys)
                     results = list(
-                                map_(WorkerWrapper(self.react_family), familyKeys,
+                                map_(WorkerWrapper(react_family), familyKeys,
                                     [newSpecies]*familieCount,
                                     [corespeciesList]*familieCount
                                     )
@@ -1889,4 +1863,30 @@ def getDB(name):
         except Exception, e:
             logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
             raise e
+
         
+def react_family(familyKey, newSpecies, coreSpecies):
+    """
+    Generate bimolecular reactions for one specific family
+    and species A is different than species B where B is one of old core species
+    :param family: in database.kinetics.families
+    :param newSpecies: new core species
+    :return: a list of new reactions
+    """
+    reactionList = []
+    families = getDB('kinetics').families
+    family = families[familyKey]
+    for oldCoreSpecies in coreSpecies:
+        if oldCoreSpecies.reactive:
+            for molA in newSpecies.molecule:
+                for molB in oldCoreSpecies.molecule:
+                    reactionList.extend(family.generateReactions(
+                        [molA, molB]))
+                    molA.clearLabeledAtoms()
+                    molB.clearLabeledAtoms()
+
+    logging.debug("{} reactions are generated from {}"
+             .format(len(reactionList), familyKey)
+            )
+
+    return reactionList

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -712,17 +712,25 @@ class CoreEdgeReactionModel:
                     corespeciesList = self.core.species
 
                     familieCount = len(familyKeys)
-                    results = map_(WorkerWrapper(react_family), familyKeys,
-                                    [newSpecies]*familieCount,
-                                    [corespeciesList]*familieCount
+                    results_AB = map_(
+                                    WorkerWrapper(react_family),
+                                    familyKeys,
+                                    [newSpecies] * familieCount,
+                                    [corespeciesList] * familieCount
                                 )
-                            
-  
-                    [newReactions.extend(result) for result in results]
+                    
 
                     # Find reactions involving the new species as bimolecular reactants
                     # or products with itself (e.g. A + A <---> products)
-                    newReactions.extend(self.react(database, newSpecies, newSpecies))
+                    results_AA = map_(
+                                    WorkerWrapper(react_family),
+                                    familyKeys,
+                                    [newSpecies] * familieCount,
+                                    [[newSpecies.copy(deep=True)]] * familieCount
+                                )
+
+                    for result in itertools.chain(results_AA, results_AB):
+                        newReactions.extend(result)
     
                 # Add new species
                 reactionsMovedFromEdge = self.addSpeciesToCore(newSpecies)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -668,7 +668,7 @@ class CoreEdgeReactionModel:
         :return: a list of new reactions
         """
         reactionList = []
-        families = get('kinetics').families
+        families = getDB('kinetics').families
         family = families[familyKey]
         for oldCoreSpecies in coreSpecies:
             if oldCoreSpecies.reactive:
@@ -1855,3 +1855,38 @@ def getKey(spc):
     """
 
     return spc.label
+
+
+def getDB(name):
+    """
+    Returns the RMG database object that corresponds
+    to the parameter name.
+
+    First, the module level is queried. If this variable
+    is empty, the broadcasted variables are queried.
+    """
+
+    database = rmgpy.data.rmg.database
+
+    if database:
+        if name == 'kinetics':
+            return database.kinetics
+        elif name == 'thermo':
+            return database.thermo
+        elif name == 'transport':
+            return database.transport
+        elif name == 'solvation':
+            return database.solvation
+        elif name == 'statmech':
+            return database.statmech
+        elif name == 'forbidden':
+            return database.forbiddenStructures
+        else:
+            raise Exception('Unrecognized database keyword: {}'.format(name))
+    else:
+        try:
+            db = get(name)
+        except Exception, e:
+            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
+            raise e
+        

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -777,7 +777,7 @@ class CoreEdgeReactionModel:
                     if bimolecularReact[i,j]:
                         reactions = reactFamilies(self.core.species[i].copy(deep=True), [self.core.species[j]]) 
                         # Consider the latest added core species as the 'new' species
-                        self.processNewReactions(self.react(database, self.core.species[i], self.core.species[j]), self.core.species[j], None)
+                        self.processNewReactions(reactions, self.core.species[j], None)
 
         ################################################################
         # Begin processing the new species and reactions

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -51,14 +51,16 @@ from rmgpy.data.base import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
+from rmgpy.data.rmg import getDB
 from rmgpy.kinetics import KineticsData
 import rmgpy.data.rmg
+
 
 
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
 
-from rmgpy.scoop_framework.util import get, map_, WorkerWrapper
+from rmgpy.scoop_framework.util import map_, WorkerWrapper
 
 ################################################################################
 
@@ -1829,40 +1831,6 @@ def getKey(spc):
     """
 
     return spc.label
-
-
-def getDB(name):
-    """
-    Returns the RMG database object that corresponds
-    to the parameter name.
-
-    First, the module level is queried. If this variable
-    is empty, the broadcasted variables are queried.
-    """
-
-    database = rmgpy.data.rmg.database
-
-    if database:
-        if name == 'kinetics':
-            return database.kinetics
-        elif name == 'thermo':
-            return database.thermo
-        elif name == 'transport':
-            return database.transport
-        elif name == 'solvation':
-            return database.solvation
-        elif name == 'statmech':
-            return database.statmech
-        elif name == 'forbidden':
-            return database.forbiddenStructures
-        else:
-            raise Exception('Unrecognized database keyword: {}'.format(name))
-    else:
-        try:
-            db = get(name)
-        except Exception, e:
-            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
-            raise e
 
         
 def react_family(familyKey, newSpecies, coreSpecies):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1860,9 +1860,8 @@ def react_family(familyKey, spcA, speciesList):
     family = families[familyKey]
 
     unimolecular = not speciesList
-
-    for molA in spcA.molecule:
-        if unimolecular:
+    if unimolecular:
+        for molA in spcA.molecule:
             reactants = [molA]
                         
             reactionList.extend(
@@ -1872,21 +1871,49 @@ def react_family(familyKey, spcA, speciesList):
             for reactant in reactants:
                 reactant.clearLabeledAtoms()
 
-        else:#bimolecular
-            for spcB in speciesList:
-                if spcB.reactive:
-                    for molB in spcB.molecule:
-                        reactants = [molA, molB]
-                        
-                        reactionList.extend(
-                            family.generateReactions(reactants)
-                            )
+    else:
 
-                        for reactant in reactants:
-                            reactant.clearLabeledAtoms()
+        reactive_species = [spc for spc in speciesList if spc.reactive]
+        speciesCount = len(reactive_species)
+        
+        if reactive_species:
+            results = map_(
+                        WorkerWrapper(reactSpecies),
+                        reactive_species,
+                        [spcA] * speciesCount,
+                        [familyKey] * speciesCount,
+                        )
+
+            for result in results:
+                reactionList.extend(result)
 
     logging.debug("{} reactions are generated from {}"
              .format(len(reactionList), familyKey)
             )
 
     return reactionList
+
+def reactSpecies(spcA, spcB, familyKey):
+    """
+    Performs a bimolecular reaction between
+    species A and B for the given family key.
+    """
+    reactionList = []
+
+    families = getDB('kinetics').families
+    family = families[familyKey]
+
+    for molA in spcA.molecule:
+        for molB in spcB.molecule:
+
+            reactants = [molA, molB]
+            
+            reactionList.extend(
+                family.generateReactions(reactants)
+                )
+
+            for reactant in reactants:
+                reactant.clearLabeledAtoms()
+
+    return reactionList
+

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2010 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import os
+import unittest 
+
+from .main import RMG
+from .model import Species
+from rmgpy import settings
+from rmgpy.data.kinetics import TemplateReaction
+from rmgpy.data.rmg import RMGDatabase, database
+from rmgpy.molecule import Molecule
+
+from .model import *
+
+###################################################
+
+TESTFAMILY = 'H_Abstraction'
+
+class TestReact(unittest.TestCase):
+
+    def setUp(self):
+        """
+        A method that is run before each unit test in this class.
+        """
+        # set-up RMG object
+        self.rmg = RMG()
+
+        # load kinetic database and forbidden structures
+        self.rmg.database = RMGDatabase()
+        path = os.path.join(settings['database.directory'])
+
+        # forbidden structure loading
+        self.rmg.database.loadForbiddenStructures(os.path.join(path, 'forbiddenStructures.py'))
+        # kinetics family loading
+        self.rmg.database.loadKinetics(os.path.join(path, 'kinetics'),
+                                       kineticsFamilies=[TESTFAMILY],
+                                       reactionLibraries=[]
+                                       )
+
+    def testReactMolecules(self):
+        """
+        Test that reaction generation for Molecule objects works.
+        """
+        
+        molecules = [Molecule(SMILES='CC'), Molecule(SMILES='[CH3]')]
+
+        reactionList = reactMolecules(molecules, TESTFAMILY)
+        
+        self.assertIsNotNone(reactionList)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
+    def testReactSpecies(self):
+        """
+        Test that reaction generation for Species objects works.
+        """
+        spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+
+        reactionList = reactSpecies(spcs, TESTFAMILY)
+        self.assertIsNotNone(reactionList)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
+    def testReactFamily(self):
+        """
+        Test that reaction generation from a family works.
+        """
+        spcA = Species().fromSMILES('[OH]')
+        spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+
+        reactionList = reactFamily(TESTFAMILY, spcA, spcs)
+        self.assertIsNotNone(reactionList)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
+    def tearDown(self):
+        """
+        Reset the loaded database
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -40,7 +40,7 @@ import rmgpy.pdep.network
 import rmgpy.reaction
 
 from rmgpy.pdep import Conformer, Configuration
-
+from rmgpy.rmg.react import reactFamily
 from rmgpy.scoop_framework.util import map_, WorkerWrapper
 
 ################################################################################
@@ -270,7 +270,6 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         network using the provided core-edge reaction model `reactionModel`,
         returning the new reactions and new species.
         """
-        from rmgpy.rmg.model import reactFamily
 
         if isomer in self.explored:
             logging.warning('Already explored isomer {0} in pressure-dependent network #{1:d}'.format(isomer, self.index))

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -40,7 +40,7 @@ import rmgpy.pdep.network
 import rmgpy.reaction
 
 from rmgpy.pdep import Conformer, Configuration
-from rmgpy.rmg.react import reactFamily
+from rmgpy.rmg.react import reactFamilies
 from rmgpy.scoop_framework.util import map_, WorkerWrapper
 
 ################################################################################
@@ -264,7 +264,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
 
         return ratios
 
-    def exploreIsomer(self, isomer, familyKeys):
+    def exploreIsomer(self, isomer):
         """
         Explore a previously-unexplored unimolecular `isomer` in this partial
         network using the provided core-edge reaction model `reactionModel`,
@@ -289,23 +289,14 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         self.products.remove(product)
         # Find reactions involving the found species as unimolecular
         # reactant or product (e.g. A <---> products)
-        familieCount = len(familyKeys)
-
-        results = map_(
-                        WorkerWrapper(reactFamily),
-                        familyKeys,
-                        [isomer] * familieCount,
-                        [[]] * familieCount
-                    )
 
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with itself (e.g. A + A <---> products)
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with other core species (e.g. A + B <---> products)
 
-        newReactions = []
-        for result in results:
-            newReactions.extend(result)
+        newReactions = reactFamilies(isomer, [])
+        
         return newReactions
 
     def addPathReaction(self, newReaction, newSpecies):

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -40,7 +40,7 @@ import rmgpy.pdep.network
 import rmgpy.reaction
 
 from rmgpy.pdep import Conformer, Configuration
-from rmgpy.rmg.react import reactFamilies
+from rmgpy.rmg.react import react
 from rmgpy.scoop_framework.util import map_, WorkerWrapper
 
 ################################################################################
@@ -295,7 +295,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with other core species (e.g. A + B <---> products)
 
-        newReactions = reactFamilies(isomer)
+        newReactions = react(isomer)
         
         return newReactions
 

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -295,7 +295,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with other core species (e.g. A + B <---> products)
 
-        newReactions = reactFamilies(isomer, [])
+        newReactions = reactFamilies(isomer)
         
         return newReactions
 

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -55,11 +55,6 @@ def react(spcA, speciesList=[]):
     else:
         combos = list(itertools.product(smiA, smiB))
 
-    families = getDB('kinetics').families
-    familyKeys = families.keys()
-
-    combos = list(itertools.product(combos, familyKeys))
-
     results = map_(
                 WorkerWrapper(reactMolecules),
                 combos
@@ -68,20 +63,23 @@ def react(spcA, speciesList=[]):
     reactionList = itertools.chain.from_iterable(results)
     return reactionList
 
-def reactMolecules(args):
+def reactMolecules(smis):
     """
     Performs a reaction between
     the resonance isomers for the given family key.
     """
-    smis, familyKey = args
-    
-    families = getDB('kinetics').families
-    family = families[familyKey]
-
     molecules = [Molecule(SMILES=smi) for smi in smis]
-    reactionList = family.generateReactions(molecules)
 
-    for reactant in molecules:
-        reactant.clearLabeledAtoms()
+    rxns = []
+    families = getDB('kinetics').families
+    for key, family in families.iteritems():
 
-    return reactionList
+        
+        reactionList = family.generateReactions(molecules)
+
+        for reactant in molecules:
+            reactant.clearLabeledAtoms()
+
+        rxns.extend(reactionList)
+
+    return rxns

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -54,7 +54,7 @@ def reactFamilies(spcA, speciesList=[]):
                 [spcA.copy(deep=True)] * familieCount,
                 [speciesList] * familieCount
             )
-    reactionList = list(itertools.chain.from_iterable(results))
+    reactionList = itertools.chain.from_iterable(results)
     return reactionList
 
 def reactFamily(familyKey, spcA, speciesList):

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#	RMG - Reaction Mechanism Generator
+#
+#	Copyright (c) 2002-2009 Prof. William H. Green (whgreen@mit.edu) and the
+#	RMG Team (rmg_dev@mit.edu)
+#
+#	Permission is hereby granted, free of charge, to any person obtaining a
+#	copy of this software and associated documentation files (the 'Software'),
+#	to deal in the Software without restriction, including without limitation
+#	the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#	and/or sell copies of the Software, and to permit persons to whom the
+#	Software is furnished to do so, subject to the following conditions:
+#
+#	The above copyright notice and this permission notice shall be included in
+#	all copies or substantial portions of the Software.
+#
+#	THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#	FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#	DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+Contains functions for generating reactions.
+"""
+import logging
+import itertools
+
+from rmgpy.data.rmg import getDB
+from rmgpy.scoop_framework.util import map_, WorkerWrapper
+        
+def reactFamily(familyKey, spcA, speciesList):
+    """
+    Generate uni and bimolecular reactions for one specific family.
+    :return: a list of new reactions
+    """
+
+    if not speciesList:
+        combos = [[spcA]]
+    else:
+        reactive_species = [spc for spc in speciesList if spc.reactive]
+        if reactive_species:
+            combos = list(itertools.product(reactive_species, [spcA]))
+        else:
+            return []
+
+    results = map_(
+                WorkerWrapper(reactSpecies),
+                combos,
+                [familyKey] * len(combos),
+                )
+
+    # flatten list of lists:
+    reactionList = list(itertools.chain.from_iterable(results))
+    
+    return reactionList
+
+def reactSpecies(speciesList, familyKey):
+    """
+    Performs a reaction between the
+    species in the list for the given family key.
+    """
+
+    molList = [spc.molecule for spc in speciesList]
+
+    combos = list(itertools.product(*molList))
+
+    results = map_(
+                WorkerWrapper(reactMolecules),
+                combos,
+                [familyKey] * len(combos),
+                )
+
+    # flatten list of lists:
+    reactionList = list(itertools.chain.from_iterable(results))
+
+    return reactionList
+
+def reactMolecules(molecules, familyKey):
+    """
+    Performs a reaction between
+    the resonance isomers for the given family key.
+    """
+
+    families = getDB('kinetics').families
+    family = families[familyKey]
+
+    reactionList = family.generateReactions(list(molecules))
+
+    for reactant in molecules:
+        reactant.clearLabeledAtoms()
+
+    return reactionList

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -38,7 +38,7 @@ from rmgpy.data.rmg import getDB
 from rmgpy.scoop_framework.util import map_, WorkerWrapper
         
 
-def reactFamilies(spcA, speciesList):
+def reactFamilies(spcA, speciesList=[]):
     """
     Generate reactions between spcA and the list of 
     species for all the reaction families available.

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -37,6 +37,26 @@ import itertools
 from rmgpy.data.rmg import getDB
 from rmgpy.scoop_framework.util import map_, WorkerWrapper
         
+
+def reactFamilies(spcA, speciesList):
+    """
+    Generate reactions between spcA and the list of 
+    species for all the reaction families available.
+    """
+    if not spcA.reactive: return []
+    
+    families = getDB('kinetics').families
+    familyKeys = families.keys()
+    familieCount = len(familyKeys)
+    results = map_(
+                WorkerWrapper(reactFamily),
+                familyKeys,
+                [spcA.copy(deep=True)] * familieCount,
+                [speciesList] * familieCount
+            )
+    reactionList = list(itertools.chain.from_iterable(results))
+    return reactionList
+
 def reactFamily(familyKey, spcA, speciesList):
     """
     Generate uni and bimolecular reactions for one specific family.

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -105,7 +105,7 @@ class TestReact(unittest.TestCase):
         spcA = Species().fromSMILES('[OH]')
         spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
 
-        reactionList = reactFamilies(spcA, spcs)
+        reactionList = list(reactFamilies(spcA, spcs))
         self.assertIsNotNone(reactionList)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
 

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -38,7 +38,7 @@ from rmgpy.data.kinetics import TemplateReaction
 from rmgpy.data.rmg import RMGDatabase, database
 from rmgpy.molecule import Molecule
 
-from .model import *
+from .react import *
 
 ###################################################
 

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -115,3 +115,6 @@ class TestReact(unittest.TestCase):
         """
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -31,14 +31,14 @@
 import os
 import unittest 
 
-from .main import RMG
-from .model import Species
 from rmgpy import settings
 from rmgpy.data.kinetics import TemplateReaction
 from rmgpy.data.rmg import RMGDatabase, database
 from rmgpy.molecule import Molecule
 
-from .react import *
+from rmgpy.rmg.main import RMG
+from rmgpy.rmg.model import Species
+from rmgpy.rmg.react import *
 
 ###################################################
 

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -98,6 +98,17 @@ class TestReact(unittest.TestCase):
         self.assertIsNotNone(reactionList)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
 
+    def testReactFamilies(self):
+        """
+        Test that reaction generation from the available families works.
+        """
+        spcA = Species().fromSMILES('[OH]')
+        spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+
+        reactionList = reactFamilies(spcA, spcs)
+        self.assertIsNotNone(reactionList)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
     def tearDown(self):
         """
         Reset the loaded database

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -8,6 +8,8 @@ from .model import Species
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase, database
 from rmgpy.molecule import Molecule
+
+from rmgpy.rmg.react import reactFamilies
 ###################################################
 
 class TestRMGWorkFlow(unittest.TestCase):
@@ -47,7 +49,7 @@ class TestRMGWorkFlow(unittest.TestCase):
         spc = Species().fromSMILES("O=C[C]=C")
         spc.generateResonanceIsomers()
         newReactions = []		
-        newReactions.extend(self.rmg.reactionModel.react(self.rmg.database, spc))
+        newReactions.extend(reactFamilies(spc))
 
         # process newly generated reactions to make sure no duplicated reactions
         self.rmg.reactionModel.processNewReactions(newReactions, spc, None)
@@ -65,7 +67,7 @@ class TestRMGWorkFlow(unittest.TestCase):
 
         # react again
         newReactions_reverse = []
-        newReactions_reverse.extend(self.rmg_dummy.reactionModel.react(self.rmg.database, spc))
+        newReactions_reverse.extend(reactFamilies(spc))
 
         # process newly generated reactions again to make sure no duplicated reactions
         self.rmg_dummy.reactionModel.processNewReactions(newReactions_reverse, spc, None)

--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -39,6 +39,7 @@ from functools import wraps
 
 try:
     from scoop import futures
+    from scoop.futures import map
     from scoop import shared
     from scoop import logger as logging
 
@@ -147,3 +148,6 @@ def get(key):
         Name error will be caught when the SCOOP library is not imported properly.
         """
         logging.debug('SCOOP not loaded. Not retrieving the shared object with key {}'.format(key))
+
+def map_(*args, **kwargs):
+    return map(*args, **kwargs)

--- a/rmgpy/scoop_framework/utilTest.py
+++ b/rmgpy/scoop_framework/utilTest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# encoding: utf-8 -*-
+
+"""
+This module contains unit tests of the rmgpy.parallel module.
+"""
+
+import os
+import sys
+import unittest
+
+from rmgpy.scoop_framework.framework import TestScoopCommon
+
+try:
+    from scoop import futures, _control, shared
+except ImportError, e:
+    import logging as logging
+    logging.debug("Could not properly import SCOOP.")
+
+from .util import *
+
+def boom():
+    return 0 / 0
+
+class WorkerWrapperTest(unittest.TestCase):
+
+    def test_WorkerWrapper(self):
+        """
+        Test that the WorkerWrapper correctly redirects the error
+        message.
+        """
+        f = WorkerWrapper(boom)    
+        with self.assertRaises(ZeroDivisionError):
+            f()
+
+
+def funcBroadcast():
+    """
+    Broadcast the data with the given key, 
+    and retrieve it again by querying the key again.
+    """
+    data = 'foo'
+    key = 'bar'
+
+    broadcast(data, key)
+
+    result = True
+    try:
+        assert data == shared.getConst(key)
+    except AssertionError:
+        return False
+    
+    return True
+
+def funcRetrieve():
+    """
+    Broadcast the data with the given key, 
+    retrieve it again by querying the key again.
+    """
+    
+    data = 'foo'
+    key = 'bar'
+
+
+    broadcast(data, key)
+
+    try:
+        assert data == get(key)
+    except AssertionError:
+        return False
+    
+    return True    
+
+class BroadcastTest(TestScoopCommon):
+
+    def __init__(self, *args, **kwargs):
+        # Parent initialization
+        super(self.__class__, self).__init__(*args, **kwargs)
+        
+        # Only setup the scoop framework once, and not in every test method:
+        super(self.__class__, self).setUp()
+
+    def test_generic(self):
+        """
+        Test that we can broadcast a simple string.
+        """
+
+        result = futures._startup(funcBroadcast)
+        self.assertEquals(result, True)
+
+class GetTest(TestScoopCommon):
+
+    def __init__(self, *args, **kwargs):
+        # Parent initialization
+        super(self.__class__, self).__init__(*args, **kwargs)
+        
+        # Only setup the scoop framework once, and not in every test method:
+        super(self.__class__, self).setUp()
+
+    def test_generic(self):
+        """
+        Test that we can retrieve a simple shared string.
+        """
+
+        result = futures._startup(funcRetrieve)
+        self.assertEquals(result, True)        
+
+if __name__ == '__main__' and os.environ.get('IS_ORIGIN', "1") == "1":
+    unittest.main()

--- a/rmgpy/scoop_framework/utilTest.py
+++ b/rmgpy/scoop_framework/utilTest.py
@@ -80,6 +80,8 @@ class BroadcastTest(TestScoopCommon):
         # Only setup the scoop framework once, and not in every test method:
         super(self.__class__, self).setUp()
 
+    @unittest.skipUnless(sys.platform.startswith("linux"),
+                         "test currently only runs on linux")
     def test_generic(self):
         """
         Test that we can broadcast a simple string.


### PR DESCRIPTION
More information can be found here: https://github.com/ReactionMechanismGenerator/RMG-Py/pull/530

These commits were reverted because we would like to place release 1.0.2 before these changes.  Release 1.0.2 will include windows build capability and the new reaction filtering algorithm.  

Note: Do not pull yet, will have conflicts with reaction filtering changes.