### PR TITLE
Improve thermo estimation for cyclics

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -928,9 +928,11 @@ class Database:
                 if center is None or atom is None:
                     return False
                 if isinstance(center, list):
-                    center = center[0]
+                    # Currently, no node in the database should have duplicate labels
+                    # The capability to have duplicate labels in Group() exists but does not have any functionality.
+                    raise DatabaseError('Nodes in the database should not have duplicate labels. Node {0} does.'.format(node))
                 # Semantic check #1: atoms with same label are equivalent
-                elif not atom.isSpecificCaseOf(center):
+                if not atom.isSpecificCaseOf(center):
                     return False
                 # Semantic check #2: labeled atoms that share bond in the group (node)
                 # also share equivalent (or more specific) bond in the structure

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1091,8 +1091,8 @@ class ThermoDatabase(object):
                         self.__addRingCorrectionThermoData(thermoData, self.groups['ring'], molecule, ring)
                     except KeyError:
                         logging.error("Couldn't find in ring database:")
-                        logging.error(ring)
-                        logging.error(ring.toAdjacencyList())
+                        logging.error(molecule)
+                        logging.error(molecule.toAdjacencyList())
                         raise
 
         return thermoData

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1135,7 +1135,14 @@ class ThermoDatabase(object):
             raise KeyError('Node not found in database.')
         # Decide which group to keep
         depthList = [len(ring_database.ancestors(entry)) for entry in matchedRingEntries]
-        mostSpecificMatchedEntry = matchedRingEntries[depthList.index(max(depthList))]
+        mostSpecificMatchIndices = [i for i, x in enumerate(depthList) if x == max(depthList)]
+        
+        mostSpecificMatchedEntries = [matchedRingEntries[idx] for idx in mostSpecificMatchIndices]
+        if len(set(mostSpecificMatchedEntries)) != 1:
+            raise DatabaseError('More than one type of node was found to be most specific for this ring. ')
+
+        # Condense the number of most specific groups down to one
+        mostSpecificMatchedEntry = matchedRingEntries[mostSpecificMatchIndices[0]]
         
         node = mostSpecificMatchedEntry
         while node.data is None and node is not None:

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1199,3 +1199,24 @@ class ThermoDatabase(object):
             return data
         else:
             return self.__addThermoData(thermoData, data)
+
+    def getRingGroupsFromComments(self, thermoData):
+        """
+        Takes a string of comments from group additivity estimation, and extracts the ring and polycyclic ring groups
+        from them, returning them as lists.
+        """
+        tokens = thermoData.comment.split()
+        ringGroups = []
+        polycyclicGroups = []
+        for token in tokens:
+            if 'ring' in token:
+                splitTokens = re.split("\(|\)",token)
+                assert len(splitTokens) == 3
+                groupLabel = splitTokens[1]
+                ringGroups.append(self.groups['ring'].entries[groupLabel])
+            if 'polycyclic' in token:
+                splitTokens = re.split("\(|\)",token)
+                assert len(splitTokens) == 3
+                groupLabel = splitTokens[1]
+                polycyclicGroups.append(self.groups['polycyclic'].entries[groupLabel])
+        return ringGroups, polycyclicGroups

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1069,31 +1069,27 @@ class ThermoDatabase(object):
         # each ring one time
         
         if cyclic:                
-            if molecule.getAllPolycyclicVertices():
-                # If the molecule has fused ring atoms, this implies that we are dealing
-                # with a polycyclic ring system, for which separate ring strain corrections may not
-                # be adequate.  Therefore, we search the polycyclic thermo group corrections
-                # instead of adding single ring strain corrections within the molecule.
-                # For now, assume only one  polycyclic RSC can be found per molecule
+            monorings, polyrings = molecule.getDisparateRings()
+            for ring in monorings:
+                # Make a temporary structure containing only the atoms in the ring
+                # NB. if any of the ring corrections depend on ligands not in the ring, they will not be found!
                 try:
