### PR TITLE
Fix appending of reactions in CoreEdgeReactionModel.addReactionLibraryToOutput()

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1900,8 +1900,8 @@ def saveChemkin(reactionModel, path, verbose_path, dictionaryPath=None, transpor
             saveTransportFile(transportPath, speciesList)
         
     else:
-        speciesList = reactionModel.core.species + reactionModel.edge.species + reactionModel.outputSpeciesList
-        rxnList = reactionModel.core.reactions + reactionModel.edge.reactions + reactionModel.outputReactionList
+        speciesList = reactionModel.core.species + reactionModel.edge.species
+        rxnList = reactionModel.core.reactions + reactionModel.edge.reactions
         saveChemkinFile(path, speciesList, rxnList, verbose = False, checkForDuplicates=False)        
         logging.info('Saving current core and edge to verbose Chemkin file...')
         saveChemkinFile(verbose_path, speciesList, rxnList, verbose = True, checkForDuplicates=False)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -767,7 +767,11 @@ class RMG(util.Subject):
         # If the user specifies it, add unused reaction library reactions to
         # an additional output species and reaction list which is written to the ouput HTML
         # file as well as the chemkin file
+        
         if self.reactionLibraries:
+            # First initialize the outputReactionList and outputSpeciesList to empty
+            self.reactionModel.outputSpeciesList = []
+            self.reactionModel.outputReactionList = []
             for library, option in self.reactionLibraries:
                 if option:
                     self.reactionModel.addReactionLibraryToOutput(library)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1456,30 +1456,17 @@ class CoreEdgeReactionModel:
 
         logging.info('Adding reaction library {0} to output file...'.format(reactionLib))
         database = rmgpy.data.rmg.database
-        reactionLibrary = database.kinetics.libraries[reactionLib]
-
-        for entry in reactionLibrary.entries.values():
-            rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:], library=reactionLibrary, kinetics=entry.data)
-            rxn.reactants = [self.makeNewSpecies(reactant)[0] for reactant in rxn.reactants]
-            rxn.products = [self.makeNewSpecies(product)[0] for product in rxn.products]
-
-            for species in rxn.reactants:
-                if species not in self.core.species and species not in self.outputSpeciesList:
-                    self.outputSpeciesList.append(species)
-
-            for species in rxn.products:
-                if species not in self.core.species and species not in self.outputSpeciesList:
-                    self.outputSpeciesList.append(species)
-
-            # Reaction library was already on the edge, so we just need to get right label
-            rxn = self.checkForExistingReaction(rxn)[1]
-            if rxn in self.core.reactions:
-                rxn.kinetics.comment = ''
-                pass
-            else:
-                rxn.kinetics.comment = ("RMG did not find reaction rate to be high enough to be included in model core.")
-                self.outputReactionList.append(rxn)
-        self.markChemkinDuplicates()
+        
+        # Append the edge reactions that are from the selected reaction library to an output species and output reactions list
+        for rxn in self.edge.reactions:
+            if isinstance(rxn, LibraryReaction):
+                if rxn.library == reactionLib:
+                    self.outputReactionList.append(rxn)
+                    
+                    for species in rxn.reactants + rxn.products:
+                        if species not in self.core.species and species not in self.outputSpeciesList:
+                            self.outputSpeciesList.append(species)
+                            
 
 
     def addReactionToUnimolecularNetworks(self, newReaction, newSpecies, network=None):


### PR DESCRIPTION
Fix bug that occurs when we try to append a ReactionLibrary to the end of the chemkin file.

There was a bug that occurred because of bad identification of the reaction library
label.  Change the way `addReactionLibraryToOutput` works to be more efficient by no longer
creating new LibraryReaction objects, since they are already in memory.

Fix the saveChemkin function so that when saving edge, it does not save the
`outputSpeciesList` or `outputReactionList`, because that would print a bunch of duplicates on the edge.

Also no longer check duplicates, because it is performed in `enlarge()` for
all core and edge reactions and also when first adding the reaction library to the edge, so this should make it more efficient.