### PR TITLE
Verbose forbidden structure debugging info

### DIFF
--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -32,10 +32,14 @@ import logging
 
 from rmgpy.species import Species
 
-def failsSpeciesConstraints(species):
+def failsSpeciesConstraints(species, verbose=False):
     """
     Pass in either a `Species` or `Molecule` object and checks whether it passes 
     the speciesConstraints set by the user.  If not, returns `True` for failing speciesConstraints.
+
+
+    If `verbose` is set to ``True``, debugging information about why
+    the molecule is forbidden will be logged.
     """
     
     from rmgpy.rmg.input import getInput
@@ -67,19 +71,35 @@ def failsSpeciesConstraints(species):
             return False        
     H = struct.getNumAtoms('H')
     if struct.getNumAtoms('C') > maxCarbonAtoms:
+        if verbose: 
+            logging.error("Species {0} exceeded 'maximumCarbonAtoms = {1}' species constraint.".format(struct.toSMILES(), maxCarbonAtoms))
         return True
     if H > maxHydrogenAtoms:
+        if verbose: 
+            logging.error("Species {0} exceeded 'maximumHydrogenAtoms = {1}' species constraint.".format(struct.toSMILES(), maxHydrogenAtoms))
         return True
     if struct.getNumAtoms('O') > maxOxygenAtoms:
+        if verbose: 
+            logging.error("Species {0} exceeded 'maximumOxygenAtoms = {1}' species constraint.".format(struct.toSMILES(), maxOxygenAtoms))
         return True
     if struct.getNumAtoms('N') > maxNitrogenAtoms:
+        if verbose:
+            logging.error("Species {0} exceeded 'maximumNitrogenAtoms = {1}' species constraint.".format(struct.toSMILES(), maxNitrogenAtoms))
         return True
     if struct.getNumAtoms('Si') > maxSiliconAtoms:
+        if verbose:
+            logging.error("Species {0} exceeded 'maximumSiliconAtoms = {1}' species constraint.".format(struct.toSMILES(), maxSiliconAtoms))
         return True
     if struct.getNumAtoms('S') > maxSulfurAtoms:
+        if verbose:
+            logging.error("Species {0} exceeded 'maximumSulfurAtoms = {1}' species constraint.".format(struct.toSMILES(), maxSulfurAtoms))
         return True
     if len(struct.atoms) - H > maxHeavyAtoms:
+        if verbose: 
+            logging.error("Species {0} exceeded 'maximumHeavyAtoms = {1}' species constraint.".format(struct.toSMILES(), maxHeavyAtoms))
         return True
     if (struct.getNumberOfRadicalElectrons() > maxRadicals):
+        if verbose: 
+            logging.error("Species {0} exceeded 'maximumRadicalElectrons = {1}' species constraint.".format(struct, maxRadicals))
         return True
     return False

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -1213,11 +1213,14 @@ class ForbiddenStructures(Database):
     from occurring.
     """
     
-    def isMoleculeForbidden(self, molecule):
+    def isMoleculeForbidden(self, molecule, verbose=False):
         """
         Return ``True`` if the given :class:`Molecule` object `molecule`
         contains forbidden functionality, or ``False`` if not. Labeled atoms
         on the forbidden structures and the molecule are honored.