-                    self.__addGroupThermoData(thermoData, self.groups['polycyclic'], molecule, {})
-                except:
-                    logging.error("Couldn't find in polycyclic ring database:")
+                    self.__addRingCorrectionThermoData(thermoData, self.groups['ring'], molecule, ring)
+                except KeyError:
+                    logging.error("Couldn't find a match in the monocyclic ring database even though monocyclic rings were found.")
                     logging.error(molecule)
                     logging.error(molecule.toAdjacencyList())
                     raise
-            else:
-                rings = molecule.getSmallestSetOfSmallestRings()
-                for ring in rings:
-                    # Make a temporary structure containing only the atoms in the ring
-                    # NB. if any of the ring corrections depend on ligands not in the ring, they will not be found!
-                    try:
-                        self.__addRingCorrectionThermoData(thermoData, self.groups['ring'], molecule, ring)
-                    except KeyError:
-                        logging.error("Couldn't find in ring database:")
-                        logging.error(molecule)
-                        logging.error(molecule.toAdjacencyList())
-                        raise
+            for ring in polyrings:
+                # Make a temporary structure containing only the atoms in the ring
+                # NB. if any of the ring corrections depend on ligands not in the ring, they will not be found!
+                try:
+                    self.__addRingCorrectionThermoData(thermoData, self.groups['polycyclic'], molecule, ring)
+                except KeyError:
+                    logging.error("Couldn't find a match in the polycyclic ring database even though polycyclic rings were found.")
+                    logging.error(molecule)
+                    logging.error(molecule.toAdjacencyList())
+                    raise
 
         return thermoData
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1141,7 +1141,7 @@ class ThermoDatabase(object):
         while node.data is None and node is not None:
             node = node.parent
         if node is None:
-            raise DatabaseError('Unable to determine thermo parameters for {0}: no library entries for {1} or any of its ancestors.'.format(molecule, mostSpecificGroup) )
+            raise DatabaseError('Unable to determine thermo parameters for {0}: no data for {1} or any of its ancestors.'.format(molecule, mostSpecificGroup) )
 
         data = node.data; comment = node.label
         while isinstance(data, basestring) and data is not None:
@@ -1174,7 +1174,7 @@ class ThermoDatabase(object):
         while node.data is None and node is not None:
             node = node.parent
         if node is None:
-            raise DatabaseError('Unable to determine thermo parameters for {0}: no library entries for {1} or any of its ancestors.'.format(molecule, node0) )
+            raise DatabaseError('Unable to determine thermo parameters for {0}: no data for node {1} or any of its ancestors.'.format(molecule, node0) )
 
         data = node.data; comment = node.label
         while isinstance(data, basestring) and data is not None:

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -148,6 +148,7 @@ class TestThermoDatabase(unittest.TestCase):
 #            for T, Cp in zip(self.Tlist, Cplist):
 #                self.assertAlmostEqual(Cp, thermoData.getHeatCapacity(T) / 4.184, places=1, msg="Cp{1} error for {0}".format(smiles, T))
 
