### PR TITLE
Improve the (poly)cyclic node name parser of rmgpy.data.ThermoDatabase

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1303,14 +1303,15 @@ class ThermoDatabase(object):
         ringGroups = []
         polycyclicGroups = []
         for token in tokens:
+            regex = "\((.*)\)" #only hit outermost parentheses
             if 'ring' in token:
-                splitTokens = re.split("\(|\)",token)
-                assert len(splitTokens) == 3
+                splitTokens = re.split(regex, token)
+                assert len(splitTokens) == 3, 'token: {}'.format(token)
                 groupLabel = splitTokens[1]
                 ringGroups.append(self.groups['ring'].entries[groupLabel])
             if 'polycyclic' in token:
-                splitTokens = re.split("\(|\)",token)
-                assert len(splitTokens) == 3
+                splitTokens = re.split(regex, token)
+                assert len(splitTokens) == 3, 'token: {}'.format(token)
                 groupLabel = splitTokens[1]
                 polycyclicGroups.append(self.groups['polycyclic'].entries[groupLabel])
         return ringGroups, polycyclicGroups

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -6,7 +6,9 @@ import unittest
 from external.wip import work_in_progress
 
 from rmgpy import settings
-from rmgpy.species import Species
+from rmgpy.data.rmg import RMGDatabase, database
+from rmgpy.rmg.main import RMG
+from rmgpy.rmg.model import Species
 from rmgpy.data.thermo import ThermoDatabase
 from rmgpy.molecule.molecule import Molecule
 
@@ -248,6 +250,32 @@ class TestCyclicThermo(unittest.TestCase):
         # therefore is not selected.  Note that this unit test will have to change if the correction is fixed later.
         self.assertEqual(polycyclicGroups[0].label, 'PolycyclicRing')
         self.assertEqual(selected_polycyclicGroups[0].label, 'C12CCC=C1CC=C2')
+    
+
+    def testGetRingGroupsFromComments(self):
+        """
+        Test that getRingGroupsFromComments method works for fused polycyclics.
+        """
+        # set-up RMG object
+        rmg = RMG()
+
+        # load kinetic database and forbidden structures
+        rmg.database = RMGDatabase()
+        path = os.path.join(settings['database.directory'])
+
+        # forbidden structure loading
+        rmg.database.loadThermo(os.path.join(path, 'thermo'))
+
+        smi = 'C12C(C3CCC2C3)C4CCC1C4'#two norbornane rings fused together
+        spc = Species().fromSMILES(smi)
+
+        spc.generateThermoData(rmg.database)
+
+        thermodb = rmg.database.thermo
+        thermodb.getRingGroupsFromComments(spc.thermo)
+
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
         
 ################################################################################
 


### PR DESCRIPTION
This PR addresses the issue with the (poly)cyclic node name parser, cf. https://github.com/ReactionMechanismGenerator/RMG-Py/issues/648 of `rmgpy.data.ThermoDatabase.getRingGroupsFromComments`

The PR constraints the regex by only matching outermost parentheses of a string, instead of every pair of parentheses. The latter would also hit parentheses contained in the names of polycyclic nodes.