### PR TITLE
Add a safety check in CERM to ensure symmetrical rxns don't enter

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -486,6 +486,12 @@ class CoreEdgeReactionModel:
         # Make sure the reactant and product lists are sorted before performing the check
         rxn.reactants.sort()
         rxn.products.sort()
+
+        # If reactants and products are identical, then something weird happened along
+        # the way and we got a symmetrical reaction.
+        if rxn.reactants == rxn.products:
+            logging.debug("Symmetrical reaction found. Returning no reaction")
+            return True, None
         
         familyObj = getFamilyLibraryObject(rxn.family)
         shortlist = self.searchRetrieveReactions(rxn)
@@ -833,6 +839,9 @@ class CoreEdgeReactionModel:
         """
         for rxn in newReactions:
             rxn, isNew = self.makeNewReaction(rxn)
+            if rxn is None:
+                # Skip this reaction because there was something wrong with it
+                continue
             if isNew:
                 # We've made a new reaction, so make sure the species involved
                 # are in the core or edge


### PR DESCRIPTION
This is a band-aid to fix https://github.com/ReactionMechanismGenerator/RMG-Py/issues/508

The best way to truly, thoroughly fix this problem is to do the proper isomorphism checks in both __createReaction and  in __generateReactions to get the right degeneracies and not create any symmetric reactions in rmgpy.data.kinetics.family



