### PR TITLE
Isotope support: reading/writing isotope-aware adjacency lists

### DIFF
--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -207,6 +207,8 @@ generatedSpeciesConstraints(
     #If this is false or missing, RMG will throw an error if the more less-stable form of O2 is entered 
     #which doesn't react in the RMG system. normally input O2 as triplet with SMILES [O][O]
     #allowSingletO2=False,
+    # maximum allowed number of non-normal isotope atoms:
+    #maximumIsotopicAtoms=2,
 )
 
 #optional block allows thermo to be estimated through quantum calculations

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -29,7 +29,8 @@
 ################################################################################
 
 import logging
-
+from numpy import isclose
+from rmgpy.molecule.element import getElement
 from rmgpy.species import Species
 
 def failsSpeciesConstraints(species):
@@ -91,5 +92,13 @@ def failsSpeciesConstraints(species):
     if maxRadicals != -1:
         if (struct.getNumberOfRadicalElectrons() > maxRadicals):
             return True
-            
+
+    maxIsotopes = speciesConstraints.get('maximumIsotopicAtoms', -1)
+    if maxIsotopes != -1:
+        counter = 0
+        for atom in struct.atoms:
+            if not isclose(atom.mass, getElement(atom.symbol).mass, atol=1e-04):
+                counter += 1
+            if counter > maxIsotopes: return True
+
     return False

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -638,11 +638,23 @@ def fromAdjacencyList(adjlist, group=False, saturateH=False):
             if not group:
                 partialCharges.append(0)
         
+
+        # Next the isotope (if provided)
+        isotope = -1
+        if len(data) > index:
+            iState = data[index]
+            if iState[0] == 'i':
+                isotope = int(iState[1:])
+                index += 1
+
+
         # Create a new atom based on the above information
         if group:
             atom = GroupAtom(atomType, unpairedElectrons, partialCharges, label, lonePairs)
         else:
             atom = Atom(atomType[0], unpairedElectrons[0], partialCharges[0], label, lonePairs[0])
+            if isotope != -1:
+                atom.element = getElement(atom.number, isotope)
 
         # Add the atom to the list
         atoms.append(atom)

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -35,6 +35,7 @@ import logging
 import re
 from .molecule import Atom, Bond
 from .group import GroupAtom, GroupBond
+from .element import getElement
 #import chempy.molecule.atomtype as atomtypes
 
 bond_orders = {'S': 1, 'D': 2, 'T': 3, 'B': 1.5}
@@ -763,6 +764,7 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
     atomUnpairedElectrons = {}
     atomLonePairs = {}
     atomCharge = {}
+    atomIsotope = {}
     if group:
         for atom in atomNumbers:
             # Atom type(s)
@@ -793,6 +795,9 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
                 atomCharge[atom] = None   # Empty list indicates wildcard
             else:
                 atomCharge[atom] = '[{0}]'.format(','.join(['+'+str(charge) if charge > 0 else ''+str(charge) for charge in atom.charge]))
+
+            # Isotopes
+            atomIsotope[atom] = -1    
     else:
         for atom in atomNumbers:
             # Atom type
@@ -803,6 +808,9 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
             atomLonePairs[atom] = str(atom.lonePairs)
             # Partial Charge(s)
             atomCharge[atom] = '+'+str(atom.charge) if atom.charge > 0 else '' + str(atom.charge)
+            # Isotopes
+            atomIsotope[atom] = atom.element.isotope
+
     
     # Determine field widths
     atomNumberWidth = max([len(s) for s in atomNumbers.values()]) + 1
@@ -831,7 +839,10 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
         # Partial charges
         if atomCharge[atom] != None:
             adjlist += ' c{0}'.format(atomCharge[atom])
-        
+        # Isotopes
+        if atomIsotope[atom] != -1:
+            adjlist += ' i{0}'.format(atomIsotope[atom])
+
         # Bonds list
         atoms2 = atom.bonds.keys()
         # sort them the same way as the atoms

--- a/rmgpy/molecule/element.pxd
+++ b/rmgpy/molecule/element.pxd
@@ -31,5 +31,6 @@ cdef class Element:
     cdef public str symbol
     cdef public float mass
     cdef public float covRadius
+    cdef public int isotope
 
 cpdef Element getElement(value)

--- a/rmgpy/molecule/element.pxd
+++ b/rmgpy/molecule/element.pxd
@@ -33,4 +33,4 @@ cdef class Element:
     cdef public float covRadius
     cdef public int isotope
 
-cpdef Element getElement(value)
+cpdef Element getElement(value, int isotope=?)

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -147,6 +147,8 @@ def getElement(value, isotope=-1):
 # Period 1
 #: Hydrogen
 H  = Element(1,   'H' , 'hydrogen'      , 0.00100794)
+D  = Element(1,   'H' , 'deuterium'     , 0.002014101, 2)
+T  = Element(1,   'H' , 'tritium'       , 0.003016049, 3)
 He = Element(2,   'He', 'helium'        , 0.004002602)
 
 # Period 2
