### PR TITLE
Add functionality to assist in saving training reactions and thermo groups to RMG

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -635,6 +635,43 @@ class KineticsFamily(Database):
         Write the given `entry` in the thermo database to the file object `f`.
         """
         return saveEntry(f, entry)
+    
+    def saveTrainingReaction(self, f, reaction, reference=None, referenceType='', shortDesc='',longDesc='', rank=3):
+        """
+        This function takes a reaction object and saves appends it to the training reactions file.
+        Rank is set to a default value of 3 unless otherwise indicated
+        """ 
+        for depository in self.depositories:
+            if depository.label.endswith('training'):
+                break
+        else:
+            logging.info('Could not find training depository in family {0}.'.format(self.label))
+            logging.info('Starting a new one')
+            depository = KineticsDepository()
+            self.depositories.append(depository)
+        
+        
+        trainingDatabase = depository
+        indices = [entry.index for entry in trainingDatabase.entries.values()]
+        if indices:
+            maxIndex = max(indices)
+        else:
+            maxIndex = 0
+            
+        entry = Entry(
+            index = maxIndex+1,
+            label = '',
+            item = reaction,
+            data = reaction.kinetics,
+            reference = reference,
+            referenceType = referenceType,
+            shortDesc = unicode(shortDesc),
+            longDesc = unicode(longDesc),
+            rank = rank,
+            )
+        
+        
+        self.saveEntry(f, entry)
 
     def save(self, path):
         """
@@ -827,9 +864,7 @@ class KineticsFamily(Database):
             if depository.label.endswith('training'):
                 break
         else:
-            logging.info('Could not find training depository in family {0}.'.format(self.label))
-            logging.info('Must be because you turned off the training depository.')
-            return
+            raise Exception("NO training found")
         
         
         index = max([e.index for e in self.rules.getEntries()] or [0]) + 1

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -636,11 +636,15 @@ class KineticsFamily(Database):
         """
         return saveEntry(f, entry)
     
-    def saveTrainingReaction(self, f, reaction, reference=None, referenceType='', shortDesc='',longDesc='', rank=3):
+    def saveTrainingReaction(self, reactions, reference=None, referenceType='', shortDesc='',longDesc='', rank=3):
         """
         This function takes a reaction object and saves appends it to the training reactions file.
         Rank is set to a default value of 3 unless otherwise indicated
         """ 
+        from rmgpy import settings
+
+        training_file = open(os.path.join(settings['database.directory'], 'kinetics', 'families', \
+            self.label, 'training', 'reactions_test.py'), 'w')
         for depository in self.depositories:
             if depository.label.endswith('training'):
                 break
@@ -650,28 +654,27 @@ class KineticsFamily(Database):
             depository = KineticsDepository()
             self.depositories.append(depository)
         
-        
         trainingDatabase = depository
         indices = [entry.index for entry in trainingDatabase.entries.values()]
         if indices:
             maxIndex = max(indices)
         else:
             maxIndex = 0
+        for i, reaction in enumerate(reactions):    
+            entry = Entry(
+                index = maxIndex+i+1,
+                label = str(reaction),
+                item = reaction,
+                data = reaction.kinetics,
+                reference = reference,
+                referenceType = referenceType,
+                shortDesc = unicode(shortDesc),
+                longDesc = unicode(longDesc),
+                rank = rank,
+                )
             
-        entry = Entry(
-            index = maxIndex+1,
-            label = '',
-            item = reaction,
-            data = reaction.kinetics,
-            reference = reference,
-            referenceType = referenceType,
-            shortDesc = unicode(shortDesc),
-            longDesc = unicode(longDesc),
-            rank = rank,
-            )
-        
-        
-        self.saveEntry(f, entry)
+            
+            self.saveEntry(training_file, entry)
 
     def save(self, path):
         """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -643,6 +643,14 @@ class KineticsFamily(Database):
         """ 
         from rmgpy import settings
 
+        training_path = os.path.join(settings['database.directory'], 'kinetics', 'families', \
+            self.label, 'training')
+
+        directory_file = os.path.join(training_path, 'directory.txt')
+
+        # Load the old set of the species of the training reactions
+        speciesDict = Database().getSpecies(directory_file)
+
         training_file = open(os.path.join(settings['database.directory'], 'kinetics', 'families', \
             self.label, 'training', 'reactions_test.py'), 'w')
         for depository in self.depositories:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -924,7 +924,9 @@ class KineticsFamily(Database):
             if depository.label.endswith('training'):
                 break
         else:
-            raise Exception("NO training found")
+            logging.info('Could not find training depository in family {0}.'.format(self.label))
+            logging.info('Must be because you turned off the training depository.')
+            return
         
         
         index = max([e.index for e in self.rules.getEntries()] or [0]) + 1

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -704,6 +704,8 @@ class KineticsFamily(Database):
             maxIndex = 0
         # save new reactions to reactions.py
         for i, reaction in enumerate(reactions):    
+            longDesc = longDesc + 'Taken from entry: {0}'.format(reaction.kinetics.comment)
+            reaction.kinetics.comment = ''
             entry = Entry(
                 index = maxIndex+i+1,
                 label = str(reaction),

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -704,7 +704,7 @@ class KineticsFamily(Database):
             maxIndex = 0
         # save new reactions to reactions.py
         for i, reaction in enumerate(reactions):    
-            longDesc = longDesc + 'Taken from entry: {0}'.format(reaction.kinetics.comment)
+            longDesc = 'Taken from entry: {0}'.format(reaction.kinetics.comment)
             reaction.kinetics.comment = ''
             entry = Entry(
                 index = maxIndex+i+1,

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -636,17 +636,22 @@ class KineticsFamily(Database):
         """
         return saveEntry(f, entry)
     
