### PR TITLE
Fix parallel generation of reactions

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1298,8 +1298,7 @@ class KineticsFamily(Database):
         `reactants`, which should be either single :class:`Molecule` objects
         or lists of same. Does not estimate the kinetics of these reactions
         at this time. Returns a list of :class:`TemplateReaction` objects
-        using :class:`Species` objects for both reactants and products
-        (but does not generate resonance isomers of these Species.)
+        using :class:`Molecule` objects for both reactants and products
         The reactions are constructed such that the forward direction is
         consistent with the template of this reaction family.
         """

--- a/rmgpy/reduction/reduction.py
+++ b/rmgpy/reduction/reduction.py
@@ -36,7 +36,7 @@ import re
 
 #local imports
 from rmgpy.chemkin import getSpeciesIdentifier
-from rmgpy.scoop_framework.util import broadcast, get, WorkerWrapper, map_
+from rmgpy.scoop_framework.util import broadcast, get, map_
 from rmgpy.scoop_framework.util import logger as logging
 from rmgpy.rmg.main import RMG
 
@@ -185,7 +185,7 @@ def findImportantReactions(rmg, tolerance):
         N = len(chunk)
         partial_results = list(
             map_(
-                WorkerWrapper(assessReaction), chunk, [rmg.reactionSystems] * N, [tolerance] * N, [simdata] * N
+                assessReaction, chunk, [rmg.reactionSystems] * N, [tolerance] * N, [simdata] * N
                 )
             )
         boolean_array.extend(partial_results)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1563,7 +1563,7 @@ class CoreEdgeReactionModel:
                 self.networkList.append(network)
 
         # Add the path reaction to that network
-        network.addPathReaction(newReaction, newSpecies)
+        network.addPathReaction(newReaction)
         
         # Return the network that the reaction was added to
         return network

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -54,7 +54,7 @@ from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 
 from rmgpy.kinetics import KineticsData
 import rmgpy.data.rmg
-from .react import react
+from .react import reactAll
 
 from pdep import PDepReaction, PDepNetwork
 # generateThermoDataFromQM under the Species class imports the qm package
@@ -768,19 +768,7 @@ class CoreEdgeReactionModel:
         else:
             # We are reacting the edge
 
-            # Select reactive species that can undergo unimolecular reactions:
-            spcTuples = [(self.core.species[i].copy(deep=True),)
-             for i in xrange(numOldCoreSpecies) if (unimolecularReact[i] and self.core.species[i].reactive)]
-
-            for i in xrange(numOldCoreSpecies):
-                for j in xrange(i, numOldCoreSpecies):
-                    # Find reactions involving the species that are bimolecular
-                    # This includes a species reacting with itself (if its own concentration is high enough)
-                    if bimolecularReact[i,j]:
-                        if self.core.species[i].reactive and self.core.species[j].reactive:
-                            spcTuples.append((self.core.species[i].copy(deep=True), self.core.species[j].copy(deep=True)))
-
-            rxns = list(react(*spcTuples))
+            rxns = reactAll(self.core.species, numOldCoreSpecies, unimolecularReact, bimolecularReact)
             spcs = [self.retrieveNewSpecies(rxn) for rxn in rxns]
             
             for rxn, spc in zip(rxns, spcs):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -730,7 +730,14 @@ class CoreEdgeReactionModel:
 
                 pdepNetwork, newSpecies = newObject
                 newReactions.extend(pdepNetwork.exploreIsomer(newSpecies))
-                newReactions = [self.inflate(rxn) for rxn in newReactions]
+
+                for rxn in newReactions:
+                    rxn = self.inflate(rxn)
+                    try:
+                        rxn.reverse = self.inflate(rxn.reverse)
+                    except AttributeError, e:
+                        pass
+                    
                 self.processNewReactions(newReactions, newSpecies, pdepNetwork)
 
             else:
@@ -751,7 +758,13 @@ class CoreEdgeReactionModel:
                         products = products.species
                         if len(products) == 1 and products[0] == species:
                             newReactions = network.exploreIsomer(species)
-                            newReactions = [self.inflate(rxn) for rxn in newReactions]
+                            for rxn in newReactions:
+                                rxn = self.inflate(rxn)
+                                try:
+                                    rxn.reverse = self.inflate(rxn.reverse)
+                                except AttributeError, e:
+                                    pass
+
                             self.processNewReactions(newReactions, species, network)
                             network.updateConfigurations(self)
                             index = 0
@@ -772,7 +785,11 @@ class CoreEdgeReactionModel:
             spcs = [self.retrieveNewSpecies(rxn) for rxn in rxns]
             
             for rxn, spc in zip(rxns, spcs):
-                rxn = self.inflate(rxn)    
+                rxn = self.inflate(rxn) 
+                try:
+                    rxn.reverse = self.inflate(rxn.reverse)
+                except AttributeError, e:
+                    pass
                 self.processNewReactions([rxn], spc)
 
         ################################################################
@@ -1767,11 +1784,6 @@ class CoreEdgeReactionModel:
         """
         reactants, products, pairs = [], [], []
 
