### PR TITLE
Solvent representation

### DIFF
--- a/documentation/source/users/rmg/liquids.rst
+++ b/documentation/source/users/rmg/liquids.rst
@@ -26,6 +26,18 @@ Your reaction system will also be different (liquidReactor rather than simpleRea
 
     )
 
+To simulate the liquidReactor, one of the initial species / concentrations must be the solvent. If the solvent species does
+not appear as the initial species, RMG run will stop and raise error. The solvent can be either reactive, or nonreactive.
+
+In order for RMG to recognize the species as the solvent, it is important to use the latest version of the RMG-database, whose
+solvent library contains solvent SMILES. If the latest database is used,  RMG can determine whether the species is the
+solvent by looking at its molecular structure (SMILES or adjacency list).
+If the old version of RMG-database without the solvent SMILES is used, then RMG can recognize the species as the solvent
+only by its string name. This means that if the solvent is named "octane" in the solvation block and it is named "n-octane"
+in the species and initialConcentrations blocks, RMG will not be able to recognize them as the same solvent species and raise
+error because the solvent is not listed as one of the initial species.
+
+
 For liquid phase generation, you can provide a list of species for which one concentration is held constant over time
 (Use the keyword ``constantSpecies=[]`` with species labels separated by ``","``). To generate meaningful liquid phase oxidation mechanism, it is 
 highly recommended to consider O2 as a constant species. To consider pyrolysis cases, it is still possible to obtain a mechanism without this option.

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -924,3 +924,25 @@ class SolvationDatabase(object):
         correction.gibbs = self.calcG(soluteData, solventData)  
         correction.entropy = self.calcS(correction.gibbs, correction.enthalpy) 
         return correction
+
+    def checkSolventinInitialSpecies(self,rmg,solventStructure):
+        """
+        Given the instance of RMG class and the solventStructure, it checks whether the solvent is listed as one
+        of the initial species.
+        If the SMILES / adjacency list for all the solvents exist in the solvent library, it uses the solvent's
+        molecular structure to determine whether the species is the solvent or not.
+        If the solvent library does not have SMILES / adjacency list, then it uses the solvent's string name
+        to determine whether the species is the solvent or not
+        """
+        for spec in rmg.initialSpecies:
+            if solventStructure is not None:
+                spec.isSolvent = spec.isIsomorphic(solventStructure)
+            else:
+                spec.isSolvent = rmg.solvent == spec.label
+            if not sum(1 if spec.isSolvent else 0 for spec in rmg.initialSpecies):
+                if solventStructure is not None:
+                    logging.info('One of the initial species must be the solvent')
+                    raise Exception('One of the initial species must be the solvent')
+                else:
+                    logging.info('One of the initial species must be the solvent with the same string name')
+                    raise Exception('One of the initial species must be the solvent with the same string name')

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -271,22 +271,25 @@ class SolventLibrary(Database):
     def loadEntry(self,
                   index,
                   label,
-                  molecule,
                   solvent,
+                  molecule=None,
                   reference=None,
                   referenceType='',
                   shortDesc='',
                   longDesc='',
                   ):
-        try:
-            mol = Species().fromSMILES(molecule)
-        except:
+        mol = molecule
+        if molecule is not None:
             try:
-                mol = Species().fromAdjacencyList(molecule)
+                mol = Species().fromSMILES(molecule)
             except:
-                logging.error("Can't understand '{0}' in solute library '{1}'".format(molecule,self.name))
-                raise
-        mol.generateResonanceIsomers()
+                logging.debug("Solvent '{0}' does not have a valid SMILES '{1}'" .format(label, molecule))
+                try:
+                    mol = Species().fromAdjacencyList(molecule)
+                except:
+                    logging.error("Can't understand '{0}' in solute library '{1}'".format(molecule, self.name))
+                    raise
+            mol.generateResonanceIsomers()
 
         self.entries[label] = Entry(
             index = index,

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -939,7 +939,7 @@ class SolvationDatabase(object):
                 spec.isSolvent = spec.isIsomorphic(solventStructure)
             else:
                 spec.isSolvent = rmg.solvent == spec.label
-            if not sum(1 if spec.isSolvent else 0 for spec in rmg.initialSpecies):
+            if not any([spec.isSolvent for spec in rmg.initialSpecies]):
                 if solventStructure is not None:
                     logging.info('One of the initial species must be the solvent')
                     raise Exception('One of the initial species must be the solvent')

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -278,23 +278,23 @@ class SolventLibrary(Database):
                   shortDesc='',
                   longDesc='',
                   ):
