### PR TITLE
Deprecate $CONDA_ENV_PATH in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 install:
   - conda env create 
   - source activate rmg_env
-  - yes 'Yes' | $CONDA_ENV_PATH/bin/mopac $MOPACKEY > /dev/null
+  - yes 'Yes' | $HOME/miniconda/envs/rmg_env/bin/mopac $MOPACKEY > /dev/null
   - make
 
 script: 


### PR DESCRIPTION
`$CONDA_ENV_PATH` variable is now deprecated as discussed in https://github.com/ReactionMechanismGenerator/RMG-Py/pull/689

Use a different variable now so that our travis builds don't break anymore.