-        for reactant, product in rxn.pairs:
-            reactant = self.getSpecies(reactant)
-            product = self.getSpecies(product)
-            pairs.append((reactant, product))
-
         for reactant in rxn.reactants:
             reactant = self.getSpecies(reactant)  
             reactants.append(reactant)
@@ -1780,9 +1792,14 @@ class CoreEdgeReactionModel:
             product = self.getSpecies(product)
             products.append(product)
 
-        rxn.pairs = pairs
-        rxn.products = products
+        for reactant, product in rxn.pairs:
+            reactant = self.getSpecies(reactant)
+            product = self.getSpecies(product)
+            pairs.append((reactant, product))
+
         rxn.reactants = reactants  
+        rxn.products = products
+        rxn.pairs = pairs
 
         return rxn
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -932,7 +932,7 @@ class CoreEdgeReactionModel:
                 # because of the way partial networks are explored
                 # Since PDepReactions are created as irreversible, not doing so
                 # would cause you to miss the reverse reactions!
-                net = self.addReactionToUnimolecularNetworks(rxn, newSpecies=newSpecies, network=pdepNetwork)
+                self.addReactionToUnimolecularNetworks(rxn, newSpecies=newSpecies, network=pdepNetwork)
                 if isinstance(rxn, LibraryReaction):
                     # If reaction came from a reaction library, omit it from the core and edge so that it does 
                     # not get double-counted with the pdep network
@@ -1549,7 +1549,7 @@ class CoreEdgeReactionModel:
                 except KeyError:
                     pass
             else:
-                return None
+                return
 
             # If no suitable network exists, create a new one
             if network is None:
@@ -1564,9 +1564,6 @@ class CoreEdgeReactionModel:
 
         # Add the path reaction to that network
         network.addPathReaction(newReaction)
-        
-        # Return the network that the reaction was added to
-        return network
 
     def updateUnimolecularReactionNetworks(self, database):
         """

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -35,7 +35,7 @@ from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase, database
 from rmgpy.rmg.main import RMG
 from rmgpy.reaction import Reaction
-
+from rmgpy.rmg.react import react
 from rmgpy.rmg.model import *
 
 ###################################################
@@ -151,8 +151,9 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
 
         spcA = Species().fromSMILES('[OH]')
         spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+        spcTuples = [(spcA, spc) for spc in spcs]
 
-        rxns = list(react(spcA, spcs))
+        rxns = list(react(*spcTuples))
 
         cerm = CoreEdgeReactionModel()
 
@@ -181,8 +182,9 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         """
         spcA = Species().fromSMILES('[OH]')
         spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+        spcTuples = [(spcA, spc) for spc in spcs]
 
-        rxns = list(react(spcA, spcs))
+        rxns = list(react(*spcTuples))
 
         cerm = CoreEdgeReactionModel()
 

--- a/rmgpy/rmg/parreactTest.py
+++ b/rmgpy/rmg/parreactTest.py
@@ -63,8 +63,9 @@ def generate():
     load()
     spcA = Species().fromSMILES('[OH]')
     spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+    spcTuples = [(spcA, spc) for spc in spcs]
 
-    reactionList = list(react(spcA, spcs))
+    reactionList = list(react(*spcTuples))
 
     if not reactionList: return False
 

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -298,7 +298,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         
         return newReactions
 
-    def addPathReaction(self, newReaction, newSpecies):
+    def addPathReaction(self, newReaction):
         """
         Add a path reaction to the network. If the path reaction already exists,
         no action is taken.

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -294,7 +294,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         # Don't find reactions involving the new species as bimolecular
         # reactants or products with other core species (e.g. A + B <---> products)
 
-        newReactions = react(isomer)
+        newReactions = react((isomer,))
         
         return newReactions
 

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -59,6 +59,7 @@ def react(*spcTuples):
     combos = []
 
     for t in spcTuples:
+        t = tuple([spc.copy(deep=True) for spc in t])
         if len(t) == 1:#unimolecular reaction
             spc, = t
             mols = [(mol, spc.index) for mol in spc.molecule]
@@ -89,7 +90,7 @@ def reactMolecules(moleculeTuples):
     families = getDB('kinetics').families
     
     molecules, reactantIndices = zip(*moleculeTuples)
-    
+
     reactionList = []
     for _, family in families.iteritems():
         rxns = family.generateReactions(molecules)
@@ -143,7 +144,7 @@ def reactAll(coreSpcList, numOldCoreSpecies, unimolecularReact, bimolecularReact
     """
 
     # Select reactive species that can undergo unimolecular reactions:
