### PR TITLE
Fix of checkForExistingSpecies for biaromatics according to issue#643

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -399,12 +399,14 @@ class CoreEdgeReactionModel:
         and the matched species (if found) or
         ``False`` and ``None`` (if not found).
         """
+        new_spec = Species(molecule=[molecule])
+        new_spec.generateResonanceIsomers()
 
         # First check cache and return if species is found
         for i, spec in enumerate(self.speciesCache):
             if spec is not None:
                 for mol in spec.molecule:
-                    if molecule.isIsomorphic(mol):
+                    if new_spec.isIsomorphic(mol):
                         self.speciesCache.pop(i)
                         self.speciesCache.insert(0, spec)
                         return True, spec
@@ -416,7 +418,7 @@ class CoreEdgeReactionModel:
         except KeyError:
             return False, None
         for spec in speciesList:
-            if spec.isIsomorphic(molecule):
+            if spec.isIsomorphic(new_spec):
                 self.speciesCache.pop()
                 self.speciesCache.insert(0, spec)
                 return True, spec

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -79,6 +79,61 @@ class TestRMGWorkFlow(unittest.TestCase):
         # whatever order of molecules in spc, the reaction template matched should be same
         self.assertEqual(target_rxns[0].template, target_rxns_reverse[0].template)
 
+    def testCheckForExistingSpeciesForBiAromatics(self):
+        """
+        Test RMG checkForExistingSpecies can correctly check isomorphism for biaromatics. 
+        In this test, DPP is a species already stored in rmg speciesDict, mol_test is a newly
+        created molecule which has one kekulized benzene ring and one double_bond-single_bond
+        benzene ring.
+        """
+
+        rmg_test = RMG()
+        rmg_test.reactionModel = CoreEdgeReactionModel()
+        DPP = Species().fromSMILES('C1=CC=C(C=C1)CCCC1C=CC=CC=1')
+        DPP.generateResonanceIsomers()
+        formula = DPP.molecule[0].getFormula()
+        if formula in rmg_test.reactionModel.speciesDict:
+            rmg_test.reactionModel.speciesDict[formula].append(DPP)
+        else:
+            rmg_test.reactionModel.speciesDict[formula] = [DPP]
+
+        mol_test = Molecule().fromAdjacencyList(
+"""
+1     C u0 p0 c0 {2,S} {3,S} {16,S} {17,S}
+2     C u0 p0 c0 {1,S} {4,S} {18,S} {19,S}
+3     C u0 p0 c0 {1,S} {5,S} {20,S} {21,S}
+4     C u0 p0 c0 {2,S} {6,B} {7,B}
+5     C u0 p0 c0 {3,S} {8,D} {9,S}
+6     C u0 p0 c0 {4,B} {10,B} {22,S}
+7     C u0 p0 c0 {4,B} {12,B} {24,S}
+8     C u0 p0 c0 {5,D} {14,S} {27,S}
+9     C u0 p0 c0 {5,S} {15,D} {28,S}
+10    C u0 p0 c0 {6,B} {11,B} {23,S}
+11    C u0 p0 c0 {10,B} {12,B} {25,S}
+12    C u0 p0 c0 {7,B} {11,B} {26,S}
+13    C u0 p0 c0 {14,D} {15,S} {29,S}
+14    C u0 p0 c0 {8,S} {13,D} {30,S}
+15    C u0 p0 c0 {9,D} {13,S} {31,S}
+16    H u0 p0 c0 {1,S}
+17    H u0 p0 c0 {1,S}
+18    H u0 p0 c0 {2,S}
+19    H u0 p0 c0 {2,S}
+20    H u0 p0 c0 {3,S}
+21    H u0 p0 c0 {3,S}
+22    H u0 p0 c0 {6,S}
+23    H u0 p0 c0 {10,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {11,S}
+26    H u0 p0 c0 {12,S}
+27    H u0 p0 c0 {8,S}
+28    H u0 p0 c0 {9,S}
+29    H u0 p0 c0 {13,S}
+30    H u0 p0 c0 {14,S}
+31    H u0 p0 c0 {15,S}
+""")
+        found, spec = rmg_test.reactionModel.checkForExistingSpecies(mol_test)
+        assert found == True
+
         
 def findTargetRxnsContaining(mol1, mol2, reactions):
     target_rxns = []


### PR DESCRIPTION
This PR includes
- fix of checkForExistingSpecies for biaromatics according to [issue#643](https://github.com/ReactionMechanismGenerator/RMG-Py/issues/643) where if the molecule has more than one aromatic rings and only some of them are kekulized, the checkForExistingSpecies will fail.By running generateResonanceIsomers in checkForExistingSpecies, it will create isomers with fully
kekulized version, which makes checkForExistingSpecies work again.

- a unittest of checkForExistingSpecies for biaromatics.