### PR TITLE
Allow rank to be an additional attribute in thermo database entries

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -189,7 +189,7 @@ class ThermoDepository(Database):
     def __init__(self, label='', name='', shortDesc='', longDesc=''):
         Database.__init__(self, label=label, name=name, shortDesc=shortDesc, longDesc=longDesc)
 
-    def loadEntry(self, index, label, molecule, thermo, reference=None, referenceType='', shortDesc='', longDesc=''):
+    def loadEntry(self, index, label, molecule, thermo, reference=None, referenceType='', shortDesc='', longDesc='', rank=None):
         entry = Entry(
             index = index,
             label = label,
@@ -199,6 +199,7 @@ class ThermoDepository(Database):
             referenceType = referenceType,
             shortDesc = shortDesc,
             longDesc = longDesc.strip(),
+            rank = rank,
         )
         self.entries[label] = entry
         return entry
@@ -228,6 +229,7 @@ class ThermoLibrary(Database):
                   referenceType='',
                   shortDesc='',
                   longDesc='',
+                  rank=None,
                   ):
         
         molecule = Molecule().fromAdjacencyList(molecule)
@@ -250,6 +252,7 @@ class ThermoLibrary(Database):
             referenceType = referenceType,
             shortDesc = shortDesc,
             longDesc = longDesc.strip(),
+            rank = rank,
         )
 
     def saveEntry(self, f, entry):
@@ -291,7 +294,11 @@ class ThermoGroups(Database):
                   referenceType='',
                   shortDesc='',
                   longDesc='',
+                  rank=3,
                   ):
+        """
+        Default rank for thermo groups is 3.
+        """
         if group[0:3].upper() == 'OR{' or group[0:4].upper() == 'AND{' or group[0:7].upper() == 'NOT OR{' or group[0:8].upper() == 'NOT AND{':
             item = makeLogicNode(group)
         else:
@@ -305,6 +312,7 @@ class ThermoGroups(Database):
             referenceType = referenceType,
             shortDesc = shortDesc,
             longDesc = longDesc.strip(),
+            rank = rank,
         )
     
     def saveEntry(self, f, entry):


### PR DESCRIPTION
Kinetics entries already have rank.  Allow rank to be entered as an attribute for thermo as well, for the purpose of prioritizing thermo.

In the initial phase, we can use human-assigned rank to sort thermo, thereafter we can use a metric associated with uncertainties to assign a rank automatically.  

Assign a rank of 3 by default to all thermo groups.