### PR TITLE
Add CoolProp dependency to anaconda build and environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - python
   - numpy >=1.10.0
   - cantera >=2.2
+  - coolprop
   - cython ==0.21
   - matplotlib >=1.5
   - rdkit >=2015.09.2

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -7,6 +7,7 @@ dependencies:
   - python
   - numpy >=1.10.0
   - cantera >=2.2
+  - coolprop
   - cython ==0.21
   - matplotlib >=1.5
   - rdkit >=2015.09.2

--- a/meta.yaml
+++ b/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - cairo # [unix]
     - cairocffi # [unix]
     - cantera >=2.2
+    - coolprop
     - coverage
     - cython ==0.21
     - gprof2dot


### PR DESCRIPTION
Coolprop is a fluids property estimator (http://coolprop.org) and its binary now found on https://anaconda.org/RMG/coolprop

Adding it as a dependency in anticipation for future solvation module reliance on this program.  