-    spcTuples = [(coreSpcList[i].copy(deep=True),)
+    spcTuples = [(coreSpcList[i],)
      for i in xrange(numOldCoreSpecies) if (unimolecularReact[i] and coreSpcList[i].reactive)]
 
     for i in xrange(numOldCoreSpecies):
@@ -152,7 +153,7 @@ def reactAll(coreSpcList, numOldCoreSpecies, unimolecularReact, bimolecularReact
             # This includes a species reacting with itself (if its own concentration is high enough)
             if bimolecularReact[i,j]:
                 if coreSpcList[i].reactive and coreSpcList[j].reactive:
-                    spcTuples.append((coreSpcList[i].copy(deep=True), coreSpcList[j].copy(deep=True)))
+                    spcTuples.append((coreSpcList[i], coreSpcList[j]))
 
     rxns = list(react(*spcTuples))
     return rxns

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -99,12 +99,11 @@ def reactMolecules(moleculeTuples):
     for reactant in molecules:
         reactant.clearLabeledAtoms()
 
-    for rxn in reactionList:
-        deflate(rxn, molecules, reactantIndices)
+    deflate(reactionList, molecules, reactantIndices)
 
     return reactionList
 
-def deflate(rxn, reactants, reactantIndices):
+def deflate(rxns, molecules, reactantIndices):
     """
     Creates a dictionary with Molecule objects as keys and newly 
     creatd Species objects as values.
@@ -114,9 +113,9 @@ def deflate(rxn, reactants, reactantIndices):
     core species.
 
     The Species object, stored as a value of the newly created dictionary,
-    is retrieved by using a Molecule object from the reactants array 
+    is retrieved by using a Molecule object from the molecules array 
     as a dictionary key. The elements in this array correspond to the 
-    Molecule objects that were used as reactants to generate reactions.
+    Molecule objects that were used as molecules to generate reactions.
 
     The Species object is replaced by the core species index in the newly
     created dictionary.
@@ -127,16 +126,19 @@ def deflate(rxn, reactants, reactantIndices):
     """    
 
     molDict = {}
-    for mol in itertools.chain(rxn.reactants, rxn.products):
-        molDict[mol] = Species(molecule=[mol])
 
     for i, coreIndex in enumerate(reactantIndices):
         if coreIndex != -1:
-            molDict[reactants[i]] = coreIndex 
+            molDict[molecules[i]] = coreIndex 
 
-    rxn.reactants = [molDict[mol] for mol in rxn.reactants]
-    rxn.products = [molDict[mol] for mol in rxn.products]
-    rxn.pairs = [(molDict[reactant],molDict[product]) for reactant, product in rxn.pairs]
+    for rxn in rxns:
+        for mol in itertools.chain(rxn.reactants, rxn.products):
+            if not mol in molDict:
+                molDict[mol] = Species(molecule=[mol])
+
+        rxn.reactants = [molDict[mol] for mol in rxn.reactants]
+        rxn.products = [molDict[mol] for mol in rxn.products]
+        rxn.pairs = [(molDict[reactant],molDict[product]) for reactant, product in rxn.pairs]
 
 def reactAll(coreSpcList, numOldCoreSpecies, unimolecularReact, bimolecularReact):
     """

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -136,3 +136,23 @@ def deflate(rxn, reactants, reactantIndices):
     rxn.reactants = [molDict[mol] for mol in rxn.reactants]
     rxn.products = [molDict[mol] for mol in rxn.products]
     rxn.pairs = [(molDict[reactant],molDict[product]) for reactant, product in rxn.pairs]
+
+def reactAll(coreSpcList, numOldCoreSpecies, unimolecularReact, bimolecularReact):
+    """
+    Reacts the core species list via uni- and bimolecular reactions.
+    """
+
+    # Select reactive species that can undergo unimolecular reactions:
+    spcTuples = [(coreSpcList[i].copy(deep=True),)
+     for i in xrange(numOldCoreSpecies) if (unimolecularReact[i] and coreSpcList[i].reactive)]
+
+    for i in xrange(numOldCoreSpecies):
+        for j in xrange(i, numOldCoreSpecies):
+            # Find reactions involving the species that are bimolecular
+            # This includes a species reacting with itself (if its own concentration is high enough)
+            if bimolecularReact[i,j]:
+                if coreSpcList[i].reactive and coreSpcList[j].reactive:
+                    spcTuples.append((coreSpcList[i].copy(deep=True), coreSpcList[j].copy(deep=True)))
+
+    rxns = list(react(*spcTuples))
+    return rxns

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -36,7 +36,7 @@ import itertools
 
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.data.rmg import getDB
-from rmgpy.scoop_framework.util import map_, WorkerWrapper
+from rmgpy.scoop_framework.util import map_
 from rmgpy.species import Species
         
 def react(spcA, speciesList=None):
@@ -80,7 +80,7 @@ def react(spcA, speciesList=None):
         combos = list(itertools.product(molsA, molsB))
 
     results = map_(
-                WorkerWrapper(reactMolecules),
+                reactMolecules,
                 combos
             )
 

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -107,7 +107,7 @@ class TestReact(unittest.TestCase):
         rxn = Reaction(reactants=[molA, molB], products=[molC],
         pairs=[(molA, molC), (molB, molC)])
 
-        deflate(rxn, reactants, reactantIndices)
+        deflate([rxn], reactants, reactantIndices)
 
         for spc, t in zip(rxn.reactants, [int, int]):
             self.assertTrue(isinstance(spc, t))
@@ -121,7 +121,7 @@ class TestReact(unittest.TestCase):
         rxn = Reaction(reactants=[molA, molB], products=[molC],
                 pairs=[(molA, molC), (molB, molC)])
 
-        deflate(rxn, reactants, reactantIndices)
+        deflate([rxn], reactants, reactantIndices)
 
         for spc, t in zip(rxn.reactants, [Species, int]):
             self.assertTrue(isinstance(spc, t))

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -84,8 +84,9 @@ class TestReact(unittest.TestCase):
         """
         spcA = Species().fromSMILES('[OH]')
         spcs = [Species().fromSMILES('CC'), Species().fromSMILES('[CH3]')]
+        spcTuples = [(spcA, spc) for spc in spcs]
 
-        reactionList = list(react(spcA, spcs))
+        reactionList = list(react(*spcTuples))
         self.assertIsNotNone(reactionList)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
 
@@ -141,7 +142,9 @@ class TestReact(unittest.TestCase):
         spcs = [Species(index=indices['CC']).fromSMILES('CC'),
                 Species(index=indices['[CH3]']).fromSMILES('[CH3]')]
 
-        reactionList = list(react(spcA, spcs))
+        spcTuples = [(spcA, spc) for spc in spcs]
+
+        reactionList = list(react(*spcTuples))
         self.assertIsNotNone(reactionList)
         self.assertEquals(len(reactionList), 3)
         for rxn in reactionList:

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -169,6 +169,47 @@ class TestReact(unittest.TestCase):
         self.assertIsNotNone(rxns)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in rxns]))
 
