### PR TITLE
Add additional details on how the 'reactive' flag for species works

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -175,10 +175,13 @@ List of species
 
 Species to be included in the core at the start of your RMG job are defined in the species block. 
 The label, reactive or inert, and structure of each reactant must be specified.
-The label field will be used throughout your mechanism to identify the species. Inert
-species in the model can be defined by setting reactive to be ``False``, for all
-other species the reactive status must be set as ``True``. The structure of the 
-species can be defined using either by using SMILES or :ref:`adjacencyList <rmgpy.molecule.adjlist>`.  
+
+The label field will be used throughout your mechanism to identify the species. 
+Inert species in the model can be defined by setting reactive to be ``False``. Reaction 
+families will no longer be applied to these species, but reactions of the inert from libraries 
+and seed mechanisms  will still be considered. For all other species the reactive status must 
+be set as ``True``. The structure of the species can be defined using either by using SMILES or 
+:ref:`adjacencyList <rmgpy.molecule.adjlist>`.  
 
 The following is an example of a typical species item, based on methane using SMILE or adjacency list to define the structure::
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -81,7 +81,9 @@ class Species(object):
     `transportData`          A set of transport collision parameters
     `molecularWeight`       The molecular weight of the species
     `energyTransferModel`   The collisional energy transfer model to use
-    `reactive`              ``True`` if the species participates in reactions, ``False`` if not
+    `reactive`              ``True`` if the species participates in reaction families, ``False`` if not
+                                Reaction libraries and seed mechanisms that include the species are
+                                always considered regardless of this variable
     `props`                 A generic 'properties' dictionary to store user-defined flags
     `aug_inchi`             Unique augmented inchi
     ======================= ====================================================


### PR DESCRIPTION
Updated the doc-strings and documentation so that users will have a better idea of what is included and excluded when using inert species. 