### PR TITLE
Some changes to resonance isomer generation

### DIFF
--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -3,6 +3,8 @@
 import cython
 import logging
 import itertools
+import sys
+from cStringIO import StringIO  # for python3: from io import StringIO
 
 # local imports
 try:
@@ -284,6 +286,20 @@ def toOBMol(mol):
     obmol.AssignSpinMultiplicity(True)
 
     return obmol
+
+def debugRDKitMol(rdmol, level=logging.INFO):
+    """
+    Takes an rdkit molecule object and logs some debugging information
+    equivalent to calling rdmol.Debug() but uses our logging framework.
+    Default logging level is INFO but can be controlled with the `level` parameter.
+    """
+    _stdout = sys.stdout
+    sys.stdout = _stringio = StringIO()
+    rdmol.Debug()
+    sys.stdout = _stdout
+    message = "RDKit Molecule debugging information:\n" + _stringio.getvalue()
+    logging.log(level, message)
+
 
 def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
     """

--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -353,19 +353,9 @@ def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
     # Make editable mol into a mol and rectify the molecule
     rdkitmol = rdkitmol.GetMol()
     if sanitize:
-        try:
-            Chem.SanitizeMol(rdkitmol)
-        except ValueError as e:
-            logging.error("Problem sanitizing molecule\n" + mol.toAdjacencyList())
-            debugRDKitMol(rdkitmol, logging.ERROR)
-            raise
+        Chem.SanitizeMol(rdkitmol)
     if removeHs:
-        try:
-            rdkitmol = Chem.RemoveHs(rdkitmol, sanitize=sanitize)
-        except ValueError as e:
-            logging.error("Problem removing H's from molecule\n" + mol.toAdjacencyList())
-            debugRDKitMol(rdkitmol, logging.ERROR)
-            raise
+        rdkitmol = Chem.RemoveHs(rdkitmol, sanitize=sanitize)
     if returnMapping:
         return rdkitmol, rdAtomIndices
     return rdkitmol

--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -341,10 +341,19 @@ def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
     # Make editable mol into a mol and rectify the molecule
     rdkitmol = rdkitmol.GetMol()
     if sanitize:
-        Chem.SanitizeMol(rdkitmol)
+        try:
+            Chem.SanitizeMol(rdkitmol)
+        except ValueError as e:
+            logging.error("Problem sanitizing molecule\n" + mol.toAdjacencyList())
+            debugRDKitMol(rdkitmol, logging.ERROR)
+            raise
     if removeHs:
-        rdkitmol = Chem.RemoveHs(rdkitmol, sanitize=sanitize)
-    
+        try:
+            rdkitmol = Chem.RemoveHs(rdkitmol, sanitize=sanitize)
+        except ValueError as e:
+            logging.error("Problem removing H's from molecule\n" + mol.toAdjacencyList())
+            debugRDKitMol(rdkitmol, logging.ERROR)
+            raise
     if returnMapping:
         return rdkitmol, rdAtomIndices
     return rdkitmol

--- a/rmgpy/molecule/generatorTest.py
+++ b/rmgpy/molecule/generatorTest.py
@@ -7,6 +7,20 @@ from .molecule import Atom, Molecule
 from .inchi import P_LAYER_PREFIX, U_LAYER_PREFIX
 from .generator import *
 
+class RDKitTest(unittest.TestCase):
+    def testDebugger(self):
+        """
+        Test the debugRDKitMol(rdmol) function doesn't crash
+        
+        We can't really test it in the unit testing framework, because 
+        that already captures and redirects standard output, and that
+        conflicts with the function, but this checks it doesn't crash.
+        """
+        import rdkit.Chem
+        import logging
+        rdmol = rdkit.Chem.MolFromSmiles('CCC')
+        message = debugRDKitMol(rdmol, level=logging.INFO)
+
 class CreateULayerTest(unittest.TestCase):
     def testC4H6(self):
         """

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -320,7 +320,12 @@ def fromRDKitMol(mol, rdkitmol):
     
     # Add hydrogen atoms to complete molecule if needed
     rdkitmol = Chem.AddHs(rdkitmol)
