### PR TITLE
Set reactive species attribute to False for inerts in loadSpeciesDictionary

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -691,6 +691,7 @@ def loadSpeciesDictionary(path):
     """
     speciesDict = {}
     
+    inerts = [Species().fromSMILES(inert) for inert in ('[He]', '[Ne]', 'N#N', '[Ar]')]
     with open(path, 'r') as f:
         adjlist = ''
         for line in f:
@@ -699,6 +700,10 @@ def loadSpeciesDictionary(path):
                 species = Species().fromAdjacencyList(adjlist)
                 species.generateResonanceIsomers()
                 label = species.label
+                for inert in inerts:
+                    if inert.isIsomorphic(species):
+                        species.reactive = False
+                        break
                 speciesDict[label] = species
                 adjlist = ''
             else:


### PR DESCRIPTION
When creating `Species` objects by loading a species dictionary, the `reactive` attribute of the created Species object is not explicitly stored, and results in setting the `reactive` attribute of the created Species object is set to `True` by default.

For inerts like Helium, this is incorrect.

This PR checks a hard-coded tuple with 4 elements (the usual inerts) and compares the species label to the elements in that tuple. If a match is found, the reactive attribute is set to `False` for the created species.
