### PR TITLE
Debug kinetics error where reverse direction kinetics cannot be found 

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1225,7 +1225,7 @@ class KineticsFamily(Database):
                     # been formed in the first place.
                     tempObject = self.forbidden
                     self.forbidden = ForbiddenStructures()  # Initialize with empty one
-                    reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints)
+                    reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True)
                     if len(reactions) != 1:
                         logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                         raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1218,7 +1218,7 @@ class KineticsFamily(Database):
                     for product in rxn.products:
                         logging.info("Product")
                         logging.info(product.toAdjacencyList())
-                        logging.error("Debugging why no reaction was found...")
+                    logging.error("Debugging why no reaction was found...")
                     logging.error("Checking whether the family's forbidden species have affected reaction generation...")
                     # Set family's forbidden structures to empty for now to see if reaction gets generated...
                     # Note that it is not necessary to check global forbidden structures, because this reaction would not have

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1228,11 +1228,16 @@ class KineticsFamily(Database):
                     reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True, failsSpeciesConstraints=failsSpeciesConstraints)
                     if len(reactions) != 1:
                         logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
+                        raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
                     else:
                         logging.error("Error was fixed, the product is a forbidden structure when used as a reactant in the reverse direction.")
-                    
-                    raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
-                rxn.reverse = reactions[0]
+                        # Delete this reaction, since it should probably also be forbidden in the initial direction
+                        # Hack fix for now
+                        del rxn
+                else:
+                    rxn.reverse = reactions[0]
+
+
             
         else: # family is not ownReverse
             # Reverse direction (the direction in which kinetics is not defined)


### PR DESCRIPTION
In the case of forbidden reaction pathway in the reverse direction, delete the forward direction reaction. Usually this means the forbidden groups aren't comprehensive enough.  But since the Transition State is banned in one direction, it is likely should be banned in the other direction as well.  See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/412

We should think about how to fix the databases to avoid this issue through unit tests or changes to the algorithm later.