### PR TITLE
Fix csv writing in Windows

### DIFF
--- a/rmgpy/rmg/listener.py
+++ b/rmgpy/rmg/listener.py
@@ -56,7 +56,7 @@ class SimulationProfileWriter(object):
         for spc in self.coreSpecies:
             header.append(getSpeciesIdentifier(spc))
 
-        with open(filename, 'w') as csvfile:
+        with open(filename, 'wb') as csvfile:
             worksheet = csv.writer(csvfile)
 
             # add header row:

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -566,7 +566,7 @@ cdef class ReactionSystem(DASx):
 
         if sensitivity:   
             for i in xrange(len(self.sensitiveSpecies)):
-                with open(sensWorksheet[i], 'w') as outfile:
+                with open(sensWorksheet[i], 'wb') as outfile:
                     worksheet = csv.writer(outfile)
                     reactionsAboveThreshold = []
                     for j in xrange(numCoreReactions + numCoreSpecies):


### PR DESCRIPTION
Closes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/594

Changes opening of csv files for writing from 'w' status to 'wb' status, preventing blank lines from being written in their .csv files when user runs RMG-Py in windows machines.  