### PR TITLE
Can't run scoop unit tests on my Mac

### DIFF
--- a/rmgpy/scoop_framework/utilTest.py
+++ b/rmgpy/scoop_framework/utilTest.py
@@ -16,6 +16,7 @@ try:
 except ImportError, e:
     import logging as logging
     logging.debug("Could not properly import SCOOP.")
+    raise
 
 from .util import *
 


### PR DESCRIPTION
This is more an issue than a pull request, but at least there's now a place for someone to fix it!

When I run `make test` on my mac with an anaconda python stack, it gets as far as the (skipped) test

```
Test that we can broadcast a simple string. ... SKIP: test currently only runs on linux
```

which is one of the [scoop](http://pyscoop.org/) tests, and then it freezes, presumably on the next scoop test.
When I press `control-C` to abort, it then prints:

```
^C
======================================================================
ERROR: test suite for <class 'rmgpy.rmg.parreactTest.ParallelReactTest'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/Users/rwest/Code/RMG-Py/rmgpy/scoop_framework/framework.py", line 99, in setUpClass
    raise Exception('Could not start server!')
Exception: Could not start server!
```

Followed by all the coverage reporting, which has this stack trace buried in the middle of it (presumably printed from a different thread):

```
Traceback (most recent call last):
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/scoop-0.7.2.0-py2.7.egg/scoop/broker/__main__.py", line 114, in <module>
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/scoop-0.7.2.0-py2.7.egg/scoop/broker/brokerzmq.py", line 184, in run
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/zmq/sugar/socket.py", line 503, in poll
    evts = dict(p.poll(timeout))
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/zmq/sugar/poll.py", line 99, in poll
    return zmq_poll(self.sockets, timeout=timeout)
  File "zmq/backend/cython/_poll.pyx", line 122, in zmq.backend.cython._poll.zmq_poll (zmq/backend/cython/_poll.c:1850)
  File "zmq/backend/cython/_poll.pyx", line 115, in zmq.backend.cython._poll.zmq_poll (zmq/backend/cython/_poll.c:1705)
  File "zmq/backend/cython/checkrc.pxd", line 25, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/_poll.c:2397)
zmq.error.ZMQError: Socket operation on non-socket
```

and finally

```
Ran 793 tests in 41.300s

FAILED (SKIP=28, errors=1)
Exception AttributeError: "'FutureQueue' object has no attribute 'socket'" in <bound method FutureQueue.__del__ of <scoop._types.FutureQueue object at 0x1217354d0>> ignored
make: *** [test] Error 1
```

If I try to isolate the test and just run 
`nosetests --nocapture --nologcapture --verbose rmgpy/scoop_framework/utilTest.py`
then this is the result:

```
(rmg5)RichardsMacBookPro13:RMG-Py rwest$ nosetests --nocapture --nologcapture --verbose rmgpy/scoop_framework/utilTest.py
ERROR
Test that we can retrieve a simple shared string. ... Traceback (most recent call last):
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/scoop-0.7.2.0-py2.7.egg/scoop/broker/__main__.py", line 84, in <module>
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/scoop-0.7.2.0-py2.7.egg/scoop/broker/brokerzmq.py", line 84, in __init__
  File "zmq/backend/cython/socket.pyx", line 487, in zmq.backend.cython.socket.Socket.bind (zmq/backend/cython/socket.c:5156)
  File "zmq/backend/cython/checkrc.pxd", line 25, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:7535)
zmq.error.ZMQError: Address already in use
ok
Test that the WorkerWrapper correctly redirects the error ... Traceback (most recent call last):
  File "/Users/rwest/Code/RMG-Py/rmgpy/scoop_framework/util.py", line 108, in __call__
    return self.myfn(*args, **kwargs)
  File "/Users/rwest/Code/RMG-Py/rmgpy/scoop_framework/utilTest.py", line 24, in boom
    return 0 / 0
ZeroDivisionError: integer division or modulo by zero

ok

======================================================================
ERROR: test suite for <class 'rmgpy.scoop_framework.utilTest.BroadcastTest'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/Users/rwest/anaconda/envs/rmg5/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/Users/rwest/Code/RMG-Py/rmgpy/scoop_framework/framework.py", line 99, in setUpClass
    raise Exception('Could not start server!')
Exception: Could not start server!

----------------------------------------------------------------------
Ran 2 tests in 3.328s

FAILED (errors=1)
```

This is my conda list:

```
(rmg5)RichardsMacBookPro13:RMG-Py rwest$ conda list
# packages in environment at /Users/rwest/anaconda/envs/rmg5:
#
3to2                      1.1.1                     <pip>
appnope                   0.1.0                    py27_0    defaults
astroid                   1.4.4                    py27_0    defaults
boost                     1.56.0                   py27_3    rdkit
bzip2                     1.0.6                         0    defaults
cairo                     1.12.18                       3    https://conda.binstar.org/rmg/osx-64/cairo-1.12.18-3.tar.bz2
cairocffi                 0.6                      py27_1    file:///Users/rwest/anaconda/conda-bld/osx-64/cairocffi-0.6-py27_1.tar.bz2
cantera                   2.2.1                    py27_0    bryanwweber
cffi                      1.2.1                    py27_0    defaults
coverage                  4.0                      py27_0    defaults
cycler                    0.9.0                    py27_0    defaults
cython                    0.21                     py27_1    defaults
decorator                 4.0.6                    py27_0    defaults
eigen                     3.2.1                         0    https://conda.binstar.org/rmg/osx-64/eigen-3.2.1-0.tar.bz2
enum34                    1.1.2                    py27_0    defaults
expat                     2.1.0                         0    https://conda.binstar.org/rwest/osx-64/expat-2.1.0-0.tar.bz2
fontconfig                2.11.1                        4    rmg
freetype                  2.5.5                         0    defaults
gprof2dot                 2015.02.03               py27_0    file:///Users/rwest/anaconda/conda-bld/osx-64/gprof2dot-2015.02.03-py27_0.tar.bz2
graphviz                  2.38.0                        3    https://conda.binstar.org/asmeurer/osx-64/graphviz-2.38.0-3.tar.bz2
greenlet                  0.4.9                    py27_0    defaults
guppy                     0.1.10                   py27_0    file:///Users/rwest/anaconda/conda-bld/osx-64/guppy-0.1.10-py27_0.tar.bz2
ipython                   4.0.3                    py27_0    defaults
ipython-genutils          0.1.0                     <pip>
ipython_genutils          0.1.0                    py27_0    defaults
jbig                      2.1                           0    defaults
jinja2                    2.8                      py27_0    defaults
jpeg                      8d                            2    https://conda.binstar.org/asmeurer/osx-64/jpeg-8d-2.tar.bz2
lazy-object-proxy         1.2.1                    py27_0    defaults
libgcc                    4.8.5                         1    defaults
libpng                    1.6.17                        0    https://conda.binstar.org/asmeurer/osx-64/libpng-1.6.17-0.tar.bz2
libtiff                   4.0.6                         1    defaults
libxml2                   2.9.2                         0    defaults
logilab-common            1.0.2                    py27_0    defaults
markupsafe                0.23                     py27_0    <unknown>
matplotlib                1.5.1               np110py27_0    defaults
mopac                     2012                          2    file:///Users/rwest/anaconda/conda-bld/osx-64/mopac-2012-2.tar.bz2
nose                      1.3.7                    py27_0    defaults
numpy                     1.10.2                   py27_0    defaults
openbabel                 2.3.2                    py27_4    file:///Users/rwest/anaconda/conda-bld/osx-64/openbabel-2.3.2-py27_4.tar.bz2
openssl                   1.0.2g                        0    defaults
path.py                   8.1.2                    py27_1    defaults
pexpect                   3.3                      py27_0    defaults
pickleshare               0.5                      py27_0    defaults
pip                       8.1.0                    py27_0    defaults
pixman                    0.32.6                        0    file:///Users/rwest/anaconda/conda-bld/osx-64/pixman-0.32.6-0.tar.bz2
pkg-config                0.28                          1    https://conda.binstar.org/asmeurer/osx-64/pkg-config-0.28-1.tar.bz2
psutil                    3.4.2                    py27_0    defaults
pycparser                 2.14                     py27_0    defaults
pydas                     1.0.2                    py27_0    rmg
pydot                     2.0.1                    py27_1    file:///Users/rwest/anaconda/conda-bld/osx-64/pydot-2.0.1-py27_1.tar.bz2
pydot2                    1.0.32                    <pip>
pydqed                    1.0.1                    py27_0    rmg
pylint                    1.5.4                    py27_0    defaults
pyparsing                 2.0.3                    py27_0    <unknown>
pyqt                      4.11.4                   py27_1    defaults
python                    2.7.11                        0    defaults
python-dateutil           2.4.2                    py27_0    defaults
python.app                1.2                      py27_4    defaults
pytz                      2015.7                   py27_0    defaults
pyzmq                     15.2.0                   py27_0    defaults
qt                        4.8.7                         1    defaults
quantities                0.11.1                   py27_0    rmg
rdkit                     2015.09.2           np110py27_0    rmg
readline                  6.2                           2    <unknown>
scipy                     0.16.1              np110py27_0    defaults
scoop                     0.7                      py27_0    rmg
setuptools                20.2.2                   py27_0    defaults
simplegeneric             0.8.1                    py27_0    defaults
singledispatch            3.4.0.3                  py27_0    defaults
sip                       4.16.9                   py27_0    defaults
six                       1.10.0                   py27_0    defaults
sqlite                    3.9.2                         0    defaults
symmetry                  1.0.1                         0    file:///Users/rwest/anaconda/conda-bld/osx-64/symmetry-1.0.1-0.tar.bz2
tk                        8.5.18                        0    <unknown>
traitlets                 4.1.0                    py27_0    defaults
wheel                     0.29.0                   py27_0    defaults
wrapt                     1.10.6                   py27_0    defaults
xlwt                      1.0.0                    py27_0    defaults
xz                        5.0.5                         0    defaults
zlib                      1.2.8                         0    <unknown>
```

Is anyone else able to run a complete `make test` on a Mac?
If so, how is your conda environment different from mine?