+
 class TestThermoDatabaseAromatics(TestThermoDatabase):
     """
     Test only Aromatic species.
@@ -164,6 +165,42 @@ class TestThermoDatabaseAromatics(TestThermoDatabase):
     def __init__(self, *args, **kwargs):
         super(TestThermoDatabaseAromatics, self).__init__(*args, **kwargs)
         self._testMethodDoc = self._testMethodDoc.strip().split('\n')[0] + " for Aromatics.\n"
+
+
+class TestCyclicThermo(unittest.TestCase):
+    """
+    Contains unit tests of the ThermoDatabase class.
+    """
+    database = ThermoDatabase()
+    database.load(os.path.join(settings['database.directory'], 'thermo'))
+    
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        
+        self.database = self.__class__.database
+    
+    def testComputeGroupAdditivityThermoForTwoRingMolecule(self):
+        """
+        The molecule being tested has two rings, one is 13cyclohexadiene5methylene
+        the other is benzene ring. This method is to test thermo estimation will
+        give two different corrections accordingly. 
+        """
+        import re
+        spec = Species().fromSMILES('CCCCCCCCCCCC(CC=C1C=CC=CC1)c1ccccc1')
+        spec.generateResonanceIsomers()
+        thermo = self.database.computeGroupAdditivityThermo(spec.molecule[1])
+        tokens = thermo.comment.split()
+        matchedRings = []
+        for token in tokens:
+            if 'ring' in token:
+                splitTokens = re.split("\(|\)",token)
+                matchedRing = splitTokens[1]
+                matchedRings.append(matchedRing)
+        matchedRings.sort()
+        expected_matchedRings = ['13cyclohexadiene5methylene', 'Ring']
+        self.assertEqual(matchedRings, expected_matchedRings)
 
 ################################################################################
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -190,17 +190,16 @@ class TestCyclicThermo(unittest.TestCase):
         import re
         spec = Species().fromSMILES('CCCCCCCCCCCC(CC=C1C=CC=CC1)c1ccccc1')
         spec.generateResonanceIsomers()
-        thermo = self.database.computeGroupAdditivityThermo(spec.molecule[1])
-        tokens = thermo.comment.split()
-        matchedRings = []
-        for token in tokens:
-            if 'ring' in token:
-                splitTokens = re.split("\(|\)",token)
-                matchedRing = splitTokens[1]
-                matchedRings.append(matchedRing)
-        matchedRings.sort()
-        expected_matchedRings = ['13cyclohexadiene5methylene', 'Ring']
-        self.assertEqual(matchedRings, expected_matchedRings)
+        thermo = self.database.getThermoDataFromGroups(spec)
+
+        ringGroups, polycyclicGroups = self.database.getRingGroupsFromComments(thermo)
+        self.assertEqual(len(ringGroups),2)
+        self.assertEqual(len(polycyclicGroups),0)
+
+        expected_matchedRingsLabels = ['13cyclohexadiene5methylene', 'Benzene']
+        expected_matchedRings = [self.database.groups['ring'].entries[label] for label in expected_matchedRingsLabels]
+
+        self.assertEqual(set(ringGroups), set(expected_matchedRings))
 
 ################################################################################
 

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -118,6 +118,10 @@ cdef class Graph:
     cpdef list getAllPolycyclicVertices(self)
     
     cpdef list getPolycyclicRings(self)
+    
+    cpdef list getMonocyclicRings(self)
+    
+    cpdef tuple getDisparateRings(self)
 
     cpdef list getAllCycles(self, Vertex startingVertex)
 

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -558,6 +558,10 @@ cdef class Graph:
         cdef set polycyclicCycle
         cdef Vertex vertex
         
+        SSSR = self.getSmallestSetOfSmallestRings()
+        if not SSSR:
+            return []
+        
         polycyclicVertices = self.getAllPolycyclicVertices()
         
         if not polycyclicVertices:
@@ -565,9 +569,7 @@ cdef class Graph:
             return []
         else: 
             # polycyclic vertices found, merge cycles together
-            # that have common polycyclic vertices
-            SSSR = self.getSmallestSetOfSmallestRings()
-            
+            # that have common polycyclic vertices            
             continuousCycles = []
             for vertex in polycyclicVertices:
                 # First check if it is in any existing continuous cycles

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -686,8 +686,11 @@ class Group(Graph):
         for atom in self.vertices:
             if atom.label != '':
                 if atom.label in labeled:
-                    labeled[atom.label] = [labeled[atom.label]]
-                    labeled[atom.label].append(atom)
+                    if isinstance(labeled[atom.label],list):
+                        labeled[atom.label].append(atom)
+                    else:
+                        labeled[atom.label] = [labeled[atom.label]]
+                        labeled[atom.label].append(atom)
                 else:
                     labeled[atom.label] = atom
         return labeled

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -944,8 +944,11 @@ class Molecule(Graph):
         for atom in self.vertices:
             if atom.label != '':
                 if atom.label in labeled:
-                    labeled[atom.label] = [labeled[atom.label]]
-                    labeled[atom.label].append(atom)
+                    if isinstance(labeled[atom.label],list):
+                        labeled[atom.label].append(atom)
+                    else:
+                        labeled[atom.label] = [labeled[atom.label]]
+                        labeled[atom.label].append(atom)
                 else:
                     labeled[atom.label] = atom
         return labeled

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -519,7 +519,29 @@ class TestMolecule(unittest.TestCase):
             else:
                 self.assertFalse(atom.label in labeled)
                 self.assertFalse(atom in labeled.values())
-
+        
+        multipleLabelMolecule = Molecule().fromAdjacencyList("""
+1 * C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2 * C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3 * C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4 * C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 *1 H u0 p0 c0 {2,S}
+8 *1 H u0 p0 c0 {2,S}
+9 H u0 p0 c0 {3,S}
+10 *1 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+""")
+        labeled = multipleLabelMolecule.getLabeledAtoms()
+        self.assertTrue('*' in labeled)
+        self.assertTrue('*1' in labeled)
+        self.assertEqual(len(labeled['*']),4)
+        self.assertEqual(len(labeled['*1']),3)
+        
     def testGetFormula(self):
         """
         Test the Molecule.getLabeledAtoms() method.

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1437,6 +1437,63 @@ multiplicity 2
         self.assertEqual(len(polyrings4), 1)
         ring = polyrings4[0]
         self.assertEqual(len(ring),7)
