### PR TITLE
Fix issue: reaction library rxns containing all input species not added to core

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -96,6 +96,9 @@ def species(label, structure, reactive=True):
     spec, isNew = rmg.reactionModel.makeNewSpecies(structure, label=label, reactive=reactive)
     if not isNew:
         raise InputError("Species {0} is a duplicate of {1}. Species in input file must be unique".format(label,spec.label))
+    # Force RMG to add the species to edge first, prior to where it is added to the core, in case it is found in 
+    # any reaction libraries along the way
+    rmg.reactionModel.addSpeciesToEdge(spec)
     rmg.initialSpecies.append(spec)
     speciesDict[label] = spec
     

--- a/rmgpy/tools/data/generate/libraryReaction/input.py
+++ b/rmgpy/tools/data/generate/libraryReaction/input.py
@@ -1,0 +1,63 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [('Methylformate', False)],
+    kineticsFamilies = ['R_Addition_MultipleBond'],
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+
+species(
+    label='HCjO',
+    reactive=True,
+    structure=adjacencyList(
+        """
+multiplicity 2
+1 C u1 p0 c0 {2,D} {3,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+        """),
+)
+
+species(
+    label='CH2O',
+    reactive=True,
+    structure=adjacencyList(
+        """
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+        """),
+)
+
+species(
+    label='Fmoml',
+    reactive=True,
+    structure=adjacencyList(
+        """
+multiplicity 2
+1 C u1 p0 c0 {3,S} {5,S} {6,S}
+2 C u0 p0 c0 {3,S} {4,D} {7,S}
+3 O u0 p2 c0 {1,S} {2,S}
+4 O u0 p2 c0 {2,D}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+        """),
+)
+
+
+simpleReactor(
+    temperature=(1399,'K'),
+    pressure=(1.93,'atm'),
+    initialMoleFractions={
+        "HCjO": 1,
+    },
+    terminationConversion={
+        'HCjO': 0.999,
+    },
+    terminationTime=(1e-3,'s'),
+)
+

--- a/rmgpy/tools/testGenerateReactions.py
+++ b/rmgpy/tools/testGenerateReactions.py
@@ -56,7 +56,47 @@ class GenerateReactionsTest(unittest.TestCase):
         self.assertEquals(count, 1)
 
         shutil.rmtree(os.path.join(folder,'pdep'))
+        
+    def testLibraryReactionEntersCore(self):
+        """
+        Test that a reaction from a Reaction Library enters the core
+        right after the initialization step if all the input species are 
+        present in that reaction.
+        
+        The following reaction from the Methylformate library
+        
+        HCjO + CH2O <=> Fmoml
+        
+        should appear in the model if HCjO, CH2O and Fmoml are all used as input species
+        """
+        from rmgpy.reaction import Reaction
+        from rmgpy.molecule import Molecule
+        folder = os.path.join(os.path.dirname(rmgpy.__file__),'tools/data/generate/libraryReaction')
+        
+        inputFile = os.path.join(folder,'input.py')
 
+        rmg = RMG()
+        rmg = execute(rmg, inputFile, folder)
+
+        self.assertIsNotNone(rmg)
+        
+        # Assert that the flagged reaction occurs
+        rxnFlagged = Reaction(reactants=[Molecule(SMILES='[CH]=O'),Molecule(SMILES='C=O')],
+                       products=[Molecule(SMILES='[CH2]OC=O')])
+
+        count = 0
+        for reaction in rmg.reactionModel.core.reactions:
+            if reaction.isIsomorphic(rxnFlagged):
+                count += 1
+
+        self.assertEquals(count, 1)
+        
+
+        # Assert that the core only has 1 reaction
+        self.assertEquals(len(rmg.reactionModel.core.reactions),1)
+        shutil.rmtree(os.path.join(folder,'pdep'))
+        
+        
     def tearDown(self):
         """
         Reset the loaded database


### PR DESCRIPTION
This closes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/515

By adding the input species to the edge in the step before reaction libraries are added to edge,
we make sure that when the input species is added, a reaction on the edge containing all input species
can get added to the core.  

The source of the bug is due to the function:

 `spec, isNew = rmg.reactionModel.makeNewSpecies()`

giving `False` even though the species is in NEITHER the core nor edge.  (The input species are created but not yet added anywhere).

This was the simplest way I could think of for fixing the bug.  There should be no other instances in which a species is not in either the core or edge when it is created when this function returns `False`.
 