### PR TITLE
revert the vertex connectivity value algorithm

### DIFF
--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -29,12 +29,14 @@ cdef class Vertex(object):
     cdef public dict edges
 
     # These attributes are used in the VF2 graph isomorphism algorithm
-    cdef public long connectivity
+    cdef public short connectivity1
+    cdef public short connectivity2
+    cdef public short connectivity3
     cdef public short sortingLabel
     cdef public bint terminal
     cdef public Vertex mapping
     cdef public bint ignore
-
+    
     cpdef Vertex copy(self)
 
     cpdef bint equivalent(self, Vertex other) except -2
@@ -43,7 +45,7 @@ cdef class Vertex(object):
 
     cpdef resetConnectivityValues(self)
 
-cpdef long getVertexConnectivityValue(Vertex vertex) except 1 # all values should be negative
+cpdef short getVertexConnectivityValue(Vertex vertex) except 1 # all values should be negative
 
 cpdef short getVertexSortingLabel(Vertex vertex) except -1 # all values should be nonnegative
 
@@ -92,8 +94,6 @@ cdef class Graph:
     cpdef list split(self)
 
     cpdef resetConnectivityValues(self)
-
-    cpdef list __update(self, old_values, trial_number)
 
     cpdef sortVertices(self)
 

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -37,20 +37,20 @@ from .vf2 cimport VF2
 
 ################################################################################
 
-MAX_NUMBER_OF_TRIALS = 2
-
 cdef class Vertex(object):
     """
     A base class for vertices in a graph. Contains several connectivity values
     useful for accelerating isomorphism searches, as proposed by
     `Morgan (1965) <http://dx.doi.org/10.1021/c160017a018>`_.
 
-    =================== =============== ==========================================
+    =================== =============== ========================================
     Attribute           Type            Description
-    =================== =============== ==========================================
-    `connectivity`      ``int``         The number of nearest neighbors
+    =================== =============== ========================================
+    `connectivity1`     ``int``         The number of nearest neighbors
+    `connectivity2`     ``int``         The sum of the neighbors' `connectivity1` values
+    `connectivity3`     ``int``         The sum of the neighbors' `connectivity2` values
     `sortingLabel`      ``int``         An integer label used to sort the vertices
-    =================== =============== ==========================================
+    =================== =============== ========================================
     
     """
 
@@ -65,7 +65,9 @@ cdef class Vertex(object):
         """
         d = {
             'edges': self.edges,
-            'connectivity': self.connectivity,
+            'connectivity1': self.connectivity1,
+            'connectivity2': self.connectivity2,
+            'connectivity3': self.connectivity3,
             'sortingLabel': self.sortingLabel,
             'terminal': self.terminal,
             'mapping': self.mapping,
@@ -74,7 +76,9 @@ cdef class Vertex(object):
 
     def __setstate__(self, d):
         self.edges = d['edges']
-        self.connectivity = d['connectivity']
+        self.connectivity1 = d['connectivity1']
+        self.connectivity2 = d['connectivity2']
+        self.connectivity3 = d['connectivity3']
         self.sortingLabel = d['sortingLabel']
         self.terminal = d['terminal']
         self.mapping = d['mapping']
@@ -108,18 +112,20 @@ cdef class Vertex(object):
         """
         Reset the cached structure information for this vertex.
         """
-        self.connectivity = -1
+        self.connectivity1 = -1
+        self.connectivity2 = -1
+        self.connectivity3 = -1
         self.sortingLabel = -1
         self.terminal = False
         self.mapping = None
 
-cpdef long getVertexConnectivityValue(Vertex vertex) except 1:
+cpdef short getVertexConnectivityValue(Vertex vertex) except 1:
     """
     Return a value used to sort vertices prior to poposing candidate pairs in
     :meth:`__VF2_pairs`. The value returned is based on the vertex's
     connectivity values (and assumes that they are set properly).
     """
-    return (-1*vertex.connectivity)
+    return ( -256*vertex.connectivity1 - 16*vertex.connectivity2 - vertex.connectivity3 )
 
 cpdef short getVertexSortingLabel(Vertex vertex) except -1:
     """
@@ -280,20 +286,6 @@ cdef class Graph:
         del edge.vertex1.edges[edge.vertex2]
         del edge.vertex2.edges[edge.vertex1]
 
-    cpdef updateConnectivityValues(self):
-        """
-        Update the connectivity values for each vertex in the graph. These are
-        used to accelerate the isomorphism checking.
-        """
-        cdef Vertex vertex
-        cdef list connectivityValues
-
-        connectivityValues = self.__update([len(vertex.edges) for vertex in self.vertices], 0)
-        for vertex, value in zip(self.vertices, connectivityValues):
-            vertex.connectivity = value
-            
-
-
     cpdef Graph copy(self, bint deep=False):
         """
         Create a copy of the current graph. If `deep` is ``True``, a deep copy
@@ -400,31 +392,25 @@ cdef class Graph:
         cdef Vertex vertex
         for vertex in self.vertices: vertex.resetConnectivityValues()
         
-    cpdef list __update(self, old_values, trial_number):
+    cpdef updateConnectivityValues(self):
         """
