### PR TITLE
Broadcast quantumMechanics 

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -47,6 +47,7 @@ from rmgpy.molecule import Molecule, Atom, Bond, Group
 import rmgpy.molecule
 from rmgpy.species import Species
 
+from rmgpy.scoop_framework.util import get
 
 #: This dictionary is used to add multiplicity to species label
 _multiplicity_labels = {1:'S',2:'D',3:'T',4:'Q',5:'V',}
@@ -763,7 +764,7 @@ class ThermoDatabase(object):
         )
 
 
-    def getThermoData(self, species, trainingSet=None, quantumMechanics=None):
+    def getThermoData(self, species, trainingSet=None):
         """
         Return the thermodynamic parameters for a given :class:`Species`
         object `species`. This function first searches the loaded libraries
@@ -772,11 +773,17 @@ class ThermoDatabase(object):
         
         Returns: ThermoData
         """
+        from rmgpy.rmg.input import getInput
         
         thermo0 = None
         
         thermo0 = self.getThermoDataFromLibraries(species)
-        
+        try:
+            quantumMechanics = getInput('quantumMechanics')
+        except Exception, e:
+            logging.debug('Quantum Mechanics DB could not be found.')
+            quantumMechanics = None
+
         if thermo0 is not None:
             logging.info("Found thermo for {0} in {1}".format(species.label,thermo0[0].comment.lower()))
             assert len(thermo0) == 3, "thermo0 should be a tuple at this point: (thermoData, library, entry)"

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -324,12 +324,12 @@ class ThermoLibrary(Database):
         
         # Internal checks for adding entry to the thermo library
         if label in self.entries.keys():
-            raise DatabaseError('Found a duplicate molecule with label {0} in the thermo library.  Please correct your library.'.format(label))
+            raise DatabaseError('Found a duplicate molecule with label {0} in the thermo library {1}.  Please correct your library.'.format(label, self.name))
         
         for entry in self.entries.values():
             if molecule.isIsomorphic(entry.item):
                 if molecule.multiplicity == entry.item.multiplicity:
