### PR TITLE
Fix species index bug in react module

### DIFF
--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -43,14 +43,35 @@ def react(spcA, speciesList=[]):
     """
     Generate reactions between spcA and the list of 
     species for all the reaction families available.
+
+    Returns an empty list if the spcA is non-reactive.
+
+    For the spcA, a list of tuples is created for each
+    resonance isomer of the species. Each tuple consists of (Molecule, index)
+    with the index the species index of the Species object.
+
+    For each Species in the the speciesList, its corresponding
+    resonance isomers are stored in a tuple ([Molecule], index) with the index 
+    the species index of the Species object.
+
+    Each tuple ([Molecule], index) is expanded into a list of tuples (Molecule, index)
+    resulting in one large list [(Molecule, index)].
+
+    Possible combinations between the spcA, and a species from the 
+    speciesList is obtained by taking the combinatorial product of the
+    two generated [(Molecule, index)] lists.
     """
     if not spcA.reactive: return []
     
     molsA = [(mol, spcA.index) for mol in spcA.molecule]
 
-    molsB = molsB = [spcB.molecule for spcB in speciesList if spcB.reactive]
-    molsB = list(itertools.chain.from_iterable(molsB))
-    molsB = [(mol, spcB.index) for mol in molsB]
+    molsB = [(spcB.molecule, spcB.index) for spcB in speciesList if spcB.reactive]
+
+    temp = []
+    for mols, index in molsB:
+        for molB in mols:
+            temp.append((molB, index))
+    molsB = temp
 
     if not molsB:
         combos = [(t,) for t in molsA]

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -86,34 +86,41 @@ def reactMolecules(moleculeTuples):
     for reactant in molecules:
         reactant.clearLabeledAtoms()
 
-    deflate(reactionList, molecules, reactantIndices)
-
-    return reactionList
-
-def deflate(reactionList, reactants, reactantIndices):
-    """
-    Return the reactions' reactants, products and pairs
-    as containing Species objects, not Molecule objects.
-    
-    Replace the species objects by unique integers for molecule 
-    objects that are found the parameter 'reactants' list.
-    """
-
     for rxn in reactionList:
-        molDict = {}
-
-        for mol in rxn.reactants:
-            molDict[mol] = Species(molecule=[mol])
-
-        for mol in rxn.products:
-            molDict[mol] = Species(molecule=[mol])
-
-        for i, coreIndex in enumerate(reactantIndices):
-            if coreIndex != -1:
-                molDict[reactants[i]] = coreIndex 
-
-        rxn.reactants = [molDict[mol] for mol in rxn.reactants]
-        rxn.products = [molDict[mol] for mol in rxn.products]
-        rxn.pairs = [(molDict[reactant],molDict[product]) for reactant, product in rxn.pairs]
+        deflate(rxn, molecules, reactantIndices)
 
     return reactionList
+
+def deflate(rxn, reactants, reactantIndices):
+    """
+    Creates a dictionary with Molecule objects as keys and newly 
+    creatd Species objects as values.
+
+    Iterates over the reactantIndices array.
+    The elements in this array correspond to the indices of the
+    core species.
+
+    The Species object, stored as a value of the newly created dictionary,
+    is retrieved by using a Molecule object from the reactants array 
+    as a dictionary key. The elements in this array correspond to the 
+    Molecule objects that were used as reactants to generate reactions.
+
+    The Species object is replaced by the core species index in the newly
+    created dictionary.
+
+    The reactants, products, and pairs objects of the reaction
+    are replaced by index integers for those cases the Molecule object
+    exists as a key in the newly created dictionary.
+    """    
+
+    molDict = {}
+    for mol in itertools.chain(rxn.reactants, rxn.products):
+        molDict[mol] = Species(molecule=[mol])
+
+    for i, coreIndex in enumerate(reactantIndices):
+        if coreIndex != -1:
+            molDict[reactants[i]] = coreIndex 
+
+    rxn.reactants = [molDict[mol] for mol in rxn.reactants]
+    rxn.products = [molDict[mol] for mol in rxn.products]
+    rxn.pairs = [(molDict[reactant],molDict[product]) for reactant, product in rxn.pairs]

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -38,7 +38,7 @@ from rmgpy.molecule import Molecule
 from rmgpy.reaction import Reaction
 
 from rmgpy.rmg.main import RMG
