### PR TITLE
Fixed unit error in liquid phase reactions and added diffusionLimiter function

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -208,13 +208,16 @@ class SoluteData():
     
     def getStokesDiffusivity(self, T, solventViscosity):
         """
-        Get diffusivity of solute using the Stokes-Einstein sphere relation. Radius is 
-        found from the McGowan volume.
+        Get diffusivity of solute using the Stokes-Einstein sphere relation. 
+        Radius is found from the McGowan volume.
+        solventViscosity should be given in  kg/s/m which equals Pa.s
+        (water is about 9e-4 Pa.s at 25C, propanol is 2e-3 Pa.s)
+        Returns D in m2/s
         """
         k_b = 1.3806488e-23 # m2*kg/s2/K
         radius = math.pow((75*self.V/3.14159/6.0221409e23),(1.0/3.0))/100 # in meters, V is in MgGowan volume in cm3/mol/100
         D = k_b*T/6/3.14159/solventViscosity/radius # m2/s
-        return D
+        return D  # m2/s
             
     def setMcGowanVolume(self, species):
         """

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -212,7 +212,7 @@ class SoluteData():
         found from the McGowan volume.
         """
         k_b = 1.3806488e-23 # m2*kg/s2/K
-        radius = math.pow((75*self.V/3.14159),(1.0/3.0))/100 # in meters
+        radius = math.pow((75*self.V/3.14159/6.0221409e23),(1.0/3.0))/100 # in meters, V is in MgGowan volume in cm3/mol/100
         D = k_b*T/6/3.14159/solventViscosity/radius # m2/s
         return D
             

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -35,6 +35,7 @@
 import os.path
 import math
 import logging
+import rmgpy.constants as constants
 from copy import deepcopy
 from base import Database, Entry, makeLogicNode, DatabaseError
 
@@ -214,9 +215,8 @@ class SoluteData():
         (water is about 9e-4 Pa.s at 25C, propanol is 2e-3 Pa.s)
         Returns D in m2/s
         """
-        k_b = 1.3806488e-23 # m2*kg/s2/K
-        radius = math.pow((75*self.V/3.14159/6.0221409e23),(1.0/3.0))/100 # in meters, V is in MgGowan volume in cm3/mol/100
-        D = k_b*T/6/3.14159/solventViscosity/radius # m2/s
+        radius = math.pow((75*self.V/constants.pi/constants.Na),(1.0/3.0))/100 # in meters, V is in MgGowan volume in cm3/mol/100
+        D = constants.kB*T/6/3.14159/solventViscosity/radius # m2/s
         return D  # m2/s
             
     def setMcGowanVolume(self, species):

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -216,7 +216,7 @@ class SoluteData():
         Returns D in m2/s
         """
         radius = math.pow((75*self.V/constants.pi/constants.Na),(1.0/3.0))/100 # in meters, V is in MgGowan volume in cm3/mol/100
-        D = constants.kB*T/6/3.14159/solventViscosity/radius # m2/s
+        D = constants.kB*T/6/constants.pi/solventViscosity/radius # m2/s
         return D  # m2/s
             
     def setMcGowanVolume(self, species):

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -59,7 +59,7 @@ class TestSoluteDatabase(TestCase):
         T = 298
         solventViscosity = 0.001
         D = soluteData.getStokesDiffusivity(T, solventViscosity)
-        self.assertAlmostEqual((D*1E12), 0.00000979)
+        self.assertAlmostEqual((D*1E12), 8.264e-10)
         
     def testSolventLibrary(self):
         "Test we can obtain solvent parameters from a library"

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -54,12 +54,13 @@ class TestSoluteDatabase(TestCase):
     
     def testDiffusivity(self):
         "Test that for a given solvent viscosity and temperature we can calculate a solute's diffusivity"
-        species = Species(molecule=[Molecule(SMILES='COC=O')])
+        species = Species(molecule=[Molecule(SMILES='O')])  # water
         soluteData = self.database.getSoluteData(species)
-        T = 298
-        solventViscosity = 0.001
-        D = soluteData.getStokesDiffusivity(T, solventViscosity)
-        self.assertAlmostEqual((D*1E12), 8.264e-10)
+        T = 298.
+        solventViscosity = 0.00089  # water is about 8.9e-4 Pa.s
+        D = soluteData.getStokesDiffusivity(T, solventViscosity)  # m2/s
+        self.assertAlmostEqual((D * 1e9), 1.3, 1)
+        # self-diffusivity of water is about 2e-9 m2/s
         
     def testSolventLibrary(self):
         "Test we can obtain solvent parameters from a library"

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -72,17 +72,18 @@ class DiffusionLimited():
         else:
             reacting = reaction.products
         assert len(reacting)==2, "Can only calculate diffusion limit in a bimolecular direction"