-                    raise DatabaseError('Adjacency list and multiplicity of {0} matches that of existing molecule {1} in thermo library.  Please correct your library.'.format(label, entry.label))
+                    raise DatabaseError('Adjacency list and multiplicity of {0} matches that of existing molecule {1} in thermo library {2}.  Please correct your library.'.format(label, entry.label, self.name))
         
         self.entries[label] = Entry(
             index = index,

--- a/rmgpy/qm/main.py
+++ b/rmgpy/qm/main.py
@@ -83,6 +83,21 @@ class QMSettings():
                 symmetryPath = 'symmetry'
         self.symmetryPath = symmetryPath
 
+    def __reduce__(self):
+        """
+        A helper function used when pickling an object.
+        """
+        return (QMSettings, (
+            self.software,
+            self.method,
+            self.fileStore,
+            self.scratchDirectory,
+            self.onlyCyclics,
+            self.maxRadicalNumber,
+            self.symmetryPath
+            )
+        )
+
     def checkAllSet(self):
         """
         Check that all the required settings are set.
@@ -129,7 +144,14 @@ class QMCalculator():
                                    maxRadicalNumber = maxRadicalNumber,
                                    )
         self.database = ThermoLibrary(name='QM Thermo Library')
-        
+    
+    def __reduce__(self):
+        """
+        A helper function used when pickling an object.
+        """
+        return (QMCalculator, (self.settings, self.database))
+
+
     def setDefaultOutputDirectory(self, outputDirectory):
         """
         IF the fileStore or scratchDirectory are not already set, put them in here.

--- a/rmgpy/qm/mainTest.py
+++ b/rmgpy/qm/mainTest.py
@@ -14,37 +14,37 @@ from rmgpy.qm.gaussian import Gaussian
 from rmgpy.qm.mopac import Mopac
 
 class TestQMSettings(unittest.TestCase):
-	"""
-	Contains unit tests for the QMSettings class.
-	"""
-	
-	def setUp(self):
-		"""
-		A function run before each unit test in this class.
-		"""
-		RMGpy_path = os.path.normpath(os.path.join(getPath(),'..'))
-		
-		self.settings1 = QMSettings(software = 'mopac',
-								   method = 'pm3',
-								   fileStore = os.path.join(RMGpy_path, 'testing', 'qm', 'QMfiles'),
-								   scratchDirectory = None,
-								   onlyCyclics = False,
-								   maxRadicalNumber = 0,
-								   )
-		
-		self.settings2 = QMSettings()
+    """
+    Contains unit tests for the QMSettings class.
+    """
+    
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        RMGpy_path = os.path.normpath(os.path.join(getPath(),'..'))
+        
+        self.settings1 = QMSettings(software = 'mopac',
+                                   method = 'pm3',
+                                   fileStore = os.path.join(RMGpy_path, 'testing', 'qm', 'QMfiles'),
+                                   scratchDirectory = None,
+                                   onlyCyclics = False,
+                                   maxRadicalNumber = 0,
+                                   )
+        
+        self.settings2 = QMSettings()
 
-	def testCheckAllSet(self):
-		"""
-		Test that checkAllSet() works correctly.
-		"""
-		try:
-			self.settings1.checkAllSet()
-		except AssertionError:
-			self.fail("checkAllSet() raised unexpected AssertionError.")
-		
-		with self.assertRaises(AssertionError):
-			self.settings2.checkAllSet()
+    def testCheckAllSet(self):
+        """
+        Test that checkAllSet() works correctly.
+        """
+        try:
+            self.settings1.checkAllSet()
+        except AssertionError:
+            self.fail("checkAllSet() raised unexpected AssertionError.")
+        
+        with self.assertRaises(AssertionError):
+            self.settings2.checkAllSet()
 
 class TestQMCalculator(unittest.TestCase):
 	"""

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -405,6 +405,11 @@ def readInputFile(path, rmg0):
     for reactionSystem in rmg.reactionSystems:
         reactionSystem.convertInitialKeysToSpeciesObjects(speciesDict)
 
+    if rmg.quantumMechanics:
+        rmg.quantumMechanics.setDefaultOutputDirectory(rmg.outputDirectory)
+        rmg.quantumMechanics.initialize()
+    broadcast(rmg.quantumMechanics, 'quantumMechanics')
+
     logging.info('')
     
 ################################################################################
@@ -457,6 +462,11 @@ def readThermoInputFile(path, rmg0):
     finally:
         f.close()
 
+    if rmg.quantumMechanics:
+        rmg.quantumMechanics.setDefaultOutputDirectory(rmg.outputDirectory)
+        rmg.quantumMechanics.initialize()
+    broadcast(rmg.quantumMechanics, 'quantumMechanics')
+    
     logging.info('')    
 
 ################################################################################
@@ -631,6 +641,8 @@ def getInput(name):
     if rmg:
         if name == 'speciesConstraints':
             return rmg.speciesConstraints
+        elif name == 'quantumMechanics':
+            return rmg.quantumMechanics
         else:
             raise Exception('Unrecognized keyword: {}'.format(name))
     else:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -212,7 +212,6 @@ class RMG(util.Subject):
         self.reactionModel.saveEdgeSpecies = self.saveEdgeSpecies
         
         if self.quantumMechanics:
-            self.quantumMechanics.setDefaultOutputDirectory(self.outputDirectory)
             self.reactionModel.quantumMechanics = self.quantumMechanics
             
     def loadThermoInput(self, path=None):
@@ -227,7 +226,6 @@ class RMG(util.Subject):
         readThermoInputFile(path, self)
         
         if self.quantumMechanics:
-            self.quantumMechanics.setDefaultOutputDirectory(self.outputDirectory)
             self.reactionModel.quantumMechanics = self.quantumMechanics
         
     def checkInput(self):
@@ -365,10 +363,6 @@ class RMG(util.Subject):
         # Make output subdirectories
         util.makeOutputSubdirectory(self.outputDirectory, 'pdep')
         util.makeOutputSubdirectory(self.outputDirectory, 'solver')
-        
-        # Do any necessary quantum mechanics startup
-        if self.quantumMechanics:
-            self.quantumMechanics.initialize()
 
         # Load databases
         self.loadDatabase()
@@ -463,7 +457,7 @@ class RMG(util.Subject):
                         """.format(spec.label))
                         
             for spec in self.initialSpecies:
