### PR TITLE
optimize the failsSpeciesConstraints function

### DIFF
--- a/examples/generateReactions/input.py
+++ b/examples/generateReactions/input.py
@@ -59,7 +59,6 @@ simpleReactor(
 #generatedSpeciesConstraints(
 #    allowed=['input species','seed mechanisms','reaction libraries'],
 #    maximumCarbonAtoms=4,
-#    maximumHydrogenAtoms=10,
 #    maximumOxygenAtoms=7,
 #    maximumNitrogenAtoms=0,
 #    maximumSiliconAtoms=0,

--- a/examples/rmg/ch3no2/input.py
+++ b/examples/rmg/ch3no2/input.py
@@ -12,7 +12,6 @@ database(
 generatedSpeciesConstraints(
     allowed = ['seed mechanisms', 'reaction libraries'],
     #maximumCarbonAtoms = 7,
-    #maximumHydrogenAtoms = 8,
     #maximumOxygenAtoms = 5,
     maximumNitrogenAtoms = 2,
     #maximumSiliconAtoms = 0,

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -196,7 +196,6 @@ generatedSpeciesConstraints(
     allowed=['input species','seed mechanisms','reaction libraries'],
 	#maximum number of each atom in a molecule
     maximumCarbonAtoms=4,
-    maximumHydrogenAtoms=10,
     maximumOxygenAtoms=7,
     maximumNitrogenAtoms=0,
     maximumSiliconAtoms=0,

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -48,14 +48,14 @@ def failsSpeciesConstraints(species):
     
 
     explicitlyAllowedMolecules = speciesConstraints.get('explicitlyAllowedMolecules', [])
-    maxCarbonAtoms = speciesConstraints.get('maximumCarbonAtoms', 1000000)
-    maxHydrogenAtoms = speciesConstraints.get('maximumHydrogenAtoms', 1000000)
-    maxOxygenAtoms = speciesConstraints.get('maximumOxygenAtoms', 1000000)
-    maxNitrogenAtoms = speciesConstraints.get('maximumNitrogenAtoms', 1000000)
-    maxSiliconAtoms = speciesConstraints.get('maximumSiliconAtoms', 1000000)
-    maxSulfurAtoms = speciesConstraints.get('maximumSulfurAtoms', 1000000)
-    maxHeavyAtoms = speciesConstraints.get('maximumHeavyAtoms', 1000000)
-    maxRadicals = speciesConstraints.get('maximumRadicalElectrons', 1000000)
+    maxCarbonAtoms = speciesConstraints.get('maximumCarbonAtoms', -1)
+    maxHydrogenAtoms = speciesConstraints.get('maximumHydrogenAtoms', -1)
+    maxOxygenAtoms = speciesConstraints.get('maximumOxygenAtoms', -1)
+    maxNitrogenAtoms = speciesConstraints.get('maximumNitrogenAtoms', -1)
+    maxSiliconAtoms = speciesConstraints.get('maximumSiliconAtoms', -1)
+    maxSulfurAtoms = speciesConstraints.get('maximumSulfurAtoms', -1)
+    maxHeavyAtoms = speciesConstraints.get('maximumHeavyAtoms', -1)
+    maxRadicals = speciesConstraints.get('maximumRadicalElectrons', -1)
     
     if isinstance(species, Species):
         struct = species.molecule[0]
@@ -64,22 +64,30 @@ def failsSpeciesConstraints(species):
         struct = species
     for molecule in explicitlyAllowedMolecules:
         if struct.isIsomorphic(molecule):
-            return False        
-    H = struct.getNumAtoms('H')
-    if struct.getNumAtoms('C') > maxCarbonAtoms:
-        return True
-    if H > maxHydrogenAtoms:
-        return True
-    if struct.getNumAtoms('O') > maxOxygenAtoms:
-        return True
-    if struct.getNumAtoms('N') > maxNitrogenAtoms:
-        return True
-    if struct.getNumAtoms('Si') > maxSiliconAtoms:
-        return True
-    if struct.getNumAtoms('S') > maxSulfurAtoms:
-        return True
-    if len(struct.atoms) - H > maxHeavyAtoms:
-        return True
-    if (struct.getNumberOfRadicalElectrons() > maxRadicals):
-        return True
+            return False  
+                  
+    if maxCarbonAtoms != -1:
+        if struct.getNumAtoms('C') > maxCarbonAtoms:
+            return True
+    if maxHydrogenAtoms != -1:
+        if struct.getNumAtoms('H') > maxHydrogenAtoms:
+            return True
+    if maxOxygenAtoms != -1:
+        if struct.getNumAtoms('O') > maxOxygenAtoms:
+            return True
+    if maxNitrogenAtoms != -1:
+        if struct.getNumAtoms('N') > maxNitrogenAtoms:
+            return True
+    if maxSiliconAtoms != -1:
+        if struct.getNumAtoms('Si') > maxSiliconAtoms:
+            return True
+    if maxSulfurAtoms != -1:
+        if struct.getNumAtoms('S') > maxSulfurAtoms:
+            return True
+    if maxHeavyAtoms != -1:
+        if struct.getNumAtoms() - struct.getNumAtoms('H') > maxHeavyAtoms:
+            return True
+    if maxRadicals != -1:
+        if (struct.getNumberOfRadicalElectrons() > maxRadicals):
+            return True
     return False

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -46,48 +46,50 @@ def failsSpeciesConstraints(species):
         logging.debug('Species constraints could not be found.')
         speciesConstraints = {}
     
-
-    explicitlyAllowedMolecules = speciesConstraints.get('explicitlyAllowedMolecules', [])
-    maxCarbonAtoms = speciesConstraints.get('maximumCarbonAtoms', -1)
-    maxHydrogenAtoms = speciesConstraints.get('maximumHydrogenAtoms', -1)
-    maxOxygenAtoms = speciesConstraints.get('maximumOxygenAtoms', -1)
-    maxNitrogenAtoms = speciesConstraints.get('maximumNitrogenAtoms', -1)
-    maxSiliconAtoms = speciesConstraints.get('maximumSiliconAtoms', -1)
-    maxSulfurAtoms = speciesConstraints.get('maximumSulfurAtoms', -1)
-    maxHeavyAtoms = speciesConstraints.get('maximumHeavyAtoms', -1)
-    maxRadicals = speciesConstraints.get('maximumRadicalElectrons', -1)
-    
     if isinstance(species, Species):
         struct = species.molecule[0]
     else:
         # expects a molecule here
         struct = species
+
+    explicitlyAllowedMolecules = speciesConstraints.get('explicitlyAllowedMolecules', [])
     for molecule in explicitlyAllowedMolecules:
         if struct.isIsomorphic(molecule):
             return False  
-                  
+    
+    maxCarbonAtoms = speciesConstraints.get('maximumCarbonAtoms', -1)          
     if maxCarbonAtoms != -1:
         if struct.getNumAtoms('C') > maxCarbonAtoms:
             return True
-    if maxHydrogenAtoms != -1:
-        if struct.getNumAtoms('H') > maxHydrogenAtoms:
-            return True
+
+    maxOxygenAtoms = speciesConstraints.get('maximumOxygenAtoms', -1)
     if maxOxygenAtoms != -1:
         if struct.getNumAtoms('O') > maxOxygenAtoms:
             return True
+
+    maxNitrogenAtoms = speciesConstraints.get('maximumNitrogenAtoms', -1)
     if maxNitrogenAtoms != -1:
         if struct.getNumAtoms('N') > maxNitrogenAtoms:
             return True
+
+    maxSiliconAtoms = speciesConstraints.get('maximumSiliconAtoms', -1)
     if maxSiliconAtoms != -1:
         if struct.getNumAtoms('Si') > maxSiliconAtoms:
             return True
+
+    maxSulfurAtoms = speciesConstraints.get('maximumSulfurAtoms', -1)
     if maxSulfurAtoms != -1:
         if struct.getNumAtoms('S') > maxSulfurAtoms:
             return True
+
+    maxHeavyAtoms = speciesConstraints.get('maximumHeavyAtoms', -1)
     if maxHeavyAtoms != -1:
         if struct.getNumAtoms() - struct.getNumAtoms('H') > maxHeavyAtoms:
             return True
+
+    maxRadicals = speciesConstraints.get('maximumRadicalElectrons', -1)
     if maxRadicals != -1:
         if (struct.getNumberOfRadicalElectrons() > maxRadicals):
             return True
+            
     return False

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -320,7 +320,6 @@ def generatedSpeciesConstraints(**kwargs):
     validConstraints = [
         'allowed',
         'maximumCarbonAtoms',
-        'maximumHydrogenAtoms',
         'maximumOxygenAtoms',
         'maximumNitrogenAtoms',
         'maximumSiliconAtoms',


### PR DESCRIPTION
This PR optimizes the frequently called function `rmgpy.constraints.failsSpeciesConstraints`. 

Previously, the atom count for C, H, N, ... was calculated for every molecule, regardless of whether there was a constraint in place. Now, the default value for a constraint is set to -1, so that it can be used to determine whether an atom count should be calculated or not.

