### PR TITLE
avoid RMG-tests branch name collisions when deploying through travis

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -64,12 +64,14 @@ cd $TARGET_DIR
 
 # create a new branch in RMG-tests with the name equal to
 # the branch name of the tested RMG-Py branch:
-git checkout -b $DEPLOY_BRANCH || true 
-git checkout $DEPLOY_BRANCH
+RMGTESTSBRANCH=rmgpy-$DEPLOY_BRANCH
+
+git checkout -b $RMGTESTSBRANCH || true 
+git checkout $RMGTESTSBRANCH
 
 # create an empty commit with the SHA-ID of the 
 # tested commit of the RMG-Py branch:
 git commit --allow-empty -m $REV
 
 # push to the branch to the RMG/RMG-tests repo:
-git push -f $REPO $DEPLOY_BRANCH > /dev/null
+git push -f $REPO $RMGTESTSBRANCH > /dev/null

--- a/rmgpy/tools/diff_models.py
+++ b/rmgpy/tools/diff_models.py
@@ -8,9 +8,8 @@ pass the
 import os
 import math
 import numpy
-from matplotlib import pylab
 import os.path
-#import matplotlib.pyplot
+
 import logging
 import argparse
 
@@ -25,7 +24,7 @@ def compareModelKinetics(model1, model2):
     Compare the kinetics of :class:`ReactionModel` objects `model1` and 
     `model2`, printing the results to stdout.
     """
-    
+    from matplotlib import pylab
     # Determine reactions that both models have in common
     commonReactions = {}
     for rxn1 in model1.reactions:


### PR DESCRIPTION
before, when a RMG-Py travis build was triggered, it created a branch on the RMG-tests repo with the same name as the one that was being pushed by RMG-Py. That lead to name collisions, e.g. for master.

Now we prepend the branch name with `rmgpy-`.

The 2nd commit avoids loading matplotlib when we don't need it, which should speed up travis builds.