### PR TITLE
Fix pdep job convergence issue

### DIFF
--- a/examples/rmg/heptane-eg5/input.py
+++ b/examples/rmg/heptane-eg5/input.py
@@ -16,7 +16,6 @@ generatedSpeciesConstraints(
 # List of species
 species(
     label='n-heptane',
-    reactive=True,
     structure=SMILES("CCCCCCC"),
 )
 
@@ -26,17 +25,31 @@ species(
     structure=SMILES("[Ar]"),
 )
 
+
 simpleReactor(
-    temperature=(1500,'K'),
+    temperature=(1600,'K'),
     pressure=(400,'Pa'),
     initialMoleFractions={
         "n-heptane": 0.02,
         "Ar": 0.98,
     },
     terminationConversion={
-        'n-heptane': 0.5,
+        'n-heptane': 0.99,
     },
-    terminationTime=(1e0,'s'),
+    terminationTime=(1e6,'s'),
+)
+
+simpleReactor(
+    temperature=(2000,'K'),
+    pressure=(400,'Pa'),
+    initialMoleFractions={
+        "n-heptane": 0.02,
+        "Ar": 0.98,
+    },
+    terminationConversion={
+        'n-heptane': 0.99,
+    },
+    terminationTime=(1e6,'s'),
 )
 
 simulator(
@@ -45,9 +58,8 @@ simulator(
 )
 
 model(
-    toleranceKeepInEdge=0.0,
     toleranceMoveToCore=0.1,
-    maximumEdgeSpecies=100000
+    toleranceInterruptSimulation=0.1
 )
 
 pressureDependence(
@@ -59,8 +71,4 @@ pressureDependence(
     interpolation=('Chebyshev', 6, 4),
 )
 
-options(
-    units='si',
-    generateOutputHTML=False,
-    generatePlots=False,
-)
+


### PR DESCRIPTION
Fixes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/558

It turns out that pdep jobs do not produce the wrong models, but the convergence takes too long because `RMG.main` was calling `enlarge(reactEdge=True)` too often without updates to `unimolecularReact` and `bimolecularReact` arrays when filterReactions was off.

This fixes the issue and also restructures the `updateReactionThresholdAndReactFlags` function to have better readability.

Also the heptane-eg5 example was updated to reflect a pdep example that takes a little longer to converge without this fix.