+    def testDeflateReaction(self):
+        """
+        Test if the deflateReaction function works.
+        """
+
+        molA = Molecule().fromSMILES('[OH]')
+        molB = Molecule().fromSMILES('CC')
+        molC = Molecule().fromSMILES('[CH3]')
+
+        reactants = [molA, molB]
+
+        # both reactants were already part of the core:
+        reactantIndices = [1, 2]
+        molDict = {molA: 1, molB: 2}
+
+        rxn = Reaction(reactants=[molA, molB], products=[molC],
+        pairs=[(molA, molC), (molB, molC)])
+
+        deflateReaction(rxn, molDict)
+
+        for spc, t in zip(rxn.reactants, [int, int]):
+            self.assertTrue(isinstance(spc, t))
+        self.assertEquals(rxn.reactants, reactantIndices)
+        for spc in rxn.products:
+            self.assertTrue(isinstance(spc, Species))
+
+        # one of the reactants was not yet part of the core:
+        reactantIndices = [-1, 2]
+        molDict = {molA: Species(molecule=[molA]), molB: 2}
+
+        rxn = Reaction(reactants=[molA, molB], products=[molC],
+                pairs=[(molA, molC), (molB, molC)])
+
+        deflateReaction(rxn, molDict)
+
+        for spc, t in zip(rxn.reactants, [Species, int]):
+            self.assertTrue(isinstance(spc, t))
+        for spc in rxn.products:
+            self.assertTrue(isinstance(spc, Species))
+
+
     def tearDown(self):
         """
         Reset the loaded database

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -30,6 +30,7 @@
 
 import os
 import unittest 
+import numpy as np
 
 from rmgpy import settings
 from rmgpy.data.kinetics import TemplateReaction
@@ -151,6 +152,22 @@ class TestReact(unittest.TestCase):
             for i, reactant in enumerate(rxn.reactants):
                 rxn.reactants[i] = Molecule().fromSMILES(indices[reactant])
             self.assertTrue(rxn.isBalanced())
+
+    def testReactAll(self):
+        """
+        Test that the reactAll function works.
+        """
+
+        spcs = [
+                Species().fromSMILES('CC'),
+                Species().fromSMILES('[CH3]'),
+                Species().fromSMILES('[OH]')
+                ]
+
+        N = len(spcs)
+        rxns = reactAll(spcs, N, np.ones(N), np.ones([N,N]))
+        self.assertIsNotNone(rxns)
+        self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in rxns]))
 
     def tearDown(self):
         """

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -48,7 +48,7 @@ class TestRMGWorkFlow(unittest.TestCase):
         spc = Species().fromSMILES("O=C[C]=C")
         spc.generateResonanceIsomers()
         newReactions = []		
