### PR TITLE
Add work around to turn off speciesConstraints for training reactions

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -41,6 +41,7 @@ import shutil
 import numpy
 import csv
 import gc
+import copy
 
 from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.molecule import Molecule
@@ -64,7 +65,6 @@ from rmgpy.restart import RestartWriter
 from rmgpy.qm.main import QMDatabaseWriter
 from rmgpy.stats import ExecutionStatsWriter
 from rmgpy.tools.sensitivity import plotSensitivity
-
 ################################################################################
 
 solvent = None
@@ -311,8 +311,12 @@ class RMG(util.Subject):
         if self.kineticsEstimator == 'rate rules':
             if '!training' not in self.kineticsDepositories:
                 logging.info('Adding rate rules from training set in kinetics families...')
+                # Temporarily remove species constraints for the training reactions
+                copySpeciesConstraints=copy.copy(self.speciesConstraints)
+                self.speciesConstraints={}
                 for family in self.database.kinetics.families.values():
                     family.addKineticsRulesFromTrainingSet(thermoDatabase=self.database.thermo)
+                self.speciesConstraints=copySpeciesConstraints
             else:
                 logging.info('Training set explicitly not added to rate rules in kinetics families...')
             logging.info('Filling in rate rules in kinetics families by averaging...')


### PR DESCRIPTION
Work around for #602 

A cleaner way to do it is to load database before we load the species constraints. The problem is that setting species constraints is embedded in the loadInput function. loadinput is needed before loadDatabase because RMG needs to know what libraries, families, etc to load. Additionally, this would change the way we implement the "allowed" option in species constraints. Overall I think its better to just use this work around.

@nickvandewiele Can you test to see if this messes up a parallel job specifically in regards to broadcasting either the species constraints or database.