### PR TITLE
Fix mutable default arguments in Python functions

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -218,7 +218,7 @@ def removeThermoData(thermoData1, thermoData2):
 
     return thermoData1
 
-def averageThermoData(thermoDataList=[]):
+def averageThermoData(thermoDataList=None):
     """
     Average a list of thermoData values together.
     Sets uncertainty values to be the approximately the 95% confidence interval, equivalent to
@@ -229,6 +229,9 @@ def averageThermoData(thermoDataList=[]):
     
     Note that uncertainties are only computed when number of values is greater than 1.
     """
+    if thermoDataList is None:
+        thermoDataList = []
+        
     import copy
     numValues = len(thermoDataList)
         

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -239,7 +239,7 @@ cdef class Arrhenius(KineticsModel):
         E = self._Ea.value_si*1000   # convert from J/mol to J/kmol
         return ct.Arrhenius(A,b,E)
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Passes in a cantera ElementaryReaction() object and sets its
         rate to a Cantera Arrhenius() object.
@@ -392,7 +392,7 @@ cdef class ArrheniusEP(KineticsModel):
         """
         self._A.value_si *= factor
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets a cantera ElementaryReaction() object with the modified Arrhenius object
         converted to an Arrhenius form.
@@ -543,7 +543,7 @@ cdef class PDepArrhenius(PDepKineticsModel):
         if self.highPlimit is not None:
             self.highPlimit.changeRate(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets a Cantera PlogReaction()'s `rates` attribute with
         A list of tuples containing [(pressure in Pa, cantera arrhenius object), (..)]
@@ -663,7 +663,7 @@ cdef class MultiArrhenius(KineticsModel):
         for kin in self.arrhenius:
             kin.changeRate(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the kinetic rates for a list of cantera `Reaction` objects
         Here, ctReaction must be a list rather than a single cantera reaction.
@@ -672,7 +672,7 @@ cdef class MultiArrhenius(KineticsModel):
             raise Exception('The number of Cantera Reaction objects does not match the number of Arrhenius objects')
 
         for i, arr in enumerate(self.arrhenius):
-            arr.setCanteraKinetics(ctReaction[i])
+            arr.setCanteraKinetics(ctReaction[i], speciesList)
     
     
 ################################################################################
@@ -782,7 +782,7 @@ cdef class MultiPDepArrhenius(PDepKineticsModel):
         for kin in self.arrhenius:
             kin.changeRate(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the PLOG kinetics for multiple cantera `Reaction` objects, provided in a list.
         ctReaction is a list of cantera reaction objects.
@@ -791,4 +791,4 @@ cdef class MultiPDepArrhenius(PDepKineticsModel):
             raise Exception('The number of Cantera Reaction objects does not match the number of PdepArrhenius objects')
 
         for i, arr in enumerate(self.arrhenius):
-            arr.setCanteraKinetics(ctReaction[i])
+            arr.setCanteraKinetics(ctReaction[i], speciesList)

--- a/rmgpy/kinetics/chebyshev.pyx
+++ b/rmgpy/kinetics/chebyshev.pyx
@@ -242,7 +242,7 @@ cdef class Chebyshev(PDepKineticsModel):
         """
         self.coeffs.value_si[0,0] += log10(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the kinetics parameters for a Cantera ChebyshevReaction() object
         Uses set_parameters(self,Tmin,Tmax,Pmin,Pmax,coeffs)

--- a/rmgpy/kinetics/falloff.pyx
+++ b/rmgpy/kinetics/falloff.pyx
@@ -119,14 +119,14 @@ cdef class ThirdBody(PDepKineticsModel):
         """
         self.arrheniusLow.changeRate(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList = []):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the kinetics and efficiencies for a cantera `ThreeBodyReaction` object
         """
         import cantera as ct
         assert isinstance(ctReaction, ct.ThreeBodyReaction), "Must be a Cantera ThreeBodyReaction object"
         ctReaction.efficiencies = PDepKineticsModel.getCanteraEfficiencies(self,speciesList)
-        self.arrheniusLow.setCanteraKinetics(ctReaction)
+        self.arrheniusLow.setCanteraKinetics(ctReaction, speciesList)
 
 ################################################################################
 
@@ -216,7 +216,7 @@ cdef class Lindemann(PDepKineticsModel):
         self.arrheniusLow.changeRate(factor)
         self.arrheniusHigh.changeRate(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the efficiencies and kinetics for a cantera reaction.
         """
@@ -374,7 +374,7 @@ cdef class Troe(PDepKineticsModel):
         self.arrheniusLow.changeRate(factor)
         self.arrheniusHigh.changeRate(factor)
 
-    def setCanteraKinetics(self, ctReaction, speciesList = []):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the efficiencies, kinetics, and troe falloff parameters
         for a cantera FalloffReaction.

--- a/rmgpy/kinetics/model.pyx
+++ b/rmgpy/kinetics/model.pyx
@@ -259,7 +259,7 @@ cdef class KineticsModel:
                 
         return discrepancy
     
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the kinetics for a cantera reaction object.
         """
@@ -496,7 +496,7 @@ cdef class PDepKineticsModel(KineticsModel):
                     break
         return efficiencies
     
-    def setCanteraKinetics(self, ctReaction, speciesList=[]):
+    def setCanteraKinetics(self, ctReaction, speciesList):
         """
         Sets the kinetics for a cantera reaction object.
         """

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -534,9 +534,9 @@ class Group(Graph):
     Corresponding alias methods have also been provided.
     """
 
-    def __init__(self, atoms=None, multiplicity=[]):
+    def __init__(self, atoms=None, multiplicity=None):
         Graph.__init__(self, atoms)
-        self.multiplicity = multiplicity
+        self.multiplicity = multiplicity if multiplicity else []
         self.update()
 
     def __reduce__(self):

--- a/rmgpy/molecule/inchiparsingTest.py
+++ b/rmgpy/molecule/inchiparsingTest.py
@@ -12,7 +12,7 @@ from .parser import *
 
 class InChIParsingTest(unittest.TestCase):
 
-    def compare(self, inchi, u_indices=[], p_indices = []):        
+    def compare(self, inchi, u_indices=None, p_indices = None):        
         u_layer = U_LAYER_PREFIX + U_LAYER_SEPARATOR.join(map(str, u_indices)) if u_indices else None
         p_layer = P_LAYER_PREFIX + P_LAYER_SEPARATOR.join(map(str, p_indices)) if p_indices else None
 

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -111,7 +111,8 @@ def find_allyl_end_with_charge(start):
     # Could not find a resonance path from start atom to end atom
     return paths
 
-def find_shortest_path(start, end, path=[]):
+def find_shortest_path(start, end, path=None):
+    path = path if path else []
     path = path + [start]
     if start == end:
         return path

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -174,7 +174,7 @@ class Reaction:
         else:
             return rmgpy.chemkin.writeReactionString(self)
     
-    def toCantera(self, speciesList=[]):
+    def toCantera(self, speciesList=None):
         """
         Converts the RMG Reaction object to a Cantera Reaction object
         with the appropriate reaction class.
@@ -182,6 +182,9 @@ class Reaction:
         from rmgpy.kinetics import Arrhenius, ArrheniusEP, MultiArrhenius, PDepArrhenius, MultiPDepArrhenius, Chebyshev, ThirdBody, Lindemann, Troe
                     
         import cantera as ct
+        
+        if speciesList is None:
+            speciesList = []
         
         # Create the dictionaries containing species strings and their stoichiometries
         # for initializing the cantera reaction object

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -39,7 +39,7 @@ from rmgpy.data.rmg import getDB
 from rmgpy.scoop_framework.util import map_, WorkerWrapper
 from rmgpy.species import Species
         
-def react(spcA, speciesList=[]):
+def react(spcA, speciesList=None):
     """
     Generate reactions between spcA and the list of 
     species for all the reaction families available.
@@ -61,6 +61,7 @@ def react(spcA, speciesList=[]):
     speciesList is obtained by taking the combinatorial product of the
     two generated [(Molecule, index)] lists.
     """
+    speciesList = speciesList if speciesList else []
     if not spcA.reactive: return []
     
     molsA = [(mol, spcA.index) for mol in spcA.molecule]

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -227,7 +227,7 @@ class Species(object):
         from rmgpy.chemkin import getSpeciesIdentifier
         return getSpeciesIdentifier(self)
         
-    def toCantera(self, speciesList=[]):
+    def toCantera(self):
         """
         Converts the RMG Species object to a Cantera Species object
         with the appropriate thermo data.

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -167,7 +167,7 @@ class Cantera:
     This class contains functions associated with an entire Cantera job
     """
     
-    def __init__(self, speciesList=None, reactionList=None, canteraFile='', outputDirectory='', conditions=[], sensitiveSpecies = []):
+    def __init__(self, speciesList=None, reactionList=None, canteraFile='', outputDirectory='', conditions=None, sensitiveSpecies = None):
         """
         `speciesList`: list of RMG species objects
         `reactionList`: list of RMG reaction objects
@@ -181,8 +181,8 @@ class Cantera:
         self.reactionMap = {}
         self.model = ct.Solution(canteraFile) if canteraFile else None
         self.outputDirectory = outputDirectory if outputDirectory else os.getcwd()
-        self.conditions = conditions
-        self.sensitiveSpecies = sensitiveSpecies
+        self.conditions = conditions if conditions else []
+        self.sensitiveSpecies = sensitiveSpecies if sensitiveSpecies else []
 
         # Make output directory if it does not yet exist:
         if not os.path.exists(self.outputDirectory):

--- a/rmgpy/tools/observablesRegression.py
+++ b/rmgpy/tools/observablesRegression.py
@@ -64,13 +64,13 @@ class ObservablesTestCase:
 
 
     """
-    def __init__(self, title='', oldDir='', newDir='', observables = {}, exptData = [], ck2cti=True):
+    def __init__(self, title='', oldDir='', newDir='', observables = None, exptData = None, ck2cti=True):
         self.title=title
         self.newDir=newDir
         self.oldDir=oldDir
         self.conditions=None
-        self.exptData=exptData
-        self.observables=observables
+        self.exptData=exptData if exptData else []
+        self.observables=observables if observables else {}
 
         # Detect if the transport file exists
         oldTransportPath = None

--- a/rmgpy/tools/plot.py
+++ b/rmgpy/tools/plot.py
@@ -289,11 +289,11 @@ class SimulationPlot(GenericPlot):
     This should be formulated as 
     {'desired_name_for_species': 'corresponding_chemkin_name_of_species'}
     """
-    def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel='', csvFile='', numSpecies=None, species={}):
+    def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel='', csvFile='', numSpecies=None, species=None):
         GenericPlot.__init__(self, xVar=xVar, yVar=yVar, title=title, xlabel=xlabel, ylabel=ylabel)
         self.csvFile = csvFile
         self.numSpecies = numSpecies
-        self.species = species
+        self.species = species if species else {}
         
     def load(self):
         if self.xVar == None and self.yVar == None:
@@ -361,11 +361,11 @@ class ReactionSensitivityPlot(GenericPlot):
     barplot() will instead plot a horizontal bar plot of the sensitivities at a given
     time step.  If time step is not given, the end step will automatically be chosen
     """
-    def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel='', csvFile='', numReactions=None, reactions={}):
+    def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel='', csvFile='', numReactions=None, reactions=None):
         GenericPlot.__init__(self, xVar=xVar, yVar=yVar, title=title, xlabel=xlabel, ylabel=ylabel)
         self.csvFile = csvFile
         self.numReactions = numReactions
