### PR TITLE
Restore a family's forbidden structures after debugging test.

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1328,7 +1328,10 @@ class KineticsFamily(Database):
                     # been formed in the first place.
                     tempObject = self.forbidden
                     self.forbidden = ForbiddenStructures()  # Initialize with empty one
-                    reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True)
+                    try:
+                        reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True)
+                    finally:
+                        self.forbidden = tempObject
                     if len(reactions) != 1:
                         logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                         raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))


### PR DESCRIPTION
See comments at
https://github.com/ReactionMechanismGenerator/RMG-Py/commit/2e2c2bedbd7135a47456be6b218659af20a7b018