### PR TITLE
do not recompute thermo when it is already available

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -460,7 +460,7 @@ class RMG(util.Subject):
                         """.format(spec.label))
                         
             for spec in self.initialSpecies:
-                spec.generateThermoData(self.database, quantumMechanics=self.quantumMechanics)
+                spec.getThermoData(self.database, quantumMechanics=self.quantumMechanics)
                 spec.generateTransportData(self.database)
                 
             # Add nonreactive species (e.g. bath gases) to core first

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -79,6 +79,21 @@ class Species(rmgpy.species.Species):
         """
         return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
 
+    def getThermoData(self, database, thermoClass=NASA, quantumMechanics=None):
+        """
+        Returns a `thermoData` object of the current Species object.
+
+        Returns the stored `thermoData` object if it is found,
+        generates a new `thermoData` object if it not found.
+        
+        """
+        if self.thermo:
+            self.processThermoData(database, self.thermo, thermoClass)
+        else:
+            self.generateThermoData(database, thermoClass, quantumMechanics)
+
+        return self.thermo
+
     def generateThermoData(self, database, thermoClass=NASA, quantumMechanics=None):
         """
         Generates thermo data, first checking Libraries, then using either QM or Database.

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -110,7 +110,7 @@ class Species(rmgpy.species.Species):
         Result stored in `self.thermo` and returned.
         """
 
-        thermo0 = database.thermo.getThermoData(self, trainingSet=None, quantumMechanics=quantumMechanics) 
+        thermo0 = database.thermo.getThermoData(self, trainingSet=None, quantumMechanics=quantumMechanics)
         
         return self.processThermoData(database, thermo0, thermoClass)
 
@@ -460,7 +460,12 @@ class CoreEdgeReactionModel:
             speciesIndex = self.speciesCounter
         else:
             speciesIndex = -1
-        spec = Species(index=speciesIndex, label=label, molecule=[molecule], reactive=reactive)
+        try:
+            spec = Species(index=speciesIndex, label=label, molecule=[molecule], reactive=reactive,
+                 thermo=object.thermo, transportData=object.transportData)
+        except AttributeError, e:
+            spec = Species(index=speciesIndex, label=label, molecule=[molecule], reactive=reactive)
+        
         spec.coreSizeAtCreation = len(self.core.species)
         spec.generateResonanceIsomers()
         spec.molecularWeight = Quantity(spec.molecule[0].getMolecularWeight()*1000.,"amu")
@@ -764,7 +769,7 @@ class CoreEdgeReactionModel:
         # Generate thermodynamics of new species
         logging.info('Generating thermodynamics for new species...')
         for spec in self.newSpeciesList:
-            spec.generateThermoData(database, quantumMechanics=self.quantumMechanics)
+            spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
             spec.generateTransportData(database)
         
         # Generate kinetics of new reactions
@@ -1369,7 +1374,7 @@ class CoreEdgeReactionModel:
                     raise ForbiddenStructureException("Species constraints forbids species {0} from seed mechanism {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, seedMechanism.label))
 
         for spec in self.newSpeciesList:            
-            if spec.reactive: spec.generateThermoData(database, quantumMechanics=self.quantumMechanics)
+            if spec.reactive: spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
             spec.generateTransportData(database)
             self.addSpeciesToCore(spec)
 
@@ -1379,8 +1384,7 @@ class CoreEdgeReactionModel:
                 # we need to make sure the barrier is positive.
                 # ...but are Seed Mechanisms run through PDep? Perhaps not.
                 for spec in itertools.chain(rxn.reactants, rxn.products):
-                    if spec.thermo is None:
-                        spec.generateThermoData(database, quantumMechanics=self.quantumMechanics)
+                    spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
                 rxn.fixBarrierHeight(forcePositive=True)
             self.addReactionToCore(rxn)
         
@@ -1437,7 +1441,7 @@ class CoreEdgeReactionModel:
                     raise ForbiddenStructureException("Species constraints forbids species {0} from reaction library {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, reactionLibrary.label))
        
         for spec in self.newSpeciesList:
-            if spec.reactive: spec.generateThermoData(database, quantumMechanics=self.quantumMechanics)
+            if spec.reactive: spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
             spec.generateTransportData(database)
             self.addSpeciesToEdge(spec)
 

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2010 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import os
+import unittest 
+
+from rmgpy import settings
+from rmgpy.data.rmg import RMGDatabase, database
+from rmgpy.rmg.main import RMG
+from rmgpy.rmg.model import *
+
+###################################################
+
+
+class TestSpecies(unittest.TestCase):
+    """
+    Contains unit tests of the Species class.
+    """
+
+    def setUp(self):
+        """
+        A method that is run before each unit test in this class.
+        """
+        # set-up RMG object
+        self.rmg = RMG()
+
+        # load kinetic database and forbidden structures
+        self.rmg.database = RMGDatabase()
+        path = os.path.join(settings['database.directory'])
+
+        # forbidden structure loading
+        self.rmg.database.loadThermo(os.path.join(path, 'thermo'))
+        
+
+    def testGetThermoData(self):
+        """
+        Test that getThermoData method of Species works.
+        """
+        spc = Species().fromSMILES('CCC')
+
+        self.assertFalse(spc.thermo)
+        spc.getThermoData(self.rmg.database)
+        self.assertTrue(spc.thermo)
+        thermo = spc.thermo
+        spc.getThermoData(self.rmg.database)
+
+        self.assertEquals(id(thermo), id(spc.thermo))
+        
+        spc.thermo = None
+        spc.getThermoData(self.rmg.database)
+        self.assertNotEquals(id(thermo), id(spc.thermo))
+
+    def tearDown(self):
+        """
+        Reset the loaded database
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/thermoEstimator.py
+++ b/scripts/thermoEstimator.py
@@ -38,7 +38,7 @@ def runThermoEstimator(inputFile):
     output = open(os.path.join(rmg.outputDirectory, 'output.txt'),'wb')
     library = ThermoLibrary(name='Thermo Estimation Library')
     for species in rmg.initialSpecies:
-        species.generateThermoData(rmg.database, quantumMechanics=rmg.reactionModel.quantumMechanics)
+        species.getThermoData(rmg.database, quantumMechanics=rmg.reactionModel.quantumMechanics)
 
         library.loadEntry(
             index = len(library.entries) + 1,


### PR DESCRIPTION
When an existing RMG job is loaded and its species are used in the RMG enlargement algorithm, then one can re-use the thermochemistry of the loaded species. 

Currently, the thermo is not retained, and recomputed again, with the risk of generating thermo that is disparate from what the loaded RMG model has.

This PR checks if a species that is used as a parameter in `CERM.makeNewSpecies` has a `thermo` attribute. If it is present, it is re-used, and not generated again.