-from rmgpy.rmg.model import Species
+from rmgpy.species import Species
 from rmgpy.rmg.react import *
 
 ###################################################
@@ -125,6 +125,29 @@ class TestReact(unittest.TestCase):
             self.assertTrue(isinstance(spc, t))
         for spc in rxn.products:
             self.assertTrue(isinstance(spc, Species))
+
+    def testReactStoreIndices(self):
+        """
+        Test that reaction generation keeps track of the original species indices.
+        """
+
+        indices = {'[OH]':1, 'CC':2, '[CH3]':3}
+
+        # make it bidirectional so that we can look-up indices as well:
+        revd=dict([reversed(i) for i in indices.items()])
+        indices.update(revd)
+
+        spcA = Species(index=indices['[OH]']).fromSMILES('[OH]')
+        spcs = [Species(index=indices['CC']).fromSMILES('CC'),
+                Species(index=indices['[CH3]']).fromSMILES('[CH3]')]
+
+        reactionList = list(react(spcA, spcs))
+        self.assertIsNotNone(reactionList)
+        self.assertEquals(len(reactionList), 3)
+        for rxn in reactionList:
+            for i, reactant in enumerate(rxn.reactants):
+                rxn.reactants[i] = Molecule().fromSMILES(indices[reactant])
+            self.assertTrue(rxn.isBalanced())
 
     def tearDown(self):
         """

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -35,6 +35,7 @@ from rmgpy import settings
 from rmgpy.data.kinetics import TemplateReaction
 from rmgpy.data.rmg import RMGDatabase, database
 from rmgpy.molecule import Molecule
+from rmgpy.reaction import Reaction
 
 from rmgpy.rmg.main import RMG
 from rmgpy.rmg.model import Species
@@ -87,6 +88,43 @@ class TestReact(unittest.TestCase):
         reactionList = list(react(spcA, spcs))
         self.assertIsNotNone(reactionList)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
+
+    def testDeflate(self):
+        """
+        Test that reaction deflate function works.
+        """
+        molA = Molecule().fromSMILES('[OH]')
+        molB = Molecule().fromSMILES('CC')
+        molC = Molecule().fromSMILES('[CH3]')
+
+        reactants = [molA, molB]
+
+        # both reactants were already part of the core:
+        reactantIndices = [1, 2]
+
+        rxn = Reaction(reactants=[molA, molB], products=[molC],
+        pairs=[(molA, molC), (molB, molC)])
+
+        deflate(rxn, reactants, reactantIndices)
+
+        for spc, t in zip(rxn.reactants, [int, int]):
+            self.assertTrue(isinstance(spc, t))
+        self.assertEquals(rxn.reactants, reactantIndices)
+        for spc in rxn.products:
+            self.assertTrue(isinstance(spc, Species))
+
+        # one of the reactants was not yet part of the core:
+        reactantIndices = [-1, 2]
+
+        rxn = Reaction(reactants=[molA, molB], products=[molC],
+                pairs=[(molA, molC), (molB, molC)])
+
+        deflate(rxn, reactants, reactantIndices)
+
+        for spc, t in zip(rxn.reactants, [Species, int]):
+            self.assertTrue(isinstance(spc, t))
+        for spc in rxn.products:
+            self.assertTrue(isinstance(spc, Species))
 
     def tearDown(self):
         """


### PR DESCRIPTION
This PR fixes a bug mentioned [here](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/c147f77a056531d7c135b66b267ae1e29d0b0919#commitcomment-17551953), which might be possibly related to [this issue](https://github.com/ReactionMechanismGenerator/RMG-Py/issues/661) as well.

The bug stored the wrong species index as a reactant in the reaction. When the reaction is _inflated_ again, it should result in replacing the index with the wrong species. This may result in unbalanced reactions.

A number of unit tests were added, and a more comprehensive inline documentation was added to explain the functionality of the functions.

How this bug did not end up generating _more_ recent RMG crashes is really still a mystery to me, and  is being investigated.