### PR TITLE
PRs from forked repo's will no longer fail Travis CI builds due to encrypted env. vars issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
   - export PYTHONPATH=$TRAVIS_BUILD_DIR/RMG-Py:$PYTHONPATH
   # Update conda itself
   - conda update --yes conda
-  - openssl aes-256-cbc -K $encrypted_244ac3091cff_key -iv $encrypted_244ac3091cff_iv -in deploy_key.enc -out deploy_key -d
   - cd ..
   - git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
   - cd RMG-Py
@@ -34,4 +33,6 @@ install:
 script: 
   - make test
   - make test-database
+
+after_success:
   - bash ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,8 @@
 
 set -e # exit with nonzero exit code if anything fails
 
+openssl aes-256-cbc -K $encrypted_244ac3091cff_key -iv $encrypted_244ac3091cff_iv -in deploy_key.enc -out deploy_key -d
+
 echo 'Travis Build Dir: '$TRAVIS_BUILD_DIR
 
 if $TRAVIS_PULL_REQUEST


### PR DESCRIPTION
Previously, pull requests from forks lead to a failure of the deploy key decryption, and a subsequent failure of the Travis CI build of RMG-Py. 

As far as I understand, for security reasons PR's from forks are [not able](https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables) to use encrypted environment variables, which is required step to push to the RMG-tests repository.

The solution offered by this PR is to move the decryption command from the `before_install` section into the deploy script. Since the deploy script will exit whenever something fails (`set -e`), it will catch such a situation. The deploy script is moved from the `script` section to the `after_success` section to avoid deploying if one of the unit tests fails.

The bad part is that PR's from forks will not trigger the tests in the RMG-tests repo. Fortunately, once something is merged into master, a call to RMG-tests is made.

I specifically created this PR from my fork to demonstrate this.

