### PR TITLE
Jinja2 error fix

### DIFF
--- a/rmgpy/rmg/outputTest.py
+++ b/rmgpy/rmg/outputTest.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2010 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import os
+import unittest
+import shutil 
+
+from model import CoreEdgeReactionModel, ReactionModel 
+from rmgpy.chemkin import loadChemkinFile
+
+from output import *
+
+###################################################
+
+class TestOutput(unittest.TestCase):
+
+	def testSaveOutputHTML(self):
+		"""
+		This example is to test if an HTML file can be generated
+		for the provided chemkin model.
+		"""
+		folder = os.path.join(os.getcwd(),'rmgpy/rmg/test_data/saveOutputHTML/')
+		
+		chemkinPath = os.path.join(folder, 'eg6', 'chem_annotated.inp')
+		dictionaryPath = os.path.join(folder,'eg6', 'species_dictionary.txt')
+
+		# loadChemkinFile
+		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath) 
+
+		# convert it into a reaction model:
+		core = ReactionModel(species, reactions)
+		cerm = CoreEdgeReactionModel(core)
+
+		out = os.path.join(folder, 'output.html')
+		saveOutputHTML(out, cerm)
+
+		self.assertTrue(os.path.isfile(out))
+		os.remove(out)
+		shutil.rmtree(os.path.join(folder,'species'))

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -103,7 +103,7 @@ class PDepReaction(rmgpy.reaction.Reaction):
         """
         Get the source of this PDepReaction
         """
-        return self.network
+        return str(self.network)
 
 ################################################################################
 

