### PR TITLE
Parallel generation of reactions in `enlarge`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,14 @@ eg7: all
 	@ echo "Running eg7: gri_mech_rxn_lib example"
 	python rmg.py testing/eg7/input.py
 	
+scoop: noQM
+	mkdir -p testing/scoop
+	rm -rf testing/scoop/*
+	cp examples/rmg/minimal/input.py testing/scoop/input.py
+	coverage erase
+	@ echo "Running minimal example with SCOOP"
+	python -m scoop -n 2 rmg.py -v testing/scoop/input.py
+
 ######### 
 # Section for setting up MOPAC calculations on the Travis-CI.org server
 ifeq ($(TRAVIS),true)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -89,6 +89,7 @@ class TemplateReaction(Reaction):
                 family=None,
                 template=None,
                 estimator=None,
+                reverse=None
                 ):
         Reaction.__init__(self,
                           index=index,
@@ -104,6 +105,7 @@ class TemplateReaction(Reaction):
         self.family = family
         self.template = template
         self.estimator = estimator
+        self.reverse = reverse
 
     def __reduce__(self):
         """
@@ -120,7 +122,8 @@ class TemplateReaction(Reaction):
                                    self.pairs,
                                    self.family,
                                    self.template,
-                                   self.estimator
+                                   self.estimator,
+                                   self.reverse,
                                    ))
 
     def getSource(self):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1343,17 +1343,6 @@ class KineticsFamily(Database):
             # Reverse direction (the direction in which kinetics is not defined)
             reactionList.extend(self.__generateReactions(reactants, forward=False))
             
-        # Return the reactions as containing Species objects, not Molecule objects
-        for reaction in reactionList:
-            moleculeDict = {}
-            for molecule in reaction.reactants:
-                moleculeDict[molecule] = Species(molecule=[molecule])
-            for molecule in reaction.products:
-                moleculeDict[molecule] = Species(molecule=[molecule])
-            reaction.reactants = [moleculeDict[molecule] for molecule in reaction.reactants]
-            reaction.products = [moleculeDict[molecule] for molecule in reaction.products]
-            reaction.pairs = [(moleculeDict[reactant],moleculeDict[product]) for reactant, product in reaction.pairs]
-
         return reactionList
     
     def calculateDegeneracy(self, reaction):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1225,10 +1225,13 @@ class KineticsFamily(Database):
         Return ``True`` if the molecule is forbidden in this family, or
         ``False`` otherwise. 
         """
-        from rmgpy.data.rmg import database
+        from rmgpy.data.rmg import getDB
+        
+        forbidden_structures = getDB('forbidden')
+
         if self.forbidden is not None and self.forbidden.isMoleculeForbidden(molecule):
             return True
-        if database.forbiddenStructures.isMoleculeForbidden(molecule):
+        if forbidden_structures.isMoleculeForbidden(molecule):
             return True
         return False
 

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -34,6 +34,7 @@ for working with the RMG database.
 """
 
 import os.path
+import logging
 
 from base import ForbiddenStructures
 from thermo import ThermoDatabase
@@ -68,7 +69,6 @@ class RMGDatabase:
         if database is None:
             database = self
         else:
-            import logging
             logging.warning("Should only make one instance of RMGDatabase because it's stored as a module-level variable!")
             logging.warning("Unexpected behaviour may result!")
 

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -43,7 +43,7 @@ from rmgpy.data.kinetics.database import KineticsDatabase
 from statmech import StatmechDatabase
 from solvation import SolvationDatabase
 
-from rmgpy.scoop_framework.util import broadcast
+from rmgpy.scoop_framework.util import get, broadcast
 
 # Module-level variable to store the (only) instance of RMGDatabase in use.
 database = None
@@ -226,3 +226,41 @@ class RMGDatabase:
         self.forbiddenStructures.saveOld(os.path.join(path, 'ForbiddenStructures.txt'))
         self.kinetics.saveOld(path)
         self.statmech.saveOld(path)
+
+def getDB(name):
+    """
+    Returns the RMG database object that corresponds
+    to the parameter name.
+
+    First, the module level is queried. If this variable
+    is empty, the broadcasted variables are queried.
+    """
+    global database
+
+    if database:
+        if name == 'kinetics':
+            return database.kinetics
+        elif name == 'thermo':
+            return database.thermo
+        elif name == 'transport':
+            return database.transport
+        elif name == 'solvation':
+            return database.solvation
+        elif name == 'statmech':
+            return database.statmech
+        elif name == 'forbidden':
+            return database.forbiddenStructures
+        else:
+            raise Exception('Unrecognized database keyword: {}'.format(name))
+    else:
+        try:
+            db = get(name)
+            if db:
+                return db
+            else:
+                raise Exception
+        except Exception, e:
+            logging.error("Did not find a way to obtain the broadcasted database for {}.".format(name))
+            raise e
+
+    raise Exception('Could not get database with name: {}'.format(name))

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -481,7 +481,10 @@ class RMG(util.Subject):
                                   
             self.initializeReactionThresholdAndReactFlags()
 
-    
+
+        self.reactionModel.initializeIndexSpeciesDict()
+            
+
     def register_listeners(self):
         """
         Attaches listener classes depending on the options 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -51,14 +51,14 @@ from rmgpy.data.base import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
+from rmgpy.data.rmg import getDB
 from rmgpy.kinetics import KineticsData
 import rmgpy.data.rmg
 
 
+
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
-
-
 
 ################################################################################
 
@@ -657,7 +657,7 @@ class CoreEdgeReactionModel:
                     moleculeA.clearLabeledAtoms()
                     moleculeB.clearLabeledAtoms()
         return reactionList
-        
+
     def enlarge(self, newObject=None, reactEdge=False, unimolecularReact=None, bimolecularReact=None):
         """
         Enlarge a reaction model by processing the objects in the list `newObject`. 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -572,8 +572,9 @@ class CoreEdgeReactionModel:
                 reactantIndex = forward.reactants.index(forward.pairs[pairIndex][0])
                 productIndex = forward.products.index(forward.pairs[pairIndex][1])
                 forward.pairs[pairIndex] = (reactants[reactantIndex], products[productIndex])
-                if hasattr(forward, 'reverse'):
-                    forward.reverse.pairs[pairIndex] = (products[productIndex], reactants[reactantIndex])
+                if hasattr(forward, 'reverse'):                   
+                    if forward.reverse:
+                        forward.reverse.pairs[pairIndex] = (products[productIndex], reactants[reactantIndex])
         forward.reactants = reactants
         forward.products  = products
 
@@ -585,7 +586,8 @@ class CoreEdgeReactionModel:
         if forward.pairs is None:
             forward.generatePairs()
             if hasattr(forward, 'reverse'):
-                forward.reverse.generatePairs()
+                if forward.reverse:
+                    forward.reverse.generatePairs()
             
         # Note in the log
         if isinstance(forward, TemplateReaction):
@@ -669,7 +671,7 @@ class CoreEdgeReactionModel:
             if isinstance(newObject, Species):
                 
                 newSpecies = newObject
-                    
+
                 objectWasInEdge = newSpecies in self.edge.species
                 
                 if not newSpecies.reactive:
@@ -787,10 +789,11 @@ class CoreEdgeReactionModel:
                     reaction.reactants, reaction.products = reaction.products, reaction.reactants
                     reaction.pairs = [(p,r) for r,p in reaction.pairs]
                 if family.ownReverse and hasattr(reaction,'reverse'):
-                    if not isForward:
-                        reaction.template = reaction.reverse.template
-                    # We're done with the "reverse" attribute, so delete it to save a bit of memory
-                    delattr(reaction,'reverse')
+                    if reaction.reverse:
+                        if not isForward:
+                            reaction.template = reaction.reverse.template
+                        # We're done with the "reverse" attribute, so delete it to save a bit of memory
+                        delattr(reaction,'reverse')
                     
         # For new reactions, convert ArrheniusEP to Arrhenius, and fix barrier heights.
         # self.newReactionList only contains *actually* new reactions, all in the forward direction.
@@ -933,66 +936,66 @@ class CoreEdgeReactionModel:
         
         
         if family.ownReverse and hasattr(reaction,'reverse'):
-            
-            # The kinetics family is its own reverse, so we could estimate kinetics in either direction
-            
-            # First get the kinetics for the other direction
-            rev_kinetics, rev_source, rev_entry, rev_isForward = family.getKinetics(reaction.reverse, template=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
-            # Now decide which direction's kinetics to keep
-            keepReverse = False
-            if (entry is not None and rev_entry is None):
-                # Only the forward has a source - use forward.
-                reason = "This direction matched an entry in {0}, the other was just an estimate.".format(reaction.family)
-            elif (entry is None and rev_entry is not None):
-                # Only the reverse has a source - use reverse.
-                keepReverse = True
-                reason = "This direction matched an entry in {0}, the other was just an estimate.".format(reaction.family)
-            elif (entry is not None and rev_entry is not None 
-                  and entry is rev_entry):
-                # Both forward and reverse have the same source and entry
-                # Use the one for which the kinetics is the forward kinetics          
-                keepReverse = G298 > 0 and isForward and rev_isForward
-                reason = "Both directions matched the same entry in {0}, but this direction is exergonic.".format(reaction.family)
-            elif self.kineticsEstimator == 'group additivity' and (kinetics.comment.find("Fitted to 1 rate")>0
-                  and not rev_kinetics.comment.find("Fitted to 1 rate")>0) :
-                    # forward kinetics were fitted to only 1 rate, but reverse are hopefully better
+            if reaction.reverse:
+                # The kinetics family is its own reverse, so we could estimate kinetics in either direction
+                
+                # First get the kinetics for the other direction
+                rev_kinetics, rev_source, rev_entry, rev_isForward = family.getKinetics(reaction.reverse, template=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
+                # Now decide which direction's kinetics to keep
+                keepReverse = False
+                if (entry is not None and rev_entry is None):
+                    # Only the forward has a source - use forward.
+                    reason = "This direction matched an entry in {0}, the other was just an estimate.".format(reaction.family)
+                elif (entry is None and rev_entry is not None):
+                    # Only the reverse has a source - use reverse.
                     keepReverse = True
-                    reason = "Other direction matched a group only fitted to 1 rate."
-            elif self.kineticsEstimator == 'group additivity' and (not kinetics.comment.find("Fitted to 1 rate")>0
-                  and rev_kinetics.comment.find("Fitted to 1 rate")>0) :
-                    # reverse kinetics were fitted to only 1 rate, but forward are hopefully better
-                    keepReverse = False
-                    reason = "Other direction matched a group only fitted to 1 rate."
-            elif entry is not None and rev_entry is not None:
-                # Both directions matched explicit rate rules
-                # Keep the direction with the lower (but nonzero) rank
-                if entry.rank < rev_entry.rank and entry.rank != 0:
-                    keepReverse = False
-                    reason = "Both directions matched explicit rate rules, but this direction has a rule with a lower rank."
-                elif rev_entry.rank < entry.rank and rev_entry.rank != 0:
-                    keepReverse = True
-                    reason = "Both directions matched explicit rate rules, but this direction has a rule with a lower rank."
-                # Otherwise keep the direction that is exergonic at 298 K
-                else:
+                    reason = "This direction matched an entry in {0}, the other was just an estimate.".format(reaction.family)
+                elif (entry is not None and rev_entry is not None 
+                      and entry is rev_entry):
+                    # Both forward and reverse have the same source and entry
+                    # Use the one for which the kinetics is the forward kinetics          
                     keepReverse = G298 > 0 and isForward and rev_isForward
-                    reason = "Both directions matched explicit rate rules, but this direction is exergonic."
-            else:
-                # Keep the direction that is exergonic at 298 K
-                # This must be done after the thermo generation step
-                keepReverse = G298 > 0 and isForward and rev_isForward
-                reason = "Both directions are estimates, but this direction is exergonic."
-            
-            if keepReverse:
-                kinetics = rev_kinetics
-                source = rev_source
-                entry = rev_entry
-                isForward = not rev_isForward
-                H298 = -H298
-                G298 = -G298
-            
-            if self.verboseComments:
-                kinetics.comment += "\nKinetics were estimated in this direction instead of the reverse because:\n{0}".format(reason)
-                kinetics.comment += "\ndHrxn(298 K) = {0:.2f} kJ/mol, dGrxn(298 K) = {1:.2f} kJ/mol".format(H298 / 1000., G298 / 1000.)
+                    reason = "Both directions matched the same entry in {0}, but this direction is exergonic.".format(reaction.family)
+                elif self.kineticsEstimator == 'group additivity' and (kinetics.comment.find("Fitted to 1 rate")>0
+                      and not rev_kinetics.comment.find("Fitted to 1 rate")>0) :
+                        # forward kinetics were fitted to only 1 rate, but reverse are hopefully better
+                        keepReverse = True
+                        reason = "Other direction matched a group only fitted to 1 rate."
+                elif self.kineticsEstimator == 'group additivity' and (not kinetics.comment.find("Fitted to 1 rate")>0
+                      and rev_kinetics.comment.find("Fitted to 1 rate")>0) :
+                        # reverse kinetics were fitted to only 1 rate, but forward are hopefully better
+                        keepReverse = False
+                        reason = "Other direction matched a group only fitted to 1 rate."
+                elif entry is not None and rev_entry is not None:
+                    # Both directions matched explicit rate rules
+                    # Keep the direction with the lower (but nonzero) rank
+                    if entry.rank < rev_entry.rank and entry.rank != 0:
+                        keepReverse = False
+                        reason = "Both directions matched explicit rate rules, but this direction has a rule with a lower rank."
+                    elif rev_entry.rank < entry.rank and rev_entry.rank != 0:
+                        keepReverse = True
+                        reason = "Both directions matched explicit rate rules, but this direction has a rule with a lower rank."
+                    # Otherwise keep the direction that is exergonic at 298 K
+                    else:
+                        keepReverse = G298 > 0 and isForward and rev_isForward
+                        reason = "Both directions matched explicit rate rules, but this direction is exergonic."
+                else:
+                    # Keep the direction that is exergonic at 298 K
+                    # This must be done after the thermo generation step
+                    keepReverse = G298 > 0 and isForward and rev_isForward
+                    reason = "Both directions are estimates, but this direction is exergonic."
+                
+                if keepReverse:
+                    kinetics = rev_kinetics
+                    source = rev_source
+                    entry = rev_entry
+                    isForward = not rev_isForward
+                    H298 = -H298
+                    G298 = -G298
+                
+                if self.verboseComments:
+                    kinetics.comment += "\nKinetics were estimated in this direction instead of the reverse because:\n{0}".format(reason)
+                    kinetics.comment += "\ndHrxn(298 K) = {0:.2f} kJ/mol, dGrxn(298 K) = {1:.2f} kJ/mol".format(H298 / 1000., G298 / 1000.)
             
         # The comments generated by the database for estimated kinetics can
         # be quite long, and therefore not very useful

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -51,11 +51,10 @@ from rmgpy.data.base import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
-from rmgpy.data.rmg import getDB
+
 from rmgpy.kinetics import KineticsData
 import rmgpy.data.rmg
-
-
+from .react import react
 
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
@@ -633,31 +632,6 @@ class CoreEdgeReactionModel:
 
         return forward
 
-    def react(self, database, speciesA, speciesB=None, only_families=None):
-        """
-        Generates reactions involving :class:`rmgpy.species.Species` speciesA and speciesB.
-        The optional only_families flag allows the user to input a list of familylabels which then
-        allow the reactions to only be generated from those families.
-        """
-        if not speciesA.reactive:
-            return []
-        reactionList = []
-        if speciesB is None:
-            # React in a unimolecular reaction
-            for moleculeA in speciesA.molecule:
-                reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA], products=None, only_families=only_families))
-                moleculeA.clearLabeledAtoms()
-        else:
-            if not speciesB.reactive:
-                return []
-            # React in a bimolecular reaction
-            for moleculeA in speciesA.molecule:
-                for moleculeB in speciesB.molecule:
-                    reactionList.extend(database.kinetics.generateReactionsFromFamilies([moleculeA, moleculeB], products=None, only_families=only_families))
-                    moleculeA.clearLabeledAtoms()
-                    moleculeB.clearLabeledAtoms()
-        return reactionList
-
     def enlarge(self, newObject=None, reactEdge=False, unimolecularReact=None, bimolecularReact=None):
         """
         Enlarge a reaction model by processing the objects in the list `newObject`. 
@@ -698,13 +672,33 @@ class CoreEdgeReactionModel:
                     logging.info('Adding species {0} to model core'.format(newSpecies))
                     display(newSpecies) # if running in IPython --pylab mode, draws the picture!
 
+                    # Find reactions involving the new species as unimolecular reactant
+                    # or product (e.g. A <---> products)
+
+                    results_A = react(newSpecies.copy(deep=True))
+
+                    # Find reactions involving the new species as bimolecular reactants
+                    # or products with other core species (e.g. A + B <---> products)
+
+                    corespeciesList = self.core.species
+
+                    results_AB = react(newSpecies.copy(deep=True), corespeciesList)                    
+
+                    # Find reactions involving the new species as bimolecular reactants
+                    # or products with itself (e.g. A + A <---> products)
+                    results_AA = react(newSpecies.copy(deep=True), [newSpecies.copy(deep=True)])
+                            
+                    newReactions.extend(results_A)
+                    newReactions.extend(results_AB)
+                    newReactions.extend(results_AA)
+    
                 # Add new species
                 reactionsMovedFromEdge = self.addSpeciesToCore(newSpecies)
 
             elif isinstance(newObject, tuple) and isinstance(newObject[0], PDepNetwork) and self.pressureDependence:
 
                 pdepNetwork, newSpecies = newObject
-                newReactions.extend(pdepNetwork.exploreIsomer(newSpecies, self, database))
+                newReactions.extend(pdepNetwork.exploreIsomer(newSpecies))
                 self.processNewReactions(newReactions, newSpecies, pdepNetwork)
 
             else:
@@ -724,7 +718,7 @@ class CoreEdgeReactionModel:
                     for products in network.products:
                         products = products.species
                         if len(products) == 1 and products[0] == species:
-                            newReactions = network.exploreIsomer(species, self, database)
+                            newReactions = network.exploreIsomer(species)
                             self.processNewReactions(newReactions, species, network)
                             network.updateConfigurations(self)
                             index = 0
@@ -744,15 +738,18 @@ class CoreEdgeReactionModel:
             for i in xrange(numOldCoreSpecies):
                 if unimolecularReact[i]:
                     # Find reactions involving the species that are unimolecular
-                    self.processNewReactions(self.react(database, self.core.species[i]), self.core.species[i], None)
+                    reactions = react(self.core.species[i].copy(deep=True)) 
+                    self.processNewReactions(reactions, self.core.species[i], None)
+
             for i in xrange(numOldCoreSpecies):
                 for j in xrange(i,numOldCoreSpecies):
                     # Find reactions involving the species that are bimolecular
                     # This includes a species reacting with itself (if its own concentration is high enough)
                     
                     if bimolecularReact[i,j]:
+                        reactions = react(self.core.species[i].copy(deep=True), [self.core.species[j]]) 
                         # Consider the latest added core species as the 'new' species
-                        self.processNewReactions(self.react(database, self.core.species[i], self.core.species[j]), self.core.species[j], None)
+                        self.processNewReactions(reactions, self.core.species[j], None)
 
         ################################################################
         # Begin processing the new species and reactions

--- a/rmgpy/rmg/parreactTest.py
+++ b/rmgpy/rmg/parreactTest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# encoding: utf-8 -*-
+
+"""
+This module contains unit tests of the rmgpy.parallel module.
+"""
+
+import os
+import sys
+import unittest
+import logging
+
+from rmgpy import settings
+from rmgpy.data.kinetics import TemplateReaction
+from rmgpy.data.rmg import RMGDatabase, database
+from rmgpy.rmg.main import RMG
+from rmgpy.rmg.model import Species
+
+from rmgpy.scoop_framework.framework import TestScoopCommon
+
+from rmgpy.rmg.react import *
+
+try:
+    from scoop import futures, _control, shared
+except ImportError, e:
+    import logging as logging
+    logging.debug("Could not properly import SCOOP.")
+
+TESTFAMILY = 'H_Abstraction'
+
+def tearDown():
+    """
+    Reset the loaded database
+    """
+    import rmgpy.data.rmg
+    rmgpy.data.rmg.database = None
+
+def load():
+    """
+    A method that is run before each unit test in this class.
+    """
+    tearDown()
+    # set-up RMG object
+    rmg = RMG()
+
+    # load kinetic database and forbidden structures
+    rmg.database = RMGDatabase()
+    path = os.path.join(settings['database.directory'])
+
+    # forbidden structure loading
+    rmg.database.loadForbiddenStructures(os.path.join(path, 'forbiddenStructures.py'))
+    # kinetics family loading
+    rmg.database.loadKinetics(os.path.join(path, 'kinetics'),
+                                   kineticsFamilies=[TESTFAMILY],
+                                   reactionLibraries=[]
+                                   )
+
+def generate():
+    """
+    Test that reaction generation from the available families works.
+    """
+    load()
+    spcA = Species().fromSMILES('[OH]')
+    spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+
+    reactionList = list(react(spcA, spcs))
+
+    if not reactionList: return False
+
+    for rxn in reactionList:
+        if not isinstance(rxn, TemplateReaction): return False
+
+    return True
+
+class ParallelReactTest(TestScoopCommon):
+
+    def __init__(self, *args, **kwargs):
+        # Parent initialization
+        super(self.__class__, self).__init__(*args, **kwargs)
+        
+        # Only setup the scoop framework once, and not in every test method:
+        super(self.__class__, self).setUp()
+    
+    @unittest.skipUnless(sys.platform.startswith("linux"),
+                          "test currently only runs on linux")
+    def test(self):
+        """
+        Test that we can generate reactions in parallel.
+        """
+
+        result = futures._startup(generate)
+        self.assertEquals(result, True)        
+
+if __name__ == '__main__' and os.environ.get('IS_ORIGIN', "1") == "1":
+    unittest.main()

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -40,6 +40,7 @@ import rmgpy.pdep.network
 import rmgpy.reaction
 
 from rmgpy.pdep import Conformer, Configuration
+from rmgpy.rmg.react import react
 
 ################################################################################
 
@@ -262,12 +263,13 @@ class PDepNetwork(rmgpy.pdep.network.Network):
 
         return ratios
 
-    def exploreIsomer(self, isomer, reactionModel, database):
+    def exploreIsomer(self, isomer):
         """
         Explore a previously-unexplored unimolecular `isomer` in this partial
         network using the provided core-edge reaction model `reactionModel`,
         returning the new reactions and new species.
         """
+
         if isomer in self.explored:
             logging.warning('Already explored isomer {0} in pressure-dependent network #{1:d}'.format(isomer, self.index))
             return []
@@ -286,13 +288,15 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         self.products.remove(product)
         # Find reactions involving the found species as unimolecular
         # reactant or product (e.g. A <---> products)
-        newReactionList = reactionModel.react(database, isomer)
+
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with itself (e.g. A + A <---> products)
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with other core species (e.g. A + B <---> products)
 
-        return newReactionList
+        newReactions = react(isomer)
+        
+        return newReactions
 
     def addPathReaction(self, newReaction, newSpecies):
         """

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#	RMG - Reaction Mechanism Generator
+#
+#	Copyright (c) 2002-2009 Prof. William H. Green (whgreen@mit.edu) and the
+#	RMG Team (rmg_dev@mit.edu)
+#
+#	Permission is hereby granted, free of charge, to any person obtaining a
+#	copy of this software and associated documentation files (the 'Software'),
+#	to deal in the Software without restriction, including without limitation
+#	the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#	and/or sell copies of the Software, and to permit persons to whom the
+#	Software is furnished to do so, subject to the following conditions:
+#
+#	The above copyright notice and this permission notice shall be included in
+#	all copies or substantial portions of the Software.
+#
+#	THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#	FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#	DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+Contains functions for generating reactions.
+"""
+import logging
+import itertools
+
+from rmgpy.molecule.molecule import Molecule
+from rmgpy.data.rmg import getDB
+from rmgpy.scoop_framework.util import map_, WorkerWrapper
+        
+def react(spcA, speciesList=[]):
+    """
+    Generate reactions between spcA and the list of 
+    species for all the reaction families available.
+    """
+    if not spcA.reactive: return []
+    
+    molsB = [spcB.molecule for spcB in speciesList if spcB.reactive]
+    molsB = list(itertools.chain.from_iterable(molsB))
+    
+    if not molsB:
+        combos = [(mol,) for mol in spcA.molecule]
+    else:
+        combos = list(itertools.product(spcA.molecule, molsB))
+
+    results = map_(
+                WorkerWrapper(reactMolecules),
+                combos
+            )
+
+    reactionList = itertools.chain.from_iterable(results)
+    return reactionList
+
+def reactMolecules(molecules):
+    """
+    Performs a reaction between
+    the resonance isomers.
+    """
+    
+    families = getDB('kinetics').families
+    
+    reactionList = []
+    for _, family in families.iteritems():
+        rxns = family.generateReactions(molecules)
+        reactionList.extend(rxns)
+
+    for reactant in molecules:
+        reactant.clearLabeledAtoms()
+
+    return reactionList

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -70,9 +70,9 @@ class TestReact(unittest.TestCase):
         Test that reaction generation for Molecule objects works.
         """
         
-        molecules = [Molecule(SMILES='CC'), Molecule(SMILES='[CH3]')]
+        moleculeTuples = [(Molecule(SMILES='CC'), -1), (Molecule(SMILES='[CH3]'), -1)]
 
-        reactionList = reactMolecules(molecules)
+        reactionList = reactMolecules(moleculeTuples)
         
         self.assertIsNotNone(reactionList)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2010 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import os
+import unittest 
+
+from rmgpy import settings
+from rmgpy.data.kinetics import TemplateReaction
+from rmgpy.data.rmg import RMGDatabase, database
+from rmgpy.molecule import Molecule
+
+from rmgpy.rmg.main import RMG
+from rmgpy.rmg.model import Species
+from rmgpy.rmg.react import *
+
+###################################################
+
+TESTFAMILY = 'H_Abstraction'
+
+class TestReact(unittest.TestCase):
+
+    def setUp(self):
+        """
+        A method that is run before each unit test in this class.
+        """
+        # set-up RMG object
+        self.rmg = RMG()
+
+        # load kinetic database and forbidden structures
+        self.rmg.database = RMGDatabase()
+        path = os.path.join(settings['database.directory'])
+
+        # forbidden structure loading
+        self.rmg.database.loadForbiddenStructures(os.path.join(path, 'forbiddenStructures.py'))
+        # kinetics family loading
+        self.rmg.database.loadKinetics(os.path.join(path, 'kinetics'),
+                                       kineticsFamilies=[TESTFAMILY],
+                                       reactionLibraries=[]
+                                       )
+
+    def testReactMolecules(self):
+        """
+        Test that reaction generation for Molecule objects works.
+        """
+        
+        molecules = [Molecule(SMILES='CC'), Molecule(SMILES='[CH3]')]
+
+        reactionList = reactMolecules(molecules)
+        
+        self.assertIsNotNone(reactionList)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
+    def testReact(self):
+        """
+        Test that reaction generation from the available families works.
+        """
+        spcA = Species().fromSMILES('[OH]')
+        spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+
+        reactionList = list(react(spcA, spcs))
+        self.assertIsNotNone(reactionList)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
+    def tearDown(self):
+        """
+        Reset the loaded database
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -8,6 +8,7 @@ from .model import Species
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase, database
 from rmgpy.molecule import Molecule
+from rmgpy.rmg.react import react
 ###################################################
 
 class TestRMGWorkFlow(unittest.TestCase):
@@ -47,7 +48,7 @@ class TestRMGWorkFlow(unittest.TestCase):
         spc = Species().fromSMILES("O=C[C]=C")
         spc.generateResonanceIsomers()
         newReactions = []		
-        newReactions.extend(self.rmg.reactionModel.react(self.rmg.database, spc))
+        newReactions.extend(react(spc))
 
         # process newly generated reactions to make sure no duplicated reactions
         self.rmg.reactionModel.processNewReactions(newReactions, spc, None)
@@ -65,7 +66,7 @@ class TestRMGWorkFlow(unittest.TestCase):
 
         # react again
         newReactions_reverse = []
-        newReactions_reverse.extend(self.rmg_dummy.reactionModel.react(self.rmg.database, spc))
+        newReactions_reverse.extend(react(spc))
 
         # process newly generated reactions again to make sure no duplicated reactions
         self.rmg_dummy.reactionModel.processNewReactions(newReactions_reverse, spc, None)

--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -139,9 +139,6 @@ def get(key):
     try:
         data = shared.getConst(key, timeout=1e-9)
         return data
-    except KeyError, e:
-        logging.error('An object with the key {} could not be found.'.format(key))
-        raise e
     except NameError:
         """
         Name error will be caught when the SCOOP library is not imported properly.

--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -39,6 +39,7 @@ from functools import wraps
 
 try:
     from scoop import futures
+    from scoop.futures import map
     from scoop import shared
     from scoop import logger as logging
 
@@ -144,3 +145,6 @@ def get(key):
         Name error will be caught when the SCOOP library is not imported properly.
         """
         logging.debug('SCOOP not loaded. Not retrieving the shared object with key {}'.format(key))
+
+def map_(*args, **kwargs):
+    return map(*args, **kwargs)

--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -137,7 +137,7 @@ def get(key):
     """
 
     try:
-        data = shared.getConst(key)
+        data = shared.getConst(key, timeout=1e-9)
         return data
     except KeyError, e:
         logging.error('An object with the key {} could not be found.'.format(key))

--- a/rmgpy/scoop_framework/utilTest.py
+++ b/rmgpy/scoop_framework/utilTest.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# encoding: utf-8 -*-
+
+"""
+This module contains unit tests of the rmgpy.parallel module.
+"""
+
+import os
+import sys
+import unittest
+
+from rmgpy.scoop_framework.framework import TestScoopCommon
+
+try:
+    from scoop import futures, _control, shared
+except ImportError, e:
+    import logging as logging
+    logging.debug("Could not properly import SCOOP.")
+
+from .util import *
+
+def boom():
+    return 0 / 0
+
+class WorkerWrapperTest(unittest.TestCase):
+
+    def test_WorkerWrapper(self):
+        """
+        Test that the WorkerWrapper correctly redirects the error
+        message.
+        """
+        f = WorkerWrapper(boom)    
+        with self.assertRaises(ZeroDivisionError):
+            f()
+
+
+def funcBroadcast():
+    """
+    Broadcast the data with the given key, 
+    and retrieve it again by querying the key again.
+    """
+    data = 'foo'
+    key = 'bar'
+
+    broadcast(data, key)
+
+    result = True
+    try:
+        assert data == shared.getConst(key)
+    except AssertionError:
+        return False
+    
+    return True
+
+def funcRetrieve():
+    """
+    Broadcast the data with the given key, 
+    retrieve it again by querying the key again.
+    """
+    
+    data = 'foo'
+    key = 'bar'
+
+
+    broadcast(data, key)
+
+    try:
+        assert data == get(key)
+    except AssertionError:
+        return False
+    
+    return True    
+
+class BroadcastTest(TestScoopCommon):
+
+    def __init__(self, *args, **kwargs):
+        # Parent initialization
+        super(self.__class__, self).__init__(*args, **kwargs)
+        
+        # Only setup the scoop framework once, and not in every test method:
+        super(self.__class__, self).setUp()
+
+    @unittest.skipUnless(sys.platform.startswith("linux"),
+                         "test currently only runs on linux")
+    def test_generic(self):
+        """
+        Test that we can broadcast a simple string.
+        """
+
+        result = futures._startup(funcBroadcast)
+        self.assertEquals(result, True)
+
+class GetTest(TestScoopCommon):
+
+    def __init__(self, *args, **kwargs):
+        # Parent initialization
+        super(self.__class__, self).__init__(*args, **kwargs)
+        
+        # Only setup the scoop framework once, and not in every test method:
+        super(self.__class__, self).setUp()
+
+    def test_generic(self):
+        """
+        Test that we can retrieve a simple shared string.
+        """
+
+        result = futures._startup(funcRetrieve)
+        self.assertEquals(result, True)        
+
+if __name__ == '__main__' and os.environ.get('IS_ORIGIN', "1") == "1":
+    unittest.main()


### PR DESCRIPTION
This PR introduces a new design for the generation of reactions in parallel.

In the `rmgpy.rmg.model.CoreEdgeReactionModel.enlarge` method, reactions between a new core species and the existing list of core species, for the given list of available reaction families. This process is parallelized across the list of core species.

- A uniform `rmgpy.scoop_framework.util.map_` interface is introduced that either uses the parallel map function of SCOOP, or the serial map of python if scoop is not loaded.
- A new test target make scoop in Makefile is created to illustrate the launch of the parallel version using the minimal example.
- A uniform `rmgpy.data.rmg.getDB` interface allows retrieving RMG-database info, either from the global `rmgpy.data.rmg.database` variable, or from broadcasted variables when that global variable is not available (e.g. on remote workers).
- the `reverse` variable is now added as a real attribute of `TemplateReaction`. Before, it already existed, but was never added in the deserialization method of `TemplateReaction`.

To reduce communication costs of sending data to/from the workers:
- reactions that are send back to the root process will contain indices of core species for the reactants/products, rather than real Species objects. This is done in the _deflate_ function of the `rmgpy.rmg.react` module. Once the reaction arrives on the root process, the index will be _inflated_ again to the original Species object.

