### PR TITLE
Fix some issues with rmgpy.qm.qmdata

### DIFF
--- a/rmgpy/qm/gaussian.py
+++ b/rmgpy/qm/gaussian.py
@@ -8,7 +8,7 @@ from subprocess import Popen
 import re
 
 from rmgpy.molecule import Molecule
-from qmdata import CCLibData
+from qmdata import parseCCLibData
 from molecule import QMMolecule
 
 class Gaussian:
@@ -149,13 +149,13 @@ class Gaussian:
         
     def parse(self):
         """
-        Parses the results of the Gaussian calculation, and returns a CCLibData object.
+        Parses the results of the Gaussian calculation, and returns a QMData object.
         """
         parser = cclib.parser.Gaussian(self.outputFilePath)
         parser.logger.setLevel(logging.ERROR) #cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
         cclibData = parser.parse()
         radicalNumber = sum([i.radicalElectrons for i in self.molecule.atoms])
-        qmData = CCLibData(cclibData, radicalNumber+1)
+        qmData = parseCCLibData(cclibData, radicalNumber+1)
         return qmData
 
     

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -17,7 +17,7 @@ import rmgpy.thermo
 import rmgpy.molecule
 import symmetry
 import qmdata
-from qmdata import CCLibData
+from qmdata import parseCCLibData
 from rmgpy.molecule import parser
 
 class Geometry:
@@ -296,13 +296,13 @@ class QMMolecule:
         
     def parse(self):
         """
-        Parses the results of the Mopac calculation, and returns a CCLibData object.
+        Parses the results of the Mopac calculation, and returns a QMData object.
         """
         parser = self.getParser(self.outputFilePath)
         parser.logger.setLevel(logging.ERROR) #cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
         cclibData = parser.parse()
         radicalNumber = self.molecule.getRadicalCount()
-        qmData = CCLibData(cclibData, radicalNumber+1) # Should `radicalNumber+1` be `self.molecule.multiplicity` in the next line of code? It's the electronic ground state degeneracy.
+        qmData = parseCCLibData(cclibData, radicalNumber+1) # Should `radicalNumber+1` be `self.molecule.multiplicity` in the next line of code? It's the electronic ground state degeneracy.
         return qmData
     
     def generateQMData(self):

--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -178,11 +178,11 @@ class MopacMol(QMMolecule, Mopac):
 
     #: Keywords that will be added at the top and bottom of the qm input file
     keywords = [
-                {'top':"precise nosym", 'bottom':"oldgeo thermo nosym precise "},
-                {'top':"precise nosym gnorm=0.0 nonr", 'bottom':"oldgeo thermo nosym precise "},
-                {'top':"precise nosym gnorm=0.0", 'bottom':"oldgeo thermo nosym precise "},
-                {'top':"precise nosym gnorm=0.0 bfgs", 'bottom':"oldgeo thermo nosym precise "},
-                {'top':"precise nosym recalc=10 dmax=0.10 nonr cycles=2000 t=2000", 'bottom':"oldgeo thermo nosym precise "},
+                {'top':"precise nosym THREADS=1", 'bottom':"oldgeo thermo nosym precise THREADS=1 "},
+                {'top':"precise nosym gnorm=0.0 nonr THREADS=1", 'bottom':"oldgeo thermo nosym precise THREADS=1 "},
+                {'top':"precise nosym gnorm=0.0 THREADS=1", 'bottom':"oldgeo thermo nosym precise THREADS=1 "},
+                {'top':"precise nosym gnorm=0.0 bfgs THREADS=1", 'bottom':"oldgeo thermo nosym precise THREADS=1 "},
+                {'top':"precise nosym recalc=10 dmax=0.10 nonr cycles=2000 t=2000 THREADS=1", 'bottom':"oldgeo thermo nosym precise THREADS=1 "},
                 ]
 
     def writeInputFile(self, attempt):

--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -6,7 +6,6 @@ from subprocess import Popen, PIPE
 import distutils.spawn
 
 from rmgpy.molecule import Molecule
-from qmdata import CCLibData
 from molecule import QMMolecule
 
 
@@ -252,7 +251,7 @@ class MopacMol(QMMolecule, Mopac):
                 return None
         result = self.parse() # parsed in cclib
         result.source = source
-        return result # a CCLibData object
+        return result
 
 
 class MopacMolPMn(MopacMol):

--- a/rmgpy/qm/qmdata.py
+++ b/rmgpy/qm/qmdata.py
@@ -23,13 +23,9 @@ class QMData(object):
         self.groundStateDegeneracy = groundStateDegeneracy
         self.numberOfAtoms = numberOfAtoms #: Number of atoms.
         self.stericEnergy = Energy(stericEnergy)
-        """
-        Steric energy.
-        """
         self.molecularMass = Mass(molecularMass)
         self.energy = Energy(energy)
         self.atomicNumbers = atomicNumbers
-        #: Rotational constants, in Hz.
         self.rotationalConstants = Frequency(rotationalConstants)
         self.atomCoords = Length(atomCoords)
         self.frequencies = Frequency(frequencies)
@@ -58,44 +54,36 @@ class QMData(object):
         string = re.sub('\s+',' ',string)
         return 'QMData({0!s})'.format(string)
         
