### PR TITLE
Atomtypes

### DIFF
--- a/rmgpy/molecule/atomtype.pxd
+++ b/rmgpy/molecule/atomtype.pxd
@@ -39,6 +39,15 @@ cdef class AtomType:
     cdef public list incrementLonePair
     cdef public list decrementLonePair
 
+    cdef public list single
+    cdef public list allDouble
+    cdef public list rDouble
+    cdef public list oDouble
+    cdef public list sDouble
+    cdef public list triple
+    cdef public list benzene
+    cdef public list lonePairs
+
     cpdef bint isSpecificCaseOf(self, AtomType other)
 
     cpdef bint equivalent(self, AtomType other)

--- a/rmgpy/molecule/atomtype.pxd
+++ b/rmgpy/molecule/atomtype.pxd
@@ -54,4 +54,6 @@ cdef class AtomType:
 
     cpdef list getFeatures(self)
 
+cpdef list getFeatures(atom, dict bonds)
+
 cpdef AtomType getAtomType(atom, dict bonds)

--- a/rmgpy/molecule/atomtype.pxd
+++ b/rmgpy/molecule/atomtype.pxd
@@ -52,4 +52,6 @@ cdef class AtomType:
 
     cpdef bint equivalent(self, AtomType other)
 
+    cpdef list getFeatures(self)
+
 cpdef AtomType getAtomType(atom, dict bonds)

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -75,9 +75,21 @@ class AtomType:
     `decrementRadical`  ``list``            The atom type(s) that result when the number of radical electrons is decremented
     `incrementLonePair` ``list``            The atom type(s) that result when the number of lone electron pairs is incremented
     `decrementLonePair` ``list``            The atom type(s) that result when the number of lone electron pairs is decremented
+
+    The following features are what are required in a given atomtype. Any int in the list is acceptable.
+    An empty list is a wildcard
+    'single'            ''list''            The total number of single bonds on the atom
+    'allDouble'         ''list''            The total number of double bonds on the atom
+    'rDouble'           ''list''            The number of double bonds to any non-oxygen, nonsulfur
+    'oDouble'           ''list''            The number of double bonds to oxygen
+    'sDouble'           ''list''            The number of double bonds to sulfur
+    'triple'            ''list''            The total number of triple bonds on the atom
+    'benzene'           ''list''            The total number of benzene bonds on the atom
+    'lonePairs'         ''list''            The number of lone pairs on the atom
     =================== =================== ====================================
 
     """
+    
 
     def __init__(self, label='', generic=None, specific=None,
                  single=None,
@@ -99,15 +111,14 @@ class AtomType:
         self.decrementRadical = []
         self.incrementLonePair = []
         self.decrementLonePair = []
-        #Number of a bonds allowed in the atomtype, (empty list is a wildcard)
-        self.single = [] if single is None else single #total number of single bonds
-        self.allDouble = [] if allDouble is None else allDouble #total number of double bonds
-        self.rDouble = [] if rDouble is None else rDouble #double bonds to anything except an O or S
+        self.single = [] if single is None else single
+        self.allDouble = [] if allDouble is None else allDouble
+        self.rDouble = [] if rDouble is None else rDouble
         self.oDouble = [] if oDouble is None else oDouble
         self.sDouble = [] if sDouble is None else sDouble
-        self.triple = []  if triple is None else triple #total number of triple bonds
-        self.benzene = [] if benzene is None else benzene #total number of benzene bonds
-        self.lonePairs = [] if lonePairs is None else lonePairs #total number of lonePairs
+        self.triple = [] if triple is None else triple
+        self.benzene = [] if benzene is None else benzene
+        self.lonePairs = [] if lonePairs is None else lonePairs
 
     def __repr__(self):
         return '<AtomType "%s">' % self.label
@@ -187,6 +198,20 @@ class AtomType:
         atom type `atomType2` or ``False``  otherwise.
         """
         return self is other or self in other.specific
+    
+    def getFeatures(self):
+        """
+        Returns a list of the features that are checked to determine atomtype
+        """
+        features=[self.single,
+                  self.allDouble,
+                  self.rDouble,
+                  self.oDouble,
+                  self.sDouble,
+                  self.triple,
+                  self.benzene,
+                  self.lonePairs,]
+        return features
 
 ################################################################################
 
