### PR TITLE
Add cantera and observable regression submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ rmgpy/solver/settings.pxi
 
 # bin/symmetry
 bin/symmetry
+
+# ipython checkpoints
+**/.ipynb_checkpoints/**
+
+# cantera files
+*.cti

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - libgcc # [unix]
   - python
   - numpy >=1.10.0
+  - cantera
   - cython ==0.21
   - matplotlib
   - rdkit >=2015.09.2

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -6,6 +6,7 @@ dependencies:
   - mingwpy
   - python
   - numpy >=1.10.0
+  - cantera
   - cython ==0.21
   - matplotlib
   - rdkit >=2015.09.2

--- a/ipython/README
+++ b/ipython/README
@@ -1,0 +1,12 @@
+This folder contains ipython notebooks containing scripts and other notes related to using RMG.
+
+If you do not have ipython installed, we suggest installing it through the jupyter package while your rmg environment is activated by typing the following commands:
+
+source activate rmg_env
+conda install jupyter
+
+
+For Windows users:
+
+activate rmg_env
+conda install jupyter

--- a/ipython/canteraSimulation.ipynb
+++ b/ipython/canteraSimulation.ipynb
@@ -17,7 +17,6 @@
    "source": [
     "from rmgpy.chemkin import *\n",
     "from rmgpy.tools.canteraModel import *\n",
-    "from rmgpy.quantity import *\n",
     "from IPython.display import display, Image"
    ]
   },
@@ -61,9 +60,9 @@
     "\n",
     "reactorType = 'IdealGasReactor'\n",
     "molFracList=[{ethane: 1}]\n",
-    "Tlist = Quantity([1300,1500,2000],'K')\n",
-    "Plist = Quantity([1],'atm')\n",
-    "reactionTime = Quantity(0.5, 'ms')"
+    "Tlist = ([1300,1500,2000],'K')\n",
+    "Plist = ([1],'atm')\n",
+    "reactionTime = (0.5, 'ms')"
    ]
   },
   {

--- a/ipython/canteraSimulation.ipynb
+++ b/ipython/canteraSimulation.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "# Create cantera object, loading in the species and reactions\n",
-    "job = Cantera(speciesList=speciesList, reactionList=reactionList)\n",
+    "job = Cantera(speciesList=speciesList, reactionList=reactionList, outputDirectory='temp')\n",
     "# The cantera file must be created from an associated chemkin file\n",
     "job.loadChemkinModel('data/minimal_model/chem_annotated.inp')\n",
     "# Generate the conditions based on the settings we declared earlier\n",
@@ -95,7 +95,7 @@
     "# Show the plots in the ipython notebook\n",
     "for i, condition in enumerate(job.conditions):\n",
     "    print 'Condition {0}'.format(i+1)\n",
-    "    display(Image(filename=\"{0}_mole_fractions.png\".format(i+1)))"
+    "    display(Image(filename=\"temp/{0}_mole_fractions.png\".format(i+1)))"
    ]
   }
  ],

--- a/ipython/canteraSimulation.ipynb
+++ b/ipython/canteraSimulation.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A Cantera Simulation Using RMG-Py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from rmgpy.chemkin import *\n",
+    "from rmgpy.tools.canteraModel import *\n",
+    "from rmgpy.quantity import *\n",
+    "from IPython.display import display, Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the species and reaction from the RMG-generated chemkin file `chem_annotated.inp` and `species_dictionary.txt` file found in your `chemkin` folder after running a job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "speciesList, reactionList = loadChemkinFile('data/minimal_model/chem_annotated.inp',\n",
+    "                                            'data/minimal_model/species_dictionary.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set a few conditions for how to react the system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Find the species: ethane\n",
+    "ethane = filter(lambda x: x.molecule[0].toSMILES() == 'CC', speciesList)[0]\n",
+    "\n",
+    "reactorType = 'IdealGasReactor'\n",
+    "molFracList=[{ethane: 1}]\n",
+    "Tlist = Quantity([1300,1500,2000],'K')\n",
+    "Plist = Quantity([1],'atm')\n",
+    "reactionTime = Quantity(0.5, 'ms')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Create cantera object, loading in the species and reactions\n",
+    "job = Cantera(speciesList=speciesList, reactionList=reactionList)\n",
+    "# The cantera file must be created from an associated chemkin file\n",
+    "job.loadChemkinModel('data/minimal_model/chem_annotated.inp')\n",
+    "# Generate the conditions based on the settings we declared earlier\n",
+    "job.generateConditions('IdealGasReactor', reactionTime, molFracList, Tlist, Plist)\n",
+    "# Simulate and plot\n",
+    "alldata = job.simulate()\n",
+    "job.plot(alldata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Show the plots in the ipython notebook\n",
+    "for i, condition in enumerate(job.conditions):\n",
+    "    print 'Condition {0}'.format(i+1)\n",
+    "    display(Image(filename=\"{0}_mole_fractions.png\".format(i+1)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/ipython/canteraSimulation.ipynb
+++ b/ipython/canteraSimulation.ipynb
@@ -56,7 +56,8 @@
    "outputs": [],
    "source": [
     "# Find the species: ethane\n",
-    "ethane = filter(lambda x: x.molecule[0].toSMILES() == 'CC', speciesList)[0]\n",
+    "speciesDict = getRMGSpeciesFromSMILES(['CC'], speciesList)\n",
+    "ethane = speciesDict['CC']\n",
     "\n",
     "reactorType = 'IdealGasReactor'\n",
     "molFracList=[{ethane: 1}]\n",

--- a/ipython/data/minimal_model/chem_annotated.inp
+++ b/ipython/data/minimal_model/chem_annotated.inp
@@ -1,0 +1,409 @@
+ELEMENTS H C O N Ne Ar He Si S Cl END
+
+SPECIES
+    Ar                  ! Ar
+    He                  ! He
+    Ne                  ! Ne
+    N2                  ! N2
+    ethane(1)           ! ethane(1)
+    CH3(2)              ! [CH3](2)
+    C2H5(3)             ! C[CH2](3)
+    H(4)                ! [H](4)
+    C(6)                ! C(6)
+    C2H4(8)             ! C=C(8)
+    H2(12)              ! [H][H](12)
+    C2H3(13)            ! [CH]=C(13)
+    C3H7(14)            ! [CH2]CC(14)
+    C#C(25)             ! C#C(25)
+    C4H7(28)            ! [CH2]CC=C(28)
+    C4H6(30)            ! C=CC=C(30)
+    C3H5(32)            ! [CH]=CC(32)
+    C4H7(38)            ! [CH2]C1CC1(38)
+    C4H7(42)            ! C=C[CH]C(42)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+Ar                      Ar1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 4.37967000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 4.37967000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+He                      He1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 9.28724000E-01 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 9.28724000E-01                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+N2                      N 2                 G200.000   6000.000  1000.00       1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R)
+ethane(1)               C 2  H 6            G100.000   5000.000  954.51        1
+ 4.58979490E+00 1.41508373E-02-4.75965840E-06 8.60303049E-10-6.21723965E-14    2
+-1.27217505E+04-3.61718686E+00 3.78034593E+00-3.24276322E-03 5.52385465E-05    3
+-6.38587824E-08 2.28640032E-11-1.16203414E+04 5.21029672E+00                   4
+
+! Thermo library: primaryThermoLibrary + radical(CH3)
+CH3(2)                  C 1  H 3            G100.000   5000.000  1337.61       1
+ 3.54142760E+00 4.76791382E-03-1.82150841E-06 3.28881950E-10-2.22549836E-14    2
+ 1.62239724E+04 1.66052159E+00 3.91546966E+00 1.84152191E-03 3.48747999E-06    3
+-3.32754149E-09 8.49978933E-13 1.62856393E+04 3.51733949E-01                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + radical(CCJ)
+C2H5(3)                 C 2  H 5            G100.000   5000.000  900.31        1
+ 5.15617174E+00 9.43129067E-03-1.81949838E-06 2.21205004E-10-1.43489057E-14    2
+ 1.20640975E+04-2.91077934E+00 3.82185005E+00-3.43378192E-03 5.09264055E-05    3
+-6.20221249E-08 2.37077855E-11 1.30660123E+04 7.61638388E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H(4)                    H 1                 G100.000   5000.000  4484.82       1
+ 2.50003916E+00-3.40586045E-08 1.10996924E-11-1.60664106E-15 8.71471667E-20    2
+ 2.54741818E+04-4.45221594E-01 2.50000000E+00-1.08860897E-13 1.40734568E-16    3
+-5.92258814E-20 7.66587112E-24 2.54742178E+04-4.44972896E-01                   4
+
+! Thermo library: primaryThermoLibrary
+C(6)                    C 1  H 4            G100.000   5000.000  1084.13       1
+ 9.08313739E-01 1.14540067E-02-4.57169366E-06 8.29181308E-10-5.66306408E-14    2
+-9.71999547E+03 1.39928224E+01 4.20540691E+00-5.35547766E-03 2.51120035E-05    3
+-2.13758865E-08 5.97507989E-12-1.01619429E+04-9.21249253E-01                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R)
+C2H4(8)                 C 2  H 4            G100.000   5000.000  940.43        1
+ 5.20280168E+00 7.82475799E-03-2.12702899E-06 3.79737061E-10-2.94709582E-14    2
+ 3.93636002E+03-6.62303115E+00 3.97980494E+00-7.57634497E-03 5.53000824E-05    3
+-6.36259576E-08 2.31784291E-11 5.07745828E+03 4.04601267E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H2(12)                  H 2                 G100.000   5000.000  1959.08       1
+ 2.78815583E+00 5.87653941E-04 1.59004331E-07-5.52726812E-11 4.34302082E-15    2
+-5.96138366E+02 1.12791966E-01 3.43536421E+00 2.12709522E-04-2.78623158E-07    3
+ 3.40265688E-10-7.76028337E-14-1.03135985E+03-3.90841769E+00                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + radical(Cds_P)
+C2H3(13)                C 2  H 3            G100.000   5000.000  931.98        1
+ 5.44813107E+00 4.98327331E-03-1.08803890E-06 1.79796949E-10-1.45062513E-14    2
+ 3.38297071E+04-4.87901034E+00 3.90665134E+00-4.06174057E-03 3.86755114E-05    3
+-4.62941932E-08 1.72884714E-11 3.47971806E+04 6.09808171E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsHH) + gauche(Cs(CsCsRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group
+! (Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + radical(RCCJ)
+C3H7(14)                C 3  H 7            G100.000   5000.000  995.41        1
+ 5.69425939E+00 1.96034259E-02-7.42054586E-06 1.35884122E-09-9.56224559E-14    2
+ 8.87586945E+03-4.32861513E+00 3.09192556E+00 1.32170970E-02 2.75852925E-05    3
+-3.90855887E-08 1.43316334E-11 1.02284112E+04 1.24057425E+01                   4
+
+! Thermo group additivity estimation: group(Ct-CtH) + other(R) + group(Ct-CtH) + other(R)
+C#C(25)                 C 2  H 2            G100.000   5000.000  888.63        1
+ 5.76205672E+00 2.37156728E-03-1.49570518E-07-2.19184024E-11 2.21803931E-15    2
+ 2.50944454E+04-9.82614977E+00 3.03574274E+00 7.71244864E-03 2.53470577E-06    3
+-1.08129911E-08 5.50741840E-12 2.58526445E+04 4.54462926E+00                   4
+
+! Thermo group additivity estimation: group(Cs-(Cds-Cds)CsHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group
+! (Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + radical(RCCJ)
+C4H7(28)                C 4  H 7            G100.000   5000.000  1000.95       1
+ 7.59476146E+00 2.06425238E-02-7.89786242E-06 1.45965147E-09-1.03414080E-13    2
+ 2.08073219E+04-1.19157525E+01 2.68060393E+00 2.10826948E-02 2.02118910E-05    3
+-3.64237902E-08 1.41442606E-11 2.27528016E+04 1.66008926E+01                   4
+
+! Thermo group additivity estimation: group(Cds-Cds(Cds-Cds)H) + gauche(CsOsCdSs) + other(R) + group(Cds-Cds(Cds-Cds)H) + gauche(CsOsCdSs) + other(R) +
+! group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R)
+C4H6(30)                C 4  H 6            G100.000   5000.000  940.95        1
+ 1.10824600E+01 1.17733335E-02-3.11402962E-06 5.37718360E-10-4.10600181E-14    2
+ 8.42123300E+03-3.51702407E+01 2.68201658E+00 1.69327220E-02 3.73632227E-05    3
+-6.26457659E-08 2.59136452E-11 1.13546033E+04 1.20325469E+01                   4
+
+! Thermo group additivity estimation: group(Cs-(Cds-Cds)HHH) + gauche(Cs(RRRR)) + other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group
+! (Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + radical(Cds_P)
+C3H5(32)                C 3  H 5            G100.000   5000.000  997.87        1
+ 5.66469529E+00 1.44326367E-02-5.46739500E-06 1.00158261E-09-7.04862777E-14    2
+ 2.93870921E+04-4.48503353E+00 3.23408549E+00 1.18207819E-02 1.70307519E-05    3
+-2.64368758E-08 9.91228999E-12 3.04873063E+04 1.03182642E+01                   4
+
+! Thermo group additivity estimation: group(Cs-CsCsCsH) + other(R) + group(Cs-CsCsHH) + other(R) + group(Cs-CsCsHH) + other(R) + group(Cs-CsHHH) +
+! other(R) + ring(Cyclopropane) + radical(Isobutyl)
+C4H7(38)                C 4  H 7            G100.000   5000.000  926.07        1
+ 1.02346473E+01 1.41131559E-02-2.99924875E-06 4.56619334E-10-3.49798669E-14    2
+ 2.27933478E+04-2.92349459E+01 3.04736392E+00 5.45573406E-03 7.53307460E-05    3
+-1.02226494E-07 4.01827541E-11 2.58269389E+04 1.40791130E+01                   4
+
+! Thermo group additivity estimation: group(Cs-(Cds-Cds)HHH) + gauche(Cs(RRRR)) + other(R) + group(Cs-(Cds-Cds)HHH) + gauche(Cs(RRRR)) + other(R) +
+! group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + radical(Allyl_P)
+C4H7(42)                C 4  H 7            G100.000   5000.000  998.55        1
+ 7.82797399E+00 2.08401442E-02-7.96757761E-06 1.47338627E-09-1.04526288E-13    2
+ 1.26472555E+04-1.65749915E+01 2.64215209E+00 2.15951606E-02 2.09692283E-05    3
+-3.79221130E-08 1.47849727E-11 1.46809423E+04 1.34334361E+01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #1
+! Template reaction: R_Recombination
+! Flux pairs: CH3(2), ethane(1); CH3(2), ethane(1); 
+! Exact match found for rate rule (C_methyl;C_methyl)
+CH3(2)+CH3(2)=ethane(1)                             8.260e+17 -1.400    1.000    
+
+! Reaction index: Chemkin #2; RMG #4
+! Template reaction: H_Abstraction
+! Flux pairs: ethane(1), C2H5(3); CH3(2), C(6); 
+! Estimated using template (C/H3/Cs;C_methyl) for rate rule (C/H3/Cs\H3;C_methyl)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+CH3(2)=C2H5(3)+C(6)                       4.488e-05 4.990     8.000    
+
+! Reaction index: Chemkin #3; RMG #2
+! Template reaction: R_Recombination
+! Flux pairs: C2H5(3), ethane(1); H(4), ethane(1); 
+! Exact match found for rate rule (C_rad/H2/Cs;H_rad)
+C2H5(3)+H(4)=ethane(1)                              1.000e+14 0.000     0.000    
+
+! Reaction index: Chemkin #4; RMG #13
+! Template reaction: R_Recombination
+! Flux pairs: CH3(2), C(6); H(4), C(6); 
+! Exact match found for rate rule (C_methyl;H_rad)
+CH3(2)+H(4)=C(6)                                    1.930e+14 0.000     0.270    
+
+! Reaction index: Chemkin #5; RMG #6
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: C2H4(8), C2H5(3); H(4), C2H5(3); 
+! Exact match found for rate rule (Cds-HH_Cds-HH;HJ)
+! Multiplied by reaction path degeneracy 2
+H(4)+C2H4(8)=C2H5(3)                                4.620e+08 1.640     1.010    
+
+! Reaction index: Chemkin #6; RMG #8
+! Template reaction: Disproportionation
+! Flux pairs: CH3(2), C(6); C2H5(3), C2H4(8); 
+! Exact match found for rate rule (C_methyl;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+CH3(2)+C2H5(3)=C(6)+C2H4(8)                         6.570e+14 -0.680    0.000    
+
+! Reaction index: Chemkin #7; RMG #11
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(3), ethane(1); C2H5(3), C2H4(8); 
+! Exact match found for rate rule (C_rad/H2/Cs;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+C2H5(3)+C2H5(3)=ethane(1)+C2H4(8)                   6.900e+13 -0.350    0.000    
+
+! Reaction index: Chemkin #8; RMG #15
+! Template reaction: H_Abstraction
+! Flux pairs: ethane(1), C2H5(3); H(4), H2(12); 
+! Estimated using template (C/H3/Cs;H_rad) for rate rule (C/H3/Cs\H3;H_rad)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+H(4)=C2H5(3)+H2(12)                       6.180e+03 3.240     7.100    
+
+! Reaction index: Chemkin #9; RMG #17
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(3), C2H4(8); H(4), H2(12); 
+! Exact match found for rate rule (H_rad;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 6
+C2H5(3)+H(4)=C2H4(8)+H2(12)                         2.166e+13 0.000     0.000    
+
+! Reaction index: Chemkin #10; RMG #18
+! Template reaction: H_Abstraction
+! Flux pairs: C(6), CH3(2); H(4), H2(12); 
+! Exact match found for rate rule (C_methane;H_rad)
+! Multiplied by reaction path degeneracy 4
+H(4)+C(6)=CH3(2)+H2(12)                             8.760e-01 4.340     8.200    
+
+! Reaction index: Chemkin #11; RMG #19
+! Template reaction: R_Recombination
+! Flux pairs: H(4), H2(12); H(4), H2(12); 
+! Exact match found for rate rule (H_rad;H_rad)
+H(4)+H(4)=H2(12)                                    1.090e+11 0.000     1.500    
+
+! Reaction index: Chemkin #12; RMG #23
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: CH3(2), C3H7(14); C2H4(8), C3H7(14); 
+! Exact match found for rate rule (Cds-HH_Cds-HH;CsJ-HHH)
+! Multiplied by reaction path degeneracy 2
+CH3(2)+C2H4(8)=C3H7(14)                             4.180e+04 2.410     5.630    
+
+! Reaction index: Chemkin #13; RMG #20
+! Template reaction: R_Recombination
+! Flux pairs: C2H3(13), C2H4(8); H(4), C2H4(8); 
+! Exact match found for rate rule (Cd_pri_rad;H_rad)
+H(4)+C2H3(13)=C2H4(8)                               1.210e+14 0.000     0.000    
+
+! Reaction index: Chemkin #14; RMG #24
+! Template reaction: H_Abstraction
+! Flux pairs: C(6), CH3(2); C2H3(13), C2H4(8); 
+! Estimated using template (C_methane;Cd_pri_rad) for rate rule (C_methane;Cd_Cd\H2_pri_rad)
+! Multiplied by reaction path degeneracy 4
+C(6)+C2H3(13)=CH3(2)+C2H4(8)                        2.236e-02 4.340     5.700    
+
+! Reaction index: Chemkin #15; RMG #27
+! Template reaction: H_Abstraction
+! Flux pairs: ethane(1), C2H5(3); C2H3(13), C2H4(8); 
+! Estimated using template (C/H3/Cs;Cd_Cd\H2_pri_rad) for rate rule (C/H3/Cs\H3;Cd_Cd\H2_pri_rad)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+C2H3(13)=C2H5(3)+C2H4(8)                  1.080e-03 4.550     3.500    
+
+! Reaction index: Chemkin #16; RMG #28
+! Template reaction: H_Abstraction
+! Flux pairs: H2(12), H(4); C2H3(13), C2H4(8); 
+! Estimated using template (H2;Cd_pri_rad) for rate rule (H2;Cd_Cd\H2_pri_rad)
+! Multiplied by reaction path degeneracy 2
+H2(12)+C2H3(13)=H(4)+C2H4(8)                        9.460e+03 2.560     5.030    
+
+! Reaction index: Chemkin #17; RMG #29
+! Template reaction: Disproportionation
+! Flux pairs: C2H3(13), C2H4(8); C2H5(3), C2H4(8); 
+! Exact match found for rate rule (Cd_pri_rad;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+C2H5(3)+C2H3(13)=C2H4(8)+C2H4(8)                    4.560e+14 -0.700    0.000    
+
+! Reaction index: Chemkin #18; RMG #59
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: C#C(25), C2H3(13); H(4), C2H3(13); 
+! Exact match found for rate rule (Ct-H_Ct-H;HJ)
+! Multiplied by reaction path degeneracy 2
+H(4)+C#C(25)=C2H3(13)                               1.030e+09 1.640     2.110    
+
+! Reaction index: Chemkin #19; RMG #61
+! Template reaction: Disproportionation
+! Flux pairs: CH3(2), C(6); C2H3(13), C#C(25); 
+! Estimated using template (C_methyl;CH_d_Rrad) for rate rule (C_methyl;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 2
+CH3(2)+C2H3(13)=C(6)+C#C(25)                        2.277e+06 1.870     -1.110   
+
+! Reaction index: Chemkin #20; RMG #65
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(3), ethane(1); C2H3(13), C#C(25); 
+! Estimated using template (Cs_rad;XH_d_Rrad) for rate rule (C_rad/H2/Cs;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 2
+C2H5(3)+C2H3(13)=ethane(1)+C#C(25)                  1.932e+06 1.870     -1.110   
+
+! Reaction index: Chemkin #21; RMG #68
+! Template reaction: Disproportionation
+! Flux pairs: H(4), H2(12); C2H3(13), C#C(25); 
+! Estimated using template (H_rad;CH_d_Rrad) for rate rule (H_rad;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 4
+H(4)+C2H3(13)=H2(12)+C#C(25)                        1.358e+09 1.500     -0.890   
+
+! Reaction index: Chemkin #22; RMG #77
+! Template reaction: Disproportionation
+! Flux pairs: C2H3(13), C2H4(8); C2H3(13), C#C(25); 
+! Estimated using template (Y_rad;XH_Rrad) for rate rule (Cd_pri_rad;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 2
+C2H3(13)+C2H3(13)=C2H4(8)+C#C(25)                   4.670e+09 0.969     -3.686   
+
+! Reaction index: Chemkin #23; RMG #71
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: C2H4(8), C4H7(28); C2H3(13), C4H7(28); 
+! Exact match found for rate rule (Cds-HH_Cds-HH;CdsJ-H)
+! Multiplied by reaction path degeneracy 2
+C2H4(8)+C2H3(13)=C4H7(28)                           2.860e+04 2.410     1.800    
+
+! Reaction index: Chemkin #24; RMG #97
+! Template reaction: Intra_R_Add_Exocyclic
+! Flux pairs: C4H7(28), C4H7(38); 
+! Exact match found for rate rule (R4_S_D;doublebond_intra_2H_pri;radadd_intra_cs2H)
+C4H7(28)=C4H7(38)                                   3.840e+10 0.210     8.780    
+
+! Reaction index: Chemkin #25; RMG #82
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: CH3(2), C3H5(32); C#C(25), C3H5(32); 
+! Exact match found for rate rule (Ct-H_Ct-H;CsJ-HHH)
+! Multiplied by reaction path degeneracy 2
+CH3(2)+C#C(25)=C3H5(32)                             1.338e+05 2.410     6.770    
+
+! Reaction index: Chemkin #26; RMG #79
+! Template reaction: R_Recombination
+! Flux pairs: C2H3(13), C4H6(30); C2H3(13), C4H6(30); 
+! Exact match found for rate rule (Cd_pri_rad;Cd_pri_rad)
+C2H3(13)+C2H3(13)=C4H6(30)                          7.230e+13 0.000     0.000    
+
+! Reaction index: Chemkin #27; RMG #98
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: C4H6(30), C4H7(28); H(4), C4H7(28); 
+! Exact match found for rate rule (Cds-CdH_Cds-HH;HJ)
+! Multiplied by reaction path degeneracy 2
+H(4)+C4H6(30)=C4H7(28)                              3.240e+08 1.640     2.400    
+
+! Reaction index: Chemkin #28; RMG #111
+! Template reaction: Disproportionation
+! Flux pairs: CH3(2), C(6); C4H7(28), C4H6(30); 
+! Estimated using template (C_methyl;Cpri_Rrad) for rate rule (C_methyl;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 2
+CH3(2)+C4H7(28)=C(6)+C4H6(30)                       2.300e+13 -0.320    0.000    
+
+! Reaction index: Chemkin #29; RMG #120
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(3), ethane(1); C4H7(28), C4H6(30); 
+! Estimated using template (C_pri_rad;Cpri_Rrad) for rate rule (C_rad/H2/Cs;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 2
+C2H5(3)+C4H7(28)=ethane(1)+C4H6(30)                 2.009e+12 0.000     -0.043   
+
+! Reaction index: Chemkin #30; RMG #132
+! Template reaction: Disproportionation
+! Flux pairs: H(4), H2(12); C4H7(28), C4H6(30); 
+! Estimated using template (H_rad;Cpri_Rrad) for rate rule (H_rad;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 4
+H(4)+C4H7(28)=H2(12)+C4H6(30)                       7.240e+12 0.000     0.000    
+
+! Reaction index: Chemkin #31; RMG #162
+! Template reaction: Disproportionation
+! Flux pairs: C2H3(13), C2H4(8); C4H7(28), C4H6(30); 
+! Estimated using template (Cd_pri_rad;Cpri_Rrad) for rate rule (Cd_pri_rad;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 2
+C2H3(13)+C4H7(28)=C2H4(8)+C4H6(30)                  2.420e+12 0.000     0.000    
+
+! Reaction index: Chemkin #32; RMG #104
+! Template reaction: intra_H_migration
+! Flux pairs: C4H7(42), C4H7(28); 
+! Exact match found for rate rule (R2H_S;C_rad_out_H/OneDe;Cs_H_out_2H)
+! Multiplied by reaction path degeneracy 3
+C4H7(42)=C4H7(28)                                   6.180e+09 1.220     47.800   
+
+! Reaction index: Chemkin #33; RMG #312
+! Template reaction: Disproportionation
+! Flux pairs: C2H5(3), ethane(1); C4H7(42), C4H6(30); 
+! Estimated using template (C_rad/H2/Cs;Cmethyl_Csrad) for rate rule (C_rad/H2/Cs;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 3
+C2H5(3)+C4H7(42)=ethane(1)+C4H6(30)                 6.900e+13 -0.350    0.000    
+
+! Reaction index: Chemkin #34; RMG #325
+! Template reaction: Disproportionation
+! Flux pairs: CH3(2), C(6); C4H7(42), C4H6(30); 
+! Estimated using template (C_methyl;Cmethyl_Csrad) for rate rule (C_methyl;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 3
+CH3(2)+C4H7(42)=C(6)+C4H6(30)                       6.570e+14 -0.680    0.000    
+
+! Reaction index: Chemkin #35; RMG #326
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: H(4), C4H7(42); C4H6(30), C4H7(42); 
+! Exact match found for rate rule (Cds-HH_Cds-CdH;HJ)
+! Multiplied by reaction path degeneracy 2
+H(4)+C4H6(30)=C4H7(42)                              4.620e+08 1.640     -0.470   
+
+! Reaction index: Chemkin #36; RMG #329
+! Template reaction: Disproportionation
+! Flux pairs: C2H3(13), C4H6(30); C4H7(42), C2H4(8); 
+! Estimated using template (Cd_pri_rad;Cmethyl_Csrad) for rate rule (Cd_pri_rad;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 3
+C2H3(13)+C4H7(42)=C2H4(8)+C4H6(30)                  4.560e+14 -0.700    0.000    
+
+! Reaction index: Chemkin #37; RMG #335
+! Template reaction: Disproportionation
+! Flux pairs: H(4), H2(12); C4H7(42), C4H6(30); 
+! Estimated using template (H_rad;Cmethyl_Csrad) for rate rule (H_rad;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 6
+H(4)+C4H7(42)=H2(12)+C4H6(30)                       2.166e+13 0.000     0.000    
+
+END
+

--- a/ipython/data/minimal_model/species_dictionary.txt
+++ b/ipython/data/minimal_model/species_dictionary.txt
@@ -1,0 +1,155 @@
+Ar
+1 Ar u0 p4 c0
+
+He
+1 He u0 p1 c0
+
+Ne
+1 Ne u0 p4 c0
+
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+ethane(1)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+
+CH3(2)
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+C2H5(3)
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+
+C(6)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+H(4)
+multiplicity 2
+1 H u1 p0 c0
+
+C2H4(8)
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+
+H2(12)
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+C3H7(14)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3  C u1 p0 c0 {1,S} {9,S} {10,S}
+4  H u0 p0 c0 {1,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+
+C2H3(13)
+multiplicity 2
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u1 p0 c0 {1,D} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+
+C#C(25)
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
+C4H7(28)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,D} {7,S}
+3  C u1 p0 c0 {1,S} {8,S} {9,S}
+4  C u0 p0 c0 {2,D} {10,S} {11,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+
+C4H7(38)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  C u0 p0 c0 {1,S} {3,S} {6,S} {7,S}
+3  C u0 p0 c0 {1,S} {2,S} {8,S} {9,S}
+4  C u1 p0 c0 {1,S} {10,S} {11,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+
+C3H5(32)
+multiplicity 2
+1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,D} {7,S}
+3 C u1 p0 c0 {2,D} {8,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {3,S}
+
+C4H6(30)
+1  C u0 p0 c0 {2,S} {3,D} {5,S}
+2  C u0 p0 c0 {1,S} {4,D} {6,S}
+3  C u0 p0 c0 {1,D} {7,S} {8,S}
+4  C u0 p0 c0 {2,D} {9,S} {10,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+
+C4H7(42)
+multiplicity 2
+1  C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2  C u0 p0 c0 {1,S} {3,D} {8,S}
+3  C u0 p0 c0 {2,D} {4,S} {9,S}
+4  C u1 p0 c0 {3,S} {10,S} {11,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+

--- a/meta.yaml
+++ b/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - argparse # [py26]
     - cairo # [unix]
     - cairocffi # [unix]
+    - cantera
     - coverage
     - cython ==0.21
     - gprof2dot

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -269,6 +269,33 @@ class Cantera:
         return allData
 
 
+def getRMGSpeciesFromSMILES(smilesList, speciesList, names=False):
+    """
+    Args:
+        smilesList: list of SMIlES for species of interest
+        speciesList: a list of RMG species objects
+        names: set to `True` if species names are desired to be returned instead of objects
+
+    Returns: A list of RMG species objects or names corresponding to the list of smiles.
+    """
+    # Not strictly necesssary, but its likely that people will forget to put the brackets around the bath gasses
+    bathGases={"Ar": "[Ar]", "He": "[He]", "Ne": "[Ne]"}
+    finalList=[]
+    for smiles in smilesList:
+        if smiles in bathGases:
+            spec = Species().fromSMILES(bathGases[smiles])
+        else:
+            spec=Species().fromSMILES(smiles)
+        spec.generateResonanceIsomers()
+
+        for rmgSpecies in speciesList:
+            if spec.isIsomorphic(rmgSpecies):
+                finalList.append(rmgSpecies)
+                break
+        else: raise KeyError("The species {0} does not appear in the species list".format(smiles))
+
+    return finalList
+
 def findIgnitionDelay(time, yVar=None, metric='maxDerivative'):
     """
     Identify the ignition delay point based on the following parameters:

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -4,7 +4,8 @@ import numpy as np
 import cantera as ct
 from rmgpy.chemkin import getSpeciesIdentifier
 from rmgpy.species import Species
-from rmgpy.tools.plot import GenericData, GenericPlot, SimulationPlot
+from rmgpy.tools.data import GenericData
+from rmgpy.tools.plot import GenericPlot, SimulationPlot
 from rmgpy.quantity import Quantity
 
 

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -42,17 +42,21 @@ class CanteraCondition:
                 molFrac[species]= value / total
 
         self.molFrac=molFrac
-        self.T0=Quantity(T0)
-        self.P0=Quantity(P0)
-        self.V0=Quantity(V0)
-
-        #Check to see that one of the three attributes T0, P0, and V0 is less unspecified
+        
+        # Check to see that one of the three attributes T0, P0, and V0 is less unspecified
         props=[T0,P0,V0]
         total=0
         for prop in props:
             if prop is None: total+=1
 
-        assert total==1, "Cantera conditions must leave one of T0, P0, and V0 state variables unspecified"
+        if not total==1:
+            raise Exception("Cantera conditions must leave one of T0, P0, and V0 state variables unspecified")
+
+
+        self.T0=Quantity(T0) if T0 else None
+        self.P0=Quantity(P0) if P0 else None
+        self.V0=Quantity(V0) if V0 else None
+
 
     def __repr__(self):
         """
@@ -270,19 +274,13 @@ class Cantera:
             # Run this individual condition as a simulation
             canteraSimulation=ct.ReactorNet([canteraReactor])
 
-            #
-            # # Initialize the variables to be saved
+            # Initialize the variables to be saved
             times=[]
             temperature=[]
             pressure=[]
             speciesData=[]
-            # times = np.zeros(100)
-            # temperature = np.zeros(100, dtype=np.float64)
-            # pressure = np.zeros(100, dtype=np.float64)
-            # speciesData = np.zeros((100,len(speciesNamesList)),dtype=np.float64)
-            #
-            #
-            # # Begin integration
+            
+            # Begin integration
             time = 0.0
             # Run the simulation over 100 time points
             while canteraSimulation.time<condition.reactionTime.value_si:
@@ -290,7 +288,6 @@ class Cantera:
                 # Advance the state of the reactor network in time from the current time to time t [s], taking as many integrator timesteps as necessary.
                 canteraSimulation.step(condition.reactionTime.value_si)
                 times.append(canteraSimulation.time)
-                print canteraSimulation.time
                 temperature.append(canteraReactor.T)
                 pressure.append(canteraReactor.thermo.P)
                 speciesData.append(canteraReactor.thermo[speciesNamesList].X)

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -1,0 +1,262 @@
+import sys
+import os.path
+import numpy as np
+import cantera as ct
+from rmgpy.chemkin import loadSpeciesDictionary, getSpeciesIdentifier
+from rmgpy.species import Species
+from rmgpy.tools.plot import *
+
+class CanteraCondition:
+    """
+    This class organizes the inputs needed for a cantera simulation
+
+    ======================= ====================================================
+    Attribute               Description
+    ======================= ====================================================
+    `reactorType`           A string of the cantera reactor type. List of supported types below:
+        IdealGasReactor: A constant volume, zero-dimensional reactor for ideal gas mixtures
+        IdealGasConstPressureReactor: A homogeneous, constant pressure, zero-dimensional reactor for ideal gas mixtures
+
+    `reactionTime`          A float giving the reaction time in seconds
+    `molFrac`               A dictionary giving the initial mol Fractions. Keys are species cantera names and the values are floats
+
+    To specifiy the system for an ideal gas, you must define 2 of the following 3 parameters:
+    `T0`                    A float giving the initial temperature in K
+    'P0'                    A float giving the initial pressure in Pa
+    'V0'                    A float giving the initial reactor volume in m^3
+    ======================= ====================================================
+
+
+    """
+    def __init__(self, reactorType, reactionTime, molFrac, T0=None, P0=None, V0=None):
+        self.reactorType=reactorType
+        self.reactionTime=float(reactionTime)
+        
+        #Normalize initialMolFrac if not already done:
+        if sum(molFrac.values())!=1.00:
+            total=sum(molFrac.values())
+            for species, value in molFrac.iteritems():
+                molFrac[species]= value / total
+        self.molFrac=molFrac
+        self.T0=float(T0) if T0 else None
+        self.P0=float(P0) if P0 else None
+        self.V0=float(V0) if V0 else None
+
+    def __repr__(self):
+        """
+        Return a string representation that can be used to reconstruct the
+        object.
+        """
+        string="Condition("
+        string += 'reactorType="{0}", '.format(self.reactorType)
+        string += 'reactionTime={:0.10f}, '.format(self.reactionTime)
+        string += 'molFrac={0}, '.format(self.molFrac.__repr__())
+        if self.T0: string += 'T0={:0.10f}, '.format(self.T0)
+        if self.P0: string += 'P0={:0.10f}, '.format(self.P0)
+        if self.V0: string += 'V0={:0.10f}, '.format(self.V0)
+        string = string[:-2] + ')'
+        return string
+
+    def __str__(self):
+        """
+        Return a string representation of the condition.
+        """
+        string=""
+        string += 'Reactor Type: {0}, '.format(self.reactorType)
+        string += 'Reaction Time: {:0.10f}, '.format(self.reactionTime)
+        if self.T0: string += 'T0: {:0.10f}, '.format(self.T0)
+        if self.P0: string += 'P0: {:0.10f}, '.format(self.P0)
+        if self.V0: string += 'V0: {:0.10f}, '.format(self.V0)
+        string += 'Initial Mole Fractions: {0}, '.format(self.molFrac.__repr__())
+        return string
+    
+class Cantera:
+    """
+    This class contains functions associated with an entire Cantera job
+    """
+    
+    def __init__(self, speciesList=None, reactionList=None, canteraFile='', outputDirectory='', conditions=[]):
+        """
+        `speciesList`: list of RMG species objects
+        `reactionList`: list of RMG reaction objects
+        `canteraFile` path of the chem.cti file associated with this job
+        `conditions`: a list of `CanteraCondition` objects
+        """
+        self.speciesList = speciesList 
+        self.reactionList = reactionList 
+        self.model = ct.Solution(canteraFile) if canteraFile else None
+        self.outputDirectory = outputDirectory if outputDirectory else os.getcwd()
+        self.conditions = conditions
+        
+    def loadChemkinModel(self, chemkinFile, **kwargs):
+        """
+        Convert a chemkin mechanism chem.inp file to a cantera mechanism file chem.cti 
+        and save it in the outputDirectory
+        Then load it into self.model
+        """
+        from cantera import ck2cti
+        print 'Converting chem.inp to chem.cti...'
+        outName=os.path.join(self.outputDirectory, "chem.cti")
+        if os.path.exists(outName):
+            os.remove(outName)
+        parser = ck2cti.Parser()
+        parser.convertMech(chemkinFile, outName=outName, **kwargs)
+        print 'Saving into Cantera Model...'
+        self.model = ct.Solution(outName)
+    
+    def generateConditions(self, reactorType, reactionTime, molFracList, Tlist=None, Plist=None, Vlist=None):
+        """
+        Creates a list of conditions from from the lists provided. 
+        
+        `reactorType`: a string indicating the Cantera reactor type
+        `reactionTime`: ScalarQuantity object for time
+        `molFracList`: a list of molfrac dictionaries wisth species keys and mole fraction values
+        `Tlist`: ArrayQuantity object of temperatures
+        `Plist`: ArrayQuantity object of pressures
+        `Vlist`: ArrayQuantity object of volumes
+        
+        This saves all the reaction conditions into the Cantera class.
+        """
+        # First translate the molFracList from species objects to species names:
+        newMolFracList = []
+        for molFrac in molFracList:
+            newMolFrac = {}
+            for key, value in molFrac.iteritems():
+                newkey = getSpeciesIdentifier(key)
+                newMolFrac[newkey] = value
+            newMolFracList.append(newMolFrac)
+            
+        molFracList = newMolFracList
+        
+        # Extract the si values from the arrays
+        reactionTime = reactionTime.value_si
+        Tlist = Tlist.value_si if Tlist is not None else None
+        Plist = Plist.value_si if Plist is not None else None
+        Vlist = Vlist.value_si if Vlist is not None else None
+        
+        
+        conditions=[]
+        
+    
+        if Tlist is None:
+            for molFrac in molFracList:
+                for P in Plist:
+                    for V in Vlist:
+                        conditions.append(CanteraCondition(reactorType, reactionTime, molFrac, P0=P, V0=V))
+    
+        elif Plist is None:
+            for molFrac in molFracList:
+                for T in Tlist:
+                    for V in Vlist:
+                        conditions.append(CanteraCondition(reactorType, reactionTime, molFrac, T0=T, V0=V))
+    
+        elif Vlist is None:
+            for molFrac in molFracList:
+                for T in Tlist:
+                    for P in Plist:
+                        conditions.append(CanteraCondition(reactorType, reactionTime, molFrac, T0=T, P0=P))
+    
+        else:
+            for molFrac in molFracList:
+                for T in Tlist:
+                    for P in Plist:
+                        for V in Vlist:
+                            conditions.append(CanteraCondition(reactorType, reactionTime, molFrac, T0=T, P0=P, V0=V))
+                            
+        self.conditions = conditions
+
+    def plot(self, data):
+        """
+        Plots data from the simulations from this cantera job.
+        Takes data in the format of a list of tuples containing (time, [list of temperature, pressure, and species data]) 
+        
+        3 plots will be created for each condition:
+        - T vs. time
+        - P vs. time
+        - Maximum 10 species mole fractions vs time
+        """
+        for i, conditionData in enumerate(data):
+            time, dataList = conditionData
+            # In RMG, any species with an index of -1 is an inert and should not be plotted
+            inertList = [species for species in self.speciesList if species.index == -1 ]
+            
+            TData = dataList[0]
+            PData = dataList[1]
+            speciesData = [data for data in dataList if data.species not in inertList]
+            
+            # plot
+            GenericPlot(xVar=time, yVar=TData).plot('{0}_temperature.png'.format(i+1))
+            GenericPlot(xVar=time, yVar=PData).plot('{0}_pressure.png'.format(i+1))
+            SimulationPlot(xVar=time, yVar=speciesData, ylabel='Mole Fraction').plot('{0}_mole_fractions.png'.format(i+1))
+            
+    def simulate(self):
+        """
+        Run all the conditions as a cantera simulation.
+        Returns the data as a list of tuples containing: (time, [list of temperature, pressure, and species data]) 
+            for each reactor condition
+        """
+        # Get all the cantera names for the species
+        speciesNamesList = [getSpeciesIdentifier(species) for species in self.speciesList]
+        
+        allData = []
+        for condition in self.conditions:
+            
+            # Set Cantera simulation conditions
+            self.model.TPX = condition.T0, condition.P0, condition.molFrac
+            
+            # Choose reactor
+            if condition.reactorType == 'IdealGasReactor':
+                canteraReactor=ct.IdealGasReactor(self.model)
+            else:
+                raise Exception('Other types of reactor conditions are currently not supported')
+            
+            # Run this individual condition as a simulation
+            canteraSimulation=ct.ReactorNet([canteraReactor])
+
+            
+            # Initialize the variables to be saved
+            times = np.zeros(100)
+            temperature = np.zeros(100, dtype=np.float64)
+            pressure = np.zeros(100, dtype=np.float64)
+            speciesData = np.zeros((100,len(speciesNamesList)),dtype=np.float64)
+
+            
+            # Begin integration
+            time = 0.0
+            # Run the simulation over 100 time points
+            for n in range(100):
+                time += condition.reactionTime/100
+                
+                # Advance the state of the reactor network in time from the current time to time t [s], taking as many integrator timesteps as necessary.
+                canteraSimulation.advance(time)
+                times[n] = time * 1e3  # time in ms
+                temperature[n] = canteraReactor.T
+                pressure[n] = canteraReactor.thermo.P
+                speciesData[n,:] = canteraReactor.thermo[speciesNamesList].X
+                
+            # Resave data into generic data objects
+            time = GenericData(label = 'Time', 
+                               data = times,
+                               units = 'ms')
+            temperature = GenericData(label='Temperature',
+                                      data = temperature,
+                                      units = 'K')
+            pressure = GenericData(label='Pressure',
+                                      data = pressure,
+                                      units = 'Pa')
+            conditionData = []
+            conditionData.append(temperature)
+            conditionData.append(pressure)
+            
+            for index, species in enumerate(self.speciesList):
+                # Create generic data object that saves the species object into the species object.  To allow easier manipulate later.
+                speciesGenericData = GenericData(label=speciesNamesList[index],
+                                          species = species,
+                                          data = speciesData[:,index],
+                                          index = species.index
+                                          )
+                conditionData.append(speciesGenericData)
+            
+            allData.append((time,conditionData))
+            
+        return allData

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -2,9 +2,9 @@ import sys
 import os.path
 import numpy as np
 import cantera as ct
-from rmgpy.chemkin import loadSpeciesDictionary, getSpeciesIdentifier
+from rmgpy.chemkin import getSpeciesIdentifier
 from rmgpy.species import Species
-from rmgpy.tools.plot import *
+from rmgpy.tools.plot import GenericData, GenericPlot, SimulationPlot
 
 
 class CanteraCondition:

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -249,7 +249,10 @@ class Cantera:
         for condition in self.conditions:
             
             # Set Cantera simulation conditions
-            self.model.TPX = condition.T0.value_si, condition.P0.value_si, condition.molFrac
+            if condition.T0 and condition.P0:
+                self.model.TPX = condition.T0.value_si, condition.P0.value_si, condition.molFrac
+            else:
+                raise Exception("Cantera conditions in which T0 and P0 are not the specified state variables are not yet implemented.")
             
             # Choose reactor
             if condition.reactorType == 'IdealGasReactor':

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -50,10 +50,10 @@ class CanteraCondition:
         """
         string="Condition("
         string += 'reactorType="{0}", '.format(self.reactorType)
-        string += 'reactionTime={:0.10f}, '.format(self.reactionTime)
+        string += 'reactionTime={:5g}, '.format(self.reactionTime)
         string += 'molFrac={0}, '.format(self.molFrac.__repr__())
-        if self.T0: string += 'T0={:0.10f}, '.format(self.T0)
-        if self.P0: string += 'P0={:0.10f}, '.format(self.P0)
+        if self.T0: string += 'T0={:5g}, '.format(self.T0)
+        if self.P0: string += 'P0={:0.5g}, '.format(self.P0)
         if self.V0: string += 'V0={:0.10f}, '.format(self.V0)
         string = string[:-2] + ')'
         return string
@@ -63,12 +63,12 @@ class CanteraCondition:
         Return a string representation of the condition.
         """
         string=""
-        string += 'Reactor Type: {0}, '.format(self.reactorType)
-        string += 'Reaction Time: {:0.10f}, '.format(self.reactionTime)
-        if self.T0: string += 'T0: {:0.10f}, '.format(self.T0)
-        if self.P0: string += 'P0: {:0.10f}, '.format(self.P0)
-        if self.V0: string += 'V0: {:0.10f}, '.format(self.V0)
-        string += 'Initial Mole Fractions: {0}, '.format(self.molFrac.__repr__())
+        string += 'Reactor Type: {0}\n'.format(self.reactorType)
+        string += 'Reaction Time: {:5g} s\n'.format(self.reactionTime)
+        if self.T0: string += 'T0: {:5g} K\n'.format(self.T0)
+        if self.P0: string += 'P0: {:5g} Pa\n'.format(self.P0)
+        if self.V0: string += 'V0: {:5g} m^3\n'.format(self.V0)
+        string += 'Initial Mole Fractions: {0}'.format(self.molFrac.__repr__())
         return string
 
 
@@ -162,7 +162,7 @@ class Cantera:
             except:
                 raise Exception('Cantera output directory could not be created.')
 
-    def generateConditions(self, reactorType, reactionTime, molFracList, Tlist, Plist):
+    def generateConditions(self, reactorType, reactionTime, molFracList, Tlist=None, Plist=None, Vlist=None):
         """
         This saves all the reaction conditions into the Cantera class.
         

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -292,8 +292,7 @@ class Cantera:
                 pressure.append(canteraReactor.thermo.P)
                 speciesData.append(canteraReactor.thermo[speciesNamesList].X)
 
-            temperature=np.array(temperature)
-            pressure=np.array(pressure)
+            # Convert speciesData to a numpy array
             speciesData=np.array(speciesData)
 
             # Resave data into generic data objects

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -332,7 +332,7 @@ def findIgnitionDelay(time, yVar=None, metric='maxDerivative'):
              but can contain multiple arrays such as species
     `metric`: can be set to 
         'maxDerivative': This is selected by default for y(t_ign) = max(dY/dt), and is typically used for a yVar containing T or P data
-        'maxHalfOH': This is selected for the case where [OH](t_ign) = [OH]_max/2 is desired
+        'maxHalfConcentration': This is selected for the case where a metric like [OH](t_ign) = [OH]_max/2 is desired
         'maxSpeciesConcentrations': This is selected for the case where the metric for ignition
             is y1*y2*...*yn(t_ign) = max(y1*y2*...*yn) such as when the time desired if for max([CH][O]).  This is
             the only metric that requires a list of arrays
@@ -356,7 +356,7 @@ def findIgnitionDelay(time, yVar=None, metric='maxDerivative'):
         index = next(i for i,d in enumerate(dydt) if d==max(dydt))
         
         return 0.5 * (time[index] + time[index+1])
-    elif metric == 'maxHalfOH':
+    elif metric == 'maxHalfConcentration':
         if len(yVar) != 1:
             raise Exception('Max([OH]/2) metric for ignition delay must be used with a single y variable.')
 

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -87,6 +87,13 @@ class Cantera:
         self.model = ct.Solution(canteraFile) if canteraFile else None
         self.outputDirectory = outputDirectory if outputDirectory else os.getcwd()
         self.conditions = conditions
+
+        # Make output directory if it does not yet exist:
+        if not os.path.exists(self.outputDirectory):
+            try:
+                os.makedirs(self.outputDirectory)
+            except:
+                raise Exception('Cantera output directory could not be created.')
         
     def loadChemkinModel(self, chemkinFile, **kwargs):
         """
@@ -187,7 +194,7 @@ class Cantera:
             # plot
             GenericPlot(xVar=time, yVar=TData).plot('{0}_temperature.png'.format(i+1))
             GenericPlot(xVar=time, yVar=PData).plot('{0}_pressure.png'.format(i+1))
-            SimulationPlot(xVar=time, yVar=speciesData, ylabel='Mole Fraction').plot('{0}_mole_fractions.png'.format(i+1))
+            SimulationPlot(xVar=time, yVar=speciesData, ylabel='Mole Fraction').plot(os.path.join(self.outputDirectory,'{0}_mole_fractions.png'.format(i+1)))
             
     def simulate(self):
         """

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -199,8 +199,11 @@ class Cantera:
         Then load it into self.model
         """
         from cantera import ck2cti
-        print 'Converting chem.inp to chem.cti...'
-        outName=os.path.join(self.outputDirectory, "chem.cti")
+        
+        base = os.path.basename(chemkinFile)
+        baseName = os.path.splitext(base)[0]
+        outName = os.path.join(self.outputDirectory, baseName + ".cti")
+        print 'Converting {0} to {1}...'.format(chemkinFile, outName)
         if os.path.exists(outName):
             os.remove(outName)
         parser = ck2cti.Parser()

--- a/rmgpy/tools/canteraTest.py
+++ b/rmgpy/tools/canteraTest.py
@@ -1,0 +1,25 @@
+import unittest
+import os
+import numpy
+from rmgpy.tools.canteraModel import *
+
+class CanteraTest(unittest.TestCase):
+
+    def testIgnitionDelay(self):
+        """
+        Test that findIgnitionDelay() works.
+        """
+
+        t = numpy.arange(0,5,0.5)
+        P = numpy.array([0,0.33,0.5,0.9,2,4,15,16,16.1,16.2])
+        OH = numpy.array([0,0.33,0.5,0.9,2,4,15,16,7,2])
+        CO = OH*0.9
+
+        t_ign = findIgnitionDelay(t,P)
+        self.assertEqual(t_ign,2.75)
+
+        t_ign = findIgnitionDelay(t,OH,'maxHalfOH')
+        self.assertEqual(t_ign,3)
+
+        t_ign = findIgnitionDelay(t,[OH,CO], 'maxSpeciesConcentrations')
+        self.assertEqual(t_ign,3.5)

--- a/rmgpy/tools/canteraTest.py
+++ b/rmgpy/tools/canteraTest.py
@@ -18,7 +18,7 @@ class CanteraTest(unittest.TestCase):
         t_ign = findIgnitionDelay(t,P)
         self.assertEqual(t_ign,2.75)
 
-        t_ign = findIgnitionDelay(t,OH,'maxHalfOH')
+        t_ign = findIgnitionDelay(t,OH,'maxHalfConcentration')
         self.assertEqual(t_ign,3)
 
         t_ign = findIgnitionDelay(t,[OH,CO], 'maxSpeciesConcentrations')

--- a/rmgpy/tools/canteraTest.py
+++ b/rmgpy/tools/canteraTest.py
@@ -1,8 +1,8 @@
 import unittest
 import os
 import numpy
-from rmgpy.tools.canteraModel import *
-
+from rmgpy.tools.canteraModel import findIgnitionDelay, CanteraCondition, Cantera
+from rmgpy.quantity import Quantity
 class CanteraTest(unittest.TestCase):
 
     def testIgnitionDelay(self):
@@ -23,3 +23,24 @@ class CanteraTest(unittest.TestCase):
 
         t_ign = findIgnitionDelay(t,[OH,CO], 'maxSpeciesConcentrations')
         self.assertEqual(t_ign,3.5)
+
+    def testRepr(self):
+        """
+        Test that the repr function for a CanteraCondition object can reconstitute
+        the same object
+        """
+        reactorType='IdealGasReactor'
+        molFrac={'CC': 0.05, '[Ar]': 0.95}
+        P=(3,'atm')
+        T=(1500,'K')
+        terminationTime=(5e-5,'s')
+        condition = CanteraCondition(reactorType, 
+                        terminationTime,
+                        molFrac, 
+                        T0=T,
+                        P0=P)
+        reprCondition=eval(condition.__repr__())
+        self.assertEqual(reprCondition.T0.value_si,Quantity(T).value_si)
+        self.assertEqual(reprCondition.P0.value_si,Quantity(P).value_si)
+        self.assertEqual(reprCondition.V0,None)
+        self.assertEqual(reprCondition.molFrac,molFrac)

--- a/rmgpy/tools/data.py
+++ b/rmgpy/tools/data.py
@@ -1,0 +1,15 @@
+
+class GenericData(object):
+    """
+    A generic data class for the purpose of plotting.
+    label is the original label for the data
+    data is the numpy array containing the data
+    The other parameters are additional common flags for data found in RMG
+    """
+    def __init__(self, label='', data=None, species=None, reaction=None, units=None, index=None):
+        self.label = label
+        self.data = data
+        self.species = species
+        self.reaction = reaction
+        self.units = units
+        self.index = index

--- a/rmgpy/tools/data.py
+++ b/rmgpy/tools/data.py
@@ -1,15 +1,31 @@
+import numpy
 
 class GenericData(object):
     """
     A generic data class for the purpose of plotting.
-    label is the original label for the data
-    data is the numpy array containing the data
-    The other parameters are additional common flags for data found in RMG
+    ======================= ==============================================================================================
+    Attribute               Description
+    ======================= ==============================================================================================
+    `label`                 A string label describing the data, can be used in a plot legend or in an axis label
+    `data`                  A numpy array of the data
+    `species`               Contains species associated with the data, often used with a Species object
+    `reaction`              Contains reaction associated with the data, often used with a Reaction object
+    `units`                 Contains a string describing the units associated with the data
+    `index`                 An integer containing the index associated with the data
+    ======================= ==============================================================================================
     """
     def __init__(self, label='', data=None, species=None, reaction=None, units=None, index=None):
-        self.label = label
-        self.data = data
+        
+        self.label = str(label) if label else None
+        
+        if isinstance(data, list):
+                self.data = numpy.array(data)
+        elif isinstance(data, numpy.ndarray):
+                self.data = data
+        else:
+            raise Exception('Data for GenericData object must be initialized as a list or numpy.array of values.')
+            
         self.species = species
         self.reaction = reaction
-        self.units = units
-        self.index = index
+        self.units = str(units) if units else None
+        self.index = int(index) if index else None

--- a/rmgpy/tools/observablesRegression.py
+++ b/rmgpy/tools/observablesRegression.py
@@ -5,18 +5,6 @@ from rmgpy.chemkin import loadChemkinFile
 from rmgpy.tools.plot import GenericData, GenericPlot, SimulationPlot, findNearest
 from rmgpy.tools.canteraModel import Cantera, generateCanteraConditions, getRMGSpeciesFromSMILES
 
-def getNearestTime(timepoint, timeArray):
-    """
-    `timePoint`: the desired time point
-    `timeArray`: the array of times in which to search for the nearest time to the one selected
-
-    Returns a tuple containing (index, value of the time point closest to the timepoint desired)
-    within the time array.
-    """
-    index = findNearest(timeArray, timepoint)
-    return (index, timeArray[index])
-
-
 def curvesSimilar(t1, y1, t2, y2, tol):
     """
     This function returns True if the two given curves are similar enough within tol. Otherwise returns False.
@@ -36,9 +24,9 @@ def curvesSimilar(t1, y1, t2, y2, tol):
     t2sync=numpy.zeros_like(t1)
     y2sync=numpy.zeros_like(t1)
     for i, timepoint1 in enumerate(t1):
-        (index, timepoint2)=getNearestTime(timepoint1, t2)
-        t2sync[i]=timepoint2
-        y2sync[i]=y2[index]
+        time_index = findNearest(t2, timepoint1)
+        t2sync[i]=t2[time_index]
+        y2sync[i]=y2[time_index]
 
     # Get R^2 value equivalent:
     normalizedError=(y1-y2sync)**2/y1**2

--- a/rmgpy/tools/observablesRegression.py
+++ b/rmgpy/tools/observablesRegression.py
@@ -1,0 +1,278 @@
+import sys
+import os.path
+import numpy 
+from rmgpy.chemkin import loadChemkinFile
+from rmgpy.tools.plot import *
+from rmgpy.tools.canteraModel import *
+
+def getNearestTime(timepoint, timeArray):
+    """
+    `timePoint`: the desired time point
+    `timeArray`: the array of times in which to search for the nearest time to the one selected
+
+    Returns a tuple containing (index, value of the time point closest to the timepoint desired)
+    within the time array.
+    """
+    index = findNearest(timeArray, timepoint)
+    return (index, timeArray[index])
+
+
+def curvesSimilar(t1, y1, t2, y2, tol):
+    """
+    This function returns True if the two given curves are similar enough within tol. Otherwise returns False.
+
+    t1: time/domain of standard curve we assume to be correct
+    y1: values of standard curve, usually either temperature in (K) or log of a mol fraction
+    t2: time/domain of test curve
+    y2: values of test curve, usually either temperature in (K) or log of a mol fraction
+
+    The test curve is first synchronized to the standard curve using geatNearestTime function. We then calculate the value of
+    (y1-y2')^2/y1^2, giving us a normalized difference for every point. If the average value of these differences is less
+    than tol, we say the curves are similar.
+
+    We choose this criteria because it is compatible with step functions we expect to see in ignition systems.
+    """
+    # Make synchornized version of t2,y2 called t2sync,y2sync.
+    t2sync=numpy.zeros_like(t1)
+    y2sync=numpy.zeros_like(t1)
+    for i, timepoint1 in enumerate(t1):
+        (index, timepoint2)=getNearestTime(timepoint1, t2)
+        t2sync[i]=timepoint2
+        y2sync[i]=y2[index]
+
+    # Get R^2 value equivalent:
+    normalizedError=(y1-y2sync)**2/y1**2
+    normalizedError=sum(normalizedError)/len(y1)
+
+    if normalizedError > tol:
+        return False
+    else: 
+        return True
+
+
+class ObservablesTestCase:
+    """
+    We use this class to run regressive tests
+
+    ======================= ==============================================================================================
+    Attribute               Description
+    ======================= ==============================================================================================
+    `title`                 A string describing the test. For regressive tests, should be same as example's name.
+    `oldDir`                A directory path containing the chem_annotated.inp and species_dictionary.txt of the old model
+    `newDir`                A directory path containing the chem_annotated.inp and species_dictionary.txt of the new model
+    `conditions`            A list of the :class: 'Condition' objects describing reaction conditions
+    `observables`           A dictionary of observables
+                            key: 'species', value: a list of smiles that correspond with species mole fraction observables
+                            key: 'variable', value: a list of state variable observables, i.e. ['Temperature'] or ['Temperature','Pressure']
+                            key: 'ignitionDelay', value: a tuple containing (ignition metric, yVar)
+                                                         for example: ('maxDerivative','P')
+                                                                      ('maxHalfConcentration', '[OH]')
+                                                                      ('maxSpeciesConcentrations',['[CH2]','[O]'])
+                                                        see findIgnitionDelay function for more details
+    'exptData'              An array of GenericData objects
+    ======================= ==============================================================================================
+
+
+    """
+    def __init__(self, title='', oldDir='', newDir='', observables = {}, exptData = []):
+        self.title=title
+        self.newDir=newDir
+        self.oldDir=oldDir
+        self.conditions=None
+        self.exptData=exptData
+        self.observables=observables
+
+        # load the species and reactions from each model
+        oldSpeciesList, oldReactionList = loadChemkinFile(os.path.join(oldDir,'chem_annotated.inp'),
+                                                          os.path.join(oldDir,'species_dictionary.txt'))
+
+        newSpeciesList, newReactionList = loadChemkinFile(os.path.join(newDir,'chem_annotated.inp'),
+                                                          os.path.join(newDir,'species_dictionary.txt'))
+        self.oldSim = Cantera(speciesList = oldSpeciesList,
+                              reactionList = oldReactionList,
+                              outputDirectory = oldDir)
+        self.newSim = Cantera(speciesList = newSpeciesList,
+                              reactionList = newReactionList,
+                              outputDirectory = newDir)
+        
+        # load each chemkin file into the cantera model
+        self.oldSim.loadChemkinModel(os.path.join(oldDir,'chem_annotated.inp'))
+        self.newSim.loadChemkinModel(os.path.join(newDir,'chem_annotated.inp'))
+
+    def __str__(self):
+        """
+        Return a string representation of this test case, using its title'.
+        """
+        return 'Observables Test Case: {0}'.format(self.title)
+
+    def generateConditions(self, reactorType, reactionTime, molFracList, Tlist=None, Plist=None, Vlist=None):
+        """
+        Creates a list of conditions from from the lists provided. 
+        
+        `reactorType`: a string indicating the Cantera reactor type
+        `reactionTime`: ScalarQuantity object for time
+        `molFracList`: a list of dictionaries containing species smiles and their mole fraction values
+        `Tlist`: ArrayQuantity object of temperatures
+        `Plist`: ArrayQuantity object of pressures
+        `Vlist`: ArrayQuantity object of volumes
+        
+        This saves all the reaction conditions into both the old and new cantera jobs.
+        """
+        # Store the conditions in the observables test case, for bookkeeping
+        self.conditions = generateCanteraConditions(reactorType, reactionTime, molFracList, Tlist=Tlist, Plist=Plist, Vlist=Vlist)
+
+        # Map the mole fractions dictionaries to species objects from the old and new models
+        oldMolFracList = []
+        newMolFracList = []
+
+        for molFracCondition in molFracList:
+            oldCondition = {}
+            newCondition = {} 
+            oldSpeciesDict = getRMGSpeciesFromSMILES(molFracCondition.keys(), self.oldSim.speciesList)
+            newSpeciesDict = getRMGSpeciesFromSMILES(molFracCondition.keys(), self.newSim.speciesList)
+            for smiles, molfrac in molFracCondition.iteritems():
+                if oldSpeciesDict[smiles] is None:
+                    raise Exception('SMILES {0} was not found in the old model!'.format(smiles))
+                if newSpeciesDict[smiles] is None:
+                    raise Exception('SMILES {0} was not found in the new model!'.format(smiles))
+
+                oldCondition[oldSpeciesDict[smiles]] = molfrac
+                newCondition[newSpeciesDict[smiles]] = molfrac
+            oldMolFracList.append(oldCondition)
+            newMolFracList.append(newCondition)
+        
+        # Generate the conditions in each simulation
+        self.oldSim.generateConditions(reactorType, reactionTime, oldMolFracList, Tlist=Tlist, Plist=Plist, Vlist=Vlist)
+        self.newSim.generateConditions(reactorType, reactionTime, newMolFracList, Tlist=Tlist, Plist=Plist, Vlist=Vlist)
+
+    def compare(self, plot=False):
+        """
+        Compare the old and new model
+        `plot`: if set to True, it will comparison plots of the two models comparing their species.
+
+        Returns a list of variables failed in a list of tuples in the format:
+        
+        (CanteraCondition, variable label, variableOld, variableNew)
+
+        """
+        # Ignore Inerts
+        inertList = ['[Ar]','[He]','[N#N]','[Ne]']
+
+        oldConditionData, newConditionData = self.runSimulations()
+
+        conditionsBroken=[]
+        variablesFailed=[]
+        
+        print ''
+        print '{0} Comparison'.format(self)
+        print '================'
+        # Check the species profile observables
+        if 'species' in self.observables:
+            oldSpeciesDict = getRMGSpeciesFromSMILES(self.observables['species'], self.oldSim.speciesList)
+            newSpeciesDict = getRMGSpeciesFromSMILES(self.observables['species'], self.newSim.speciesList)
+        
+        # Check state variable observables 
+        implementedVariables = ['temperature','pressure']
+        if 'variable' in self.observables:
+            for item in self.observables['variable']:
+                if item.lower() not in implementedVariables:
+                    print 'Observable variable {0} not yet implemented'.format(item)
+                    
+        print ''
+        print 'The following observables did not match:'
+        print ''
+        for i in range(len(oldConditionData)):
+            timeOld, dataListOld = oldConditionData[i]
+            timeNew, dataListNew = newConditionData[i]
+
+            # Compare species observables
+            if 'species' in self.observables:
+                for smiles in self.observables['species']:
+                    
+                    fail = False
+                    oldRmgSpecies = oldSpeciesDict[smiles]
+                    newRmgSpecies = newSpeciesDict[smiles]
+                    
+                    if oldRmgSpecies:
+                        variableOld = next((data for data in dataListOld if data.species == oldRmgSpecies), None)
+                    else:
+                        print 'No RMG species found for observable species {0} in old model.'.format(smiles)
+                        fail = True
+                    if newRmgSpecies:
+                        variableNew = next((data for data in dataListNew if data.species == newRmgSpecies), None)
+                    else:
+                        print 'No RMG species found for observable species {0} in new model.'.format(smiles)
+                        fail = True
+                    
+                    if fail is False:
+                        if not curvesSimilar(timeOld.data, variableOld.data, timeNew.data, variableNew.data, 0.05):
+                            fail = True
+                            
+                        # Try plotting only when species are found in both models
+                        if plot:
+                            oldSpeciesPlot = SimulationPlot(xVar=timeOld, yVar=variableOld)
+                            newSpeciesPlot = SimulationPlot(xVar=timeNew, yVar=variableNew)
+                            oldSpeciesPlot.comparePlot(newSpeciesPlot,
+                                                       title='Observable Species {0} Comparison'.format(smiles),
+                                                       ylabel='Mole Fraction',
+                                                       filename='condition_{0}_species_{1}.png'.format(i+1,smiles))
+                    
+                    # Append to failed variables or conditions if this test failed
+                    if fail:
+                        if i not in conditionsBroken: conditionsBroken.append(i)
+                        print "Observable species {0} does not match between old model {1} and \
+new model {2} in condition {3:d}.".format(smiles,
+                                           variableOld.label, 
+                                           variableNew.label,
+                                           i+1)
+                        variablesFailed.append((self.conditions[i], smiles, variableOld, variableNew))
+                    
+            
+            # Compare state variable observables
+            if 'variable' in self.observables:
+                for varName in self.observables['variable']:
+                    variableOld = next((data for data in dataListOld if data.label == varName), None)
+                    variableNew = next((data for data in dataListNew if data.label == varName), None)
+                    if not curvesSimilar(timeOld.data, variableOld.data, timeNew.data, variableNew.data, 0.05):
+                        if i not in conditionsBroken: conditionsBroken.append(i)
+                        print "Observable variable {0} does not match between old model and \
+new model in condition {1:d}.".format(variableOld.label, i+1)
+                        variablesFailed.append((self.conditions[i], varName, variableOld, variableNew))
+                    
+                    if plot:
+                        oldVarPlot = GenericPlot(xVar=timeOld, yVar=variableOld)
+                        newVarPlot = GenericPlot(xVar=timeNew, yVar=variableNew)
+                        oldVarPlot.comparePlot(newSpeciesPlot,
+                                                   title='Observable Variable {0} Comparison'.format(varName),
+                                                   filename='condition_{0}_variable_{1}.png'.format(i+1, varName))
+                        
+            # Compare ignition delay observables
+            if 'ignitionDelay' in self.observables:
+                print 'Ignition delay observable comparison not implemented yet.'
+                
+                
+        
+        print ''
+        print 'The following reaction conditions were broken:'
+        print ''
+        for index in conditionsBroken:
+            print "Condition {0:d}:".format(index+1)
+            print str(self.conditions[index])
+            print ''
+
+        return variablesFailed
+
+    def runSimulations(self):
+        """
+        Run a selection of conditions in Cantera and return
+        generic data objects containing the time, pressure, temperature,
+        and mole fractions from the simulations.
+
+        Returns (oldConditionData, newConditionData)
+        where conditionData is a list of of tuples: (time, dataList) for each condition in the same order as conditions
+        time is a GenericData object which gives the time domain for each profile
+        dataList is a list of GenericData objects for the temperature, profile, and mole fraction of major species
+        """
+        oldConditionData = self.oldSim.simulate()
+        newConditionData = self.newSim.simulate()
+        return (oldConditionData, newConditionData)

--- a/rmgpy/tools/observablesRegression.py
+++ b/rmgpy/tools/observablesRegression.py
@@ -2,8 +2,8 @@ import sys
 import os.path
 import numpy 
 from rmgpy.chemkin import loadChemkinFile
-from rmgpy.tools.plot import *
-from rmgpy.tools.canteraModel import *
+from rmgpy.tools.plot import GenericData, GenericPlot, SimulationPlot, findNearest
+from rmgpy.tools.canteraModel import Cantera, generateCanteraConditions, getRMGSpeciesFromSMILES
 
 def getNearestTime(timepoint, timeArray):
     """

--- a/rmgpy/tools/plot.py
+++ b/rmgpy/tools/plot.py
@@ -3,6 +3,7 @@ import matplotlib as mpl
 # This must be called before pylab, matplotlib.pyplot, or matplotlib.backends is imported
 mpl.use('Agg')
 import matplotlib.pyplot as plt
+from rmgpy.tools.data import GenericData
         
 def parseCSVData(csvFile):
     """
@@ -85,20 +86,7 @@ def findNearest(array, value):
     idx = (numpy.abs(array-value)).argmin()
     return idx
 
-class GenericData(object):
-    """
-    A generic data class for the purpose of plotting.
-    label is the original label for the data
-    data is the numpy array containing the data
-    The other parameters are additional common flags for data found in RMG
-    """
-    def __init__(self, label='', data=None, species=None, reaction=None, units=None, index=None):
-        self.label = label
-        self.data = data
-        self.species = species
-        self.reaction = reaction
-        self.units = units
-        self.index = index
+
 
 class GenericPlot(object):
     """

--- a/rmgpy/tools/plot.py
+++ b/rmgpy/tools/plot.py
@@ -106,7 +106,11 @@ class GenericPlot(object):
     """
     def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel=''):
         self.xVar = xVar
-        self.yVar = yVar
+        # Convert yVar to a list if it wasn't one already
+        if isinstance(yVar, GenericData):
+            self.yVar = [yVar]
+        else:
+            self.yVar = yVar
         self.title = title
         self.xlabel = xlabel
         self.ylabel = ylabel
@@ -119,12 +123,9 @@ class GenericPlot(object):
         fig=plt.figure()
         
         ax = fig.add_subplot(111)
+
         xVar = self.xVar
         yVar = self.yVar
-        # Convert yVar to a list if it wasn't one already
-        if isinstance(yVar, GenericData):
-            yVar = [yVar]
-        
             
         if len(yVar) == 1:
             y = yVar[0]
@@ -194,7 +195,7 @@ class GenericPlot(object):
         plt.axis('tight')
         fig.savefig(filename, bbox_inches='tight')
     
-    def comparePlot(self, otherGenericPlot, filename=''):
+    def comparePlot(self, otherGenericPlot, filename='', title='', xlabel='', ylabel=''):
         """
         Plot a comparison data plot of this data vs a second GenericPlot class
         """
@@ -220,32 +221,35 @@ class GenericPlot(object):
                 
             if len(yVar) == 1:
                 y = yVar[0]
-                ax.plot(xVar.data, y.data)
-                # Create a ylabel for the label of the y variable
+                ax.plot(xVar.data, y.data, styles[i])
+                # Save a ylabel based on the y variable's label if length of yVar contains only 1 variable
                 if not self.ylabel and y.label:
-                    ylabel = y.label
-                    if y.units: ylabel += ' ({0})'.format(y.units)
-                    plt.ylabel(ylabel)
+                    self.ylabel = y.label
+                    if y.units: self.ylabel += ' ({0})'.format(y.units)
             else:
                 for y in yVar:
                     ax.plot(xVar.data, y.data, styles[i], label=y.label)
             
             # Plot the second set of data
             
-        # Use the labels from this data object
-        
-        if self.xlabel:
+        # Prioritize using the function's x and y labels, otherwise the labels from this data object
+        if xlabel:
+            plt.xlabel(xlabel)
+        elif self.xlabel:
             plt.xlabel(self.xlabel)
         elif self.xVar.label:
             xlabel = self.xVar.label
             if self.xVar.units: xlabel += ' ({0})'.format(self.xVar.units)
             plt.xlabel(xlabel)
-            
-        if self.ylabel:
+        
+        if ylabel:
+            plt.ylabel(ylabel)
+        elif self.ylabel:
             plt.ylabel(self.ylabel)
-            
-        if self.title:
-            plt.title(self.title)
+        
+        # Use user inputted title
+        if title:
+            plt.title(title)
             
         ax.grid('on')
         handles, labels = ax.get_legend_handles_labels()
@@ -318,7 +322,7 @@ class SimulationPlot(GenericPlot):
         GenericPlot.plot(self, filename=filename)
     
     
-    def comparePlot(self, otherSimulationPlot, filename=''):
+    def comparePlot(self, otherSimulationPlot, filename='', title='', xlabel='', ylabel=''):
         
         filename = filename if filename else 'simulation_compare.png'
         self.load()
@@ -328,7 +332,7 @@ class SimulationPlot(GenericPlot):
         if self.numSpecies:
             self.yVar = self.yVar[:self.numSpecies]
             otherSimulationPlot.yVar = otherSimulationPlot.yVar[:self.numSpecies]
-        GenericPlot.comparePlot(self, otherSimulationPlot, filename)
+        GenericPlot.comparePlot(self, otherSimulationPlot, filename, title, xlabel, ylabel)
         
 class ReactionSensitivityPlot(GenericPlot):
     """


### PR DESCRIPTION
New submodules under `rmgpy.tools`: `canteraModel` and `observablesRegression`

`canteraModel`
Contains classes for creating cantera conditions and cantera jobs.  Is able to mostly automatically simulate reactor conditions and plot them
Cantera dependency as also been added to anaconda build and environment.  

`observablesRegression`
Contains a class for testing observables between two models.  Experimental data handling not yet implemented but will probably be implemented by @nyee 

Also added an `ipython` folder to the RMG-Py main folder, containing useful scripts or other educational ipython notebooks.  Currently only the cantera simulation ipynb is in there.