-        Recursively generates updated connectivity values, until the number 
-        of different connectivity values does not increase anymore. 
+        Update the connectivity values for each vertex in the graph. These are
+        used to accelerate the isomorphism checking.
         """
         cdef Vertex vertex1, vertex2
-        cdef list new_values
-        
-        new_values = []
+        cdef short count
         
         for vertex1 in self.vertices:
+            count = len(vertex1.edges)
+            vertex1.connectivity1 = count
+        for vertex1 in self.vertices:
             count = 0
-            for vertex2 in vertex1.edges: count += old_values[self.vertices.index(vertex2)]
-            new_values.append(count)
-
-        element_count_old = len(set(old_values))
-        element_count_new = len(set(new_values))
-
-        if element_count_new > element_count_old:
-            return self.__update(new_values, 0)
-        elif element_count_new == element_count_old and trial_number <= MAX_NUMBER_OF_TRIALS:
-            trial_number += 1
-            return self.__update(new_values, trial_number)
-        else:
-            return old_values
+            for vertex2 in vertex1.edges: count += vertex2.connectivity1
+            vertex1.connectivity2 = count
+        for vertex1 in self.vertices:
+            count = 0
+            for vertex2 in vertex1.edges: count += vertex2.connectivity2
+            vertex1.connectivity3 = count
 
     cpdef sortVertices(self):
         """
@@ -433,18 +419,14 @@ cdef class Graph:
         """
         cdef Vertex vertex
         cdef int index
-        cdef list connectivityValues
-
         # Only need to conduct sort if there is an invalid sorting label on any vertex
         for vertex in self.vertices:
             if vertex.sortingLabel < 0: break
         else:
-            self.vertices.sort(key=getVertexSortingLabel)
             return
         # If we need to sort then let's also update the connecitivities so
         # we're sure they are right, since the sorting labels depend on them
         self.updateConnectivityValues()
-
         self.vertices.sort(key=getVertexConnectivityValue)
         for index, vertex in enumerate(self.vertices):
             vertex.sortingLabel = index

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -232,7 +232,9 @@ class TestGraph(unittest.TestCase):
         """
         self.graph.resetConnectivityValues()
         for vertex in self.graph.vertices:
-            self.assertEqual(vertex.connectivity, -1)
+            self.assertEqual(vertex.connectivity1, -1)
+            self.assertEqual(vertex.connectivity2, -1)
+            self.assertEqual(vertex.connectivity3, -1)
             self.assertEqual(vertex.sortingLabel, -1)
     
     def test_updateConnectivityValues(self):
@@ -240,17 +242,29 @@ class TestGraph(unittest.TestCase):
         Test the Graph.updateConnectivityValues() method.
         """
         self.graph.updateConnectivityValues()
-        self.assertEqual(self.graph.vertices[0].connectivity, 10)
+        self.assertEqual(self.graph.vertices[0].connectivity1, 1)
+        self.assertEqual(self.graph.vertices[0].connectivity2, 2)
+        self.assertEqual(self.graph.vertices[0].connectivity3, 3)
         self.assertEqual(self.graph.vertices[0].sortingLabel, -1)
-        self.assertEqual(self.graph.vertices[1].connectivity, 19)
+        self.assertEqual(self.graph.vertices[1].connectivity1, 2)
+        self.assertEqual(self.graph.vertices[1].connectivity2, 3)
+        self.assertEqual(self.graph.vertices[1].connectivity3, 6)
         self.assertEqual(self.graph.vertices[1].sortingLabel, -1)
-        self.assertEqual(self.graph.vertices[2].connectivity, 23)
+        self.assertEqual(self.graph.vertices[2].connectivity1, 2)
+        self.assertEqual(self.graph.vertices[2].connectivity2, 4)
+        self.assertEqual(self.graph.vertices[2].connectivity3, 7)
         self.assertEqual(self.graph.vertices[2].sortingLabel, -1)
-        self.assertEqual(self.graph.vertices[3].connectivity, 23)
+        self.assertEqual(self.graph.vertices[3].connectivity1, 2)
+        self.assertEqual(self.graph.vertices[3].connectivity2, 4)
+        self.assertEqual(self.graph.vertices[3].connectivity3, 7)
         self.assertEqual(self.graph.vertices[3].sortingLabel, -1)
-        self.assertEqual(self.graph.vertices[4].connectivity, 19)
+        self.assertEqual(self.graph.vertices[4].connectivity1, 2)
+        self.assertEqual(self.graph.vertices[4].connectivity2, 3)
+        self.assertEqual(self.graph.vertices[4].connectivity3, 6)
         self.assertEqual(self.graph.vertices[4].sortingLabel, -1)
-        self.assertEqual(self.graph.vertices[5].connectivity, 10)
+        self.assertEqual(self.graph.vertices[5].connectivity1, 1)
+        self.assertEqual(self.graph.vertices[5].connectivity2, 2)
+        self.assertEqual(self.graph.vertices[5].connectivity3, 3)
         self.assertEqual(self.graph.vertices[5].sortingLabel, -1)
     
     def test_sortVertices(self):
@@ -261,11 +275,17 @@ class TestGraph(unittest.TestCase):
         self.graph.sortVertices()
         for vertex1, vertex2 in zip(self.graph.vertices[:-1], self.graph.vertices[1:]):
             self.assertTrue(vertex1.sortingLabel < vertex2.sortingLabel)
-            self.assertTrue(vertex1.connectivity >= vertex2.connectivity)
+            self.assertTrue(vertex1.connectivity3 >= vertex2.connectivity3)
+            self.assertTrue(vertex1.connectivity2 >= vertex2.connectivity2)
+            self.assertTrue(vertex1.connectivity1 >= vertex2.connectivity1)
     
     def test_vertex_connectivity_values(self):
         """
         Tests the vertex connectivity values as introduced by Morgan (1965).