--- a/rmgpy/rmg/test_data/saveOutputHTML/eg6/chem_annotated.inp
+++ b/rmgpy/rmg/test_data/saveOutputHTML/eg6/chem_annotated.inp
@@ -1,0 +1,342 @@
+ELEMENTS H C O N Ne Ar He Si S Cl END
+
+SPECIES
+    Ar                  ! Ar
+    He                  ! He
+    Ne                  ! Ne
+    N2                  ! N2
+    ethane(1)           ! ethane(1)
+    O2(2)               ! O2(2)
+    CH3(3)              ! [CH3](3)
+    C2H5(4)             ! C[CH2](4)
+    H(5)                ! [H](5)
+    CH3O2(10)           ! CO[O](10)
+    CH3O2(12)           ! [CH2]OO(12)
+    CH2O(17)            ! C=O(17)
+    HO(18)              ! [OH](18)
+    O(25)               ! O(25)
+    H2(31)              ! [H][H](31)
+    C2H4(56)            ! C=C(56)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+Ar                      Ar1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 4.37967000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 4.37967000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+He                      He1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 9.28724000E-01 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 9.28724000E-01                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+N2                      N 2                 G200.000   6000.000  1000.00       1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R)
+ethane(1)               C 2  H 6            G100.000   5000.000  954.53        1
+ 4.58997390E+00 1.41505285E-02-4.75947845E-06 8.60260221E-10-6.21688243E-14    2
+-1.27218243E+04-3.61819191E+00 3.78029291E+00-3.24211430E-03 5.52361704E-05    3
+-6.38555558E-08 2.28625654E-11-1.16203391E+04 5.21048530E+00                   4
+
+! Thermo library: primaryThermoLibrary
+O2(2)                   O 2                 G100.000   5000.000  1074.55       1
+ 3.15382071E+00 1.67804388E-03-7.69974332E-07 1.51275484E-10-1.08782432E-14    2
+-1.04081724E+03 6.16755890E+00 3.53732245E+00-1.21571669E-03 5.31620326E-06    3
+-4.89446524E-09 1.45846294E-12-1.03858849E+03 4.68368176E+00                   4
+
+! Thermo library: primaryThermoLibrary + radical(CH3)
+CH3(3)                  C 1  H 3            G100.000   5000.000  1337.63       1
+ 3.54146159E+00 4.76786209E-03-1.82148094E-06 3.28875850E-10-2.22545011E-14    2
+ 1.62239559E+04 1.66032608E+00 3.91546733E+00 1.84154615E-03 3.48740903E-06    3
+-3.32746709E-09 8.49953855E-13 1.62856394E+04 3.51742525E-01                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + radical(CCJ)
+C2H5(4)                 C 2  H 5            G100.000   5000.000  900.30        1
+ 5.15612067E+00 9.43138060E-03-1.81955154E-06 2.21217788E-10-1.43499804E-14    2
+ 1.20641180E+04-2.91049373E+00 3.82186929E+00-3.43402417E-03 5.09273273E-05    3
+-6.20234340E-08 2.37083980E-11 1.30660115E+04 7.61631583E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H(5)                    H 1                 G100.000   5000.000  4570.96       1
+ 2.49829732E+00 1.45963990E-06-4.69032548E-10 6.69551836E-14-3.58258629E-18    2
+ 2.54758061E+04-4.34136157E-01 2.50000000E+00 1.77470207E-12-2.27500193E-15    3
+ 9.48631670E-19-1.21629755E-22 2.54742178E+04-4.44972895E-01                   4
+
+! Thermo group additivity estimation: group(Os-OsCs) + gauche(Os(CsR)) + other(R) + group(Cs-OsHHH) + gauche(Cs(RRRR)) + other(R) + group(Os-OsH) +
+! gauche(Os(RR)) + other(R) + radical(ROOJ)
+CH3O2(10)               C 1  H 3  O 2       G100.000   5000.000  2084.41       1
+ 6.57567157E+00 8.54664273E-03-3.32717977E-06 5.46744622E-10-3.32634472E-14    2
+-1.31781565E+03-9.27498054E+00 3.63256066E+00 1.09261817E-02-2.68760045E-06    3
+-4.10051413E-10 1.71714165E-13 6.19120076E+02 8.78863204E+00                   4
+
+! Thermo group additivity estimation: group(Os-OsCs) + gauche(Os(CsR)) + other(R) + group(Cs-OsHHH) + gauche(Cs(RRRR)) + other(R) + group(Os-OsH) +
+! gauche(Os(RR)) + other(R) + radical(CsJOOH)
+CH3O2(12)               C 1  H 3  O 2       G100.000   5000.000  1630.18       1
+ 6.76120381E+00 9.55439274E-03-4.10305027E-06 7.51597845E-10-5.08672503E-14    2
+ 4.71507755E+03-9.97120316E+00 3.12221827E+00 1.84834759E-02-1.23191306E-05    3
+ 4.11160316E-09-5.66151087E-13 5.90151208E+03 9.36311831E+00                   4
+
+! Thermo group additivity estimation: group(Cds-OdHH) + other(R) + group(Od-Cd) + other(R)
+CH2O(17)                C 1  H 2  O 1       G100.000   5000.000  1402.29       1
+ 3.18000182E+00 9.55591485E-03-6.27297722E-06 1.33553694E-09-9.68403800E-14    2
+-1.50752517E+04 4.31047357E+00 4.32289309E+00-5.06324280E-03 2.15154762E-05    3
+-1.76520604E-08 4.31812417E-12-1.42789563E+04 2.39243598E+00                   4
+
+! Thermo library: primaryThermoLibrary
+HO(18)                  H 1  O 1            G100.000   5000.000  1145.76       1
+ 3.07193412E+00 6.04024883E-04-1.39833939E-08-2.13434380E-11 2.48056143E-15    2
+ 3.57938933E+03 4.57803245E+00 3.51456882E+00 2.92686370E-05-5.32135048E-07    3
+ 1.01945685E-09-3.85932376E-13 3.41425416E+03 2.10434601E+00                   4
+
+! Thermo library: primaryThermoLibrary
+O(25)                   H 2  O 1            G100.000   5000.000  1130.23       1
+ 2.84325453E+00 2.75107885E-03-7.81027808E-07 1.07242793E-10-5.79385352E-15    2
+-2.99586146E+04 5.91039675E+00 4.05763525E+00-7.87929251E-04 2.90875330E-06    3
+-1.47516282E-09 2.12832955E-13-3.02815866E+04-3.11361942E-01                   4
+
+! Thermo library: primaryThermoLibrary
+H2(31)                  H 2                 G100.000   5000.000  1959.07       1
+ 2.78817485E+00 5.87629226E-04 1.59015901E-07-5.52750034E-11 4.34319008E-15    2
+-5.96149590E+02 1.12679202E-01 3.43536403E+00 2.12711102E-04-2.78626742E-07    3
+ 3.40268499E-10-7.76035298E-14-1.03135984E+03-3.90841699E+00                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R)
+C2H4(56)                C 2  H 4            G100.000   5000.000  940.44        1
+ 5.20294372E+00 7.82451164E-03-2.12688492E-06 3.79702680E-10-2.94680849E-14    2
+ 3.93630185E+03-6.62382783E+00 3.97976020E+00-7.57579352E-03 5.52980432E-05    3
+-6.36231570E-08 2.31771655E-11 5.07746019E+03 4.04617155E+00                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #12
+! PDep reaction: PDepNetwork #2
+! Flux pairs: CH3(3), ethane(1); CH3(3), ethane(1); 
+CH3(3)+CH3(3)(+M)=ethane(1)(+M)                     1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 1.298e+01    6.224e-01    -1.447e-01   1.776e-02   /
+    CHEB/ -1.148e+00   8.424e-01    -1.025e-01   -2.396e-02  /
+    CHEB/ -6.621e-01   3.937e-01    2.545e-02    -2.785e-02  /
+    CHEB/ -3.217e-01   1.480e-01    4.225e-02    -6.280e-03  /
+    CHEB/ -1.547e-01   4.315e-02    2.488e-02    4.196e-03   /
+    CHEB/ -7.153e-02   5.351e-03    9.588e-03    4.799e-03   /
+
+! Reaction index: Chemkin #2; RMG #20
+! PDep reaction: PDepNetwork #3
+! Flux pairs: O2(2), CH3O2(10); CH3(3), CH3O2(10); 
+O2(2)+CH3(3)(+M)=CH3O2(10)(+M)                      1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 9.906e+00    1.649e+00    -2.717e-01   -8.152e-03  /
+    CHEB/ -1.260e-01   7.109e-01    1.753e-01    -2.709e-02  /
+    CHEB/ -4.554e-01   1.128e-01    7.054e-02    1.957e-02   /
+    CHEB/ -1.370e-01   -2.744e-03   8.533e-03    7.998e-03   /
+    CHEB/ -1.841e-02   -1.076e-02   -4.723e-03   2.076e-04   /
+    CHEB/ 2.646e-02    -1.206e-02   -4.031e-03   -7.600e-04  /
+
+! Reaction index: Chemkin #3; RMG #23
+! PDep reaction: PDepNetwork #3
+! Flux pairs: O2(2), CH3O2(12); CH3(3), CH3O2(12); 
+O2(2)+CH3(3)(+M)=CH3O2(12)(+M)                      1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 1.330e+00    2.397e+00    -7.142e-02   -3.845e-02  /
+    CHEB/ 6.096e+00    1.186e-01    8.049e-02    4.173e-02   /
+    CHEB/ 3.893e-01    -1.521e-02   -8.781e-03   -3.003e-03  /
+    CHEB/ 3.430e-02    -1.000e-02   -7.319e-03   -4.324e-03  /
+    CHEB/ -1.551e-03   1.587e-04    -2.249e-04   -4.544e-04  /
+    CHEB/ 1.685e-03    -1.441e-03   -9.737e-04   -5.018e-04  /
+
+! Reaction index: Chemkin #4; RMG #58
+! PDep reaction: PDepNetwork #6
+! Flux pairs: CH3O2(12), CH3O2(10); 
+CH3O2(12)(+M)=CH3O2(10)(+M)                         1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ -7.511e+00   4.881e+00    -8.210e-02   -4.396e-02  /
+    CHEB/ 1.076e+01    1.231e-01    8.274e-02    4.208e-02   /
+    CHEB/ -2.251e-01   -9.125e-03   -4.367e-03   -4.323e-04  /
+    CHEB/ -1.484e-01   -9.467e-03   -6.791e-03   -3.881e-03  /
+    CHEB/ -2.688e-02   -1.518e-03   -1.439e-03   -1.160e-03  /
+    CHEB/ 3.991e-02    -3.067e-03   -2.150e-03   -1.185e-03  /
+
+! Reaction index: Chemkin #5; RMG #60
+! PDep reaction: PDepNetwork #6
+! Flux pairs: CH3O2(12), HO(18); CH3O2(12), CH2O(17); 
+CH3O2(12)(+M)=HO(18)+CH2O(17)(+M)                   1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 8.869e+00    2.496e+00    -2.791e-03   -1.701e-03  /
+    CHEB/ 2.424e-01    -5.637e-03   -4.201e-03   -2.558e-03  /
+    CHEB/ -2.131e-01   -3.440e-03   -2.560e-03   -1.555e-03  /
+    CHEB/ -1.197e-01   -2.006e-03   -1.491e-03   -9.034e-04  /
+    CHEB/ -3.184e-02   -1.323e-03   -9.818e-04   -5.939e-04  /
+    CHEB/ 7.953e-03    -9.325e-04   -6.915e-04   -4.179e-04  /
+
+! Reaction index: Chemkin #6; RMG #55
+! PDep reaction: PDepNetwork #4
+! Flux pairs: CH3O2(10), HO(18); CH3O2(10), CH2O(17); 
+CH3O2(10)(+M)=HO(18)+CH2O(17)(+M)                   1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ -6.710e+00   2.382e+00    -8.157e-02   -4.368e-02  /
+    CHEB/ 1.320e+01    1.231e-01    8.275e-02    4.213e-02   /
+    CHEB/ -3.514e-01   -9.366e-03   -4.539e-03   -5.295e-04  /
+    CHEB/ -1.458e-01   -9.522e-03   -6.836e-03   -3.912e-03  /
+    CHEB/ -5.517e-02   -1.463e-03   -1.400e-03   -1.137e-03  /
+    CHEB/ -2.115e-03   -2.989e-03   -2.094e-03   -1.153e-03  /
+
+! Reaction index: Chemkin #7; RMG #52
+! PDep reaction: PDepNetwork #3
+! Flux pairs: CH3(3), CH2O(17); O2(2), HO(18); 
+O2(2)+CH3(3)(+M)=HO(18)+CH2O(17)(+M)                1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 6.432e+00    -1.024e-01   -7.090e-02   -3.818e-02  /
+    CHEB/ 4.724e+00    1.183e-01    8.033e-02    4.168e-02   /
+    CHEB/ 1.301e-01    -1.552e-02   -9.009e-03   -3.137e-03  /
+    CHEB/ -8.150e-04   -9.987e-03   -7.318e-03   -4.330e-03  /
+    CHEB/ -3.841e-02   2.691e-04    -1.441e-04   -4.066e-04  /
+    CHEB/ -4.148e-02   -1.354e-03   -9.107e-04   -4.645e-04  /
+
+! Reaction index: Chemkin #8; RMG #69
+! Template reaction: H_Abstraction
+! Flux pairs: ethane(1), C2H5(4); HO(18), O(25); 
+! Estimated using template (C/H3/Cs;O_pri_rad) for rate rule (C/H3/Cs\H3;O_pri_rad)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+HO(18)=C2H5(4)+O(25)                      2.862e+09 1.152     2.680    
+
+! Reaction index: Chemkin #9; RMG #161
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(4), ethane(1); C2H5(4), C2H4(56); 
+! Exact match found for rate rule (C_rad/H2/Cs;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+C2H5(4)+C2H5(4)=ethane(1)+C2H4(56)                  6.900e+13 -0.350    0.000    
+
+! Reaction index: Chemkin #10; RMG #167
+! Template reaction: Disproportionation
+! Flux pairs: HO(18), O(25); C2H5(4), C2H4(56); 
+! Exact match found for rate rule (O_pri_rad;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+C2H5(4)+HO(18)=C2H4(56)+O(25)                       7.230e+13 0.000     0.000    
+
+! Reaction index: Chemkin #11; RMG #253
+! PDep reaction: PDepNetwork #55
+! Flux pairs: H(5), C2H5(4); C2H4(56), C2H5(4); 
+H(5)+C2H4(56)(+M)=C2H5(4)(+M)                       1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 1.199e+01    9.208e-01    -1.769e-01   1.706e-02   /
+    CHEB/ -1.607e-01   9.815e-01    -1.668e-02   -3.901e-02  /
+    CHEB/ -4.416e-01   3.463e-01    7.163e-02    -1.287e-02  /
+    CHEB/ -2.054e-01   7.911e-02    3.818e-02    7.148e-03   /
+    CHEB/ -5.720e-02   -1.046e-02   9.901e-03    5.655e-03   /
+    CHEB/ 3.043e-03    -1.897e-02   -3.867e-03   1.705e-03   /
+
+! Reaction index: Chemkin #12; RMG #255
+! PDep reaction: PDepNetwork #60
+! Flux pairs: H(5), O(25); HO(18), O(25); 
+H(5)+HO(18)(+M)=O(25)(+M)                           1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 1.091e+01    2.403e+00    -6.633e-02   -3.467e-02  /
+    CHEB/ -8.119e-01   6.156e-02    4.191e-02    2.184e-02   /
+    CHEB/ -2.691e-01   6.583e-03    4.629e-03    2.561e-03   /
+    CHEB/ -1.010e-01   1.509e-03    1.014e-03    5.151e-04   /
+    CHEB/ -4.353e-02   5.752e-04    3.744e-04    1.783e-04   /
+    CHEB/ -1.973e-02   1.961e-04    1.268e-04    5.958e-05   /
+
+! Reaction index: Chemkin #13; RMG #256
+! PDep reaction: PDepNetwork #61
+! Flux pairs: C2H5(4), ethane(1); H(5), ethane(1); 
+C2H5(4)+H(5)(+M)=ethane(1)(+M)                      1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 1.263e+01    1.544e+00    -3.476e-01   -1.177e-02  /
+    CHEB/ -1.081e+00   6.828e-01    1.690e-01    -5.354e-02  /
+    CHEB/ -5.522e-01   2.004e-01    1.056e-01    1.543e-02   /
+    CHEB/ -2.785e-01   4.367e-02    3.733e-02    1.903e-02   /
+    CHEB/ -1.293e-01   -6.726e-03   5.540e-03    9.788e-03   /
+    CHEB/ -5.407e-02   -1.512e-02   -4.688e-03   2.432e-03   /
+
+! Reaction index: Chemkin #14; RMG #257
+! PDep reaction: PDepNetwork #61
+! Flux pairs: C2H5(4), CH3(3); H(5), CH3(3); 
+C2H5(4)+H(5)(+M)=CH3(3)+CH3(3)(+M)                  1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 1.338e+01    -8.489e-01   -3.184e-01   -1.728e-02  /
+    CHEB/ 4.328e-01    7.345e-01    2.090e-01    -4.070e-02  /
+    CHEB/ 9.526e-03    1.562e-01    1.036e-01    3.017e-02   /
+    CHEB/ -7.024e-02   -6.181e-03   1.856e-02    2.236e-02   /
+    CHEB/ -6.369e-02   -3.064e-02   -9.400e-03   5.427e-03   /
+    CHEB/ -4.024e-02   -1.898e-02   -1.096e-02   -2.679e-03  /
+
+! Reaction index: Chemkin #15; RMG #238
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(4), C2H4(56); H(5), H2(31); 
+! Exact match found for rate rule (H_rad;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 6
+C2H5(4)+H(5)=H2(31)+C2H4(56)                        2.166e+13 0.000     0.000    
+
+! Reaction index: Chemkin #16; RMG #241
+! Template reaction: H_Abstraction
+! Flux pairs: ethane(1), C2H5(4); H(5), H2(31); 
+! Estimated using template (C/H3/Cs;H_rad) for rate rule (C/H3/Cs\H3;H_rad)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+H(5)=C2H5(4)+H2(31)                       6.180e+03 3.240     7.100    
+
+! Reaction index: Chemkin #17; RMG #247
+! Template reaction: H_Abstraction
+! Flux pairs: HO(18), O(25); H2(31), H(5); 
+! Exact match found for rate rule (H2;O_pri_rad)
+! Multiplied by reaction path degeneracy 2
+H2(31)+HO(18)=H(5)+O(25)                            1.820e+09 1.210     4.710    
+
+! Reaction index: Chemkin #18; RMG #332
+! PDep reaction: PDepNetwork #52
+! Flux pairs: H(5), H2(31); H(5), H2(31); 
+H(5)+H(5)(+M)=H2(31)(+M)                            1.000e+00 0.000     0.000    
+    TCHEB/ 300.000   3000.000 /
+    PCHEB/ 0.001     98.692   /
+    CHEB/ 6 4/
+    CHEB/ 8.580e+00    1.837e+00    -2.176e-01   -1.845e-02  /
+    CHEB/ 1.838e-02    2.326e-01    8.461e-02    -1.429e-02  /
+    CHEB/ -1.128e-01   4.510e-02    2.184e-03    -3.653e-03  /
+    CHEB/ -4.227e-02   1.131e-02    9.073e-04    1.155e-03   /
+    CHEB/ -1.677e-02   3.527e-03    1.245e-03    9.920e-04   /
+    CHEB/ -6.470e-03   1.265e-03    6.507e-04    5.358e-04   /
+
+END
+

--- a/rmgpy/rmg/test_data/saveOutputHTML/eg6/species_dictionary.txt
+++ b/rmgpy/rmg/test_data/saveOutputHTML/eg6/species_dictionary.txt
@@ -1,0 +1,95 @@
+Ar
+1 Ar u0 p4 c0
+
+He
+1 He u0 p1 c0
+
+Ne
+1 Ne u0 p4 c0
+
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+ethane(1)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+
+O2(2)
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+CH3(3)
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+CH3O2(10)
+multiplicity 2
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 O u1 p2 c0 {1,S}
+
+CH3O2(12)
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 O u0 p2 c0 {1,S} {6,S}
+6 H u0 p0 c0 {5,S}
+
+HO(18)
+multiplicity 2
+1 H u0 p0 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+CH2O(17)
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+C2H5(4)
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+
+O(25)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+C2H4(56)
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+
+H(5)
+multiplicity 2
+1 H u1 p0 c0
+
+H2(31)
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+


### PR DESCRIPTION
ensures the `getSource()` method of `rmgpy.rmg.pdep.PdepReaction` returns a string, and not an object.

adds a test that tries to save output HTML with output module

should fix #539