-        newReactions.extend(react(spc))
+        newReactions.extend(react((spc,)))
 
         # process newly generated reactions to make sure no duplicated reactions
         self.rmg.reactionModel.processNewReactions(newReactions, spc, None)
@@ -66,7 +66,7 @@ class TestRMGWorkFlow(unittest.TestCase):
 
         # react again
         newReactions_reverse = []
-        newReactions_reverse.extend(react(spc))
+        newReactions_reverse.extend(react((spc,)))
 
         # process newly generated reactions again to make sure no duplicated reactions
         self.rmg_dummy.reactionModel.processNewReactions(newReactions_reverse, spc, None)

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -34,6 +34,13 @@ class TestRMGWorkFlow(unittest.TestCase):
         self.rmg.database.loadKinetics(os.path.join(path, 'kinetics'), \
                                        kineticsFamilies=['R_Addition_MultipleBond'],reactionLibraries=[])
 
+    def tearDown(self):
+        """
+        Reset the loaded database
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+        
     @work_in_progress
     def testDeterministicReactionTemplateMatching(self):
         """

--- a/rmgpy/scoop_framework/util.py
+++ b/rmgpy/scoop_framework/util.py
@@ -151,4 +151,4 @@ def get(key):
         logging.debug('SCOOP not loaded. Not retrieving the shared object with key {}'.format(key))
 
 def map_(*args, **kwargs):
-    return map(*args, **kwargs)
+    return map(WorkerWrapper(args[0]), *args[1:], **kwargs)

--- a/rmgpy/util.py
+++ b/rmgpy/util.py
@@ -29,6 +29,9 @@
 
 import os.path
 import shutil
+from functools import wraps
+import time
+import logging
 
 
 class Subject(object):
@@ -115,3 +118,13 @@ def makeOutputSubdirectory(outputDirectory, folder):
         # The directory already exists, so delete it (and all its content!)
         shutil.rmtree(dir)
     os.mkdir(dir)
+
+def timefn(fn):
+    @wraps(fn)
+    def measure_time(*args, **kwargs):
+        t1 = time.time()
+        result = fn(*args, **kwargs)
+        t2 = time.time()
+        logging.info ("@timefn: {} took {:.2f} seconds".format(fn.func_name, t2 - t1))
+        return result
+    return measure_time


### PR DESCRIPTION
Before the reaction filtering modifications, the `enlarge` method would react one new core species against N existing species. After that change, the `enlarge` method would react all N core species against all N species, but filter out those combinations that would lead to negligible reactions.

The original design of the parallel generation of reactions would be used in the new O(N²) design of `enlarge`, resulting in zero speedup.

This PR fixes that by modifying the parallel design to the new structure of `enlarge`. A new function `rmgpy.rmg.react.reactAll` encapsulates the reaction generation.

A critical section in CERM.enlarge is shown here:
```python
rxns = reactAll(self.core.species, numOldCoreSpecies, unimolecularReact, bimolecularReact)
spcs = [self.retrieveNewSpecies(rxn) for rxn in rxns]
            
for rxn, spc in zip(rxns, spcs):
     rxn = self.inflate(rxn)    
     self.processNewReactions([rxn], spc)
```
`CERM.processNewReactions` requires passing the Species `spc` that was used to originally generate the reactions. In the parallel design the reference to that species is lost due to de/serialization to/from workers. Hence we need to find it back somehow and this is done in `CERM.retrieveNewSpecies`. The method searches for any reactant/product of the given reaction that is an integer instead of a Molecule object. An integer is an indication that the species was already part of the core, and hence refers to the original Species object.