+        N_a = 6.022e23 # Avogadro's Number
         radii = 0.0
         diffusivities = 0.0
         for spec in reacting:
             soluteData = self.database.getSoluteData(spec)
             # calculate radius with the McGowan volume and assuming sphere
-            radius = ((75*soluteData.V/3.14159)**(1/3))/100
+            radius = ((75*soluteData.V/3.14159/N_a)**(1/3))/100 #m
             diff = soluteData.getStokesDiffusivity(T, self.getSolventViscosity(T))
-            radii += radius
-            diffusivities += diff
-        N_a = 6.022e23 # Avogadro's Number
-        k_diff = 4*3.14159*radii*diffusivities*N_a
+            radii += radius #meters
+            diffusivities += diff #m^2/s
+        
+        k_diff = 4*3.14159*radii*diffusivities*N_a #m3/mol-s
         return k_diff
 
 

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -73,6 +73,7 @@ class DiffusionLimited():
         
         This is the upper limit on the rate, in the specified direction.
         (ie. forward direction if forward=True [default] or reverse if forward=False)
+        Returns the rate coefficient k_diff in m3/mol/s.
         """
         if forward:
             reacting = reaction.reactants
@@ -85,12 +86,12 @@ class DiffusionLimited():
         for spec in reacting:
             soluteData = self.database.getSoluteData(spec)
             # calculate radius with the McGowan volume and assuming sphere
-            radius = ((75*soluteData.V/3.14159/N_a)**(1/3))/100 #m
+            radius = ((75 * soluteData.V / 3.14159 / N_a) ** (1. / 3)) / 100  # m
             diff = soluteData.getStokesDiffusivity(T, self.getSolventViscosity(T))
-            radii += radius #meters
+            radii += radius  # meters
             diffusivities += diff #m^2/s
         
-        k_diff = 4*3.14159*radii*diffusivities*N_a #m3/mol-s
+        k_diff = 4 * 3.14159 * radii * diffusivities * N_a  # m3/mol/s
         return k_diff
 
 

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -60,6 +60,13 @@ class DiffusionLimited():
                     k_eff = k_eff_reverse * Keq
         return k_eff        
     
+    def getDiffusionFactor(self, reaction, T):
+        """
+        Return the diffusion factor of the specified reaction.
+        """
+        return self.getEffectiveRate(reaction, T)/reaction.kinetics.getRateCoefficient(T,P=0)
+
+    
     def getDiffusionLimit(self, T, reaction, forward=True):
         """
         Return the diffusive limit on the rate coefficient, k_diff.

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -1,5 +1,6 @@
 import rmgpy.quantity as quantity
 import logging
+import rmgpy.constants as constants
 from rmgpy.species import Species
 from rmgpy.data.solvation import SolventData, SoluteData, SoluteGroups, SolvationDatabase
 from rmgpy.reaction import Reaction
@@ -80,18 +81,17 @@ class DiffusionLimited():
         else:
             reacting = reaction.products
         assert len(reacting)==2, "Can only calculate diffusion limit in a bimolecular direction"
-        N_a = 6.022e23 # Avogadro's Number
         radii = 0.0
         diffusivities = 0.0
         for spec in reacting:
             soluteData = self.database.getSoluteData(spec)
             # calculate radius with the McGowan volume and assuming sphere
-            radius = ((75 * soluteData.V / 3.14159 / N_a) ** (1. / 3)) / 100  # m
+            radius = ((75 * soluteData.V / 3.14159 / constants.Na) ** (1. / 3)) / 100  # m
             diff = soluteData.getStokesDiffusivity(T, self.getSolventViscosity(T))
             radii += radius  # meters
             diffusivities += diff #m^2/s
         
-        k_diff = 4 * 3.14159 * radii * diffusivities * N_a  # m3/mol/s
+        k_diff = 4 * 3.14159 * radii * diffusivities * constants.Na  # m3/mol/s
         return k_diff
 
 

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -86,12 +86,12 @@ class DiffusionLimited():
         for spec in reacting:
             soluteData = self.database.getSoluteData(spec)
             # calculate radius with the McGowan volume and assuming sphere
-            radius = ((75 * soluteData.V / 3.14159 / constants.Na) ** (1. / 3)) / 100  # m
+            radius = ((75 * soluteData.V / constants.pi / constants.Na) ** (1. / 3)) / 100  # m
             diff = soluteData.getStokesDiffusivity(T, self.getSolventViscosity(T))
             radii += radius  # meters
             diffusivities += diff #m^2/s
         