-                spec.getThermoData(self.database, quantumMechanics=self.quantumMechanics)
+                spec.getThermoData(self.database)
                 spec.generateTransportData(self.database)
                 
             # Add nonreactive species (e.g. bath gases) to core first

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -83,7 +83,7 @@ class Species(rmgpy.species.Species):
         """
         return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
 
-    def getThermoData(self, database, thermoClass=NASA, quantumMechanics=None):
+    def getThermoData(self, database, thermoClass=NASA):
         """
         Returns a `thermoData` object of the current Species object.
 
@@ -94,16 +94,14 @@ class Species(rmgpy.species.Species):
         if self.thermo:
             self.processThermoData(database, self.thermo, thermoClass)
         else:
-            self.generateThermoData(database, thermoClass, quantumMechanics)
+            self.generateThermoData(database, thermoClass)
 
         return self.thermo
 
-    def generateThermoData(self, database, thermoClass=NASA, quantumMechanics=None):
+    def generateThermoData(self, database, thermoClass=NASA):
         """
         Generates thermo data, first checking Libraries, then using either QM or Database.
         
-        If quantumMechanics is not None, it is asked to calculate the thermo.
-        Failing that, the database is used.
         
         The database generates the thermo data for each structure (resonance isomer),
         picks that with lowest H298 value.
@@ -114,7 +112,7 @@ class Species(rmgpy.species.Species):
         Result stored in `self.thermo` and returned.
         """
 
-        thermo0 = database.thermo.getThermoData(self, trainingSet=None, quantumMechanics=quantumMechanics)
+        thermo0 = database.thermo.getThermoData(self, trainingSet=None)
         
         return self.processThermoData(database, thermo0, thermoClass)
 
@@ -799,7 +797,7 @@ class CoreEdgeReactionModel:
         # Generate thermodynamics of new species
         logging.info('Generating thermodynamics for new species...')
         for spec in self.newSpeciesList:
-            spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
+            spec.getThermoData(database)
             spec.generateTransportData(database)
         
         # Generate kinetics of new reactions
@@ -1405,7 +1403,7 @@ class CoreEdgeReactionModel:
                     raise ForbiddenStructureException("Species constraints forbids species {0} from seed mechanism {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, seedMechanism.label))
 
         for spec in self.newSpeciesList:            
-            if spec.reactive: spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
+            if spec.reactive: spec.getThermoData(database)
             spec.generateTransportData(database)
             self.addSpeciesToCore(spec)
 
@@ -1415,7 +1413,7 @@ class CoreEdgeReactionModel:
                 # we need to make sure the barrier is positive.
                 # ...but are Seed Mechanisms run through PDep? Perhaps not.
                 for spec in itertools.chain(rxn.reactants, rxn.products):
-                    spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
+                    spec.getThermoData(database)
                 rxn.fixBarrierHeight(forcePositive=True)
             self.addReactionToCore(rxn)
         
@@ -1472,7 +1470,7 @@ class CoreEdgeReactionModel:
                     raise ForbiddenStructureException("Species constraints forbids species {0} from reaction library {1}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label, reactionLibrary.label))
        
         for spec in self.newSpeciesList:
-            if spec.reactive: spec.getThermoData(database, quantumMechanics=self.quantumMechanics)
+            if spec.reactive: spec.getThermoData(database)
             spec.generateTransportData(database)
             self.addSpeciesToEdge(spec)
 


### PR DESCRIPTION
This PR changes the way the quantumMechanics object is passed around throughout RMG.

In the past, the object was created upon reading the RMG input file, and passed down as a parameter throughout multiple functions.

This PR removes the QM parameter from these functions, and instead fetches it from the global RMG object. In addition, the QM object is broadcast to all available workers: when thermochemistry is calculated on a remote worker (not yet implemented, WIP), this PR allows the retrieval of the QM broadcasted object when it is needed.

_Implementation details:_

**Broadcast:**
the quantumMechanics attribute of the global RMG object is a `QMCalculator` instance. Upon reading the RMG input file, the `rmg.quantumMechanics` attribute is broadcast under the key "quantumMechanics" when it is available.

**Retrieval:**
in the method `rmgpy.data.thermo.ThermoDatabase.getThermoData`, it is verified whether then quantumMechanics object exists. If it exists, it is used in the same hierarchical way as before.