### PR TITLE
Write reduced model during optimization

### DIFF
--- a/examples/reduction/minimal/chemkin/chem_annotated.inp
+++ b/examples/reduction/minimal/chemkin/chem_annotated.inp
@@ -1,0 +1,372 @@
+ELEMENTS H C O N Ne Ar He Si S Cl END
+
+SPECIES
+    Ar                  ! Ar
+    He                  ! He
+    Ne                  ! Ne
+    N2                  ! N2
+    ethane(1)           ! ethane(1)
+    CH3(2)              ! [CH3](2)
+    C2H5(3)             ! C[CH2](3)
+    H(4)                ! [H](4)
+    C(6)                ! C(6)
+    C2H4(8)             ! C=C(8)
+    H2(12)              ! [H][H](12)
+    C2H3(13)            ! [CH]=C(13)
+    C3H7(14)            ! [CH2]CC(14)
+    C#C(25)             ! C#C(25)
+    C4H7(28)            ! [CH2]CC=C(28)
+    C4H6(30)            ! C=CC=C(30)
+    C3H5(32)            ! [CH]=CC(32)
+    C4H7(38)            ! [CH2]C1CC1(38)
+    C4H7(42)            ! C=C[CH]C(42)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+Ar                      Ar1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 4.37967000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 4.37967000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+He                      He1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 9.28724000E-01 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 9.28724000E-01                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne1                 G200.000   6000.000  1000.00       1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+N2                      N 2                 G200.000   6000.000  1000.00       1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R)
+ethane(1)               C 2  H 6            G100.000   5000.000  954.53        1
+ 4.58997390E+00 1.41505285E-02-4.75947845E-06 8.60260221E-10-6.21688243E-14    2
+-1.27218243E+04-3.61819191E+00 3.78029291E+00-3.24211430E-03 5.52361704E-05    3
+-6.38555558E-08 2.28625654E-11-1.16203391E+04 5.21048530E+00                   4
+
+! Thermo library: primaryThermoLibrary + radical(CH3)
+CH3(2)                  C 1  H 3            G100.000   5000.000  1337.63       1
+ 3.54146159E+00 4.76786209E-03-1.82148094E-06 3.28875850E-10-2.22545011E-14    2
+ 1.62239559E+04 1.66032608E+00 3.91546733E+00 1.84154615E-03 3.48740903E-06    3
+-3.32746709E-09 8.49953855E-13 1.62856394E+04 3.51742525E-01                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + group(Cs-CsHHH) + gauche(Cs(CsRRR)) + other(R) + radical(CCJ)
+C2H5(3)                 C 2  H 5            G100.000   5000.000  900.30        1
+ 5.15612067E+00 9.43138060E-03-1.81955154E-06 2.21217788E-10-1.43499804E-14    2
+ 1.20641180E+04-2.91049373E+00 3.82186929E+00-3.43402417E-03 5.09273273E-05    3
+-6.20234340E-08 2.37083980E-11 1.30660115E+04 7.61631583E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H(4)                    H 1                 G100.000   5000.000  4570.96       1
+ 2.49829732E+00 1.45963990E-06-4.69032548E-10 6.69551836E-14-3.58258629E-18    2
+ 2.54758061E+04-4.34136157E-01 2.50000000E+00 1.77470207E-12-2.27500193E-15    3
+ 9.48631670E-19-1.21629755E-22 2.54742178E+04-4.44972895E-01                   4
+
+! Thermo library: primaryThermoLibrary
+C(6)                    C 1  H 4            G100.000   5000.000  1084.12       1
+ 9.08278050E-01 1.14540655E-02-4.57172682E-06 8.29189010E-10-5.66312716E-14    2
+-9.71997984E+03 1.39930246E+01 4.20541310E+00-5.35554899E-03 2.51122436E-05    3
+-2.13761821E-08 5.97519843E-12-1.01619432E+04-9.21271573E-01                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R)
+C2H4(8)                 C 2  H 4            G100.000   5000.000  940.44        1
+ 5.20294372E+00 7.82451164E-03-2.12688492E-06 3.79702680E-10-2.94680849E-14    2
+ 3.93630185E+03-6.62382783E+00 3.97976020E+00-7.57579352E-03 5.52980432E-05    3
+-6.36231570E-08 2.31771655E-11 5.07746019E+03 4.04617155E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H2(12)                  H 2                 G100.000   5000.000  1959.07       1
+ 2.78817485E+00 5.87629226E-04 1.59015901E-07-5.52750034E-11 4.34319008E-15    2
+-5.96149590E+02 1.12679202E-01 3.43536403E+00 2.12711102E-04-2.78626742E-07    3
+ 3.40268499E-10-7.76035298E-14-1.03135984E+03-3.90841699E+00                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + radical(Cds_P)
+C2H3(13)                C 2  H 3            G100.000   5000.000  931.97        1
+ 5.44799578E+00 4.98350870E-03-1.08817688E-06 1.79829928E-10-1.45090109E-14    2
+ 3.38297623E+04-4.87825197E+00 3.90669557E+00-4.06228810E-03 3.86775481E-05    3
+-4.62970100E-08 1.72897519E-11 3.47971787E+04 6.09792480E+00                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + group(Cs-CsCsHH) + gauche(Cs(CsCsRR)) + other(R) + group
+! (Cs-CsHHH) + gauche(Cs(Cs(CsRR)RRR)) + other(R) + radical(RCCJ)
+C3H7(14)                C 3  H 7            G100.000   5000.000  995.41        1
+ 5.69430152E+00 1.96033543E-02-7.42050458E-06 1.35883147E-09-9.56216475E-14    2
+ 8.87585173E+03-4.32885235E+00 3.09191508E+00 1.32172227E-02 2.75848448E-05    3
+-3.90849999E-08 1.43313800E-11 1.02284117E+04 1.24057799E+01                   4
+
+! Thermo group additivity estimation: group(Ct-CtH) + other(R) + group(Ct-CtH) + other(R)
+C#C(25)                 C 2  H 2            G100.000   5000.000  888.64        1
+ 5.76207781E+00 2.37152998E-03-1.49548398E-07-2.19237341E-11 2.21848824E-15    2
+ 2.50944370E+04-9.82626759E+00 3.03573436E+00 7.71255481E-03 2.53429827E-06    3
+-1.08124066E-08 5.50714193E-12 2.58526449E+04 4.54465886E+00                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cs-CsHHH)
+! + gauche(Cs(CsRRR)) + other(R) + group(Cs-(Cds-Cds)CsHH) + gauche(Cs(CsRRR)) + other(R) + radical(RCCJ)
+C4H7(28)                C 4  H 7            G100.000   5000.000  1000.95       1
+ 7.59471914E+00 2.06425956E-02-7.89790375E-06 1.45966122E-09-1.03414888E-13    2
+ 2.08073397E+04-1.19155141E+01 2.68061422E+00 2.10825717E-02 2.02123278E-05    3
+-3.64243621E-08 1.41445056E-11 2.27528011E+04 1.66008558E+01                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-Cds
+! (Cds-Cds)H) + gauche(CsOsCdSs) + other(R) + group(Cds-Cds(Cds-Cds)H) + gauche(CsOsCdSs) + other(R)
+C4H6(30)                C 4  H 6            G100.000   5000.000  940.94        1
+ 1.10822419E+01 1.17737116E-02-3.11425072E-06 5.37771117E-10-4.10644270E-14    2
+ 8.42132232E+03-3.51690176E+01 2.68208510E+00 1.69318777E-02 3.73663437E-05    3
+-6.26500507E-08 2.59155776E-11 1.13546004E+04 1.20323036E+01                   4
+
+! Thermo group additivity estimation: group(Cds-CdsHH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cs-(Cds-
+! Cds)HHH) + gauche(Cs(RRRR)) + other(R) + radical(Cds_P)
+C3H5(32)                C 3  H 5            G100.000   5000.000  997.88        1
+ 5.66471792E+00 1.44325983E-02-5.46737286E-06 1.00157739E-09-7.04858445E-14    2
+ 2.93870825E+04-4.48516098E+00 3.23407992E+00 1.18208487E-02 1.70305145E-05    3
+-2.64365643E-08 9.91215619E-12 3.04873066E+04 1.03182841E+01                   4
+
+! Thermo group additivity estimation: group(Cs-CsHHH) + other(R) + group(Cs-CsCsHH) + other(R) + group(Cs-CsCsHH) + other(R) + group(Cs-CsCsCsH) +
+! other(R) + ring(Cyclopropane) + radical(Isobutyl)
+C4H7(38)                C 4  H 7            G100.000   5000.000  926.06        1
+ 1.02344188E+01 1.41135542E-02-2.99948260E-06 4.56675293E-10-3.49845534E-14    2
+ 2.27934407E+04-2.92336660E+01 3.04744056E+00 5.45478227E-03 7.53343014E-05    3
+-1.02231435E-07 4.01850124E-11 2.58269356E+04 1.40788412E+01                   4
+
+! Thermo group additivity estimation: group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cds-CdsCsH) + gauche(CsOsCdSs) + other(R) + group(Cs-(Cds-
+! Cds)HHH) + gauche(Cs(RRRR)) + other(R) + group(Cs-(Cds-Cds)HHH) + gauche(Cs(RRRR)) + other(R) + radical(Allyl_P)
+C4H7(42)                C 4  H 7            G100.000   5000.000  998.56        1
+ 7.82805776E+00 2.08400020E-02-7.96749567E-06 1.47336693E-09-1.04524685E-13    2
+ 1.26472202E+04-1.65754633E+01 2.64213152E+00 2.15954070E-02 2.09683526E-05    3
+-3.79209643E-08 1.47844796E-11 1.46809432E+04 1.34335096E+01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #1
+! Template reaction: R_Recombination
+! Exact match found for rate rule (C_methyl;C_methyl)
+CH3(2)+CH3(2)=ethane(1)                             8.260e+17 -1.400    1.000    
+
+! Reaction index: Chemkin #2; RMG #4
+! Template reaction: H_Abstraction
+! Estimated using template (C/H3/Cs;C_methyl) for rate rule (C/H3/Cs\H3;C_methyl)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+CH3(2)=C2H5(3)+C(6)                       4.488e-05 4.990     8.000    
+
+! Reaction index: Chemkin #3; RMG #2
+! Template reaction: R_Recombination
+! Exact match found for rate rule (C_rad/H2/Cs;H_rad)
+C2H5(3)+H(4)=ethane(1)                              1.000e+14 0.000     0.000    
+
+! Reaction index: Chemkin #4; RMG #13
+! Template reaction: R_Recombination
+! Exact match found for rate rule (C_methyl;H_rad)
+CH3(2)+H(4)=C(6)                                    1.930e+14 0.000     0.270    
+
+! Reaction index: Chemkin #5; RMG #6
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Cds-HH_Cds-HH;HJ)
+! Multiplied by reaction path degeneracy 2
+C2H4(8)+H(4)=C2H5(3)                                4.620e+08 1.640     1.010    
+
+! Reaction index: Chemkin #6; RMG #8
+! Template reaction: Disproportionation
+! Exact match found for rate rule (C_methyl;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+CH3(2)+C2H5(3)=C2H4(8)+C(6)                         6.570e+14 -0.680    0.000    
+
+! Reaction index: Chemkin #7; RMG #11
+! Template reaction: Disproportionation
+! Exact match found for rate rule (C_rad/H2/Cs;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+C2H5(3)+C2H5(3)=ethane(1)+C2H4(8)                   6.900e+13 -0.350    0.000    
+
+! Reaction index: Chemkin #8; RMG #15
+! Template reaction: H_Abstraction
+! Estimated using template (C/H3/Cs;H_rad) for rate rule (C/H3/Cs\H3;H_rad)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+H(4)=H2(12)+C2H5(3)                       6.180e+03 3.240     7.100    
+
+! Reaction index: Chemkin #9; RMG #17
+! Template reaction: Disproportionation
+! Exact match found for rate rule (H_rad;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 6
+C2H5(3)+H(4)=C2H4(8)+H2(12)                         2.166e+13 0.000     0.000    
+
+! Reaction index: Chemkin #10; RMG #18
+! Template reaction: H_Abstraction
+! Exact match found for rate rule (C_methane;H_rad)
+! Multiplied by reaction path degeneracy 4
+H(4)+C(6)=H2(12)+CH3(2)                             8.760e-01 4.340     8.200    
+
+! Reaction index: Chemkin #11; RMG #19
+! Template reaction: R_Recombination
+! Exact match found for rate rule (H_rad;H_rad)
+H(4)+H(4)=H2(12)                                    1.090e+11 0.000     1.500    
+
+! Reaction index: Chemkin #12; RMG #23
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Cds-HH_Cds-HH;CsJ-HHH)
+! Multiplied by reaction path degeneracy 2
+C2H4(8)+CH3(2)=C3H7(14)                             4.180e+04 2.410     5.630    
+
+! Reaction index: Chemkin #13; RMG #20
+! Template reaction: R_Recombination
+! Exact match found for rate rule (Cd_pri_rad;H_rad)
+C2H3(13)+H(4)=C2H4(8)                               1.210e+14 0.000     0.000    
+
+! Reaction index: Chemkin #14; RMG #24
+! Template reaction: H_Abstraction
+! Estimated using template (C_methane;Cd_pri_rad) for rate rule (C_methane;Cd_Cd\H2_pri_rad)
+! Multiplied by reaction path degeneracy 4
+C2H3(13)+C(6)=C2H4(8)+CH3(2)                        2.236e-02 4.340     5.700    
+
+! Reaction index: Chemkin #15; RMG #27
+! Template reaction: H_Abstraction
+! Estimated using template (C/H3/Cs;Cd_Cd\H2_pri_rad) for rate rule (C/H3/Cs\H3;Cd_Cd\H2_pri_rad)
+! Multiplied by reaction path degeneracy 6
+ethane(1)+C2H3(13)=C2H4(8)+C2H5(3)                  1.080e-03 4.550     3.500    
+
+! Reaction index: Chemkin #16; RMG #28
+! Template reaction: H_Abstraction
+! Estimated using template (H2;Cd_pri_rad) for rate rule (H2;Cd_Cd\H2_pri_rad)
+! Multiplied by reaction path degeneracy 2
+H2(12)+C2H3(13)=C2H4(8)+H(4)                        9.460e+03 2.560     5.030    
+
+! Reaction index: Chemkin #17; RMG #29
+! Template reaction: Disproportionation
+! Exact match found for rate rule (Cd_pri_rad;Cmethyl_Csrad)
+! Multiplied by reaction path degeneracy 3
+C2H3(13)+C2H5(3)=C2H4(8)+C2H4(8)                    4.560e+14 -0.700    0.000    
+
+! Reaction index: Chemkin #18; RMG #59
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Ct-H_Ct-H;HJ)
+! Multiplied by reaction path degeneracy 2
+C#C(25)+H(4)=C2H3(13)                               1.030e+09 1.640     2.110    
+
+! Reaction index: Chemkin #19; RMG #61
+! Template reaction: Disproportionation
+! Estimated using template (C_methyl;CH_d_Rrad) for rate rule (C_methyl;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 2
+C2H3(13)+CH3(2)=C#C(25)+C(6)                        2.277e+06 1.870     -1.110   
+
+! Reaction index: Chemkin #20; RMG #65
+! Template reaction: Disproportionation
+! Estimated using template (Cs_rad;XH_d_Rrad) for rate rule (C_rad/H2/Cs;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 2
+C2H3(13)+C2H5(3)=ethane(1)+C#C(25)                  1.932e+06 1.870     -1.110   
+
+! Reaction index: Chemkin #21; RMG #68
+! Template reaction: Disproportionation
+! Estimated using template (H_rad;CH_d_Rrad) for rate rule (H_rad;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 4
+C2H3(13)+H(4)=H2(12)+C#C(25)                        1.358e+09 1.500     -0.890   
+
+! Reaction index: Chemkin #22; RMG #77
+! Template reaction: Disproportionation
+! Estimated using template (Y_rad;XH_Rrad) for rate rule (Cd_pri_rad;Cd_Cdrad)
+! Multiplied by reaction path degeneracy 2
+C2H3(13)+C2H3(13)=C2H4(8)+C#C(25)                   4.670e+09 0.969     -3.686   
+
+! Reaction index: Chemkin #23; RMG #71
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Cds-HH_Cds-HH;CdsJ-H)
+! Multiplied by reaction path degeneracy 2
+C2H4(8)+C2H3(13)=C4H7(28)                           2.860e+04 2.410     1.800    
+
+! Reaction index: Chemkin #24; RMG #97
+! Template reaction: Intra_R_Add_Exocyclic
+! Exact match found for rate rule (R4_S_D;doublebond_intra_2H_pri;radadd_intra_cs2H)
+C4H7(28)=C4H7(38)                                   3.840e+10 0.210     8.780    
+
+! Reaction index: Chemkin #25; RMG #82
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Ct-H_Ct-H;CsJ-HHH)
+! Multiplied by reaction path degeneracy 2
+C#C(25)+CH3(2)=C3H5(32)                             1.338e+05 2.410     6.770    
+
+! Reaction index: Chemkin #26; RMG #79
+! Template reaction: R_Recombination
+! Exact match found for rate rule (Cd_pri_rad;Cd_pri_rad)
+C2H3(13)+C2H3(13)=C4H6(30)                          7.230e+13 0.000     0.000    
+
+! Reaction index: Chemkin #27; RMG #98
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Cds-CdH_Cds-HH;HJ)
+! Multiplied by reaction path degeneracy 2
+C4H6(30)+H(4)=C4H7(28)                              3.240e+08 1.640     2.400    
+
+! Reaction index: Chemkin #28; RMG #111
+! Template reaction: Disproportionation
+! Estimated using template (C_methyl;Cpri_Rrad) for rate rule (C_methyl;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 2
+C4H7(28)+CH3(2)=C4H6(30)+C(6)                       2.300e+13 -0.320    0.000    
+
+! Reaction index: Chemkin #29; RMG #121
+! Template reaction: Disproportionation
+! Estimated using template (C_pri_rad;Cpri_Rrad) for rate rule (C_rad/H2/Cs;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 2
+C4H7(28)+C2H5(3)=ethane(1)+C4H6(30)                 2.009e+12 0.000     -0.043   
+
+! Reaction index: Chemkin #30; RMG #132
+! Template reaction: Disproportionation
+! Estimated using template (H_rad;Cpri_Rrad) for rate rule (H_rad;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 4
+C4H7(28)+H(4)=H2(12)+C4H6(30)                       7.240e+12 0.000     0.000    
+
+! Reaction index: Chemkin #31; RMG #163
+! Template reaction: Disproportionation
+! Estimated using template (Cd_pri_rad;Cpri_Rrad) for rate rule (Cd_pri_rad;C/H2/De_Csrad)
+! Multiplied by reaction path degeneracy 2
+C2H3(13)+C4H7(28)=C2H4(8)+C4H6(30)                  2.420e+12 0.000     0.000    
+
+! Reaction index: Chemkin #32; RMG #104
+! Template reaction: intra_H_migration
+! Exact match found for rate rule (R2H_S;C_rad_out_H/OneDe;Cs_H_out_2H)
+! Multiplied by reaction path degeneracy 3
+C4H7(42)=C4H7(28)                                   6.180e+09 1.220     47.800   
+
+! Reaction index: Chemkin #33; RMG #312
+! Template reaction: Disproportionation
+! Estimated using template (C_rad/H2/Cs;Cmethyl_Csrad) for rate rule (C_rad/H2/Cs;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 3
+C4H7(42)+C2H5(3)=ethane(1)+C4H6(30)                 6.900e+13 -0.350    0.000    
+
+! Reaction index: Chemkin #34; RMG #325
+! Template reaction: Disproportionation
+! Estimated using template (C_methyl;Cmethyl_Csrad) for rate rule (C_methyl;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 3
+C4H7(42)+CH3(2)=C4H6(30)+C(6)                       6.570e+14 -0.680    0.000    
+
+! Reaction index: Chemkin #35; RMG #326
+! Template reaction: R_Addition_MultipleBond
+! Exact match found for rate rule (Cds-HH_Cds-CdH;HJ)
+! Multiplied by reaction path degeneracy 2
+C4H6(30)+H(4)=C4H7(42)                              4.620e+08 1.640     -0.470   
+
+! Reaction index: Chemkin #36; RMG #330
+! Template reaction: Disproportionation
+! Estimated using template (Cd_pri_rad;Cmethyl_Csrad) for rate rule (Cd_pri_rad;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 3
+C2H3(13)+C4H7(42)=C2H4(8)+C4H6(30)                  4.560e+14 -0.700    0.000    
+
+! Reaction index: Chemkin #37; RMG #335
+! Template reaction: Disproportionation
+! Estimated using template (H_rad;Cmethyl_Csrad) for rate rule (H_rad;Cmethyl_Csrad/H/Cd)
+! Multiplied by reaction path degeneracy 6
+C4H7(42)+H(4)=H2(12)+C4H6(30)                       2.166e+13 0.000     0.000    
+
+END
+

--- a/rmgpy/reduction/optimization.py
+++ b/rmgpy/reduction/optimization.py
@@ -112,6 +112,10 @@ def bisect(low, high, error, targets, reactionModel, rmg, reactionSystemIndex, o
         if isInvalid(devs, error):
             high = midpoint
         else:
+            if len(newImportantReactions) == 0:
+                logging.error('Model reduction resulted in a model with 0 reactions.')
+                logging.error('Perhaps change reactor conditions to allow for more adequate reduction. Exiting...')
+                break
             low = midpoint
             importantReactions = newImportantReactions
             final_devs = devs

--- a/rmgpy/reduction/optimization.py
+++ b/rmgpy/reduction/optimization.py
@@ -31,6 +31,7 @@
 import numpy as np
 
 from reduction import reduceModel
+from output import writeModel
 from rmgpy.scoop_framework.util import logger as logging
 
 def optimize(target_label, reactionModel, rmg, reactionSystemIndex, error, orig_observable):
@@ -114,6 +115,7 @@ def bisect(low, high, error, targets, reactionModel, rmg, reactionSystemIndex, o
             low = midpoint
             importantReactions = newImportantReactions
             final_devs = devs
+            writeModel(rmg, chemkin_name='chem_reduced_{}.inp'.format(len(importantReactions)))
             
         if np.abs((midpoint - old_trial) / old_trial) < THRESHOLD:
             break


### PR DESCRIPTION
This PR adds a number of fixes:

- write the state of reduced model during the optimization. If the reduction does not converge, the intermediate states of the reduced model can be used instead.
- break if the reduced model reaches 0 zero reactions. It implies that the reduction could not be adequately carried out.
- add missing `chem_annotated.inp` in the reduction example folder.