### PR TITLE
Fixes to TransportData

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1447,13 +1447,6 @@ def writeReactionString(reaction, javaLibrary = False):
     if len(reaction_string) > 52:
         logging.warning("Chemkin reaction string {0!r} is too long for Chemkin 2!".format(reaction_string))
     return reaction_string
-
-################################################################################
-
-def writeTransportEntry(species, verbose = True):
-    """
-    Return a string representation of the reaction as used in a Chemkin file. Lists the 
-    """
     
 ################################################################################
 

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -752,7 +752,7 @@ def loadTransportFile(path, speciesDict):
     """
     with open(path, 'r') as f:
         for line0 in f:
-            line = removeCommentFromLine(line0)[0]
+            line, comment = removeCommentFromLine(line0)
             line = line.strip()
             if line != '':
                 # This line contains an entry, so parse it
@@ -766,6 +766,7 @@ def loadTransportFile(path, speciesDict):
                     dipoleMoment = (float(data[3]),'De'),
                     polarizability = (float(data[4]),'angstrom^3'),
                     rotrelaxcollnum = float(data[5]),
+                    comment = comment.strip(),
                 )
 
 def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments = True, thermoPath = None):

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1750,7 +1750,7 @@ def saveTransportFile(path, species):
                     spec.transportData.sigma.value_si * 1e10,
                     (spec.transportData.dipoleMoment.value_si * constants.c * 1e21 if spec.transportData.dipoleMoment else 0),
                     (spec.transportData.polarizability.value_si * 1e30 if spec.transportData.polarizability else 0),
-                    (spec.Zrot.value_si if spec.Zrot else 0),
+                    (spec.transportData.rotrelaxcollnum if spec.transportData.rotrelaxcollnum else 0),
                     spec.transportData.comment,
                 ))
 

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -760,12 +760,13 @@ def loadTransportFile(path, speciesDict):
                 data = line[16:].split()
                 species = speciesDict[label]
                 species.transportData = TransportData(
+                    shapeIndex = int(data[0]),
                     sigma = (float(data[2]),'angstrom'),
                     epsilon = (float(data[1]),'K'),
+                    dipoleMoment = (float(data[3]),'De'),
+                    polarizability = (float(data[4]),'angstrom^3'),
+                    rotrelaxcollnum = float(data[5]),
                 )
-                species.dipoleMoment = (float(data[3]),'De')
-                species.polarizability = (float(data[4]),'angstrom^3')
-                species.Zrot = (float(data[5]),'')
 
 def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments = True, thermoPath = None):
     """

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1747,20 +1747,12 @@ def saveTransportFile(path, species):
             
             label = getSpeciesIdentifier(spec)
             
