### PR TITLE
Add a method "toGroup" for the conversion of Molecule to Group objects

### DIFF
--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -534,9 +534,9 @@ class Group(Graph):
     Corresponding alias methods have also been provided.
     """
 
-    def __init__(self, atoms=None):
+    def __init__(self, atoms=None, multiplicity=[]):
         Graph.__init__(self, atoms)
-        self.multiplicity = []
+        self.multiplicity = multiplicity
         self.update()
 
     def __reduce__(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1568,7 +1568,7 @@ class Molecule(Graph):
                                          lonePairs=[atom.lonePairs]
                                          )
                     
-        group = Group(atoms=groupAtoms.values())            
+        group = Group(atoms=groupAtoms.values(), multiplicity=[self.multiplicity])            
         
         # Create GroupBond for each bond between atoms in the molecule
         for atom in self.atoms:

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -41,7 +41,7 @@ import os
 import re
 import numpy
 import urllib
-
+from collections import OrderedDict
 
 import element as elements
 try:
@@ -56,6 +56,7 @@ import rmgpy.constants as constants
 import rmgpy.molecule.parser as parser
 import rmgpy.molecule.generator as generator
 import rmgpy.molecule.resonance as resonance
+from rmgpy.molecule.group import GroupAtom, GroupBond, Group
 
 ################################################################################
 
@@ -1552,3 +1553,30 @@ class Molecule(Graph):
         self.multiplicity = 1
 
         return added
+
+    def toGroup(self):
+        """
+        This method converts a list of atoms in a Molecule to a Group object.
+        """
+        
+        # Create GroupAtom object for each atom in the molecule
+        groupAtoms = OrderedDict()# preserver order of atoms in original container
+        for atom in self.atoms:
+            groupAtoms[atom] = GroupAtom(atomType=[atom.atomType],
+                                         radicalElectrons=[atom.radicalElectrons],
+                                         charge=[atom.charge],
+                                         lonePairs=[atom.lonePairs]
+                                         )
+                    
+        group = Group(atoms=groupAtoms.values())            
+        
+        # Create GroupBond for each bond between atoms in the molecule
+        for atom in self.atoms:
+            for bondedAtom, bond in atom.edges.iteritems():
+                group.addBond(GroupBond(groupAtoms[atom],groupAtoms[bondedAtom], order=[bond.order]))
+            
+        group.update()
+        
+        return group
+
+

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1552,7 +1552,27 @@ multiplicity 2
         sssr5_sizes = sorted([len(ring) for ring in sssr5])
         sssr5_sizes_expected = [6, 6, 6]
         self.assertEqual(sssr5_sizes, sssr5_sizes_expected)
+    
+    def testToGroup(self):
+        """
+        Test if we can convert a Molecule object into a Group object.
+        """
+        mol = Molecule().fromSMILES('CC(C)CCCC(C)C1CCC2C3CC=C4CC(O)CCC4(C)C3CCC12C')#cholesterol
+        group = mol.toGroup()
         
+        self.assertTrue(isinstance(group, Group))
+        
+        self.assertEquals(len(mol.atoms), len(group.atoms))
+
+        molbondcount = sum([1 for atom in mol.atoms for bondedAtom, bond in atom.edges.iteritems()])
+        groupbondcount = sum([1 for atom in group.atoms for bondedAtom, bond in atom.edges.iteritems()])
+        self.assertEquals(molbondcount, groupbondcount)
+
+        for i, molAt in enumerate(mol.atoms):
+            groupAtom = group.atoms[i]
+            atomTypes = [groupAtomType.equivalent(molAt.atomType) for groupAtomType in groupAtom.atomType]
+            self.assertTrue(any(atomTypes))
+
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a method that converts a Molecule to Group object.

a unittest checks instance type, atom type, atom count, bond count. 