+        
+    def testGetMonocyclicRings(self):
+        """
+        Test that monocyclic rings within a molecule are returned properly in the function
+        `Graph().getMonocyclicRings()`
+        """
+        m1 = Molecule(SMILES='C(CCCC1CCCCC1)CCCC1CCCC1')
+        monorings = m1.getMonocyclicRings()
+        self.assertEqual(len(monorings),2)
+        
+        m2 = Molecule(SMILES='C(CCC1C2CCC1CC2)CC1CCC1')
+        monorings = m2.getMonocyclicRings()
+        self.assertEqual(len(monorings),1)
+        self.assertEqual(len(monorings[0]),4)
+        
+        m3 = Molecule(SMILES='CCCCC')
+        monorings = m3.getMonocyclicRings()
+        self.assertEqual(len(monorings),0)
+        
+    def testGetDisparateRings(self):
+        """
+        Test that monocyclic rings within a molecule are returned properly in the function
+        `Graph().getDisparateRings()`
+        """
+        
+        # norbornane
+        m1 = Molecule(SMILES='C1CC2CCC1C2')
+        monorings, polyrings = m1.getDisparateRings()
+        self.assertEqual(len(monorings), 0)
+        self.assertEqual(len(polyrings), 1)
+        self.assertEqual(len(polyrings[0]),7)  # 7 carbons in cycle
+        
+        m2 = Molecule(SMILES='C(CCC1C2CCC1CC2)CC1CCC1')
+        monorings, polyrings = m2.getDisparateRings()
+        self.assertEqual(len(monorings),1)
+        self.assertEqual(len(polyrings),1)
+        self.assertEqual(len(monorings[0]),4)
+        self.assertEqual(len(polyrings[0]),7)
+        
+        
+        m3 = Molecule(SMILES='C1CCC2(CC1)CC2CCCCC1CCC1')
+        monorings, polyrings = m3.getDisparateRings()
+        self.assertEqual(len(polyrings), 1)
+        self.assertEqual(len(monorings),1)
+        self.assertEqual(len(monorings[0]),4)
+        self.assertEqual(len(polyrings[0]),8)
+        
+        m4 = Molecule(SMILES='CCCC')
+        monorings, polyrings = m4.getDisparateRings()
+        self.assertEqual(len(monorings),0)
+        self.assertEqual(len(polyrings),0)
+        
+        m5 = Molecule(SMILES='C1=CC=C(CCCC2CC2)C(=C1)CCCCCC1CC1')
+        monorings, polyrings = m5.getDisparateRings()
+        self.assertEqual(len(monorings),3)
+        self.assertEqual(len(polyrings),0)
+        
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously the ring correction is always same for all the rings in molecule. This PR fixed this issue by feeding information of each ring when adding ring correction thermo data. A demonstration of this PR can be found [here](https://github.com/KEHANG/rmg_issue/blob/master/thermo_issues/thermo_correction_for_multiple-ring_molecules.ipynb).