@@ -245,7 +270,7 @@ atomTypes['Cs'  ] = AtomType('Cs',   generic=['R','R!H','C','Val4'],  specific=[
 atomTypes['Cd'  ] = AtomType('Cd',   generic=['R','R!H','C','Val4'],  specific=[],
                              single=[], allDouble=[1], rDouble=[1], oDouble=[0], sDouble=[0], triple=[0], benzene=[0])
 atomTypes['Cdd' ] = AtomType('Cdd',  generic=['R','R!H','C','Val4'],  specific=[],
-                             single=[0], allDouble=[2], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+                             single=[0], allDouble=[2], rDouble=[0,1,2], oDouble=[0,1,2], sDouble=[0,1,2], triple=[0], benzene=[0])
 atomTypes['Ct'  ] = AtomType('Ct',   generic=['R','R!H','C','Val4'],  specific=[],
                              single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
 atomTypes['CO'  ] = AtomType('CO',   generic=['R','R!H','C','Val4'],  specific=[],
@@ -259,6 +284,7 @@ atomTypes['CS'  ] = AtomType('CS',   generic=['R','R!H','C','Val4'],  specific=[
 
 atomTypes['N'   ] = AtomType('N',    generic=['R','R!H','Val5'],      specific=['N1d','N3s','N3d','N3t','N3b','N5s','N5d','N5dd','N5t','N5b'],
                              single=[], allDouble=[], rDouble=[], oDouble=[], sDouble=[], triple=[], benzene=[])
+#Eg: [N-]=[N+]=N terminal nitrogen on azide (two lone pairs)
 atomTypes['N1d' ] = AtomType('N1d',  generic=['R','R!H','N','Val5'],  specific=[],
                              single=[0], allDouble=[1], rDouble=[1], oDouble=[], sDouble=[], triple=[0], benzene=[0], lonePairs=[2])
 atomTypes['N3s' ] = AtomType('N3s',  generic=['R','R!H','N','Val5'],  specific=[],
@@ -269,12 +295,16 @@ atomTypes['N3t' ] = AtomType('N3t',  generic=['R','R!H','N','Val5'],  specific=[
                              single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
 atomTypes['N3b' ] = AtomType('N3b',  generic=['R','R!H','N','Val5'],  specific=[],
                              single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[2])
+#Eg [NH4+]
 atomTypes['N5s' ] = AtomType('N5s',  generic=['R','R!H','N','Val5'],  specific=[],
                              single=[4], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+#Eg O[N+](=O)(O-) nitrate group
 atomTypes['N5d' ] = AtomType('N5d',  generic=['R','R!H','N','Val5'],  specific=[],
                              single=[2], allDouble=[1], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+#Eg N=[N+]=[N-] center nitrogen on azide
 atomTypes['N5dd'] = AtomType('N5dd', generic=['R','R!H','N','Val5'],  specific=[],
                              single=[0], allDouble=[2], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+#Eg C[N+]#[C-] isocyano group
 atomTypes['N5t' ] = AtomType('N5t',  generic=['R','R!H','N','Val5'],  specific=[],
                              single=[1], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
 atomTypes['N5b' ] = AtomType('N5b',  generic=['R','R!H','N','Val5'],  specific=[],
@@ -299,7 +329,7 @@ atomTypes['SiO' ] = AtomType('SiO',  generic=['R','R!H','Si','Val4'], specific=[
 atomTypes['Sid' ] = AtomType('Sid',  generic=['R','R!H','Si','Val4'], specific=[],
                              single=[], allDouble=[1], rDouble=[], oDouble=[0], sDouble=[], triple=[0], benzene=[0])
 atomTypes['Sidd'] = AtomType('Sidd', generic=['R','R!H','Si','Val4'], specific=[],
-                             single=[], allDouble=[2], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+                             single=[], allDouble=[2], rDouble=[0,1,2], oDouble=[0,1,2], sDouble=[0,1,2], triple=[0], benzene=[0])
 atomTypes['Sit' ] = AtomType('Sit',  generic=['R','R!H','Si','Val4'], specific=[],
                              single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
 atomTypes['Sib' ] = AtomType('Sib',  generic=['R','R!H','Si','Val4'], specific=[],
@@ -379,6 +409,10 @@ atomTypes['Cl'  ].setActions(incrementBond=[],               decrementBond=['Cl'
 
 atomTypes['Ar'  ].setActions(incrementBond=[],               decrementBond=[],               formBond=[],            breakBond=[],            incrementRadical=[],       decrementRadical=[],       incrementLonePair=[],      decrementLonePair=[])
 
+#list of elements that do not have more specific atomTypes
+allElements=['H', 'He', 'C', 'O', 'N', 'Si', 'S', 'Ne','Cl', 'Ar', ]
+nonSpecifics=['H', 'He', 'Ne', 'Cl', 'Ar',]
+
 for atomType in atomTypes.values():
     for items in [atomType.generic, atomType.specific,
       atomType.incrementBond, atomType.decrementBond, atomType.formBond,
@@ -392,12 +426,11 @@ def getAtomType(atom, bonds):
     with local bond structure `bonds`, a ``dict`` containing atom-bond pairs.
     """
 
-    cython.declare(atomType=str, atomSymbol=str)
+    cython.declare(atomSymbol=str)
     cython.declare(single=cython.int, allDouble=cython.int, rDouble=cython.int,
                    sDouble=cython.int, oDouble=cython.int, triple=cython.int,
                    benzene=cython.int)
-
-    atomType = ''
+    cython.declare(molFeatureList=cython.list, featureNames=cython.list)
     
     # Count numbers of each higher-order bond type
     single = 0; rDouble = 0; oDouble = 0; sDouble = 0; triple = 0; benzene = 0
@@ -410,66 +443,27 @@ def getAtomType(atom, bonds):
             elif atom2.isSulfur():
                 sDouble += 1
             else:
-                # rDouble is for allDouble bonds NOT to Oxygen or Sulfur
+                # rDouble is for double bonds NOT to oxygen or Sulfur
                 rDouble += 1
         elif bond12.isTriple(): triple += 1
         elif bond12.isBenzene(): benzene += 1
 
     # allDouble is for all double bonds, to anything
     allDouble = rDouble + oDouble + sDouble
+    molFeatureList = [single, allDouble, rDouble, oDouble, sDouble, triple, benzene, atom.lonePairs]
 
     # Use element and counts to determine proper atom type
     atomSymbol = atom.symbol
-    if atomSymbol == 'H':
-        atomType = 'H'
-    elif atomSymbol == 'He':
-        atomType = 'He'
-    elif atomSymbol == 'C':
-        if   allDouble == 0 and triple == 0 and benzene == 0:                  atomType = 'Cs'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and rDouble == 1: atomType = 'Cd'
-        elif allDouble == 2 and triple == 0 and benzene == 0:                  atomType = 'Cdd'
-        elif allDouble == 0 and triple == 1 and benzene == 0:                  atomType = 'Ct'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and oDouble == 1: atomType = 'CO'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and sDouble == 1: atomType = 'CS'
-        elif allDouble == 0 and triple == 0 and benzene == 2:                  atomType = 'Cb'
-        elif allDouble == 0 and triple == 0 and benzene == 3:                  atomType = 'Cbf'
-    elif atomSymbol == 'N':
-        if   allDouble == 0 and triple == 0 and benzene == 0 and single in [0, 1, 2, 3]: atomType = 'N3s'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and single == 0 and rDouble == 1 and atom.lonePairs == 2: atomType = 'N1d'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and single in [0, 1]: atomType = 'N3d'
-        elif allDouble == 0 and triple == 1 and benzene == 0 and single == 0: atomType = 'N3t'
-        elif allDouble == 0 and triple == 0 and benzene == 2 and single == 0: atomType = 'N3b'
-        elif allDouble == 0 and triple == 0 and benzene == 0 and single == 4: atomType = 'N5s'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and single == 2: atomType = 'N5d'
-        elif allDouble == 2 and triple == 0 and benzene == 0 and single == 0: atomType = 'N5dd'
-        elif allDouble == 0 and triple == 1 and benzene == 0 and single == 1: atomType = 'N5t'
-        elif allDouble == 0 and triple == 0 and benzene == 2 and single == 1: atomType = 'N5b'
-    elif atomSymbol == 'O':
-        if   allDouble == 0 and triple == 0 and benzene == 0: atomType = 'Os'
-        elif allDouble == 1 and triple == 0 and benzene == 0: atomType = 'Od'
-        elif len(bonds) == 0:                              atomType = 'Oa'
-        elif allDouble == 0 and triple == 1 and benzene == 0: atomType = 'Ot'
-    elif atomSymbol == 'Ne':
-        atomType = 'Ne'
-    elif atomSymbol == 'Si':
-        if   allDouble == 0 and triple == 0 and benzene == 0: atomType = 'Sis'
-        elif allDouble == 1 and triple == 0 and benzene == 0 and oDouble == 1: atomType = 'SiO'
-        elif allDouble == 1 and triple == 0 and benzene == 0: atomType = 'Sid'
-        elif allDouble == 2 and triple == 0 and benzene == 0: atomType = 'Sidd'
-        elif allDouble == 0 and triple == 1 and benzene == 0: atomType = 'Sit'
-        elif allDouble == 0 and triple == 0 and benzene == 2: atomType = 'Sib'
-        elif allDouble == 0 and triple == 0 and benzene == 3: atomType = 'Sibf'
-    elif atomSymbol == 'S':
-        if   allDouble == 0 and triple == 0 and benzene == 0: atomType = 'Ss'
-        elif allDouble == 1 and triple == 0 and benzene == 0: atomType = 'Sd'
-        elif len(bonds) == 0:                              atomType = 'Sa'
-    elif atomSymbol == 'Cl':
-        atomType = 'Cl'
-    elif atomSymbol == 'Ar':
-        atomType = 'Ar'
+    #These elements do not do not have a more specific atomType
+    if atomSymbol in nonSpecifics:
+        return atomTypes[atomSymbol]
+    for specificAtomType in atomTypes[atomSymbol].specific:
+        atomtypeFeatureList = specificAtomType.getFeatures()
+        for molFeature, atomtypeFeature in zip(molFeatureList, atomtypeFeatureList):
+            if atomtypeFeature == []:
+                continue
+            elif not molFeature in atomtypeFeature:
+                break
+        else: return specificAtomType
+    else: raise AtomTypeError('Unable to determine atom type for atom {0}, which has {1:d} double bonds to C, {2:d} double bonds to O, {3:d} double bonds to S, {4:d} triple bonds, and {5:d} benzene bonds.'.format(atom, rDouble, oDouble, sDouble, triple, benzene))
 
-    # Raise exception if we could not identify the proper atom type
-    if atomType == '':
-        raise AtomTypeError('Unable to determine atom type for atom {0}, which has {1:d} double bonds to C, {2:d} double bonds to O, {3:d} double bonds to S, {4:d} triple bonds, and {5:d} benzene bonds.'.format(atom, rDouble, oDouble, sDouble, triple, benzene))
-
-    return atomTypes[atomType]

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -111,14 +111,14 @@ class AtomType:
         self.decrementRadical = []
         self.incrementLonePair = []
         self.decrementLonePair = []
-        self.single = [] if single is None else single
-        self.allDouble = [] if allDouble is None else allDouble
-        self.rDouble = [] if rDouble is None else rDouble
-        self.oDouble = [] if oDouble is None else oDouble
-        self.sDouble = [] if sDouble is None else sDouble
-        self.triple = [] if triple is None else triple
-        self.benzene = [] if benzene is None else benzene
-        self.lonePairs = [] if lonePairs is None else lonePairs
+        self.single = single or []
+        self.allDouble = allDouble or []
+        self.rDouble = rDouble or []
+        self.oDouble = oDouble or []
+        self.sDouble = sDouble or []
+        self.triple = triple or []
+        self.benzene = benzene or []
+        self.lonePairs = lonePairs or []
 
     def __repr__(self):
         return '<AtomType "%s">' % self.label
@@ -475,7 +475,7 @@ def getAtomType(atom, bonds):
         for molFeature, atomtypeFeature in zip(molFeatureList, atomtypeFeatureList):
             if atomtypeFeature == []:
                 continue
-            elif not molFeature in atomtypeFeature:
+            elif molFeature not in atomtypeFeature:
                 break
         else: return specificAtomType
     else:

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -79,7 +79,15 @@ class AtomType:
 
     """
 
-    def __init__(self, label='', generic=None, specific=None):
+    def __init__(self, label='', generic=None, specific=None,
+                 single=None,
+                 allDouble=None,
+                 rDouble=None,
+                 oDouble=None,
+                 sDouble=None,
+                 triple=None,
+                 benzene=None,
+                 lonePairs=None,):
         self.label = label
         self.generic = generic or []
         self.specific = specific or []
@@ -91,6 +99,15 @@ class AtomType:
         self.decrementRadical = []
         self.incrementLonePair = []
         self.decrementLonePair = []
+        #Number of a bonds allowed in the atomtype, (empty list is a wildcard)
+        self.single = [] if single is None else single #total number of single bonds
+        self.allDouble = [] if allDouble is None else allDouble #total number of double bonds
+        self.rDouble = [] if rDouble is None else rDouble #double bonds to anything except an O or S
+        self.oDouble = [] if oDouble is None else oDouble
+        self.sDouble = [] if sDouble is None else sDouble
+        self.triple = []  if triple is None else triple #total number of triple bonds
+        self.benzene = [] if benzene is None else benzene #total number of benzene bonds
+        self.lonePairs = [] if lonePairs is None else lonePairs #total number of lonePairs
 
     def __repr__(self):
         return '<AtomType "%s">' % self.label
@@ -111,6 +128,14 @@ class AtomType:
             'decrementRadical': self.decrementRadical,
             'incrementLonePair': self.incrementLonePair,
             'decrementLonePair': self.decrementLonePair,
+            'single': self.single,
+            'allDouble': self.allDouble,
+            'rDouble': self.rDouble,
+            'oDouble': self.oDouble,
+            'sDouble': self.sDouble,
+            'triple': self.triple,
+            'benzene': self.benzene,
+            'lonePairs': self.lonePairs
         }
         return (AtomType, (), d)
 
@@ -129,6 +154,14 @@ class AtomType:
         self.decrementRadical = d['decrementRadical']
         self.incrementLonePair = d['incrementLonePair']
         self.decrementLonePair = d['decrementLonePair']
+        self.single = d['single']
+        self.allDouble = d['allDouble']
+        self.rDouble = d['rDouble']
+        self.oDouble = d['oDouble']
+        self.sDouble = d['sDouble']
+        self.triple = d['triple']
+        self.benzene = d['benzene']
+        self.lonePairs = d['lonePairs']
 
     def setActions(self, incrementBond, decrementBond, formBond, breakBond, incrementRadical, decrementRadical, incrementLonePair, decrementLonePair):
         self.incrementBond = incrementBond
@@ -185,70 +218,102 @@ atomTypes['R!H']  = AtomType(label='R!H', generic=['R'], specific=[
     'Ne',
     'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf',
     'S','Ss','Sd','Sa',
-    'Cl','Ar']
-)
+    'Cl','Ar'])
+
 atomTypes['Val4'] = AtomType(label='Val4', generic=['R','R!H'], specific=[
     'C','Cs','Cd','Cdd','Ct','CO','Cb','Cbf','CS',
-    'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf']
-)
+    'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf'])
+
 atomTypes['Val5'] = AtomType(label='Val5', generic=['R','R!H'], specific=[
-    'N','N1d','N3s','N3d','N3t','N3b','N5s','N5d','N5dd','N5t','N5b']
-)
+    'N','N1d','N3s','N3d','N3t','N3b','N5s','N5d','N5dd','N5t','N5b'])
+
 atomTypes['Val6'] = AtomType(label='Val6', generic=['R','R!H'], specific=[
     'O','Os','Od','Oa','Ot',
-    'S','Ss','Sd','Sa']
-)
+    'S','Ss','Sd','Sa'])
+
 atomTypes['Val7'] = AtomType(label='Val7', generic=['R','R!H'], specific=[
-    'Cl']
-)
+    'Cl'])
 
 atomTypes['H'   ] = AtomType('H',    generic=['R'],            specific=[])
 
 atomTypes['He'   ] = AtomType('He',  generic=['R','R!H'],      specific=[])
 
-atomTypes['C'   ] = AtomType('C',    generic=['R','R!H','Val4'],      specific=['Cs','Cd','Cdd','Ct','CO','Cb','Cbf','CS'])
-atomTypes['Cs'  ] = AtomType('Cs',   generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['Cd'  ] = AtomType('Cd',   generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['Cdd' ] = AtomType('Cdd',  generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['Ct'  ] = AtomType('Ct',   generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['CO'  ] = AtomType('CO',   generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['Cb'  ] = AtomType('Cb',   generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['Cbf' ] = AtomType('Cbf',  generic=['R','R!H','C','Val4'],  specific=[])
-atomTypes['CS'  ] = AtomType('CS',   generic=['R','R!H','C','Val4'],  specific=[])
+atomTypes['C'   ] = AtomType('C',    generic=['R','R!H','Val4'],      specific=['Cs','Cd','Cdd','Ct','CO','Cb','Cbf','CS'],
+                             single=[], allDouble=[], rDouble=[], oDouble=[], sDouble=[], triple=[], benzene=[],)
+atomTypes['Cs'  ] = AtomType('Cs',   generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0],)
+atomTypes['Cd'  ] = AtomType('Cd',   generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[1], rDouble=[1], oDouble=[0], sDouble=[0], triple=[0], benzene=[0])
+atomTypes['Cdd' ] = AtomType('Cdd',  generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[0], allDouble=[2], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Ct'  ] = AtomType('Ct',   generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
+atomTypes['CO'  ] = AtomType('CO',   generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[1], rDouble=[0], oDouble=[1], sDouble=[0], triple=[0], benzene=[0])
+atomTypes['Cb'  ] = AtomType('Cb',   generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[0], triple=[0], benzene=[2])
+atomTypes['Cbf' ] = AtomType('Cbf',  generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[3])
+atomTypes['CS'  ] = AtomType('CS',   generic=['R','R!H','C','Val4'],  specific=[],
+                             single=[], allDouble=[1], rDouble=[0], oDouble=[0], sDouble=[1], triple=[0], benzene=[0])
 
-atomTypes['N'   ] = AtomType('N',    generic=['R','R!H','Val5'],      specific=['N1d','N3s','N3d','N3t','N3b','N5s','N5d','N5dd','N5t','N5b'])
-atomTypes['N1d' ] = AtomType('N1d',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N3s' ] = AtomType('N3s',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N3d' ] = AtomType('N3d',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N3t' ] = AtomType('N3t',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N3b' ] = AtomType('N3b',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N5s' ] = AtomType('N5s',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N5d' ] = AtomType('N5d',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N5dd'] = AtomType('N5dd', generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N5t' ] = AtomType('N5t',  generic=['R','R!H','N','Val5'],  specific=[])
-atomTypes['N5b' ] = AtomType('N5b',  generic=['R','R!H','N','Val5'],  specific=[])
+atomTypes['N'   ] = AtomType('N',    generic=['R','R!H','Val5'],      specific=['N1d','N3s','N3d','N3t','N3b','N5s','N5d','N5dd','N5t','N5b'],
+                             single=[], allDouble=[], rDouble=[], oDouble=[], sDouble=[], triple=[], benzene=[])
+atomTypes['N1d' ] = AtomType('N1d',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[0], allDouble=[1], rDouble=[1], oDouble=[], sDouble=[], triple=[0], benzene=[0], lonePairs=[2])
+atomTypes['N3s' ] = AtomType('N3s',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[0,1,2,3], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['N3d' ] = AtomType('N3d',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[0,1], allDouble=[1], rDouble=[], oDouble=[], sDouble=[], triple=[], benzene=[])
+atomTypes['N3t' ] = AtomType('N3t',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
+atomTypes['N3b' ] = AtomType('N3b',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[2])
+atomTypes['N5s' ] = AtomType('N5s',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[4], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['N5d' ] = AtomType('N5d',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[2], allDouble=[1], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['N5dd'] = AtomType('N5dd', generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[0], allDouble=[2], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['N5t' ] = AtomType('N5t',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[1], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
+atomTypes['N5b' ] = AtomType('N5b',  generic=['R','R!H','N','Val5'],  specific=[],
+                             single=[1], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[2])
 
 atomTypes['O'   ] = AtomType('O',    generic=['R','R!H','Val6'],      specific=['Os','Od','Oa','Ot'])
-atomTypes['Os'  ] = AtomType('Os',   generic=['R','R!H','O','Val6'],  specific=[])
-atomTypes['Od'  ] = AtomType('Od',   generic=['R','R!H','O','Val6'],  specific=[])
-atomTypes['Oa'  ] = AtomType('Oa',   generic=['R','R!H','O','Val6'],  specific=[])
-atomTypes['Ot'  ] = AtomType('Ot',   generic=['R','R!H','O','Val6'],  specific=[])
+atomTypes['Os'  ] = AtomType('Os',   generic=['R','R!H','O','Val6'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Od'  ] = AtomType('Od',   generic=['R','R!H','O','Val6'],  specific=[],
+                             single=[], allDouble=[1], rDouble=[], oDouble=[], sDouble=[], triple=[], benzene=[])
+atomTypes['Oa'  ] = AtomType('Oa',   generic=['R','R!H','O','Val6'],  specific=[],
+                             single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Ot'  ] = AtomType('Ot',   generic=['R','R!H','O','Val6'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
 
 atomTypes['Ne'  ] = AtomType('Ne',   generic=['R','R!H'],      specific=[])
-
 atomTypes['Si'  ] = AtomType('Si',   generic=['R','R!H','Val4'],      specific=['Sis','Sid','Sidd','Sit','SiO','Sib','Sibf'])
-atomTypes['Sis' ] = AtomType('Sis',  generic=['R','R!H','Si','Val4'], specific=[])
-atomTypes['Sid' ] = AtomType('Sid',  generic=['R','R!H','Si','Val4'], specific=[])
-atomTypes['Sidd'] = AtomType('Sidd', generic=['R','R!H','Si','Val4'], specific=[])
-atomTypes['Sit' ] = AtomType('Sit',  generic=['R','R!H','Si','Val4'], specific=[])
-atomTypes['SiO' ] = AtomType('SiO',  generic=['R','R!H','Si','Val4'], specific=[])
-atomTypes['Sib' ] = AtomType('Sib',  generic=['R','R!H','Si','Val4'], specific=[])
-atomTypes['Sibf'] = AtomType('Sibf', generic=['R','R!H','Si','Val4'], specific=[])
+atomTypes['Sis' ] = AtomType('Sis',  generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['SiO' ] = AtomType('SiO',  generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[1], rDouble=[], oDouble=[1], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Sid' ] = AtomType('Sid',  generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[1], rDouble=[], oDouble=[0], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Sidd'] = AtomType('Sidd', generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[2], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Sit' ] = AtomType('Sit',  generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
+atomTypes['Sib' ] = AtomType('Sib',  generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[2])
+atomTypes['Sibf'] = AtomType('Sibf', generic=['R','R!H','Si','Val4'], specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[3])
 
 atomTypes['S'   ] = AtomType('S',    generic=['R','R!H','Val6'],      specific=['Ss','Sd','Sa'])
-atomTypes['Ss'  ] = AtomType('Ss',   generic=['R','R!H','S','Val6'],  specific=[])
-atomTypes['Sd'  ] = AtomType('Sd',   generic=['R','R!H','S','Val6'],  specific=[])
-atomTypes['Sa'  ] = AtomType('Sa',   generic=['R','R!H','S','Val6'],  specific=[])
+atomTypes['Ss'  ] = AtomType('Ss',   generic=['R','R!H','S','Val6'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Sd'  ] = AtomType('Sd',   generic=['R','R!H','S','Val6'],  specific=[],
+                             single=[], allDouble=[1], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['Sa'  ] = AtomType('Sa',   generic=['R','R!H','S','Val6'],  specific=[],
+                             single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
 
 atomTypes['Cl'  ] = AtomType('Cl',   generic=['R','R!H','Val7'],      specific=[])
 
@@ -328,30 +393,30 @@ def getAtomType(atom, bonds):
     """
 
     cython.declare(atomType=str, atomSymbol=str)
-    cython.declare(single=cython.int, double=cython.int, doubleR=cython.int,
-                   doubleS=cython.int, doubleO=cython.int, triple=cython.int,
+    cython.declare(single=cython.int, allDouble=cython.int, rDouble=cython.int,
+                   sDouble=cython.int, oDouble=cython.int, triple=cython.int,
                    benzene=cython.int)
 
     atomType = ''
     
     # Count numbers of each higher-order bond type
-    single = 0; doubleR = 0; doubleO = 0; doubleS = 0; triple = 0; benzene = 0
+    single = 0; rDouble = 0; oDouble = 0; sDouble = 0; triple = 0; benzene = 0
     for atom2, bond12 in bonds.iteritems():
         if bond12.isSingle():
             single += 1
         elif bond12.isDouble():
             if atom2.isOxygen(): 
-                doubleO += 1
+                oDouble += 1
             elif atom2.isSulfur():
-                doubleS += 1
+                sDouble += 1
             else:
-                # doubleR is for double bonds NOT to Oxygen or Sulfur
-                doubleR += 1
+                # rDouble is for allDouble bonds NOT to Oxygen or Sulfur
+                rDouble += 1
         elif bond12.isTriple(): triple += 1
         elif bond12.isBenzene(): benzene += 1
 
-    # double is for all double bonds, to anything
-    double = doubleR + doubleO + doubleS
+    # allDouble is for all double bonds, to anything
+    allDouble = rDouble + oDouble + sDouble
 
     # Use element and counts to determine proper atom type
     atomSymbol = atom.symbol
@@ -360,43 +425,43 @@ def getAtomType(atom, bonds):
     elif atomSymbol == 'He':
         atomType = 'He'
     elif atomSymbol == 'C':
-        if   double == 0 and triple == 0 and benzene == 0:                  atomType = 'Cs'
-        elif double == 1 and triple == 0 and benzene == 0 and doubleR == 1: atomType = 'Cd'
-        elif double == 2 and triple == 0 and benzene == 0:                  atomType = 'Cdd'
-        elif double == 0 and triple == 1 and benzene == 0:                  atomType = 'Ct'
-        elif double == 1 and triple == 0 and benzene == 0 and doubleO == 1: atomType = 'CO'
-        elif double == 1 and triple == 0 and benzene == 0 and doubleS == 1: atomType = 'CS'
-        elif double == 0 and triple == 0 and benzene == 2:                  atomType = 'Cb'
-        elif double == 0 and triple == 0 and benzene == 3:                  atomType = 'Cbf'
+        if   allDouble == 0 and triple == 0 and benzene == 0:                  atomType = 'Cs'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and rDouble == 1: atomType = 'Cd'
+        elif allDouble == 2 and triple == 0 and benzene == 0:                  atomType = 'Cdd'
+        elif allDouble == 0 and triple == 1 and benzene == 0:                  atomType = 'Ct'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and oDouble == 1: atomType = 'CO'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and sDouble == 1: atomType = 'CS'
+        elif allDouble == 0 and triple == 0 and benzene == 2:                  atomType = 'Cb'
+        elif allDouble == 0 and triple == 0 and benzene == 3:                  atomType = 'Cbf'
     elif atomSymbol == 'N':
-        if   double == 0 and triple == 0 and benzene == 0 and single in [0, 1, 2, 3]: atomType = 'N3s'
-        elif double == 1 and triple == 0 and benzene == 0 and single == 0 and doubleR == 1 and atom.lonePairs == 2: atomType = 'N1d'
-        elif double == 1 and triple == 0 and benzene == 0 and single in [0, 1]: atomType = 'N3d'
-        elif double == 0 and triple == 1 and benzene == 0 and single == 0: atomType = 'N3t'
-        elif double == 0 and triple == 0 and benzene == 2 and single == 0: atomType = 'N3b'
-        elif double == 0 and triple == 0 and benzene == 0 and single == 4: atomType = 'N5s'
-        elif double == 1 and triple == 0 and benzene == 0 and single == 2: atomType = 'N5d'
-        elif double == 2 and triple == 0 and benzene == 0 and single == 0: atomType = 'N5dd'
-        elif double == 0 and triple == 1 and benzene == 0 and single == 1: atomType = 'N5t'
-        elif double == 0 and triple == 0 and benzene == 2 and single == 1: atomType = 'N5b'
+        if   allDouble == 0 and triple == 0 and benzene == 0 and single in [0, 1, 2, 3]: atomType = 'N3s'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and single == 0 and rDouble == 1 and atom.lonePairs == 2: atomType = 'N1d'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and single in [0, 1]: atomType = 'N3d'
+        elif allDouble == 0 and triple == 1 and benzene == 0 and single == 0: atomType = 'N3t'
+        elif allDouble == 0 and triple == 0 and benzene == 2 and single == 0: atomType = 'N3b'
+        elif allDouble == 0 and triple == 0 and benzene == 0 and single == 4: atomType = 'N5s'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and single == 2: atomType = 'N5d'
+        elif allDouble == 2 and triple == 0 and benzene == 0 and single == 0: atomType = 'N5dd'
+        elif allDouble == 0 and triple == 1 and benzene == 0 and single == 1: atomType = 'N5t'
+        elif allDouble == 0 and triple == 0 and benzene == 2 and single == 1: atomType = 'N5b'
     elif atomSymbol == 'O':
-        if   double == 0 and triple == 0 and benzene == 0: atomType = 'Os'
-        elif double == 1 and triple == 0 and benzene == 0: atomType = 'Od'
+        if   allDouble == 0 and triple == 0 and benzene == 0: atomType = 'Os'
+        elif allDouble == 1 and triple == 0 and benzene == 0: atomType = 'Od'
         elif len(bonds) == 0:                              atomType = 'Oa'
-        elif double == 0 and triple == 1 and benzene == 0: atomType = 'Ot'
+        elif allDouble == 0 and triple == 1 and benzene == 0: atomType = 'Ot'
     elif atomSymbol == 'Ne':
         atomType = 'Ne'
     elif atomSymbol == 'Si':
-        if   double == 0 and triple == 0 and benzene == 0: atomType = 'Sis'
-        elif double == 1 and triple == 0 and benzene == 0 and doubleO == 1: atomType = 'SiO'
-        elif double == 1 and triple == 0 and benzene == 0: atomType = 'Sid'
-        elif double == 2 and triple == 0 and benzene == 0: atomType = 'Sidd'
-        elif double == 0 and triple == 1 and benzene == 0: atomType = 'Sit'
-        elif double == 0 and triple == 0 and benzene == 2: atomType = 'Sib'
-        elif double == 0 and triple == 0 and benzene == 3: atomType = 'Sibf'
+        if   allDouble == 0 and triple == 0 and benzene == 0: atomType = 'Sis'
+        elif allDouble == 1 and triple == 0 and benzene == 0 and oDouble == 1: atomType = 'SiO'
+        elif allDouble == 1 and triple == 0 and benzene == 0: atomType = 'Sid'
+        elif allDouble == 2 and triple == 0 and benzene == 0: atomType = 'Sidd'
+        elif allDouble == 0 and triple == 1 and benzene == 0: atomType = 'Sit'
+        elif allDouble == 0 and triple == 0 and benzene == 2: atomType = 'Sib'
+        elif allDouble == 0 and triple == 0 and benzene == 3: atomType = 'Sibf'
     elif atomSymbol == 'S':
-        if   double == 0 and triple == 0 and benzene == 0: atomType = 'Ss'
-        elif double == 1 and triple == 0 and benzene == 0: atomType = 'Sd'
+        if   allDouble == 0 and triple == 0 and benzene == 0: atomType = 'Ss'
+        elif allDouble == 1 and triple == 0 and benzene == 0: atomType = 'Sd'
         elif len(bonds) == 0:                              atomType = 'Sa'
     elif atomSymbol == 'Cl':
         atomType = 'Cl'
@@ -405,6 +470,6 @@ def getAtomType(atom, bonds):
 
     # Raise exception if we could not identify the proper atom type
     if atomType == '':
-        raise AtomTypeError('Unable to determine atom type for atom {0}, which has {1:d} double bonds to C, {2:d} double bonds to O, {3:d} double bonds to S, {4:d} triple bonds, and {5:d} benzene bonds.'.format(atom, doubleR, doubleO, doubleS, triple, benzene))
+        raise AtomTypeError('Unable to determine atom type for atom {0}, which has {1:d} double bonds to C, {2:d} double bonds to O, {3:d} double bonds to S, {4:d} triple bonds, and {5:d} benzene bonds.'.format(atom, rDouble, oDouble, sDouble, triple, benzene))
 
     return atomTypes[atomType]

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -69,6 +69,14 @@ cdef class GroupBond(Edge):
 
     cpdef __changeBond(self, short order)
 
+    cpdef bint isSingle(self) except -2
+
+    cpdef bint isDouble(self) except -2
+
+    cpdef bint isTriple(self) except -2
+
+    cpdef bint isBenzene(self) except -2
+
     cpdef applyAction(self, list action)
 
     cpdef bint equivalent(self, Edge other) except -2

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -143,3 +143,5 @@ cdef class Group(Graph):
     cpdef list findSubgraphIsomorphisms(self, Graph other, dict initialMap=?)
     
     cpdef bint isIdentical(self, Graph other)
+
+    cpdef bint standardizeAtomType(self)

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -59,6 +59,9 @@ cdef class GroupAtom(Vertex):
 
     cpdef bint isSpecificCaseOf(self, Vertex other) except -2
 
+    cpdef bint isOxygen(self)
+
+    cpdef bint isSulfur(self)
 ################################################################################
 
 cdef class GroupBond(Edge):

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -147,3 +147,5 @@ cdef class Group(Graph):
     cpdef bint standardizeAtomType(self)
 
     cpdef bint addExplicitLigands(self)
+
+    cpdef bint standardizeGroup(self)

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -145,3 +145,5 @@ cdef class Group(Graph):
     cpdef bint isIdentical(self, Graph other)
 
     cpdef bint standardizeAtomType(self)
+
+    cpdef bint addExplicitLigands(self)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -386,6 +386,26 @@ class GroupAtom(Vertex):
             if group.charge: return False
         # Otherwise self is in fact a specific case of other
         return True
+
+    def isOxygen(self):
+        """
+        Return ``True`` if the atom represents an oxygen atom or ``False`` if
+        not.
+        """
+        allOxygens = [atomTypes['O']] + atomTypes['O'].specific
+        checkList=[x in allOxygens for x in self.atomType]
+
+        return not False in checkList
+
+    def isSulfur(self):
+        """
+        Return ``True`` if the atom represents an sulfur atom or ``False`` if
+        not.
+        """
+        allSulfur = [atomTypes['S']] + atomTypes['S'].specific
+        checkList=[x in allSulfur for x in self.atomType]
+
+        return not False in checkList
 ################################################################################
 
 class GroupBond(Edge):

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1024,5 +1024,50 @@ class Group(Graph):
 
         return modified
 
+    def addExplicitLigands(self):
+        """
+        This function Od/Sd ligand to CO or CS atomtypes if they are not already there.
 
+        Returns a 'True' if the group was modified otherwise returns 'False'
+        """
 
+        modified = False
+
+        atomsToAddTo=[]
+
+        viableToCheck = True
+        for atom in self.atoms:
+            if len(atom.atomType) > 1:
+                viableToCheck = False
+                break
+            elif len(atom.radicalElectrons) > 1:
+                viableToCheck = False
+                break
+            elif len(atom.lonePairs) > 1:
+                viableToCheck = False
+                break
+            for bond in atom.bonds.values():
+                if len(bond.order) > 1:
+                    viableToCheck = False
+                    break
+        if not viableToCheck: return modified
+
+        for index, atom in enumerate(self.atoms):
+            claimedAtomType = atom.atomType[0]
+            if claimedAtomType is atomTypes['CO'] or claimedAtomType is atomTypes['CS']:
+                for atom2, bond12 in atom.bonds.iteritems():
+                    if bond12.isDouble():
+                        break
+                else: atomsToAddTo.append(index)
+
+        for atomIndex in atomsToAddTo:
+            modified = True
+            if self.atoms[atomIndex].atomType[0] is atomTypes['CO']:
+                newAtom = GroupAtom(atomType=[atomTypes['Od']], radicalElectrons=[0], charge=[], label='', lonePairs=None)
+            elif self.atoms[atomIndex].atomType[0] is atomTypes['CS']:
+                newAtom = GroupAtom(atomType=[atomTypes['Sd']], radicalElectrons=[0], charge=[], label='', lonePairs=None)
+            self.addAtom(newAtom)
+            newBond = GroupBond(self.atoms[atomIndex], newAtom, order=['D'])
+            self.addBond(newBond)
+
+        return modified

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -946,25 +946,6 @@ class Group(Graph):
                    atomTypes['Si']:4
                    }
 
-        #see if this is a group we can check, must not have any OR groups in
-        #its bonds or atomtypes
-        viableToCheck = True
-        for atom in self.atoms:
-            if len(atom.atomType) > 1:
-                viableToCheck = False
-                break
-            elif len(atom.radicalElectrons) > 1:
-                viableToCheck = False
-                break
-            elif len(atom.lonePairs) > 1:
-                viableToCheck = False
-                break
-            for bond in atom.bonds.values():
-                if len(bond.order) > 1:
-                    viableToCheck = False
-                    break
-        if not viableToCheck: return modified
-
         #list of :class:AtomType which are elements with more sub-divided atomtypes beneath them
         specifics= [elementLabel for elementLabel in allElements if not elementLabel in nonSpecifics]
         for index, atom in enumerate(self.atoms):
@@ -1035,23 +1016,6 @@ class Group(Graph):
 
         atomsToAddTo=[]
 
-        viableToCheck = True
-        for atom in self.atoms:
-            if len(atom.atomType) > 1:
-                viableToCheck = False
-                break
-            elif len(atom.radicalElectrons) > 1:
-                viableToCheck = False
-                break
-            elif len(atom.lonePairs) > 1:
-                viableToCheck = False
-                break
-            for bond in atom.bonds.values():
-                if len(bond.order) > 1:
-                    viableToCheck = False
-                    break
-        if not viableToCheck: return modified
-
         for index, atom in enumerate(self.atoms):
             claimedAtomType = atom.atomType[0]
             if claimedAtomType is atomTypes['CO'] or claimedAtomType is atomTypes['CS']:
@@ -1071,3 +1035,45 @@ class Group(Graph):
             self.addBond(newBond)
 
         return modified
+
+    def standardizeGroup(self):
+        """
+        This function modifies groups to make them have a standard AdjList form.
+
+        Currently it makes atomtypes as specific as possible and makes CO/CS atomtypes
+        have explicit Od/Sd ligands. Other functions can be added as necessary
+
+        We also only check when there is exactly one atomType, one bondType, one
+        radical setting. For any group where there are wildcards or multiple
+        attributes, we do not apply this check.
+
+        Returns a 'True' if the group was modified otherwise returns 'False'
+        """
+
+        modified = False
+
+        #see if this is a group we can check, must not have any OR groups in
+        #its bonds or atomtypes
+        viableToCheck = True
+        for atom in self.atoms:
+            if len(atom.atomType) > 1:
+                viableToCheck = False
+                break
+            elif len(atom.radicalElectrons) > 1:
+                viableToCheck = False
+                break
+            elif len(atom.lonePairs) > 1:
+                viableToCheck = False
+                break
+            for bond in atom.bonds.values():
+                if len(bond.order) > 1:
+                    viableToCheck = False
+                    break
+        if not viableToCheck: return modified
+
+        #If viable then we apply current conventions:
+        checkList=[]
+        checkList.append(self.standardizeAtomType())
+        checkList.append(self.addExplicitLigands())
+
+        return True in checkList

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -433,6 +433,34 @@ class GroupBond(Edge):
         """
         return GroupBond(self.vertex1, self.vertex2, self.order[:])
 
+    def isSingle(self):
+        """
+        Return ``True`` if the bond represents a single bond or ``False`` if
+        not. Bonds with any wildcards will return  ``False``.
+        """
+        return self.order[0] == 'S' and len(self.order) == 1
+
+    def isDouble(self):
+        """
+        Return ``True`` if the bond represents a double bond or ``False`` if
+        not. Bonds with any wildcards will return  ``False``.
+        """
+        return self.order[0] == 'D' and len(self.order) == 1
+
+    def isTriple(self):
+        """
+        Return ``True`` if the bond represents a triple bond or ``False`` if
+        not. Bonds with any wildcards will return  ``False``.
+        """
+        return self.order[0] == 'T' and len(self.order) == 1
+
+    def isBenzene(self):
+        """
+        Return ``True`` if the bond represents a benzene bond or ``False`` if
+        not. Bonds with any wildcards will return  ``False``.
+        """
+        return self.order[0] == 'B' and len(self.order) == 1
+
     def __changeBond(self, order):
         """
         Update the bond group as a result of applying a CHANGE_BOND action,

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -395,7 +395,7 @@ class GroupAtom(Vertex):
         allOxygens = [atomTypes['O']] + atomTypes['O'].specific
         checkList=[x in allOxygens for x in self.atomType]
 
-        return not False in checkList
+        return all(checkList)
 
     def isSulfur(self):
         """
@@ -405,7 +405,7 @@ class GroupAtom(Vertex):
         allSulfur = [atomTypes['S']] + atomTypes['S'].specific
         checkList=[x in allSulfur for x in self.atomType]
 
-        return not False in checkList
+        return all(checkList)
 ################################################################################
 
 class GroupBond(Edge):
@@ -942,12 +942,12 @@ class Group(Graph):
         #dictionary of element to expected valency
         valency = {atomTypes['C'] : 4,
                    atomTypes['O'] : 2,
-                   atomTypes ['S']: 2,
+                   atomTypes['S']: 2,
                    atomTypes['Si']:4
                    }
 
         #list of :class:AtomType which are elements with more sub-divided atomtypes beneath them
-        specifics= [elementLabel for elementLabel in allElements if not elementLabel in nonSpecifics]
+        specifics= [elementLabel for elementLabel in allElements if elementLabel not in nonSpecifics]
         for index, atom in enumerate(self.atoms):
             claimedAtomType = atom.atomType[0]
             newAtomType = None
@@ -963,10 +963,9 @@ class Group(Graph):
             if not element: continue
             #Don't standardize atomtypes for nitrogen for now. My feeling is that
             # the work on the nitrogen atomtypes is still incomplete
-            elif element == atomTypes['N']: continue
+            elif element is atomTypes['N']: continue
 
             groupFeatures = getFeatures(atom, atom.bonds)
-            # print groupFeatures
 
             single = groupFeatures[0]
             allDouble = groupFeatures[1]
@@ -977,7 +976,6 @@ class Group(Graph):
             else:
                 bondValency =  single + 2 * allDouble + 3 * triple + 3.0/2.0 * benzene
             filledValency =  atom.radicalElectrons[0] + bondValency
-            # print index, atom, filledValency
 
             #For an atomtype to be known for certain, the valency must be filled
             #within 1 of the total valency available
@@ -987,7 +985,7 @@ class Group(Graph):
                     for molFeature, atomtypeFeature in zip(groupFeatures, atomtypeFeatureList):
                         if atomtypeFeature == []:
                             continue
-                        elif not molFeature in atomtypeFeature:
+                        elif molFeature not in atomtypeFeature:
                             break
                     else:
                         if specificAtomType is atomTypes['Oa'] or specificAtomType is atomTypes['Sa']:
@@ -999,7 +997,7 @@ class Group(Graph):
                             break
 
             #set the new atom type if the algorithm found one
-            if newAtomType and not newAtomType is claimedAtomType:
+            if newAtomType and newAtomType is not claimedAtomType:
                 atom.atomType[0] = newAtomType
                 modified = True
 
@@ -1076,4 +1074,4 @@ class Group(Graph):
         checkList.append(self.standardizeAtomType())
         checkList.append(self.addExplicitLigands())
 
-        return True in checkList
+        return any(checkList)

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -394,8 +394,6 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
         family = self.database.kinetics.families[family_name]
         targetLabel=['Cd', 'CO', 'CS', 'Cdd']
         targetAtomTypes=[atomTypes[x] for x in targetLabel]
-        oxygen=[atomTypes['O']] + atomTypes['O'].specific
-        sulfur=[atomTypes['S']] + atomTypes['S'].specific
 
         #ignore product entries that get created from training reactions
         ignore=[]
@@ -426,8 +424,8 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
                             #Ignore ligands that are not double bonded
                             if 'D' in bond.order:
                                 for ligAtomType in ligand.atomType:
-                                    if ligand.atomType[0] in oxygen: correctAtomList.append('CO')
-                                    elif ligand.atomType[0] in sulfur: correctAtomList.append('CS')
+                                    if ligand.atomType[0].isSpecificCaseOf(atomTypes['O']): correctAtomList.append('CO')
+                                    elif ligand.atomType[0].isSpecificCaseOf(atomTypes['S']): correctAtomList.append('CS')
 
                     #remove duplicates from correctAtom:
                     correctAtomList=list(set(correctAtomList))
@@ -522,8 +520,6 @@ The following adjList may have atoms in a different ordering than the input file
         """
         targetLabel=['Cd', 'CO', 'CS', 'Cdd']
         targetAtomTypes=[atomTypes[x] for x in targetLabel]
-        oxygen=[atomTypes['O']] + atomTypes['O'].specific
-        sulfur=[atomTypes['S']] + atomTypes['S'].specific
 
         for entryName, entry in group.entries.iteritems():
             if isinstance(entry.item, Group):
@@ -543,8 +539,8 @@ The following adjList may have atoms in a different ordering than the input file
                             #Ignore ligands that are not double bonded
                             if 'D' in bond.order:
                                 for ligAtomType in ligand.atomType:
-                                    if ligand.atomType[0] in oxygen: correctAtomList.append('CO')
-                                    elif ligand.atomType[0] in sulfur: correctAtomList.append('CS')
+                                    if ligand.atomType[0].isSpecificCaseOf(atomTypes['O']): correctAtomList.append('CO')
+                                    elif ligand.atomType[0].isSpecificCaseOf(atomTypes['S']): correctAtomList.append('CS')
 
                     #remove duplicates from correctAtom:
                     correctAtomList=list(set(correctAtomList))


### PR DESCRIPTION
This PR moves the hard-coded portion of atomTypes from the function getAtomType to the initialization of each atomType. I think this is better because each Atomtype instance previously was not tied in anyway with its definition and could not actually be defined without the getAtomType function.

The new implementation of getAtomType might be slower than previously as it matches more objects, but @KEHANG was telling me that atomtyping is not really limiting. I'm not very familiar with speed checks, so it might be worthwhile for somebody else to try it.

I seemed to have made a mess the branch naming for #700, so I've created a new pull request. Much more updated