### PR TITLE
ArrayQuantity: better uncertainty handling

### DIFF
--- a/rmgpy/quantity.pxd
+++ b/rmgpy/quantity.pxd
@@ -60,8 +60,11 @@ cdef class ScalarQuantity(Units):
 cdef class ArrayQuantity(Units):
 
     cdef public numpy.ndarray value_si
-    cdef public str uncertaintyType
-    cdef public numpy.ndarray uncertainty
+    cdef public str _uncertaintyType
+    cdef public numpy.ndarray uncertainty_si
+
+    cpdef str getUncertaintyType(self)
+    cpdef     setUncertaintyType(self, str v)
 
     cpdef bint isUncertaintyAdditive(self) except -2
 


### PR DESCRIPTION
Make the `ArrayQuantity` class more like the `ScalarQuantity` class in the way they store and use uncertainties as a property, with an `uncertainty_si` attribute. This eliminates confusion due to the differences in the two classes and makes `ArrayQuantity` more robust.

Also added a suite of unit tests.