### PR TITLE
Fixed unit error in the solute radius

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -211,8 +211,9 @@ class SoluteData():
         Get diffusivity of solute using the Stokes-Einstein sphere relation. Radius is 
         found from the McGowan volume.
         """
+        N_a=6.0221409e+23 #Avogadro's number, mol^-1
         k_b = 1.3806488e-23 # m2*kg/s2/K
-        radius = math.pow((75*self.V/3.14159),(1.0/3.0))/100 # in meters
+        radius = math.pow((75*self.V/(3.14159*N_a)),(1.0/3.0))/100 # in meters
         D = k_b*T/6/3.14159/solventViscosity/radius # m2/s
         return D
             

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -59,7 +59,7 @@ class TestSoluteDatabase(TestCase):
         T = 298
         solventViscosity = 0.001
         D = soluteData.getStokesDiffusivity(T, solventViscosity)
-        self.assertAlmostEqual((D*1E12), 0.00000979)
+        self.assertAlmostEqual(D, 8.264e-10)
         
     def testSolventLibrary(self):
         "Test we can obtain solvent parameters from a library"

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -72,17 +72,17 @@ class DiffusionLimited():
         else:
             reacting = reaction.products
         assert len(reacting)==2, "Can only calculate diffusion limit in a bimolecular direction"
+        N_a = 6.022e23 # Avogadro's Number
         radii = 0.0
         diffusivities = 0.0
         for spec in reacting:
             soluteData = self.database.getSoluteData(spec)
             # calculate radius with the McGowan volume and assuming sphere
-            radius = ((75*soluteData.V/3.14159)**(1/3))/100
-            diff = soluteData.getStokesDiffusivity(T, self.getSolventViscosity(T))
+            radius = ((75*soluteData.V/(3.14159*N_a))**(1/3))/100 # meter
+            diff = soluteData.getStokesDiffusivity(T, self.getSolventViscosity(T)) # m^2/s
             radii += radius
             diffusivities += diff
-        N_a = 6.022e23 # Avogadro's Number
-        k_diff = 4*3.14159*radii*diffusivities*N_a
+        k_diff = 4*3.14159*radii*diffusivities*N_a # m^3/(mol*s)
         return k_diff
 
 


### PR DESCRIPTION
There was a unit error in the conversion of the solute's McGowan volume to the radius when calculating the solute's diffusivity. The unit of the McGowan volume is cm^3/mol/100, and the unit of the radius should be meter. Therefore, the McGowan volume needs to be divided by Avogadro's number to cancel out mol^-1. There was the same error in the calculation of diffusion rates. 

The two errors canceled out completely so the final values of diffusion rates were not affected at all. But the corrections were made for clarification