-        self.reactions = reactions
+        self.reactions = reactions if reactions else {}
         
     def load(self):
         if self.xVar == None and self.yVar == None:
@@ -434,11 +434,11 @@ class ThermoSensitivityPlot(GenericPlot):
     barplot() will instead plot a horizontal bar plot of the sensitivities at a given
     time step.  If time step is not given, the end step will automatically be chosen
     """
-    def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel='', csvFile='', numSpecies=None, species={}):
+    def __init__(self, xVar=None, yVar=None, title='', xlabel='', ylabel='', csvFile='', numSpecies=None, species=None):
         GenericPlot.__init__(self, xVar=xVar, yVar=yVar, title=title, xlabel=xlabel, ylabel=ylabel)
         self.csvFile = csvFile
         self.numSpecies = numSpecies
-        self.species = species
+        self.species = species if species else {}
     
     def load(self):
         if self.xVar == None and self.yVar == None:


### PR DESCRIPTION
Fixes https://github.com/ReactionMechanismGenerator/RMG-Py/issues/640

Initializing a class or using a mutable default object in a function leads to problems when recreating a new instance of that class.  This is one of the Python gotchas discussed here: https://pythonconquerstheuniverse.wordpress.com/2012/02/15/mutable-default-arguments/:

“Expressions in default arguments are calculated when the function is defined, not when it’s called.”

I did a regex search for functions and classes initialized with [] or {} default values and fixed their behavior.