-        k_diff = 4 * 3.14159 * radii * diffusivities * constants.Na  # m3/mol/s
+        k_diff = 4 * constants.pi * radii * diffusivities * constants.Na  # m3/mol/s
         return k_diff
 
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -642,23 +642,25 @@ class Reaction:
         Decrease the pre-exponential factor (A) by the diffusion factor
         to account for the diffusion limit at the specified temperature.
         """
-        # Decrease self.kinetics.A (if Arrhenius or ArrheniusEP)
-        if diffusionLimiter.enabled:
-            # Add a comment to self.kinetics.comment
-            self.kinetics.comment.append("Pre-exponential factor A has been decreased by the diffusion factor.")
-            # Obtain effective rate
-            try:
-                k = self.__k_effective_cache[T]
-            except KeyError:
-                k = diffusionLimiter.getEffectiveRate(self, T)
-                self.__k_effective_cache[T] = k
-        else:
-            k=self.kinetics.getRateCoefficient(T, P=0)
+        if not diffusionLimiter.enabled:
+            return
+        # Obtain effective rate
+        try:
+            k = self.__k_effective_cache[T]
+        except KeyError:
+            k = diffusionLimiter.getEffectiveRate(self, T)
+            self.__k_effective_cache[T] = k
+
         # calculate diffusion factor
-        diffusionFactor=k/self.kinetics.getRateCoefficient(T,P=0)
+        diffusionFactor = k / self.kinetics.getRateCoefficient(T, P=0)
         # update preexponential factor
         self.kinetics.A = self.kinetics.A * diffusionFactor
-        
+        # Add a comment to self.kinetics.comment
+        self.kinetics.comment.append(
+            ("Pre-exponential factor A has been decreased by the "
+             "diffusion factor {0.2g} evaluated at {1} K.").format(
+                diffusionFactor, T))
+
     def fixBarrierHeight(self, forcePositive=False):
         """
         Turns the kinetics into Arrhenius (if they were ArrheniusEP)

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -639,14 +639,26 @@ class Reaction:
 
     def fixDiffusionLimitedA(self, T):
         """
-        Decrease the pre-exponential factor (A) by a factor of getDiffusionFactor
-        to account for the diffusion limit.
+        Decrease the pre-exponential factor (A) by the diffusion factor
+        to account for the diffusion limit at the specified temperature.
         """
         # Decrease self.kinetics.A (if Arrhenius or ArrheniusEP)
-        self.kinetics.A = self.kinetics.A * self.getDiffusionFactor(T)
-        # Add a comment to self.kinetics.comment
-        self.kinetics.comment.append("Pre-exponential factor A has been decreased by the diffusion factor.")
-    
+        if diffusionLimiter.enabled:
+            # Add a comment to self.kinetics.comment
+            self.kinetics.comment.append("Pre-exponential factor A has been decreased by the diffusion factor.")
+            # Obtain effective rate
+            try:
+                k = self.__k_effective_cache[T]
+            except KeyError:
+                k = diffusionLimiter.getEffectiveRate(self, T)
+                self.__k_effective_cache[T] = k
+        else:
+            k=self.kinetics.getRateCoefficient(T, P=0)
+        # calculate diffusion factor
+        diffusionFactor=k/self.kinetics.getRateCoefficient(T,P=0)
+        # update preexponential factor
+        self.kinetics.A = self.kinetics.A * diffusionFactor
+        
     def fixBarrierHeight(self, forcePositive=False):
         """
         Turns the kinetics into Arrhenius (if they were ArrheniusEP)

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -646,10 +646,10 @@ class Reaction:
             return
         # Obtain effective rate
         try:
-            k = self.__k_effective_cache[T]
+            k = self.k_effective_cache[T]
         except KeyError:
             k = diffusionLimiter.getEffectiveRate(self, T)
-            self.__k_effective_cache[T] = k
+            self.k_effective_cache[T] = k
 
         # calculate diffusion factor
         diffusionFactor = k / self.kinetics.getRateCoefficient(T, P=0)

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -929,7 +929,7 @@ class TestReaction(unittest.TestCase):
     
     def testPickleLiquidReaction(self):
         """
-        Test that a Reaction with a __k_effective_cache object can be successfully pickled and unpickled with no loss of information.
+        Test that a Reaction with a k_effective_cache object can be successfully pickled and unpickled with no loss of information.
         """
         global diffusionLimiter        
         import cPickle


### PR DESCRIPTION
The unit error regarding the diffusivity is corrected. 
Also, all the constants, such as pi, Na and kB are all replaced by the values from rmgpy.constants module. 

fixDiffusionLimitedA(T) function is added for liquid phase reactions. When it is enabled, the Pre-exponential factor A is decreased by the diffusion factor evaluated at a reaction temperature. This corrected pre-exponential factor can be used only for isothermal liquid reactions.