### PR TITLE
Fix 32-bit precision problem in eckhart tunneling value

### DIFF
--- a/rmgpy/kinetics/tunneling.pyx
+++ b/rmgpy/kinetics/tunneling.pyx
@@ -244,7 +244,7 @@ cdef class Eckart(TunnelingModel):
             # If all of 2*pi*a, 2*pi*b, and 2*pi*d are sufficiently small,
             # compute as normal
             if twopia < 200. and twopib < 200. and twopid < 200.:
-                kappa[r] = 1 - (cosh(twopia-twopib)+cosh(twopid)) / (cosh(twopia+twopib)+cosh(twopid))
+                kappa[r] = 1 - (numpy.cosh(twopia-twopib)+numpy.cosh(twopid)) / (numpy.cosh(twopia+twopib)+numpy.cosh(twopid))
             # If one of the following is true, then we can eliminate most of the
             # exponential terms after writing out the definition of cosh and
             # dividing all terms by exp(2*pi*d)


### PR DESCRIPTION
This closes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/533

By using numpy.cosh rather than libc's cosh, we can eliminate the 32-bit precision test which fails for eckhart tunneling.

It appears that we do not use the libc version of the cosh function anywhere else in the code, so hopefully this resolve these sorts of issues for good.