### PR TITLE
Fix liquid reactor bug

### DIFF
--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -372,8 +372,6 @@ cdef class ReactionSystem(DASx):
         cdef int i, j, k
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
         cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
-        #cdef numpy.ndarray[bool, ndim=1] unimolecularThreshold
-        #cdef numpy.ndarray[bool, ndim=2] bimolecularThreshold
         
         # cython declations for sensitivity analysis
         cdef numpy.ndarray[numpy.int_t, ndim=1] sensSpeciesIndices

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -468,7 +468,7 @@ cdef class ReactionSystem(DASx):
             networkLeakRateRatios = numpy.abs(self.networkLeakRates/charRate)
 
             # Update the maximum species rate and maximum network leak rate arrays
-            for i in xrange(numCoreSpecies):
+            for index in xrange(numCoreSpecies):
                 if maxCoreSpeciesRates[index] < coreSpeciesRates[index]:
                     maxCoreSpeciesRates[index] = coreSpeciesRates[index]
             for index in xrange(numEdgeSpecies):


### PR DESCRIPTION
This addresses a small typo in base.pyx

it reused the `index` variable with the value it was last set to.

On the bright side, this serious bug did not lead to model differences for other simulations, which begs the question: "how is that even possible?".