-            molecule = spec.molecule[0]
-            if len(molecule.atoms) == 1:
-                shapeIndex = 0
-            elif molecule.isLinear():
-                shapeIndex = 1
-            else:
-                shapeIndex = 2
-            
             if missingData:
                 f.write('! {0:19s} {1!r}\n'.format(label, spec.transportData))
             else:
                 f.write('{0:19} {1:d}   {2:9.3f} {3:9.3f} {4:9.3f} {5:9.3f} {6:9.3f}    ! {7:s}\n'.format(
                     label,
-                    shapeIndex,
+                    spec.transportData.shapeIndex,
                     spec.transportData.epsilon.value_si / constants.R,
                     spec.transportData.sigma.value_si * 1e10,
                     (spec.transportData.dipoleMoment.value_si * constants.c * 1e21 if spec.transportData.dipoleMoment else 0),

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1734,8 +1734,7 @@ def saveTransportFile(path, species):
         f.write("! {0:15} {1:8} {2:9} {3:9} {4:9} {5:9} {6:9} {7:9}\n".format('Species','Shape', 'LJ-depth', 'LJ-diam', 'DiplMom', 'Polzblty', 'RotRelaxNum','Data'))
         f.write("! {0:15} {1:8} {2:9} {3:9} {4:9} {5:9} {6:9} {7:9}\n".format('Name','Index', 'epsilon/k_B', 'sigma', 'mu', 'alpha', 'Zrot','Source'))
         for spec in species:            
-            if (not spec.transportData or
-                len(spec.molecule) == 0):
+            if not spec.transportData:
                 missingData = True
             else:
                 missingData = False

--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 from chemkin import *
+import rmgpy
 ###################################################
 
 class ChemkinTest(unittest.TestCase):
@@ -10,7 +11,7 @@ class ChemkinTest(unittest.TestCase):
 		This example is mainly to test if family info can be correctly 
 		parsed from comments like '!Template reaction: R_Recombination'.
 		"""
-		folder = os.path.join(os.getcwd(),'rmgpy/test_data/chemkin/chemkin_py')
+		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
 		
 		chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
 		dictionaryPath = os.path.join(folder,'minimal', 'species_dictionary.txt')
@@ -32,7 +33,7 @@ class ChemkinTest(unittest.TestCase):
 		an entry in H_Abstraction, the other was just an estimate.'
 		won't interfere reaction family info retrival.
 		"""
-		folder = os.path.join(os.getcwd(),'rmgpy/test_data/chemkin/chemkin_py')
+		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
 		
 		chemkinPath = os.path.join(folder, 'pdd', 'chem.inp')
 		dictionaryPath = os.path.join(folder,'pdd', 'species_dictionary.txt')
@@ -45,3 +46,28 @@ class ChemkinTest(unittest.TestCase):
 
 		reaction2 = reactions[1]
 		self.assertEqual(reaction2.family, "H_Abstraction")
+		
+	def testTransportDataReadAndWrite(self):
+		"""
+		Test that we can write to chemkin and recreate the same transport object
+		"""
+		from rmgpy.species import Species
+		from rmgpy.molecule import Molecule
+		from rmgpy.transport import TransportData
+		
+		Ar = Species(label="Ar", transportData=TransportData(shapeIndex=0, epsilon=(1134.93,'J/mol'), sigma=(3.33,'angstrom'), dipoleMoment=(0,'De'), polarizability=(0,'angstrom^3'), rotrelaxcollnum=0.0, comment="""GRI-Mech"""))
+		
+		Ar_write = Species(label="Ar")
+		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data')
+		
+		tempTransportPath = os.path.join(folder, 'tran_temp.dat')
+		
+		saveTransportFile(tempTransportPath, [Ar])
+		speciesDict = {'Ar': Ar_write}
+		loadTransportFile(tempTransportPath, speciesDict)
+		self.assertEqual(repr(Ar),repr(Ar_write))
+		
+		os.remove(tempTransportPath)
+		
+
+		

--- a/rmgpy/data/transport.py
+++ b/rmgpy/data/transport.py
@@ -409,13 +409,19 @@ class TransportDatabase(object):
         Tb = criticalPoint.Tb
         if criticalPoint.linear != molecule.isLinear():
             logging.warning("Group-based structure index and isLinear() function disagree about linearity of {mol!r}".format(mol=molecule))
-        shapeIndex = 1 if molecule.isLinear() else 2
+            
+        if len(molecule.atoms) == 1:
+            shapeIndex = 0
+        elif molecule.isLinear():
+            shapeIndex = 1
+        else:
+            shapeIndex = 2
           
         # Acetone values from Joback thesis: Tc = 511.455  (based on experimental Tb)  Pc = 47.808    Vc = 209.000    Tb = 322.082
         #print "Tc={Tc:.2f} K, Pc={Pc:.4g} bar, Vc={Vc:.4g} cm3/mol, Tb={Tb:.4g} K, average of {isomers} isomers".format(Tc=Tc,Pc=Pc,Vc=Vc,Tb=Tb,isomers=counter)
         #print 'Estimated with Tc={Tc:.2f} K, Pc={Pc:.4g} bar (from Joback method)'.format(Tc=Tc,Pc=Pc)
         transport = TransportData(
-                     shapeIndex = shapeIndex,  # 1 if linear, else 2
+                     shapeIndex = shapeIndex, 
                      epsilon = (.77 * Tc * constants.R, 'J/mol'),
                      sigma = (2.44 * (Tc/Pc)**(1./3), 'angstroms'),
                      dipoleMoment = (0, 'C*m'),
@@ -567,10 +573,15 @@ class TransportDatabase(object):
             sigma = (5.949e-10,"m")
             epsilon = (399.3,"K")
         
-        shapeIndex = 1 if species.molecule[0].isLinear() else 2
+        if len(species.molecule[0].atoms) == 1:
+            shapeIndex = 0
+        elif species.molecule[0].isLinear():
+            shapeIndex = 1
+        else:
+            shapeIndex = 2
             
         transport = TransportData(
-            shapeIndex = shapeIndex,  # 1 if linear, else 2
+            shapeIndex = shapeIndex,  
             epsilon = epsilon,
             sigma = sigma,
             dipoleMoment = (0, 'C*m'),

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -70,16 +70,15 @@ class Species(rmgpy.species.Species):
 
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 
                  molecule=None, transportData=None, molecularWeight=None, 
-                 dipoleMoment=None, polarizability=None, Zrot=None, 
                  energyTransferModel=None, reactive=True, props=None, coreSizeAtCreation=0):
-        rmgpy.species.Species.__init__(self, index, label, thermo, conformer, molecule, transportData, molecularWeight, dipoleMoment, polarizability, Zrot, energyTransferModel, reactive, props)
+        rmgpy.species.Species.__init__(self, index, label, thermo, conformer, molecule, transportData, molecularWeight, energyTransferModel, reactive, props)
         self.coreSizeAtCreation = coreSizeAtCreation
 
     def __reduce__(self):
         """
         A helper function used when pickling an object.
         """
-        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.dipoleMoment, self.polarizability, self.Zrot, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
+        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
 
     def generateThermoData(self, database, thermoClass=NASA, quantumMechanics=None):
         """

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -43,9 +43,6 @@ cdef class Species:
     cdef public object transportData
     cdef public list molecule
     cdef public ScalarQuantity _molecularWeight
-    cdef public ScalarQuantity _dipoleMoment
-    cdef public ScalarQuantity _polarizability
-    cdef public ScalarQuantity _Zrot
     cdef public bint reactive
     cdef public object energyTransferModel
     cdef public dict props

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -78,9 +78,6 @@ class Species(object):
     `molecule`              A list of the :class:`Molecule` objects describing the molecular structure
     `transportData`          A set of transport collision parameters
     `molecularWeight`       The molecular weight of the species
-    `dipoleMoment`          The molecular dipole moment
-    `polarizability`        The polarizability alpha
-    `Zrot`                  The rotational relaxation collision number
     `energyTransferModel`   The collisional energy transfer model to use
     `reactive`              ``True`` if the species participates in reactions, ``False`` if not
     `props`                 A generic 'properties' dictionary to store user-defined flags
@@ -92,7 +89,6 @@ class Species(object):
 
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 
                  molecule=None, transportData=None, molecularWeight=None, 
-                 dipoleMoment=None, polarizability=None, Zrot=None, 
                  energyTransferModel=None, reactive=True, props=None, aug_inchi=None):
         self.index = index
         self.label = label
@@ -102,9 +98,6 @@ class Species(object):
         self.transportData = transportData
         self.reactive = reactive
         self.molecularWeight = molecularWeight
-        self.dipoleMoment = dipoleMoment
-        self.polarizability = polarizability
-        self.Zrot = Zrot
         self.energyTransferModel = energyTransferModel        
         self.props = props or {}
         self.aug_inchi = aug_inchi
@@ -133,9 +126,6 @@ class Species(object):
         if self.transportData is not None: string += 'transportData={0!r}, '.format(self.transportData)
         if not self.reactive: string += 'reactive={0}, '.format(self.reactive)
         if self.molecularWeight is not None: string += 'molecularWeight={0!r}, '.format(self.molecularWeight)
-        if self.dipoleMoment is not None: string += 'dipoleMoment={0!r}, '.format(self.dipoleMoment)
-        if self.polarizability is not None: string += 'polarizability={0!r}, '.format(self.polarizability)
-        if self.Zrot is not None: string += 'Zrot={0!r}, '.format(self.Zrot)
         if self.energyTransferModel is not None: string += 'energyTransferModel={0!r}, '.format(self.energyTransferModel)
         string = string[:-2] + ')'
         return string
@@ -157,31 +147,13 @@ class Species(object):
         """
         A helper function used when pickling an object.
         """
-        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.dipoleMoment, self.polarizability, self.Zrot, self.energyTransferModel, self.reactive, self.props))
+        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props))
 
     def getMolecularWeight(self):
         return self._molecularWeight
     def setMolecularWeight(self, value):
         self._molecularWeight = quantity.Mass(value)
     molecularWeight = property(getMolecularWeight, setMolecularWeight, """The molecular weight of the species.""")
-
-    def getDipoleMoment(self):
-        return self._dipoleMoment
-    def setDipoleMoment(self, value):
-        self._dipoleMoment = quantity.DipoleMoment(value)
-    dipoleMoment = property(getDipoleMoment, setDipoleMoment, """The molecular dipole moment.""")
-
-    def getPolarizability(self):
-        return self._polarizability
-    def setPolarizability(self, value):
-        self._polarizability = quantity.Volume(value)
-    polarizability = property(getPolarizability, setPolarizability, """The polarizability alpha.""")
-
-    def getZrot(self):
-        return self._Zrot
-    def setZrot(self, value):
-        self._Zrot = quantity.Dimensionless(value)
-    Zrot = property(getZrot, setZrot, """The rotational relaxation collision number.""")
 
     def generateResonanceIsomers(self):
         """
@@ -405,9 +377,6 @@ class Species(object):
         other.transportData = deepcopy(self.transportData)
 
         other.molecularWeight = deepcopy(self.molecularWeight)
-        other.dipoleMoment = deepcopy(self.dipoleMoment)
-        other.polarizability = deepcopy(self.polarizability)
-        other.Zrot = deepcopy(self.Zrot)
         other.energyTransferModel = deepcopy(self.energyTransferModel)
         other.reactive = self.reactive        
         other.props = deepcopy(self.props)

--- a/rmgpy/transport.py
+++ b/rmgpy/transport.py
@@ -21,7 +21,7 @@ class TransportData:
     `sigma`             Lennard-Jones collision diameter
     `dipoleMoment`      Dipole Moment
     `polarizability`    Polarizability Volume
-    `rotrelaxcollnum`   Rotational relaxation number
+    `rotrelaxcollnum`   Rotational relaxation number at 298 K, saved as a double.
     =================  ============================================================
     
     """


### PR DESCRIPTION
What started as a small fix led to the discovery of multiple bugs.

Summary of fixes:
- Fixes loading of all the transport data from a chemkin `tran.dat` file into the `TransportData` object
- Estimate shape index for monatomic molecules correctly within their estimation methods, not when it reaches the `saveTransportFile` function in `rmgpy.chemkin`
- Deletes duplicate `dipoleMoment`, `polarzibility`, and `Zrot` attributes from the `Species` class and closes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/615
- Correctly saves the rotational relaxation number from the `TransportData` object rather than from `Species.zRot`, which never had anything saved inside.