### PR TITLE
un/pickle reaction when diffusionLimiter.enabled is set to True

### DIFF
--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -47,6 +47,7 @@ cdef class Reaction:
     cdef public bint duplicate
     cdef public int degeneracy
     cdef public list pairs
+    cdef public dict k_effective_cache
     
     cpdef bint isIsomerization(self)
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -115,7 +115,7 @@ class Reaction:
         self.pairs = pairs
         
         if diffusionLimiter.enabled:
-            self.__k_effective_cache = {}
+            self.k_effective_cache = {}
 
     def __repr__(self):
         """
@@ -629,10 +629,10 @@ class Reaction:
         """
         if diffusionLimiter.enabled:
             try:
-                k = self.__k_effective_cache[T]
+                k = self.k_effective_cache[T]
             except KeyError:
                 k = diffusionLimiter.getEffectiveRate(self, T)
-                self.__k_effective_cache[T] = k
+                self.k_effective_cache[T] = k
             return k
         else:
             return  self.kinetics.getRateCoefficient(T, P)

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -926,7 +926,28 @@ class TestReaction(unittest.TestCase):
         
         self.assertEqual(self.reaction.duplicate, reaction.duplicate)
         self.assertEqual(self.reaction.degeneracy, reaction.degeneracy)   
-        
+    
+    def testPickleLiquidReaction(self):
+        """
+        Test that a Reaction with a __k_effective_cache object can be successfully pickled and unpickled with no loss of information.
+        """
+        global diffusionLimiter        
+        import cPickle
+        from rmgpy.kinetics.diffusionLimited import diffusionLimiter
+
+        rxn = Reaction()
+        reaction = cPickle.loads(cPickle.dumps(rxn,-1))
+
+        self.assertIsNone(reaction.k_effective_cache)
+
+        diffusionLimiter.enabled = True
+
+        rxn = Reaction()
+        reaction = cPickle.loads(cPickle.dumps(rxn,-1))
+
+        self.assertIsNotNone(reaction.k_effective_cache)
+
+        diffusionLimiter.enabled = False
 
 class TestReactionToCantera(unittest.TestCase):
     """

--- a/rmgpy/tools/testGenerateReactions.py
+++ b/rmgpy/tools/testGenerateReactions.py
@@ -96,6 +96,10 @@ class GenerateReactionsTest(unittest.TestCase):
         self.assertEquals(len(rmg.reactionModel.core.reactions),1)
         shutil.rmtree(os.path.join(folder,'pdep'))
         
+    
+    def setUp(self):
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
         
     def tearDown(self):
         """


### PR DESCRIPTION
A few small changes to the way Reaction.__k_effective_cache is stored.

https://github.com/ReactionMechanismGenerator/RMG-Py/issues/271

- renaming it to k_effective_cache
- a unit test that shows the un/pickling is correctly done

The whole design of this attribute can really be improved a lot. This is only some patchwork.