-        mol = molecule
+        spc = molecule
         if molecule is not None:
             try:
-                mol = Species().fromSMILES(molecule)
+                spc = Species().fromSMILES(molecule)
             except:
                 logging.debug("Solvent '{0}' does not have a valid SMILES '{1}'" .format(label, molecule))
                 try:
-                    mol = Species().fromAdjacencyList(molecule)
+                    spc = Species().fromAdjacencyList(molecule)
                 except:
                     logging.error("Can't understand '{0}' in solute library '{1}'".format(molecule, self.name))
                     raise
-            mol.generateResonanceIsomers()
+            spc.generateResonanceIsomers()
 
         self.entries[label] = Entry(
             index = index,
             label = label,
-            item = mol,
+            item = spc,
             data = solvent,
             reference = reference,
             referenceType = referenceType,
@@ -344,10 +344,11 @@ class SoluteLibrary(Database):
                   longDesc='',
                   ):
         try:
-            mol = Molecule(SMILES=molecule)
+            spc = Species().fromSMILES(molecule)
         except:
+            logging.debug("Solute '{0}' does not have a valid SMILES '{1}'" .format(label, molecule))
             try:
-                mol = Molecule().fromAdjacencyList(molecule)
+                spc = Species().fromAdjacencyList(molecule)
             except:
                 logging.error("Can't understand '{0}' in solute library '{1}'".format(molecule,self.name))
                 raise