-    Chem.rdmolops.Kekulize(rdkitmol, clearAromaticFlags=True)
+    try:
+        Chem.rdmolops.Kekulize(rdkitmol, clearAromaticFlags=True)
+    except ValueError as e:
+        logging.error("Trouble Keukulizing species")
+        rdkitmol.Debug()
+        raise
     
     # iterate through atoms in rdkitmol
     for i in xrange(rdkitmol.GetNumAtoms()):

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -26,6 +26,7 @@ from .adjlist import PeriodicSystem, bond_orders, ConsistencyChecker
 import rmgpy.molecule.inchi as inchiutil
 import rmgpy.molecule.util as util
 import rmgpy.molecule.pathfinder as pathfinder
+import rmgpy.molecule.generator as generator
 
 # constants
 
@@ -324,7 +325,7 @@ def fromRDKitMol(mol, rdkitmol):
         Chem.rdmolops.Kekulize(rdkitmol, clearAromaticFlags=True)
     except ValueError as e:
         logging.error("Trouble Keukulizing species")
-        rdkitmol.Debug()
+        generator.debugRDKitMol(rdkitmol, logging.ERROR)
         raise
     
     # iterate through atoms in rdkitmol

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -321,12 +321,7 @@ def fromRDKitMol(mol, rdkitmol):
     
     # Add hydrogen atoms to complete molecule if needed
     rdkitmol = Chem.AddHs(rdkitmol)
-    try:
-        Chem.rdmolops.Kekulize(rdkitmol, clearAromaticFlags=True)
-    except ValueError as e:
-        logging.error("Trouble Keukulizing species")
-        generator.debugRDKitMol(rdkitmol, logging.ERROR)
-        raise
+    Chem.rdmolops.Kekulize(rdkitmol, clearAromaticFlags=True)
     
     # iterate through atoms in rdkitmol
     for i in xrange(rdkitmol.GetNumAtoms()):

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -272,22 +272,25 @@ def generateAromaticResonanceIsomers(mol):
 
 def generateKekulizedResonanceIsomers(mol):
     """
-    Generate the kekulized (single-double bond) form of the molecule.
+    Generate a kekulized (single-double bond) form of the molecule.
+    
+    Returns a single Kekule form, as an element of a list of length 1.
+    If there's an error (eg. in RDKit) then it just returns an empty list.
     """
-    cython.declare(isomers=list, atom=Atom)
-    isomers = []
+    cython.declare(atom=Atom)
     for atom in mol.atoms:
         if atom.atomType.label == 'Cb' or atom.atomType.label == 'Cbf':
             break
     else:
-        return isomers
+        return []
    
-
-    rdkitmol = generator.toRDKitMol(mol)  # This perceives aromaticit
-    isomer = parser.fromRDKitMol(Molecule(), rdkitmol)# This step Kekulizes the molecule
+    try:
+        rdkitmol = generator.toRDKitMol(mol)  # This perceives aromaticity
+        isomer = parser.fromRDKitMol(Molecule(), rdkitmol)  # This step Kekulizes the molecule
+    except ValueError:
+        return []
     isomer.updateAtomTypes()
-    isomers.append(isomer)  
-    return isomers
+    return [isomer]
 
 def generate_isomorphic_isomers(mol):
     """


### PR DESCRIPTION
I think the net result of this is mostly that when it fails to generate kekule resonance form due to an RDKit error, it carries on silently without (just like was already done for failing to generate aromatic resonance forms). This fixes the probelm @ejtierne was having in #590.

I also created a "debugRDKitMol" function which is useful at times. We should put it in some error handlers in other places where we hit RDKit errors.

The next step would be to silence the very many `[15:01:43] Explicit valence for atom # 13 N, 4, is greater than permitted` messages that get printed to the standard error stream. This would require some fancy IO juggling like in my debugRDKitMol function. I was tempted to try this, but then came across [this blog post](http://rdkit.blogspot.com/2016/03/capturing-error-information.html) suggesting there'll be some built in support in the next RDKit (not sure if it captures and silences, or just captures).