-    def saveTrainingReaction(self, reactions, reference=None, referenceType='', shortDesc='',longDesc='', rank=3):
+    def saveTrainingReactions(self, reactions, reference=None, referenceType='', shortDesc='', rank=3):
         """
-        This function takes a reaction object and saves appends it to the training reactions file.
-        Rank is set to a default value of 3 unless otherwise indicated
+        This function takes a list of reactions appends it to the training reactions file.  It ignores the existence of
+        duplicate reactions.  
+        
+        The rank for each new reaction's kinetics is set to a default value of 3 unless the user specifies differently 
+        for those reactions.
+        
+        For each entry, the long description is imported from the kinetics comment. 
         """ 
         from rmgpy import settings
 
         training_path = os.path.join(settings['database.directory'], 'kinetics', 'families', \
             self.label, 'training')
 
-        directory_file = os.path.join(training_path, 'dictionary_test.txt')
+        directory_file = os.path.join(training_path, 'dictionary.txt')
 
         # Load the old set of the species of the training reactions
         speciesDict = Database().getSpecies(directory_file)
@@ -683,7 +688,7 @@ class KineticsFamily(Database):
                     speciesDict[spec.label] = spec
 
         training_file = open(os.path.join(settings['database.directory'], 'kinetics', 'families', \
-            self.label, 'training', 'reactions_test.py'), 'a')
+            self.label, 'training', 'reactions.py'), 'a')
         training_file.write("\n\n")
 
         # get max reaction entry index from the existing training data
@@ -717,7 +722,6 @@ class KineticsFamily(Database):
                 longDesc = unicode(longDesc),
                 rank = rank,
                 )
-            
             
             self.saveEntry(training_file, entry)
         training_file.close()

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -202,6 +202,21 @@ def addThermoData(thermoData1, thermoData2, groupAdditivity=False):
                 thermoData1.comment = 'Thermo group additivity estimation: ' + thermoData2.comment
             
         return thermoData1