+        
+        First CV1 is the number of neighbours
+        CV2 is the sum of neighbouring CV1 values
+        CV3 is the sum of neighbouring CV2 values
         
         Graph:     Expected (and tested) values:
         
@@ -273,8 +293,6 @@ class TestGraph(unittest.TestCase):
         |                    |           |             |
         5                    1           3             4
         
-                                # = 3     # = 4         # = 4
-                                         *selected*
         """
         vertices = [Vertex() for i in range(6)]
         edges = [
@@ -291,8 +309,14 @@ class TestGraph(unittest.TestCase):
     
         graph.updateConnectivityValues()
 
-        for i,cv_ in enumerate([11, 15, 18, 10, 7, 11]):
-            cv = vertices[i].connectivity
+        for i,cv_ in enumerate([1,3,2,2,1,1]):
+            cv = vertices[i].connectivity1
+            self.assertEqual(cv, cv_, "On vertex {0:d} got connectivity[0]={1:d} but expected {2:d}".format(i,cv,cv_))
+        for i,cv_ in enumerate([3,4,5,3,2,3]):
+            cv = vertices[i].connectivity2
+            self.assertEqual(cv, cv_, "On vertex {0:d} got connectivity[0]={1:d} but expected {2:d}".format(i,cv,cv_))
+        for i,cv_ in enumerate([4,11,7,7,3,4]):
+            cv = vertices[i].connectivity3
             self.assertEqual(cv, cv_, "On vertex {0:d} got connectivity[0]={1:d} but expected {2:d}".format(i,cv,cv_))
 
     def test_isomorphism(self):
@@ -393,7 +417,9 @@ class TestGraph(unittest.TestCase):
 
         self.assertEqual(len(graph0.vertices), len(graph.vertices))
         for v1, v2 in zip(graph0.vertices, graph.vertices):
-            self.assertEqual(v1.connectivity, v2.connectivity)
+            self.assertEqual(v1.connectivity1, v2.connectivity1)
+            self.assertEqual(v1.connectivity2, v2.connectivity2)
+            self.assertEqual(v1.connectivity3, v2.connectivity3)
             self.assertEqual(v1.sortingLabel, v2.sortingLabel)
             self.assertEqual(len(v1.edges), len(v2.edges))
         self.assertTrue(graph0.isIsomorphic(graph))

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -90,7 +90,9 @@ class GroupAtom(Vertex):
         """
         d = {
             'edges': self.edges,
-            'connectivity': self.connectivity,
+            'connectivity1': self.connectivity1,
+            'connectivity2': self.connectivity2,
+            'connectivity3': self.connectivity3,
             'sortingLabel': self.sortingLabel,
         }
         atomType = self.atomType
