### PR TITLE
Add a function for getting polycyclic cycles only

### DIFF
--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -116,6 +116,8 @@ cdef class Graph:
     cpdef list getAllCyclicVertices(self)
     
     cpdef list getAllPolycyclicVertices(self)
+    
+    cpdef list getPolycyclicRings(self)
 
     cpdef list getAllCycles(self, Vertex startingVertex)
 

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -545,8 +545,49 @@ cdef class Graph:
                     else:
                         if vertex not in polycyclicVertices:
                             polycyclicVertices.append(vertex)     
-        return polycyclicVertices                                    
-
+        return polycyclicVertices        
+    
+    cpdef list getPolycyclicRings(self):
+        """
+        Return a list of cycles that are polycyclic.
+        In other words, merge the cycles which are fused or spirocyclic into 
+        a single polycyclic cycle, and return only those cycles. 
+        Cycles which are not polycyclic are not returned.
+        """
+        cdef list polycyclicVertices, continuousCycles, SSSR
+        cdef set polycyclicCycle
+        cdef Vertex vertex
+        
+        polycyclicVertices = self.getAllPolycyclicVertices()
+        
+        if not polycyclicVertices:
+            # no polycyclic vertices detected
+            return []
+        else: 
+            # polycyclic vertices found, merge cycles together
+            # that have common polycyclic vertices
+            SSSR = self.getSmallestSetOfSmallestRings()
+            
+            continuousCycles = []
+            for vertex in polycyclicVertices:
+                # First check if it is in any existing continuous cycles
+                for cycle in continuousCycles:
+                    if vertex in cycle:
+                        polycyclicCycle = cycle
+                        break
+                else:
+                    # Otherwise create a new cycle
+                    polycyclicCycle = set()
+                    continuousCycles.append(polycyclicCycle)
+                    
+                for cycle in SSSR:
+                    if vertex in cycle:
+                        polycyclicCycle.update(cycle)
+                        
+            # convert each set to a list
+            continuousCycles = [list(cycle) for cycle in continuousCycles]
+            return continuousCycles
+        
     cpdef list getAllCycles(self, Vertex startingVertex):
         """
         Given a starting vertex, returns a list of all the cycles containing

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -512,9 +512,9 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(len(cycleList), 1)
         self.assertEqual(len(cycleList[0]), 4)
         
-    def test_getContinuousRings(self):
+    def test_getPolycyclicRings(self):
         """
-        Test that the Graph.getContinuousRings() method returns 3 distinct continuous rings.
+        Test that the Graph.getPolycyclicRings() method returns only polycyclic rings.
         """
         vertices = [Vertex() for i in range(27)]
         bonds = [
@@ -566,7 +566,7 @@ class TestGraph(unittest.TestCase):
         
         self.assertEqual(polycyclicVertices, expectedPolycyclicVertices)
         
-        continuousRings = graph.getContinuousRings()
+        continuousRings = graph.getPolycyclicRings()
         expectedContinuousRings = [[vertices[index] for index in [1,2,3,4,5,6,22,23,24,25]],
                                    #[vertices[index] for index in [7,8,9,21,20]], # This is a nonpolycyclic ring
                                    [vertices[index] for index in [10,11,12,13,14,16]],

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -511,6 +511,72 @@ class TestGraph(unittest.TestCase):
         cycleList = self.graph.getSmallestSetOfSmallestRings()
         self.assertEqual(len(cycleList), 1)
         self.assertEqual(len(cycleList[0]), 4)
+        
+    def test_getContinuousRings(self):
+        """
+        Test that the Graph.getContinuousRings() method returns 3 distinct continuous rings.
+        """
+        vertices = [Vertex() for i in range(27)]
+        bonds = [
+                 (0,1),
+                 (1,2),
+                 (2,3),
+                 (3,4),
+                 (4,5),
+                 (5,6),
+                 (6,7),
+                 (7,8),
+                 (8,9),
+                 (9,10),
+                 (10,11),
+                 (11,12),
+                 (12,13),
+                 (13,14),
+                 (14,15),
+                 (14,12),
+                 (12,16),
+                 (16,10),
+                 (10,17),
+                 (17,18),
+                 (18,19),
+                 (9,20),
+                 (20,21),
+                 (21,7),
+                 (6,22),
+                 (22,23),
+                 (22,4),
+                 (23,3),
+                 (23,24),
+                 (24,25),
+                 (25,1)
+                 ]
+        edges = []
+        for bond in bonds:
+            edges.append(Edge(vertices[bond[0]], vertices[bond[1]]))
+
+        graph = Graph()
+        for vertex in vertices: graph.addVertex(vertex)
+        for edge in edges: graph.addEdge(edge)
+        graph.updateConnectivityValues()
+        
+        SSSR = graph.getSmallestSetOfSmallestRings()
+        self.assertEqual(len(SSSR),6)
+        polycyclicVertices = set(graph.getAllPolycyclicVertices())
+        expectedPolycyclicVertices = set([vertices[index] for index in [3,23,4,22,12]])
+        
+        self.assertEqual(polycyclicVertices, expectedPolycyclicVertices)
+        
+        continuousRings = graph.getContinuousRings()
+        expectedContinuousRings = [[vertices[index] for index in [1,2,3,4,5,6,22,23,24,25]],
+                                   #[vertices[index] for index in [7,8,9,21,20]], # This is a nonpolycyclic ring
+                                   [vertices[index] for index in [10,11,12,13,14,16]],
+                                   ]
+        
+        # Convert to sets for comparison purposes
+        continuousRings = [set(ring) for ring in continuousRings]
+        expectedContinuousRings = [set(ring) for ring in expectedContinuousRings]
+        for ring in expectedContinuousRings:
+            self.assertTrue(ring in continuousRings)
 
 ################################################################################
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1407,8 +1407,36 @@ multiplicity 2
             except OverflowError:
                 self.fail('Creation of C{} failed!'.format(i))
 
-
-
+    def testGetPolycyclicRings(self):
+        """
+        Test that polycyclic rings within a molecule are returned properly in the function
+        `Graph().getPolycyclicRings()`
+        """
+        # norbornane
+        m1 = Molecule(SMILES='C1CC2CCC1C2')
+        polyrings1 = m1.getPolycyclicRings()
+        self.assertEqual(len(polyrings1), 1)
+        ring = polyrings1[0]
+        self.assertEqual(len(ring),7)  # 7 carbons in cycle
+        
+        # dibenzyl
+        m2 = Molecule(SMILES='C1=CC=C(C=C1)CCC1C=CC=CC=1')
+        polyrings2 = m2.getPolycyclicRings()
+        self.assertEqual(len(polyrings2), 0)
+        
+        # spiro[2.5]octane
+        m3 = Molecule(SMILES='C1CCC2(CC1)CC2')
+        polyrings3 = m3.getPolycyclicRings()
+        self.assertEqual(len(polyrings3), 1)
+        ring = polyrings3[0]
+        self.assertEqual(len(ring),8)
+        
+        # 1-phenyl norbornane
+        m4 = Molecule(SMILES='C1=CC=C(C=C1)C12CCC(CC1)C2')
+        polyrings4 = m4.getPolycyclicRings()
+        self.assertEqual(len(polyrings4), 1)
+        ring = polyrings4[0]
+        self.assertEqual(len(ring),7)
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
Was originally intending to return all distinct cycles, but this function now correctly returns a list of only the polycyclic cycles, which will be useful for fitting polycyclic thermo groups.