### PR TITLE
replace rxn.family by rxn.getSource() call in checkModels script

### DIFF
--- a/scripts/checkModels.py
+++ b/scripts/checkModels.py
@@ -260,7 +260,7 @@ def printThermo(spec):
     ))
 
 def printReaction(rxn):
-    logger.error('rxn: {}\t\tfamily: {}'.format(rxn, rxn.family))
+    logger.error('rxn: {}\t\torigin: {}'.format(rxn, rxn.getSource()))
 
 def printReactionComments(rxn):
     logger.error('kinetics: {}'.format(rxn.kinetics.comment))


### PR DESCRIPTION
This PR avoids AttributeError exceptions in the `scripts/checkModel.py` where rxn.family is fetched for PDepReaction instances.

