### PR TITLE
Read chemkin files literally: Don't load new bath gases when loading a chemkin file

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -798,21 +798,6 @@ def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments 
                 f.seek(-len(line0), 1)
                 readSpeciesBlock(f, speciesDict, speciesAliases, speciesList)
                 
-                # Also always add in a few bath gases (since RMG-Java does)
-                for label, smiles in [('Ar','[Ar]'), ('He','[He]'), ('Ne','[Ne]'), ('N2','N#N')]:
-                    molecule = Molecule().fromSMILES(smiles)
-                    for species in speciesList:
-                        if species.label == label:
-                            if len(species.molecule) == 0:
-                                species.molecule = [molecule]
-                            break
-                        if species.isIsomorphic(molecule):
-                            break
-                    else:
-                        species = Species(label=label, molecule=[molecule])
-                        speciesList.append(species)
-                        speciesDict[label.upper()] = species                            
-                
             elif 'THERM' in line.upper() and thermoPath is None:
                 # Skip this if a thermo file is specified
                 # Unread the line (we'll re-read it in readThermoBlock())

--- a/rmgpy/tools/testSensitivity.py
+++ b/rmgpy/tools/testSensitivity.py
@@ -17,7 +17,7 @@ class SensitivityTest(unittest.TestCase):
         
         runSensitivity(inputFile, chemkinFile, dictFile)
 
-        simfile = os.path.join(folder,'solver', 'simulation_1_17.csv')
+        simfile = os.path.join(folder,'solver', 'simulation_1_13.csv')
         sensfile = os.path.join(folder,'solver', 'sensitivity_1_SPC_1.csv')
 
         self.assertTrue(os.path.isfile(simfile))


### PR DESCRIPTION
There is a design change to the loading of chemkin files.  I think we should no longer
follow RMG-Java's way, and instead read in chemkin files more literally, especially
since all RMG-Py jobs do write almost all the bath gases.  This is also
so that the indices and readouts match cantera and chemkin more closely without unexpected
loading of species.