-class CCLibData(QMData):
+def parseCCLibData(cclibData, groundStateDegeneracy):
     """
-    QM Data extracted from a cclib data object
-    
-    This data objects collects information that CCLib was able to
-    retrieve from a quantum chemistry output file.
+    Parses a CCLib data object and returns QMData object.
     """
+    try:
+        numberOfAtoms = cclibData.natom
+        molecularMass = (cclibData.molmass, 'amu')
+        energy = (cclibData.scfenergies[-1], 'eV/molecule')
+        atomicNumbers = cclibData.atomnos
+        rotationalConstants = ([i * 1e9 for i in cclibData.rotcons[-1]],'hertz')
+        atomCoords = (cclibData.atomcoords[-1], 'angstrom')
+        frequencies = (cclibData.vibfreqs, 'cm^-1')
 
-    def __init__(self,
-                 cclib_data,
-                 groundStateDegeneracy = -1
-                 ):
-        
-        #: data object returned by a parsing tool like CCLib.parse()
-        self.cclib_data = cclib_data
-        try:
-            numberOfAtoms = cclib_data.natom
-            molecularMass = (cclib_data.molmass,'amu')
-            energy = (cclib_data.scfenergies[-1],'eV/molecule') # final optimized PM3 energy (cclib gives this in eV)
-            atomicNumbers = cclib_data.atomnos
-            rotationalConstants = ([i * 1e9 for i in cclib_data.rotcons[-1]],'hertz') # Hz. #print the final rotational constants (note that ideally we would use next to last value ([-2]) as this has more significant digits and is for the same geometry, but there is a complication for linear molecules (labeled as "Rotational constant" rather than "...constants"...there might be some ways around this like looking for "Rotational constant" string instead, but it is probably not a big deal to just use rounded values
-            atomCoords = (cclib_data.atomcoords[-1],"angstrom") # I assume Angstrom (not Bohr?)
-            frequencies = (cclib_data.vibfreqs, "cm^-1") # 1/cm
+    except AttributeError, e:
+        logging.error("The passed in cclibData has these attributes: {0!r}".format(cclibData._attrlist))
+        raise e
 
-        except AttributeError, e:
-            logging.error("The passed in cclib_data has these attributes: {0!r}".format(cclib_data._attrlist))
-            raise e
-        
-        QMData.__init__( self,
-            groundStateDegeneracy = groundStateDegeneracy,
-            numberOfAtoms = numberOfAtoms,
-            molecularMass = molecularMass,
-            energy = energy,
-            atomicNumbers = atomicNumbers,
-            rotationalConstants = rotationalConstants,
-            atomCoords = atomCoords,
-            frequencies = frequencies,
-            )
-        if hasattr(cclib_data, 'stericenergy'):
-            # steric energy
-            self.stericEnergy = (cclib_data.stericenergy, 'eV/molecule') # this is eV.  /27.2113845 for Hartrees
+    if hasattr(cclibData, 'stericenergy'):
+        stericEnergy = (cclibData.stericenergy, 'eV/molecule')
+    else:
+        stericEnergy = None
+
+    return QMData(
+        groundStateDegeneracy=groundStateDegeneracy,
+        numberOfAtoms=numberOfAtoms,
+        stericEnergy=stericEnergy,
+        molecularMass=molecularMass,
+        energy=energy,
+        atomicNumbers=atomicNumbers,
+        rotationalConstants=rotationalConstants,
+        atomCoords=atomCoords,
+        frequencies=frequencies
+    )

--- a/rmgpy/qm/qmdata.py
+++ b/rmgpy/qm/qmdata.py
@@ -3,7 +3,7 @@ import re
 import logging
 from rmgpy.quantity import Energy, Mass, Length, Frequency
 
-class QMData:
+class QMData(object):
     """
     General class for data extracted from a QM calculation
     """

--- a/rmgpy/qm/qmdata.py
+++ b/rmgpy/qm/qmdata.py
@@ -8,15 +8,15 @@ class QMData:
     General class for data extracted from a QM calculation
     """
     def __init__(self,
-                 groundStateDegeneracy = None,
+                 groundStateDegeneracy = -1,
                  numberOfAtoms = None,
                  stericEnergy = None,
                  molecularMass = None,
                  energy = 0,
-                 atomicNumbers = [],
-                 rotationalConstants = [],
-                 atomCoords = [],
-                 frequencies = [],
+                 atomicNumbers = None,
+                 rotationalConstants = None,
+                 atomCoords = None,
+                 frequencies = None,
                  source = None,
                  ):
         #: Electronic ground state degeneracy in RMG taken as number of radicals +1
@@ -68,7 +68,7 @@ class CCLibData(QMData):
 
     def __init__(self,
                  cclib_data,
-                 groundStateDegeneracy
+                 groundStateDegeneracy = -1
                  ):
         
         #: data object returned by a parsing tool like CCLib.parse()


### PR DESCRIPTION
This PR fixes issues with some of the qm classes:

- limit the no. of threads used by MOPAC calculations to 1 (to avoid CPU contention when concurrent thermo will be implemented)
- remove mutable argumets in QMData constructor
- remove CCLibData class and replace it by a module function. It's easier, and more pythonic. The class was not adding anything anyway.