### PR TITLE
fix a typo in calling cantera ideal gas constPressure reactor

### DIFF
--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -344,7 +344,7 @@ class Cantera:
             if condition.reactorType == 'IdealGasReactor':
                 canteraReactor=ct.IdealGasReactor(self.model)
             elif condition.reactorType == 'IdealGasConstPressureReactor':
-                canteraReactor=ct.IdealConstPressureGasReactor(self.model)
+                canteraReactor=ct.IdealGasConstPressureReactor(self.model)
             else:
                 raise Exception('Other types of reactor conditions are currently not supported')
             


### PR DESCRIPTION
This PR fixed a typo in calling `IdealGasConstPressureReactor` from `cantera`
see http://www.cantera.org/docs/sphinx/html/cython/zerodim.html#idealgasconstpressurereactor