+    
+def removeThermoData(thermoData1, thermoData2):
+    """
+    Remove the thermodynamic data `thermoData2` from the data `thermoData1`,
+    and return `thermoData1`.
+    """
+    if len(thermoData1.Tdata.value_si) != len(thermoData2.Tdata.value_si) or any([T1 != T2 for T1, T2 in zip(thermoData1.Tdata.value_si, thermoData2.Tdata.value_si)]):
+        raise Exception('Cannot take the difference between these ThermoData objects due to their having different temperature points.')
+
+    for i in range(thermoData1.Tdata.value_si.shape[0]):
+        thermoData1.Cpdata.value_si[i] -= thermoData2.Cpdata.value_si[i]
+    thermoData1.H298.value_si -= thermoData2.H298.value_si
+    thermoData1.S298.value_si -= thermoData2.S298.value_si
+
+    return thermoData1
 
 def averageThermoData(thermoDataList=[]):
     """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -203,6 +203,49 @@ def addThermoData(thermoData1, thermoData2, groupAdditivity=False):
             
         return thermoData1
 
+def averageThermoData(thermoDataList=[]):
+    """
+    Average a list of thermoData values together.
+    Sets uncertainty values to be the approximately the 95% confidence interval, equivalent to
+    2 standard deviations calculated using the sample standard variance:
+    
+    Uncertainty = 2s
+    s = sqrt( sum(abs(x - x.mean())^2) / N - 1) where N is the number of values averaged
+    
+    Note that uncertainties are only computed when number of values is greater than 1.
+    """
+    import copy
+    numValues = len(thermoDataList)
+        
+    if numValues == 0:
+        raise Exception('No thermo data values were inputted to be averaged.')
+    else:
+        print 'Averaging thermo data over {0} value(s).'.format(numValues)
+        
+        if numValues == 1:
+            return copy.deepcopy(thermoDataList[0])
+        
+        else:
+            averagedThermoData = copy.deepcopy(thermoDataList[0])
+            for thermoData in thermoDataList[1:]:
+                averagedThermoData = addThermoData(averagedThermoData, thermoData)
+
+
+            for i in range(averagedThermoData.Tdata.value_si.shape[0]):
+                averagedThermoData.Cpdata.value_si[i] /= numValues
+
+                cpData = [thermoData.Cpdata.value_si[i] for thermoData in thermoDataList]
+                averagedThermoData.Cpdata.uncertainty[i] = 2*numpy.std(cpData, ddof=1)
+
+            HData = [thermoData.H298.value_si for thermoData in thermoDataList]
+            averagedThermoData.H298.value_si /= numValues
+            averagedThermoData.H298.uncertainty_si = 2*numpy.std(HData, ddof=1)
+
+            SData = [thermoData.S298.value_si for thermoData in thermoDataList]
+            averagedThermoData.S298.value_si /= numValues
+            averagedThermoData.S298.uncertainty_si = 2*numpy.std(SData, ddof=1)
+            return averagedThermoData
+
 ################################################################################
 
 class ThermoDepository(Database):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1227,8 +1227,10 @@ class ThermoDatabase(object):
         
         mostSpecificMatchedEntries = [matchedRingEntries[idx] for idx in mostSpecificMatchIndices]
         if len(set(mostSpecificMatchedEntries)) != 1:
-            raise DatabaseError('More than one type of node was found to be most specific for this ring. ')
-
+            logging.warning('More than one type of node was found to be most specific for this ring.')
+            logging.warning('This is either due to a database error in the ring or polycyclic groups, or a partial match between the group and the full ring.')
+            logging.warning(mostSpecificMatchedEntries)
+            
         # Condense the number of most specific groups down to one
         mostSpecificMatchedEntry = matchedRingEntries[mostSpecificMatchIndices[0]]
         


### PR DESCRIPTION
This pull request complements the one in RMG-database carrying scripts for saving kinetics library to training reactions and extracting polycyclic groups from thermo libraries.

Main additions:
- A function to save training reactions to disk and overwrite old ones.  Automatically creates the correct atom labels according to RMG reaction family templates.  Also recognizes existing species in the training dictionary.txt and saves new species accordingly.
- A function to retrieve labeled atoms
- An averageThermoData function for use when averaging several groups together and calculates uncertainty automatically with error = 2s, where s is the sample standard deviation
- Don't crash when more than one most specific ring group is found for thermo