### PR TITLE
Constrain versions of matplotlib and cantera

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - libgcc # [unix]
   - python
   - numpy >=1.10.0
-  - cantera
+  - cantera >=2.2
   - cython ==0.21
   - matplotlib >=1.5
   - rdkit >=2015.09.2

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera
   - cython ==0.21
-  - matplotlib
+  - matplotlib >=1.5
   - rdkit >=2015.09.2
   - pydas >=1.0.1
   - pydqed >=1.0.0

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera
   - cython ==0.21
-  - matplotlib
+  - matplotlib >=1.5
   - rdkit >=2015.09.2
   - quantities
   - scipy

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -6,7 +6,7 @@ dependencies:
   - mingwpy
   - python
   - numpy >=1.10.0
-  - cantera
+  - cantera >=2.2
   - cython ==0.21
   - matplotlib >=1.5
   - rdkit >=2015.09.2

--- a/meta.yaml
+++ b/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - jinja2
     - libgcc # [unix]
     - markupsafe
-    - matplotlib
+    - matplotlib >=1.5
     - nose
     - numpy
     - openbabel
@@ -55,7 +55,7 @@ requirements:
     - jinja2
     - libgcc # [unix]
     - markupsafe
-    - matplotlib
+    - matplotlib >=1.5
     - mopac
     - nose
     - numpy

--- a/meta.yaml
+++ b/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - argparse # [py26]
     - cairo # [unix]
     - cairocffi # [unix]
-    - cantera
+    - cantera >=2.2
     - coverage
     - cython ==0.21
     - gprof2dot


### PR DESCRIPTION
This PR ensures that people use up-to-date versions of cantera, matplotlib.