@@ -103,7 +105,9 @@ class GroupAtom(Vertex):
         A helper function used when unpickling an object.
         """
         self.edges = d['edges']
-        self.connectivity = d['connectivity']
+        self.connectivity1 = d['connectivity1']
+        self.connectivity2 = d['connectivity2']
+        self.connectivity3 = d['connectivity3']
         self.sortingLabel = d['sortingLabel']
 
     def __str__(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -115,7 +115,9 @@ class Atom(Vertex):
         """
         d = {
             'edges': self.edges,
-            'connectivity': self.connectivity,
+            'connectivity1': self.connectivity1,
+            'connectivity2': self.connectivity2,
+            'connectivity3': self.connectivity3,
             'sortingLabel': self.sortingLabel,
             'atomType': self.atomType.label if self.atomType else None,
             'lonePairs': self.lonePairs,
@@ -127,7 +129,9 @@ class Atom(Vertex):
         A helper function used when unpickling an object.
         """
         self.edges = d['edges']
-        self.connectivity = d['connectivity']
+        self.connectivity1 = d['connectivity1']
+        self.connectivity2 = d['connectivity2']
+        self.connectivity3 = d['connectivity3']
         self.sortingLabel = d['sortingLabel']
         self.atomType = atomTypes[d['atomType']] if d['atomType'] else None
         self.lonePairs = d['lonePairs']

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1395,8 +1395,16 @@ multiplicity 2
         except OverflowError:
             self.fail("updateConnectivityValues() raised OverflowError unexpectedly!")
 
-        
-
+    def testLargeMolCreation(self):
+        """
+        Test that molecules greater than C80 can be created.
+        """
+        for i in xrange(1,80):
+            smi = 'C'*i
+            try:
+                m = Molecule(SMILES=smi)
+            except OverflowError:
+                self.fail('Creation of C{} failed!'.format(i))
 
 
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1397,9 +1397,10 @@ multiplicity 2
 
     def testLargeMolCreation(self):
         """
-        Test that molecules greater than C80 can be created.
+        Test molecules between C1 to C201 in 10 carbon intervals to make
+        sure that overflow errors are not generated.
         """
-        for i in xrange(1,80):
+        for i in xrange(1,202,10):
             smi = 'C'*i
             try:
                 m = Molecule(SMILES=smi)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -66,7 +66,9 @@ def generateAdjacentResonanceIsomers(mol):
                 for index in range(len(mol.vertices)):
                     v1 = mol.vertices[index]
                     v2 = isomer.vertices[index]
-                    v2.connectivity = v1.connectivity
+                    v2.connectivity1 = v1.connectivity1
+                    v2.connectivity2 = v1.connectivity2
+                    v2.connectivity3 = v1.connectivity3
                     v2.sortingLabel = v1.sortingLabel
                 # Restore current isomer
                 atom1.incrementRadical()
@@ -109,7 +111,9 @@ def generateLonePairRadicalResonanceIsomers(mol):
                 for index in range(len(mol.vertices)):
                     v1 = mol.vertices[index]
                     v2 = isomer.vertices[index]
-                    v2.connectivity = v1.connectivity
+                    v2.connectivity1 = v1.connectivity1
+                    v2.connectivity2 = v1.connectivity2
+                    v2.connectivity3 = v1.connectivity3
                     v2.sortingLabel = v1.sortingLabel
                 # Restore current isomer
                 atom1.incrementRadical()
@@ -156,7 +160,9 @@ def generateN5dd_N5tsResonanceIsomers(mol):
                 for index in range(len(mol.vertices)):
                     v1 = mol.vertices[index]
                     v2 = isomer.vertices[index]
-                    v2.connectivity = v1.connectivity
+                    v2.connectivity1 = v1.connectivity1
+                    v2.connectivity2 = v1.connectivity2
+                    v2.connectivity3 = v1.connectivity3
                     v2.sortingLabel = v1.sortingLabel
                 # Restore current isomer
                 bond12.incrementOrder()
@@ -187,7 +193,9 @@ def generateN5dd_N5tsResonanceIsomers(mol):
                 for index in range(len(mol.vertices)):
                     v1 = mol.vertices[index]
                     v2 = isomer.vertices[index]
-                    v2.connectivity = v1.connectivity
+                    v2.connectivity1 = v1.connectivity1
+                    v2.connectivity2 = v1.connectivity2
+                    v2.connectivity3 = v1.connectivity3
                     v2.sortingLabel = v1.sortingLabel
                 # Restore current isomer
                 bond12.incrementOrder()

--- a/rmgpy/molecule/vf2.pyx
+++ b/rmgpy/molecule/vf2.pyx
@@ -223,7 +223,9 @@ cdef class VF2:
         
         if not self.subgraph:
             # To be feasible the connectivity values must be an exact match
-            if vertex1.connectivity != vertex2.connectivity: return False
+            if vertex1.connectivity1 != vertex2.connectivity1: return False
+            if vertex1.connectivity2 != vertex2.connectivity2: return False
+            if vertex1.connectivity3 != vertex2.connectivity3: return False
         
         # Semantic check #1: vertex1 and vertex2 must be equivalent
         if self.subgraph:


### PR DESCRIPTION
revert it back to the triple connectivity values per Vertex,
which has less discriminatory power, but is more robust for larger
molecules.

should address #564 