### PR TITLE
Remove redundant method parameters of RMG.execute(...)

### DIFF
--- a/rmg.py
+++ b/rmg.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
             'RMG': RMG
             }
 
-        command = """rmg = RMG(); rmg.execute(inputFile, output_dir, **kwargs)"""
+        command = """rmg = RMG(inputFile=inputFile, outputDirectory=output_dir); rmg.execute(**kwargs)"""
 
         stats_file = os.path.join(args.output_directory,'RMG.profile')
         print("Running under cProfile")
@@ -160,6 +160,5 @@ if __name__ == '__main__':
         
     else:
 
-        rmg = RMG()
-
-        rmg.execute(inputFile, output_dir, **kwargs)
+        rmg = RMG(inputFile=inputFile, outputDirectory=output_dir)
+        rmg.execute(**kwargs)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -323,7 +323,7 @@ class RMG(util.Subject):
             for family in self.database.kinetics.families.values():
                 family.fillKineticsRulesByAveragingUp()
     
-    def initialize(self, inputFile, output_directory, **kwargs):
+    def initialize(self, **kwargs):
         """
         Initialize an RMG job using the command-line arguments `args` as returned
         by the :mod:`argparse` package.
@@ -338,9 +338,6 @@ class RMG(util.Subject):
         # Print out RMG header
         self.logHeader()
         
-        # Set directories
-        self.outputDirectory = output_directory
-        
         try:
             restart = kwargs['restart']
         except KeyError:
@@ -352,7 +349,7 @@ class RMG(util.Subject):
                 raise Exception("No restart file")
             
         # Read input file
-        self.loadInput(inputFile)
+        self.loadInput(self.inputFile)
 
         # Check input file 
         self.checkInput()
@@ -513,13 +510,13 @@ class RMG(util.Subject):
                     self.outputDirectory, index, self.reactionModel.core.species))  
         
 
-    def execute(self, inputFile, output_directory, **kwargs):
+    def execute(self, **kwargs):
         """
         Execute an RMG job using the command-line arguments `args` as returned
         by the :mod:`argparse` package.
         """
     
-        self.initialize(inputFile, output_directory, **kwargs)
+        self.initialize(**kwargs)
 
         # register listeners
         self.register_listeners()

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -265,9 +265,10 @@ class LiquidReactorCheck(unittest.TestCase):
         rmg = RMG()
 
         ##use the liquid phase example to load every input parameters
-        inp=os.path.join("examples","rmg","liquid_phase_constSPC","input.py") #In order to work on every system, use of os.path
-        
-        rmg.initialize(inp, rmg.outputDirectory)
+        inp = os.path.join("examples","rmg","liquid_phase_constSPC","input.py") #In order to work on every system, use of os.path
+        rmg.inputFile = inp
+
+        rmg.initialize()
             
         if rmg.solvent is not None:
             ##call the function to identify indices in the solver

--- a/rmgpy/tools/generate_reactions.py
+++ b/rmgpy/tools/generate_reactions.py
@@ -117,15 +117,15 @@ def main():
 
     initializeLog(level, os.path.join(args.output_directory,'RMG.log'))
 
-    rmg = RMG()
+    rmg = RMG(inputFile=inputFile, outputDirectory=args.output_directory)
 
     # Add output listeners:
     rmg.attach(ChemkinWriter(args.output_directory))
     rmg.attach(OutputHTMLWriter(args.output_directory))
 
-    execute(rmg, inputFile, args.output_directory, **kwargs)
+    execute(rmg, **kwargs)
 
-def execute(rmg, inputFile, output_directory, **kwargs):
+def execute(rmg, **kwargs):
     """
 
     Generates all the possible reactions involving a given
@@ -137,7 +137,7 @@ def execute(rmg, inputFile, output_directory, **kwargs):
     Returns an RMG object.
     """   
     import numpy
-    rmg.initialize(inputFile, output_directory, **kwargs)
+    rmg.initialize(**kwargs)
     
     rmg.reactionModel.enlarge(reactEdge=True,
         unimolecularReact=rmg.unimolecularReact,

--- a/rmgpy/tools/loader.py
+++ b/rmgpy/tools/loader.py
@@ -57,7 +57,7 @@ def loadRMGPyJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=T
     from rmgpy.rmg.main import RMG
     
     # Load the specified RMG input file
-    rmg = RMG()
+    rmg = RMG(inputFile=inputFile)
     rmg.loadInput(inputFile)
     rmg.outputDirectory = os.path.abspath(os.path.dirname(inputFile))
     
@@ -115,7 +115,7 @@ def loadRMGJavaJob(inputFile, chemkinFile=None, speciesDict=None, useChemkinName
     
     # Load the specified RMG-Java input file
     # This implementation only gets the information needed to generate flux diagrams
-    rmg = RMG()
+    rmg = RMG(inputFile=inputFile)
     rmg.loadRMGJavaInput(inputFile)
     rmg.outputDirectory = os.path.abspath(os.path.dirname(inputFile))
     

--- a/rmgpy/tools/testGenerateReactions.py
+++ b/rmgpy/tools/testGenerateReactions.py
@@ -13,8 +13,8 @@ class GenerateReactionsTest(unittest.TestCase):
         
         inputFile = os.path.join(folder,'input.py')
         
-        rmg = RMG()
-        rmg = execute(rmg, inputFile, folder)
+        rmg = RMG(inputFile=inputFile, outputDirectory=folder)
+        rmg = execute(rmg)
 
         self.assertIsNotNone(rmg)
         self.assertIsNotNone(rmg.reactionModel.outputSpeciesList)
@@ -40,8 +40,8 @@ class GenerateReactionsTest(unittest.TestCase):
         
         inputFile = os.path.join(folder,'input.py')
 
-        rmg = RMG()
-        rmg = execute(rmg, inputFile, folder)
+        rmg = RMG(inputFile=inputFile, outputDirectory=folder)
+        rmg = execute(rmg)
 
         self.assertIsNotNone(rmg)
         
@@ -75,8 +75,8 @@ class GenerateReactionsTest(unittest.TestCase):
         
         inputFile = os.path.join(folder,'input.py')
 
-        rmg = RMG()
-        rmg = execute(rmg, inputFile, folder)
+        rmg = RMG(inputFile=inputFile, outputDirectory=folder)
+        rmg = execute(rmg)
 
         self.assertIsNotNone(rmg)
         


### PR DESCRIPTION
This PR removes 2 redundant parameters from the execute method of the RMG class. The data, i.e. input file and output directory) can already be provided to the RMG object when a new RMG instance is initialized.