@@ -355,7 +356,7 @@ class SoluteLibrary(Database):
         self.entries[label] = Entry(
             index = index,
             label = label,
-            item = mol,
+            item = spc,
             data = solute,
             reference = reference,
             referenceType = referenceType,
@@ -661,9 +662,8 @@ class SolvationDatabase(object):
         :class:`DatabaseError` is raised.
         """
         for label, entry in library.entries.iteritems():
-            for molecule in species.molecule:
-                if molecule.isIsomorphic(entry.item) and entry.data is not None:
-                    return (deepcopy(entry.data), library, entry)
+            if species.isIsomorphic(entry.item) and entry.data is not None:
+                return (deepcopy(entry.data), library, entry)
         return None
 
     def getSoluteDataFromGroups(self, species):

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -8,7 +8,7 @@ from external.wip import work_in_progress
 from rmgpy import settings
 from rmgpy.molecule import Molecule
 from rmgpy.rmg.main import Species
-from rmgpy.data.solvation import DatabaseError, SoluteData, SolvationDatabase
+from rmgpy.data.solvation import DatabaseError, SoluteData, SolvationDatabase, SolventLibrary
 from rmgpy.rmg.main import RMG
 
 ###################################################
@@ -189,31 +189,75 @@ multiplicity 2
 
         # Case 1. when SMILES for solvent is available, the molecular structures of the initial species and the solvent
         # are compared to check whether the solvent is in the initial species list
+
         # Case 1-1: the solvent water is not in the initialSpecies list, so it raises Exception
-        self.rmg=RMG()
-        self.rmg.initialSpecies = []
+        rmg=RMG()
+        rmg.initialSpecies = []
         solute = Species(label='n-octane', molecule=[Molecule().fromSMILES('C(CCCCC)CC')])
-        self.rmg.initialSpecies.append(solute)
-        self.rmg.solvent = 'water'
-        self.solventStructure = Species().fromSMILES('O')
-        self.assertRaises(Exception,self.database.checkSolventinInitialSpecies,self.rmg,self.solventStructure)
+        rmg.initialSpecies.append(solute)
+        rmg.solvent = 'water'
+        solventStructure = Species().fromSMILES('O')
+        self.assertRaises(Exception, self.database.checkSolventinInitialSpecies, rmg, solventStructure)
+
         # Case 1-2: the solvent is now octane and it is listed as the initialSpecies. Although the string
         # names of the solute and the solvent are different, because the solvent SMILES is provided,
         # it can identify the 'n-octane' as the solvent
-        self.rmg.solvent = 'octane'
-        self.solventStructure = Species().fromSMILES('CCCCCCCC')
-        self.database.checkSolventinInitialSpecies(self.rmg,self.solventStructure)
-        self.assertEqual(1,self.rmg.initialSpecies[0].isSolvent)
+        rmg.solvent = 'octane'
+        solventStructure = Species().fromSMILES('CCCCCCCC')
+        self.database.checkSolventinInitialSpecies(rmg, solventStructure)
+        self.assertTrue(rmg.initialSpecies[0].isSolvent)
 
         # Case 2: the solvent SMILES is not provided. In this case, it can identify the species as the
         # solvent by looking at the string name.
+
         # Case 2-1: Since 'n-octane and 'octane' are not equal, it raises Exception
-        self.solventStructure = None
-        self.assertRaises(Exception,self.database.checkSolventinInitialSpecies,self.rmg,self.solventStructure)
+        solventStructure = None
+        self.assertRaises(Exception, self.database.checkSolventinInitialSpecies, rmg, solventStructure)
+
         # Case 2-2: The label 'n-ocatne' is corrected to 'octane', so it is identified as the solvent
-        self.rmg.initialSpecies[0].label = 'octane'
-        self.database.checkSolventinInitialSpecies(self.rmg,self.solventStructure)
-        self.assertEqual(1,self.rmg.initialSpecies[0].isSolvent)
+        rmg.initialSpecies[0].label = 'octane'
+        self.database.checkSolventinInitialSpecies(rmg, solventStructure)
+        self.assertTrue(rmg.initialSpecies[0].isSolvent)
+
+    def testSolventMolecule(self):
+        " Test we can give a proper value for the solvent molecular structure when different solvent databases are given "
+
+        # solventlibrary.entries['solvent_label'].item should be the instance of Species with the solvent's molecular structure
+        # if the solvent database contains the solvent SMILES or adjacency list. If not, then item is None
+
+        # Case 1: When the solventDatabase does not contain the solvent SMILES, the item attribute is None
+        solventlibrary = SolventLibrary()
+        solventlibrary.loadEntry(index=1, label='water', solvent=None)
+        self.assertTrue(solventlibrary.entries['water'].item is None)
+
+        # Case 2: When the solventDatabase contains the correct solvent SMILES, the item attribute is the instance of
+        # Species with the correct solvent molecular structure
+        solventlibrary.loadEntry(index=2, label='octane', solvent=None, molecule='CCCCCCCC')
+        solventSpecies = Species().fromSMILES('C(CCCCC)CC')
+        self.assertTrue(solventSpecies.isIsomorphic(solventlibrary.entries['octane'].item))
+
+        # Case 3: When the solventDatabase contains the correct solvent adjacency list, the item attribute is the instance of
+        # the species with the correct solvent molecular structure.
+        # This will display the SMILES Parse Error message from the external function, but ignore it.
+        solventlibrary.loadEntry(index=3, label='ethanol', solvent=None, molecule=
+"""
+1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3 O u0 p2 c0 {2,S} {9,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+9 H u0 p0 c0 {3,S}
+""")
+        solventSpecies = Species().fromSMILES('CCO')
+        self.assertTrue(solventSpecies.isIsomorphic(solventlibrary.entries['ethanol'].item))
+
+        # Case 4: when the solventDatabase contains incorrect values for the molecule attribute, it raises Exception
+        # This will display the SMILES Parse Error message from the external function, but ignore it.
+        self.assertRaises(Exception, solventlibrary.loadEntry, index=4, label='benzene', solvent=None, molecule='ring')
+
 #####################################################
 
 if __name__ == '__main__':

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -438,23 +438,8 @@ class RMG(util.Subject):
                         raise ForbiddenStructureException("Species constraints forbids input species {0}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label))
 
             # For liquidReactor, checks whether the solvent is listed as one of the initial species.
-            # If the SMILES / adjacency list for all the solvents exist in the solvent library, it uses the solvent's
-            # molecular structure to determine whether the species is the solvent or not.
-            # If the solvent library does not have SMILES / adjacency list, then it uses the solvent's string name
-            # to determine whether the species is the solvent or not
             if self.solvent:
-                    for spec in self.initialSpecies:
-                        if Species.solventStructure is not None:
-                            spec.isSolvent = spec.isIsomorphic(Species.solventStructure)
-                        else:
-                            spec.isSolvent = self.solvent == spec.label
-                    if not sum(1 if spec.isSolvent else 0 for spec in self.initialSpecies):
-                        if Species.solventStructure is not None:
-                            logging.info('One of the initial species must be the solvent')
-                            raise Exception('One of the initial species must be the solvent')
-                        else:
-                            logging.info('One of the initial species must be the solvent with the same string name')
-                            raise Exception('One of the initial species must be the solvent with the same string name')
+                self.database.solvation.checkSolventinInitialSpecies(self,Species.solventStructure)
 
             #Check to see if user has input Singlet O2 into their input file or libraries
             #This constraint is special in that we only want to check it once in the input instead of every time a species is made

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -436,7 +436,16 @@ class RMG(util.Subject):
                         pass
                     else:
                         raise ForbiddenStructureException("Species constraints forbids input species {0}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label))
-            
+
+            # For liquidReactor, checks whether the solvent is listed as one of the initial species by comparing the
+            # the molecular structures of the initialSpecies and the solvent
+            if self.solvent:
+                for spec in self.initialSpecies:
+                    spec.isSolvent = spec.isIsomorphic(Species.solventStructure)
+                if not sum(1 if spec.isSolvent else 0 for spec in self.initialSpecies):
+                    logging.info('One of the initial species must be a solvent')
+                    raise Exception('One of the initial species must be a solvent')
+
             #Check to see if user has input Singlet O2 into their input file or libraries
             #This constraint is special in that we only want to check it once in the input instead of every time a species is made
             if 'allowSingletO2' in self.speciesConstraints and self.speciesConstraints['allowSingletO2']:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -376,6 +376,7 @@ class RMG(util.Subject):
         if self.solvent:
             Species.solventData = self.database.solvation.getSolventData(self.solvent)
             Species.solventName = self.solvent
+            Species.solventStructure = self.database.solvation.getSolventStructure(self.solvent)
             diffusionLimiter.enable(Species.solventData, self.database.solvation)
             logging.info("Setting solvent data for {0}".format(self.solvent))
     

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -64,9 +64,9 @@ from pdep import PDepReaction, PDepNetwork
 class Species(rmgpy.species.Species):
     solventName = None
     solventData = None
-    solventStructure = None
+    solventStructure = None # solventStructure is the instance of species class whose molecule attribute corresponds to the solvent SMILES
     solventViscosity = None
-    isSolvent = False
+    isSolvent = False # returns True if the species is the solvent and False if not
     diffusionTemp = None
 
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -64,7 +64,9 @@ from pdep import PDepReaction, PDepNetwork
 class Species(rmgpy.species.Species):
     solventName = None
     solventData = None
+    solventStructure = None
     solventViscosity = None
+    isSolvent = False
     diffusionTemp = None
 
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -64,7 +64,9 @@ from pdep import PDepReaction, PDepNetwork
 class Species(rmgpy.species.Species):
     solventName = None
     solventData = None
-    solventStructure = None # solventStructure is the instance of species class whose molecule attribute corresponds to the solvent SMILES
+    # solventStructure is the instance of species class whose molecule attribute corresponds to the solvent SMILES.
+    # If the solvent library does not contain the SMILES of the solvent, then the solventStructure is None
+    solventStructure = None
     solventViscosity = None
     isSolvent = False # returns True if the species is the solvent and False if not
     diffusionTemp = None


### PR DESCRIPTION
I added a new solvent attribute called molecule that stores the solvent's molecular structure and a new Species attribute called isSolvent which gives Boolean True if the species is the solvent and False if not. 

In main.py, I added new codes that check,  for every liquid phase reactions, whether any of the initial species is the solvent. If none of the initial species is the solvent, then it raises Exception with the error message. 

If the RMGPy-database is not updated (with the one containing my latest pull request), RMG will determine whether the species is the solvent or not based on the solvent's string name

If the RMGPy-database is updated with the version containing my latest pull request, RMG will determine whether the species is the solvent or not based on the solvent's molecular structures.