### PR TITLE
Update lone pairs

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -286,6 +286,13 @@ class Atom(Vertex):
         """
         return self.element.number == 8
 
+    def isSilicon(self):
+        """
+        Return ``True`` if the atom represents an silicon atom or ``False`` if
+        not.
+        """
+        return self.element.number == 14
+
     def incrementRadical(self):
         """
         Update the atom pattern as a result of applying a GAIN_RADICAL action,
@@ -1510,9 +1517,11 @@ class Molecule(Graph):
                         order = order + 3
                     if bond12.isBenzene():
                         order = order + 1.5
-                        
-                atom1.lonePairs = 4 - atom1.radicalElectrons - int(order)
-        
+
+                if atom1.isSilicon() or atom1.isCarbon():
+                    atom1.lonePairs = (4 - atom1.radicalElectrons - int(order)) / 2
+                else:     
+                    atom1.lonePairs = 4 - atom1.radicalElectrons - int(order)
             else:
                 atom1.lonePairs = 0
                 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1330,7 +1330,21 @@ multiplicity 2
                         rdkitmol.GetBondBetweenAtoms(rdAtomIndices[at1],rdAtomIndices[at2])
                     except RuntimeError:
                         self.fail("RDKit failed in finding the bond in the original atom!")
-                        
+    
+    def testUpdateLonePairs(self):
+        adjlist = """
+1 Si u0 p1 c0 {2,S} {3,S}
+2 H  u0 p0 c0 {1,S}
+3 H  u0 p0 c0 {1,S}
+"""
+
+        mol = Molecule().fromAdjacencyList(adjlist)
+        mol.updateLonePairs()
+        lp = 0
+        for atom in mol.atoms:
+            lp += atom.lonePairs
+        self.assertEqual(lp, 1)
+                    
     def testLargeMolUpdate(self):
         adjlist = """
 1  C u0 p0 c0 {7,S} {33,S} {34,S} {35,S}


### PR DESCRIPTION
This is an update to pull request #582 which I will now close. 

@nickvandewiele to answer your questions, yes this will also be an issue for Carbon and possibly we never caught it earlier because CH2 singlet is less common. I updated the pull request to reflect this.
Also, I did not consider the integer arithmetic, but I think it's ok. We should not have fractional numbers of lone pairs, and I also cannot think of any situation (for carbon or silicon) where the number on the left side would be odd.