### PR TITLE
Use chemkin names when loading an RMG Job

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -769,7 +769,7 @@ def loadTransportFile(path, speciesDict):
                     comment = comment.strip(),
                 )
 
-def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments = True, thermoPath = None):
+def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments = True, thermoPath = None, useChemkinNames=False):
     """
     Load a Chemkin input file located at `path` on disk to `path`, returning lists of the species
     and reactions in the Chemkin file. The 'thermoPath' point to a separate thermo file, or, if 'None' is 
@@ -905,12 +905,13 @@ def loadChemkinFile(path, dictionaryPath=None, transportPath=None, readComments 
     if transportPath:
         loadTransportFile(transportPath, speciesDict)
     
-    # Apply species aliases if known
-    for spec in speciesList:
-        try:
-            spec.label = speciesAliases[spec.label]
-        except KeyError:
-            pass
+    if not useChemkinNames:
+        # Apply species aliases if known
+        for spec in speciesList:
+            try:
+                spec.label = speciesAliases[spec.label]
+            except KeyError:
+                pass
     
     # Attempt to extract index from species label
     indexPattern = re.compile(r'\(\d+\)$')

--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -70,4 +70,29 @@ class ChemkinTest(unittest.TestCase):
 		os.remove(tempTransportPath)
 		
 
+	def testUseChemkinNames(self):
+		"""
+		Test that the official chemkin names are used as labels for the created Species objects.
+		"""
+
+		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
 		
+		chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
+		dictionaryPath = os.path.join(folder,'minimal', 'species_dictionary.txt')
+
+		# loadChemkinFile
+		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath, useChemkinNames=True) 
+
+		expected = [
+			'Ar',
+			'He',
+			'Ne',
+			'N2',
+			'ethane',
+			'CH3',
+			'C2H5',
+			'C'
+		]
+
+		for spc, label in zip(species, expected):
+			self.assertEqual(spc.label, label)

--- a/rmgpy/tools/loader.py
+++ b/rmgpy/tools/loader.py
@@ -38,19 +38,19 @@ from rmgpy.chemkin import loadChemkinFile
 
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 
-def loadRMGJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=True, useJava=False):
+def loadRMGJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=True, useJava=False, useChemkinNames=False):
 
     if useJava:
         # The argument is an RMG-Java input file
-        rmg = loadRMGJavaJob(inputFile, chemkinFile, speciesDict, generateImages)
+        rmg = loadRMGJavaJob(inputFile, chemkinFile, speciesDict, generateImages, useChemkinNames=useChemkinNames)
         
     else:
         # The argument is an RMG-Py input file
-        rmg = loadRMGPyJob(inputFile, chemkinFile, speciesDict, generateImages)
+        rmg = loadRMGPyJob(inputFile, chemkinFile, speciesDict, generateImages, useChemkinNames=useChemkinNames)
 
     return rmg
 
-def loadRMGPyJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=True):
+def loadRMGPyJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=True, useChemkinNames=False):
     """
     Load the results of an RMG-Py job generated from the given `inputFile`.
     """
@@ -66,7 +66,7 @@ def loadRMGPyJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=T
         chemkinFile = os.path.join(os.path.dirname(inputFile), 'chemkin', 'chem.inp')
     if not speciesDict:
         speciesDict = os.path.join(os.path.dirname(inputFile), 'chemkin', 'species_dictionary.txt')
-    speciesList, reactionList = loadChemkinFile(chemkinFile, speciesDict)
+    speciesList, reactionList = loadChemkinFile(chemkinFile, speciesDict, useChemkinNames=useChemkinNames)
     
     # Map species in input file to corresponding species in Chemkin file
     speciesDict = {}
@@ -106,7 +106,7 @@ def loadRMGPyJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=T
     
     return rmg
 
-def loadRMGJavaJob(inputFile, chemkinFile=None, speciesDict=None):
+def loadRMGJavaJob(inputFile, chemkinFile=None, speciesDict=None, useChemkinNames=False):
     """
     Load the results of an RMG-Java job generated from the given `inputFile`.
     """
@@ -124,7 +124,7 @@ def loadRMGJavaJob(inputFile, chemkinFile=None, speciesDict=None):
         chemkinFile = os.path.join(os.path.dirname(inputFile), 'chemkin', 'chem.inp')
     if not speciesDict:
         speciesDict = os.path.join(os.path.dirname(inputFile), 'RMG_Dictionary.txt')
-    speciesList, reactionList = loadChemkinFile(chemkinFile, speciesDict)
+    speciesList, reactionList = loadChemkinFile(chemkinFile, speciesDict, useChemkinNames=useChemkinNames)
     
     # Bath gas species don't appear in RMG-Java species dictionary, so handle
     # those as a special case


### PR DESCRIPTION
When an RMG job was loaded from an existing chem.inp and species dictionary, the current algorithm would look if next to the species names a comment was added, e.g.:

```
SPECIES
    Ar                  ! Ar
    He                  ! He
    Ne                  ! Ne
    N2                  ! N2
    ethane(1)           ! ethane(1)
    CH3(2)              ! [CH3](2)
    S(3)             ! C[CH2](3)
    C(6)                ! C(6)
END
```

If a species description in the comment section was found, it would use that as the species label, as it is often more descriptive than the chemkin name.

There are some situations where it is preferable to keep the original chemkin name as they are unique, and chemkin compatible.

This PR allows the user to specify if the labels of the loaded species should be the original chemkin name, or the more descriptive string found in the comment section.

For that matter, a flag `useChemkinNames=False` in the function `chemkin.loadChemkinFile` which can also be specified upstream in the `loader.loadRMGJob` functions is added.

A unit test is added as well.