@@ -154,8 +156,10 @@ Li = Element(3,   'Li', 'lithium'       , 0.006941)
 Be = Element(4,   'Be', 'beryllium'     , 0.009012182)
 B  = Element(5,   'B',  'boron'         , 0.010811)
 C  = Element(6,   'C' , 'carbon'        , 0.0120107)
+C13= Element(6,   'C' , 'carbon-13'     , 0.0130033, 13)
 N  = Element(7,   'N' , 'nitrogen'      , 0.01400674)
 O  = Element(8,   'O' , 'oxygen'        , 0.0159994)
+O18= Element(8,   'O' , 'oxygen-18'     , 0.0179999, 18)
 F  = Element(9,   'F' , 'fluorine'      , 0.018998403)
 Ne = Element(10,  'Ne', 'neon'          , 0.0201797)
 
@@ -273,8 +277,8 @@ Cn = Element(112, 'Cn', 'copernicum'    , 0.285)
 
 # A list of the elements, sorted by increasing atomic number
 elementList = [
-    H, He,
-    Li, Be, B, C, N, O, F, Ne,
+    H, D, T, He,
+    Li, Be, B, C, C13, N, O, O18, F, Ne,
     Na, Mg, Al, Si, P, S, Cl, Ar,
     K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn, Ga, Ge, As, Se, Br, Kr,
     Rb, Sr, Y, Zr, Nb, Mo, Tc, Ru, Rh, Pd, Ag, Cd, In, Sn, Sb, Te, I, Xe,

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -107,7 +107,7 @@ class Element:
     
 ################################################################################
 
-def getElement(value):
+def getElement(value, isotope=-1):
     """
     Return the :class:`Element` object corresponding to the given parameter
     `value`. If an integer is provided, the value is treated as the atomic
@@ -119,22 +119,22 @@ def getElement(value):
         # The parameter is an integer; assume this is the atomic number
         number = value
         for element in elementList:
-            if element.number == number:
+            if element.number == number and element.isotope == isotope:
                 return element
         # If we reach this point that means we did not find an appropriate element,
         # so we raise an exception
-        raise ElementError("No element found with atomic number %i." % (number))
+        raise ElementError("No element found with atomic number %i, and isotope %i" % (number, isotope))
     elif isinstance(value, str):
         # The parameter is a string; assume this is the element symbol
         symbol = value
         for element in elementList:
-            if element.symbol == symbol:
+            if element.symbol == symbol and element.isotope == isotope:
                 return element
         # If we reach this point that means we did not find an appropriate element,
         # so we raise an exception
-        raise ElementError("No element found with symbol %s." % (symbol))
+        raise ElementError("No element found with symbol %s, and isotope %i." % (symbol, isotope))
     else:
-        raise ElementError('No element found based on parameter %s "%r".' % (type(value), value))
+        raise ElementError('No element found based on parameter %s "%r", isotope: %i.' % (type(value), value, isotope))
 
 ################################################################################
 

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -67,17 +67,19 @@ class Element:
     `name`      ``str``         The IUPAC name of the element
     `mass`      ``float``       The mass of the element in kg/mol
     `covRadius` ``float``       Covalent bond radius in Angstrom
+    `isotope`   ``int``         The isotope integer of the element
     =========== =============== ================================================
     
     This class is specifically for properties that all atoms of the same element
     share. Ideally there is only one instance of this class for each element.
     """
     
-    def __init__(self, number, symbol, name, mass):
+    def __init__(self, number, symbol, name, mass, isotope=-1):
         self.number = number
         self.symbol = intern(symbol)
         self.name = name
         self.mass = mass
+        self.isotope = isotope
         try:
             self.covRadius = _rdkit_periodic_table.GetRcovalent(symbol)
         except RuntimeError:
@@ -95,13 +97,13 @@ class Element:
         """
         Return a representation that can be used to reconstruct the object.
         """
-        return "Element(%s, '%s', '%s', %s)" % (self.number, self.symbol, self.name, self.mass)
+        return "Element(%s, '%s', '%s', %s, %s)" % (self.number, self.symbol, self.name, self.mass, self.isotope)
 
     def __reduce__(self):
         """
         A helper function used when pickling an object.
         """
-        return (Element, (self.number, self.symbol, self.name, self.mass))
+        return (Element, (self.number, self.symbol, self.name, self.mass, self.isotope))
     
 ################################################################################
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -233,7 +233,19 @@ class TestAtom(unittest.TestCase):
         self.assertEqual(self.atom.radicalElectrons, atom.radicalElectrons)
         self.assertEqual(self.atom.charge, atom.charge)
         self.assertEqual(self.atom.label, atom.label)
-        
+    
+    def testIsotopeEquivalent(self):
+        """
+        Test the Atom.equivalent() method for non-normal isotopes
+        """
+
+        atom1 = Atom(element=getElement('H'))
+        atom2 = Atom(element=getElement('H', 2))
+        atom3 = Atom(element=getElement('H'))
+
+        self.assertFalse(atom1.equivalent(atom2))
+        self.assertTrue(atom1.equivalent(atom3))
+
 ################################################################################
 
 class TestBond(unittest.TestCase):

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1573,6 +1573,115 @@ multiplicity 2
             atomTypes = [groupAtomType.equivalent(molAt.atomType) for groupAtomType in groupAtom.atomType]
             self.assertTrue(any(atomTypes))
 
+    def testToAdjacencyListWithIsotopes(self):
+        """
+        Test the Molecule.toAdjacencyList() method works for atoms with unexpected isotopes.
+        """
+
+        mol = Molecule().fromSMILES('CC')
+        mol.atoms[0].element = getElement('C', 13)
+
+        adjlist = mol.toAdjacencyList().translate(None, '\n ')
+        adjlistExp = """
+        1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+        2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+        3 H u0 p0 c0 {1,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {2,S}
+        7 H u0 p0 c0 {2,S}
+        8 H u0 p0 c0 {2,S}
+        """.translate(None, '\n ')
+        
+        self.assertEquals(adjlist, adjlistExp)
+
+        mol = Molecule().fromSMILES('CC')
+        mol.atoms[2].element = getElement('H', 2)
+
+        adjlist = mol.toAdjacencyList().translate(None, '\n ')
+        adjlistExp = """
+        1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+        2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+        3 H u0 p0 c0 i2 {1,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {2,S}
+        7 H u0 p0 c0 {2,S}
+        8 H u0 p0 c0 {2,S}
+        """.translate(None, '\n ')
+        
+        self.assertEquals(adjlist, adjlistExp)
+
+
+        mol = Molecule().fromSMILES('OC')
+        mol.atoms[0].element = getElement('O', 18)
+
+        adjlist = mol.toAdjacencyList().translate(None, '\n ')
+        adjlistExp = """
+        1 O u0 p2 c0 i18 {2,S} {3,S}
+        2 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+        3 H u0 p0 c0 {1,S}
+        4 H u0 p0 c0 {2,S}
+        5 H u0 p0 c0 {2,S}
+        6 H u0 p0 c0 {2,S}
+        """.translate(None, '\n ')
+        
+        self.assertEquals(adjlist, adjlistExp)
+
+    def testFromAdjacencyListWithIsotopes(self):
+        """
+        Test the Molecule.fromAdjacencyList() method works for atoms with unexpected isotopes.
+        """
+
+        exp = Molecule().fromSMILES('CC')
+        exp.atoms[0].element = getElement('C', 13)
+
+        adjlistCalc = """
+        1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+        2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+        3 H u0 p0 c0 {1,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {2,S}
+        7 H u0 p0 c0 {2,S}
+        8 H u0 p0 c0 {2,S}
+        """
+        calc = Molecule().fromAdjacencyList(adjlistCalc)
+        
+        self.assertTrue(exp.isIsomorphic(calc))
+
+        exp = Molecule().fromSMILES('CC')
+        exp.atoms[2].element = getElement('H', 2)
+
+        adjlistCalc = """
+        1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+        2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+        3 H u0 p0 c0 i2 {1,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {2,S}
+        7 H u0 p0 c0 {2,S}
+        8 H u0 p0 c0 {2,S}
+        """
+        calc = Molecule().fromAdjacencyList(adjlistCalc)
+        
+        self.assertTrue(exp.isIsomorphic(calc))
+
+        exp = Molecule().fromSMILES('OC')
+        exp.atoms[0].element = getElement('O', 18)
+
+        adjlistCalc = """
+        1 O u0 p2 c0 i18 {2,S} {3,S}
+        2 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+        3 H u0 p0 c0 {1,S}
+        4 H u0 p0 c0 {2,S}
+        5 H u0 p0 c0 {2,S}
+        6 H u0 p0 c0 {2,S}
+        """
+        calc = Molecule().fromAdjacencyList(adjlistCalc)
+        
+        self.assertTrue(exp.isIsomorphic(calc))
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -327,6 +327,7 @@ def generatedSpeciesConstraints(**kwargs):
         'maximumHeavyAtoms',
         'maximumRadicalElectrons',
         'allowSingletO2',
+        'maximumIsotopicAtoms'
     ]
 
     for key, value in kwargs.items():


### PR DESCRIPTION
[edit]: I changed the adjacency list representation to `i13`, with mass in g/mol rather than kg/mol

This PR is a first step in supporting molecules with non-normal isotopes, like C-13.

Isotopic information for atoms with non-normal isotopes is represented by a `i` layer, e.g.: ethane with one carbon-13 is represented as follows:
```python
        1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
        2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
        3 H u0 p0 c0 {1,S}
        4 H u0 p0 c0 {1,S}
        5 H u0 p0 c0 {1,S}
        6 H u0 p0 c0 {2,S}
        7 H u0 p0 c0 {2,S}
        8 H u0 p0 c0 {2,S}
```

This PR implements the following: 
- It writes out adjacency lists with `i`-layers, if present.
- It reads adjacency lists with `i`-layers and converts it into the correct Molecule object.
- It updates the `Atom.equivalent()` method to allow for distinguishing between atoms with distinct masses.
- It adds a new species constraint `maximumIsotopeCount`, that can be added in the RMG-Py input file.