### PR TITLE
Allow the profiling of RMG Jobs that do not converge

### DIFF
--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -165,6 +165,9 @@ options(
 	#gets RMG to generate edge species chemkin files. Uses lots of memory in output.
 	#Helpful for seeing why some reaction are not appearing in core model.  
     saveEdgeSpecies=False,
+    #Sets a time limit in the form DD:HH:MM:SS after which the RMG job will stop. Useful for profiling on jobs that
+    #do not converge.
+    #wallTime = '00:00:00',
 )
 
 # optional module allows for correction to unimolecular reaction rates at low pressures and/or temperatures.

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -306,7 +306,7 @@ def pressureDependence(
     rmg.pressureDependence.activeKRotor = True
     rmg.pressureDependence.rmgmode = True
 
-def options(units='si', saveRestartPeriod=None, generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, saveEdgeSpecies=False):
+def options(units='si', saveRestartPeriod=None, generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, saveEdgeSpecies=False, wallTime='00:00:00:00'):
     rmg.units = units
     rmg.saveRestartPeriod = Quantity(saveRestartPeriod) if saveRestartPeriod else None
     if generateOutputHTML:
@@ -318,6 +318,7 @@ def options(units='si', saveRestartPeriod=None, generateOutputHTML=False, genera
     if saveEdgeSpecies:
         logging.warning('Edge species saving was turned on.  This will slow down model generation for large simulations.')
     rmg.saveEdgeSpecies = saveEdgeSpecies
+    rmg.wallTime = wallTime
 
 def generatedSpeciesConstraints(**kwargs):
 
@@ -624,6 +625,7 @@ def saveInputFile(path, rmg):
     f.write('    saveSimulationProfiles = {0},\n'.format(rmg.saveSimulationProfiles))
     f.write('    saveEdgeSpecies = {0},\n'.format(rmg.saveEdgeSpecies))
     f.write('    verboseComments = {0},\n'.format(rmg.verboseComments))
+    f.write('    wallTime = {0},\n'.format(rmg.wallTime))
     f.write(')\n\n')
     
     f.close()

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -124,7 +124,7 @@ class RMG(util.Subject):
     `saveEdgeSpecies`                   ``True`` to save chemkin and HTML files of the edge species, ``False`` otherwise
     `pressureDependence`                Whether to process unimolecular (pressure-dependent) reaction networks
     `quantumMechanics`                  Whether to apply quantum mechanical calculations instead of group additivity to certain molecular types.
-    `wallTime`                          The maximum amount of CPU time in seconds to expend on this job; used to stop gracefully so we can still get profiling information
+    `wallTime`                          The maximum amount of CPU time in the form DD:HH:MM:SS to expend on this job; used to stop gracefully so we can still get profiling information
     ----------------------------------- ------------------------------------------------
     `initializationTime`                The time at which the job was initiated, in seconds since the epoch (i.e. from time.time())
     `done`                              Whether the job has completed (there is nothing new to add)
@@ -188,7 +188,7 @@ class RMG(util.Subject):
         self.pressureDependence = None
         self.quantumMechanics = None
         self.speciesConstraints = {}
-        self.wallTime = 0
+        self.wallTime = '00:00:00:00'
         self.initializationTime = 0
 
         self.execTime = []
@@ -376,28 +376,12 @@ class RMG(util.Subject):
             Species.solventStructure = self.database.solvation.getSolventStructure(self.solvent)
             diffusionLimiter.enable(Species.solventData, self.database.solvation)
             logging.info("Setting solvent data for {0}".format(self.solvent))
-    
-        # Set wall time
-        try:
-            walltime = kwargs['walltime']
-        except KeyError:
-            walltime = '0'
 
-        if walltime  == '0': 
-            self.wallTime = 0
-        else:
-            data = walltime[0].split(':')
-            if len(data) == 1:
-                self.wallTime = int(data[-1])
-            elif len(data) == 2:
-                self.wallTime = int(data[-1]) + 60 * int(data[-2])
-            elif len(data) == 3:
-                self.wallTime = int(data[-1]) + 60 * int(data[-2]) + 3600 * int(data[-3])
-            elif len(data) == 4:
-                self.wallTime = int(data[-1]) + 60 * int(data[-2]) + 3600 * int(data[-3]) + 86400 * int(data[-4])
-            else:
-                raise ValueError('Invalid format for wall time; should be HH:MM:SS.')
-    
+        data = self.wallTime.split(':')
+        self.wallTime = int(data[-1]) + 60 * int(data[-2]) + 3600 * int(data[-3]) + 86400 * int(data[-4])
+        if not len(data) == 4:
+            raise ValueError('Invalid format for wall time; should be DD:HH:MM:SS.')
+
         # Initialize reaction model
         if restart:
             self.loadRestartFile(os.path.join(self.outputDirectory,'restart.pkl'))
@@ -648,7 +632,6 @@ class RMG(util.Subject):
                             bimolecularReact=self.bimolecularReact)
 
             self.saveEverything()
-
 
             # Consider stopping gracefully if the next iteration might take us
             # past the wall time


### PR DESCRIPTION
Allows a value wallTime to be read in on the input file. After wallTime lapses the RMG job terminates and profiling data is created. 