+
+        If `verbose` is set to ``True``, debugging information about why
+        the molecule is forbidden will be logged.
         """
         for entry in self.entries.values():
             entryLabeledAtoms = entry.item.getLabeledAtoms()
@@ -1229,6 +1232,9 @@ class ForbiddenStructures(Database):
                 initialMap[moleculeLabeledAtoms[label]] = entryLabeledAtoms[label]
             else:
                 if molecule.isMappingValid(entry.item, initialMap) and molecule.isSubgraphIsomorphic(entry.item, initialMap):
+                    if verbose:
+                        logging.error("Molecule {0} was forbidden because it matched forbidden structure entry {1} with the following structure:".format(molecule.toSMILES(), entry.label))
+                        logging.error('\n{}'.format(entry.item.toAdjacencyList()))
                     return True
             
         # Until we have more thermodynamic data of molecular ions we will forbid them
@@ -1236,6 +1242,8 @@ class ForbiddenStructures(Database):
         for atom in molecule.atoms:
             molecule_charge += atom.charge
         if molecule_charge != 0:
+            if verbose:
+                logging.error("Molecule {0} was forbidden because it has a net non-neutral charge".format(molecule.toSMILES()))
             return True
         
         return False

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1331,6 +1331,8 @@ class KineticsFamily(Database):
                         # Delete this reaction, since it should probably also be forbidden in the initial direction
                         # Hack fix for now
                         del rxn
+                        # reset the forbidden structures back to the original set
+                        self.forbidden=tempObject
                 else:
                     rxn.reverse = reactions[0]
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1327,7 +1327,12 @@ class KineticsFamily(Database):
                         logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                         raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
                     else:
-                        logging.error("Error was fixed, the product is a forbidden structure when used as a reactant in the reverse direction.")
+                        # Print some additional logging information about why the product or reactant was forbidden
+                        logging.error("Error was fixed for reaction, the product is a forbidden structure when used as a reactant in the reverse direction.")
+                        logging.error("It may be worthwhile to further investigate why the species was forbidden as it may be a chemistry problem in the database.")
+                        for struct in rxn.reactants + rxn.products:
+                            self.isMoleculeForbidden(reactant.molecule[0], verbose = True)
+                            failsSpeciesConstraints(struct, verbose = True)
                         # Delete this reaction, since it should probably also be forbidden in the initial direction
                         # Hack fix for now
                         del rxn

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -431,12 +431,14 @@ class RMG(util.Subject):
                     if 'allowed' in self.speciesConstraints and 'input species' in self.speciesConstraints['allowed']:
                         logging.warning('Input species {0} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.'.format(spec.label))
                     else:
+                        self.database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0], verbose = True)
                         raise ForbiddenStructureException("Input species {0} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label))
                 if failsSpeciesConstraints(spec):
                     if 'allowed' in self.speciesConstraints and 'input species' in self.speciesConstraints['allowed']:
                         self.speciesConstraints['explicitlyAllowedMolecules'].append(spec.molecule[0])
                         pass
                     else:
+                        failsSpeciesConstraints(spec, verbose=True)
                         raise ForbiddenStructureException("Species constraints forbids input species {0}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label))
             
             #Check to see if user has input Singlet O2 into their input file or libraries

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1353,11 +1353,13 @@ class CoreEdgeReactionModel:
                 if 'allowed' in rmg.speciesConstraints and 'seed mechanisms' in rmg.speciesConstraints['allowed']:
                     logging.warning("Species {0} from seed mechanism {1} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.".format(spec.label, seedMechanism.label))
                 else:
+                    database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0], verbose=True)
                     raise ForbiddenStructureException("Species {0} from seed mechanism {1} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label, seedMechanism.label))
             if failsSpeciesConstraints(spec):
                 if 'allowed' in rmg.speciesConstraints and 'seed mechanisms' in rmg.speciesConstraints['allowed']:
                     rmg.speciesConstraints['explicitlyAllowedMolecules'].extend(spec.molecule)
                 else:
+                    failsSpeciesConstraints(spec, verbose=True)
                     raise ForbiddenStructureException("Species constraints forbids species {0} from seed mechanism {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, seedMechanism.label))
 
         for spec in self.newSpeciesList:            
@@ -1421,11 +1423,13 @@ class CoreEdgeReactionModel:
                 if 'allowed' in rmg.speciesConstraints and 'reaction libraries' in rmg.speciesConstraints['allowed']:
                     logging.warning("Species {0} from reaction library {1} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.".format(spec.label, reactionLibrary.label))
                 else:
+                    database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0], verbose=True)
                     raise ForbiddenStructureException("Species {0} from reaction library {1} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label, reactionLibrary.label))
             if failsSpeciesConstraints(spec):
                 if 'allowed' in rmg.speciesConstraints and 'reaction libraries' in rmg.speciesConstraints['allowed']:
                     rmg.speciesConstraints['explicitlyAllowedMolecules'].extend(spec.molecule)
                 else:
+                    failsSpeciesConstraints(spec, verbose=True)
                     raise ForbiddenStructureException("Species constraints forbids species {0} from reaction library {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, reactionLibrary.label))
        
         for spec in self.newSpeciesList:


### PR DESCRIPTION
Closes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/572 as suggested by @cfgoldsmith 

Adds the feature of printing more verbose debugging info when raising a `ForbiddenStructureException`.  This helps the user quickly identify why the exception was raised and allows them to address it as either a human error or database problem.

Also fixes the bug introduced in  2e2c2bedbd where forbiddenStructures are set to None permanently.

Don't merge yet, somebody should review/test.
