### PR TITLE
Fix bug that forgets generating transport data when needed.

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1744,7 +1744,7 @@ def saveTransportFile(path, species):
         f.write("! {0:15} {1:8} {2:9} {3:9} {4:9} {5:9} {6:9} {7:9}\n".format('Species','Shape', 'LJ-depth', 'LJ-diam', 'DiplMom', 'Polzblty', 'RotRelaxNum','Data'))
         f.write("! {0:15} {1:8} {2:9} {3:9} {4:9} {5:9} {6:9} {7:9}\n".format('Name','Index', 'epsilon/k_B', 'sigma', 'mu', 'alpha', 'Zrot','Source'))
         for spec in species:
-            transportData = spec.transportData
+            transportData = spec.getTransportData()
             if (not transportData):
                 missingData = True
             else:
@@ -1753,17 +1753,17 @@ def saveTransportFile(path, species):
             label = getSpeciesIdentifier(spec)
             
             if missingData:
-                f.write('! {0:19s} {1!r}\n'.format(label, spec.transportData))
+                f.write('! {0:19s} {1!r}\n'.format(label, transportData))
             else:
                 f.write('{0:19} {1:d}   {2:9.3f} {3:9.3f} {4:9.3f} {5:9.3f} {6:9.3f}    ! {7:s}\n'.format(
                     label,
-                    spec.transportData.shapeIndex,
-                    spec.transportData.epsilon.value_si / constants.R,
-                    spec.transportData.sigma.value_si * 1e10,
-                    (spec.transportData.dipoleMoment.value_si * constants.c * 1e21 if spec.transportData.dipoleMoment else 0),
-                    (spec.transportData.polarizability.value_si * 1e30 if spec.transportData.polarizability else 0),
-                    (spec.transportData.rotrelaxcollnum if spec.transportData.rotrelaxcollnum else 0),
-                    spec.transportData.comment,
+                    transportData.shapeIndex,
+                    transportData.epsilon.value_si / constants.R,
+                    transportData.sigma.value_si * 1e10,
+                    (transportData.dipoleMoment.value_si * constants.c * 1e21 if transportData.dipoleMoment else 0),
+                    (transportData.polarizability.value_si * 1e30 if transportData.polarizability else 0),
+                    (transportData.rotrelaxcollnum if transportData.rotrelaxcollnum else 0),
+                    transportData.comment,
                 ))
 
 def saveChemkinFile(path, species, reactions, verbose = True, checkForDuplicates=True):

--- a/rmgpy/pdep/configuration.pyx
+++ b/rmgpy/pdep/configuration.pyx
@@ -168,18 +168,18 @@ cdef class Configuration:
         cdef double sigma, epsilon, mu, gasConc, frac, Tred, omega22
         
         assert self.isUnimolecular()
-        assert isinstance(self.species[0].transportData, TransportData)
+        assert isinstance(self.species[0].getTransportData(), TransportData)
         for spec, frac in bathGas.items():
-            assert isinstance(spec.transportData, TransportData)
+            assert isinstance(spec.getTransportData(), TransportData)
         
         bathGasSigma = 0.0; bathGasEpsilon = 1.0; bathGasMW = 0.0
         for spec, frac in bathGas.iteritems():
-            bathGasSigma += spec.transportData.sigma.value_si * frac
-            bathGasEpsilon *= spec.transportData.epsilon.value_si ** frac
+            bathGasSigma += spec.getTransportData().sigma.value_si * frac
+            bathGasEpsilon *= spec.getTransportData().epsilon.value_si ** frac
             bathGasMW += spec._molecularWeight.value_si * frac
         
-        sigma = 0.5 * (self.species[0].transportData.sigma.value_si + bathGasSigma)
-        epsilon = sqrt((self.species[0].transportData.epsilon.value_si * bathGasEpsilon))
+        sigma = 0.5 * (self.species[0].getTransportData().sigma.value_si + bathGasSigma)
+        epsilon = sqrt((self.species[0].getTransportData().epsilon.value_si * bathGasEpsilon))
         mu = 1.0 / (1.0/self.species[0]._molecularWeight.value_si + 1.0/bathGasMW)
         gasConc = P / constants.kB / T
         

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -41,7 +41,6 @@ from rmgpy.display import display
 #import rmgpy.chemkin
 import rmgpy.constants as constants
 from rmgpy.constraints import failsSpeciesConstraints
-from rmgpy.data.rmg import getDB
 from rmgpy.quantity import Quantity
 import rmgpy.species
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
@@ -98,21 +97,6 @@ class Species(rmgpy.species.Species):
         self.conformer.E0 = self.getThermoData().E0
         self.conformer.modes = conformer.modes
         self.conformer.spinMultiplicity = conformer.spinMultiplicity
-            
-    def generateTransportData(self):
-        """
-        Generate the transportData parameters for the species.
-        """
-
-        try:
-            transportDB = getDB('transport')        
-            if not transportDB: raise Exception
-        except Exception, e:
-            logging.debug('Could not obtain the transport database. Not generating transport...')
-            raise e
-
-        #count = sum([1 for atom in self.molecule[0].vertices if atom.isNonHydrogen()])
-        self.transportData = transportDB.getTransportProperties(self)[0]
     
     def generateEnergyTransferModel(self):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -685,7 +685,7 @@ class CoreEdgeReactionModel:
         # Update unimolecular (pressure dependent) reaction networks
         if self.pressureDependence:
             # Recalculate k(T,P) values for modified networks
-            self.updateUnimolecularReactionNetworks(database)
+            self.updateUnimolecularReactionNetworks()
             logging.info('')
             
         # Check new core and edge reactions for Chemkin duplicates
@@ -1419,7 +1419,7 @@ class CoreEdgeReactionModel:
         # Add the path reaction to that network
         network.addPathReaction(newReaction)
 
-    def updateUnimolecularReactionNetworks(self, database):
+    def updateUnimolecularReactionNetworks(self):
         """
         Iterate through all of the currently-existing unimolecular reaction
         networks, updating those that have been marked as invalid. In each update,
@@ -1465,7 +1465,7 @@ class CoreEdgeReactionModel:
         updatedNetworks = []
         for network in self.networkList:
             if not network.valid:
-                network.update(self, database, self.pressureDependence)
+                network.update(self, self.pressureDependence)
                 updatedNetworks.append(network)
             
         # PDepReaction objects generated from partial networks are irreversible

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -45,8 +45,6 @@ from rmgpy.quantity import Quantity
 import rmgpy.species
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
 from rmgpy.thermo.thermoengine import submit
-from rmgpy.pdep import SingleExponentialDown
-from rmgpy.statmech import  Conformer
 
 from rmgpy.data.base import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
@@ -84,19 +82,6 @@ class Species(rmgpy.species.Species):
         """
         return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
 
-    def generateStatMech(self, database):
-        """
-        Generate molecular degree of freedom data for the species. You must
-        have already provided a thermodynamics model using e.g.
-        :meth:`generateThermoData()`.
-        """
-        molecule = self.molecule[0]
-        conformer = database.statmech.getStatmechData(molecule, self.getThermoData())
-        if self.conformer is None:
-            self.conformer = Conformer()
-        self.conformer.E0 = self.getThermoData().E0
-        self.conformer.modes = conformer.modes
-        self.conformer.spinMultiplicity = conformer.spinMultiplicity
     
     def generateEnergyTransferModel(self):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -41,6 +41,7 @@ from rmgpy.display import display
 #import rmgpy.chemkin
 import rmgpy.constants as constants
 from rmgpy.constraints import failsSpeciesConstraints
+from rmgpy.data.rmg import getDB
 from rmgpy.quantity import Quantity
 import rmgpy.species
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
@@ -98,12 +99,20 @@ class Species(rmgpy.species.Species):
         self.conformer.modes = conformer.modes
         self.conformer.spinMultiplicity = conformer.spinMultiplicity
             
-    def generateTransportData(self, database):
+    def generateTransportData(self):
         """
         Generate the transportData parameters for the species.
         """
+
+        try:
+            transportDB = getDB('transport')        
+            if not transportDB: raise Exception
+        except Exception, e:
+            logging.debug('Could not obtain the transport database. Not generating transport...')
+            raise e
+
         #count = sum([1 for atom in self.molecule[0].vertices if atom.isNonHydrogen()])
-        self.transportData = database.transport.getTransportProperties(self)[0]
+        self.transportData = transportDB.getTransportProperties(self)[0]
         
 
         #previous method for calculating transport properties

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -82,17 +82,6 @@ class Species(rmgpy.species.Species):
         """
         return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
 
-    
-    def generateEnergyTransferModel(self):
-        """
-        Generate the collisional energy transfer model parameters for the
-        species. This "algorithm" is *very* much in need of improvement.
-        """
-        self.energyTransferModel = SingleExponentialDown(
-            alpha0 = (300*0.011962,"kJ/mol"),
-            T0 = (300,"K"),
-            n = 0.85,
-        ) 
 ################################################################################
 
 class ReactionModel:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -534,7 +534,6 @@ class CoreEdgeReactionModel:
         and instead the algorithm proceeds to react the core species together
         to form edge reactions.
         """
-        database = rmgpy.data.rmg.database
         
         numOldCoreSpecies = len(self.core.species)
         numOldCoreReactions = len(self.core.reactions)
@@ -1331,7 +1330,6 @@ class CoreEdgeReactionModel:
         """
 
         logging.info('Adding reaction library {0} to output file...'.format(reactionLib))
-        database = rmgpy.data.rmg.database
         
         # Append the edge reactions that are from the selected reaction library to an output species and output reactions list
         for rxn in self.edge.reactions:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -113,29 +113,6 @@ class Species(rmgpy.species.Species):
 
         #count = sum([1 for atom in self.molecule[0].vertices if atom.isNonHydrogen()])
         self.transportData = transportDB.getTransportProperties(self)[0]
-        
-
-        #previous method for calculating transport properties
-        '''
-        if count == 1:
-            self.transportData.sigma = (3.758e-10,"m")
-            self.transportData.epsilon = (148.6,"K")
-        elif count == 2:
-            self.transportData.sigma = (4.443e-10,"m")
-            self.transportData.epsilon = (110.7,"K")
-        elif count == 3:
-            self.transportData.sigma = (5.118e-10,"m")
-            self.transportData.epsilon = (237.1,"K")
-        elif count == 4:
-            self.transportData.sigma = (4.687e-10,"m")
-            self.transportData.epsilon = (531.4,"K")
-        elif count == 5:
-            self.transportData.sigma = (5.784e-10,"m")
-            self.transportData.epsilon = (341.1,"K")
-        else:
-            self.transportData.sigma = (5.949e-10,"m")
-            self.transportData.epsilon = (399.3,"K")
-        '''
     
     def generateEnergyTransferModel(self):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -43,7 +43,6 @@ import rmgpy.constants as constants
 from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.quantity import Quantity
 import rmgpy.species
-from rmgpy.thermo import Wilhoit, NASA, ThermoData
 from rmgpy.thermo.thermoengine import submit
 
 from rmgpy.data.base import ForbiddenStructureException

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -495,15 +495,15 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         # Generate states data for unimolecular isomers and reactants if necessary
         for isomer in self.isomers:
             spec = isomer.species[0]
-            if not spec.hasStatMech(): spec.generateStatMech(database)
+            if not spec.hasStatMech(): spec.generateStatMech()
         for reactants in self.reactants:
             for spec in reactants.species:
-                if not spec.hasStatMech(): spec.generateStatMech(database)
+                if not spec.hasStatMech(): spec.generateStatMech()
         # Also generate states data for any path reaction reactants, so we can
         # always apply the ILT method in the direction the kinetics are known
         for reaction in self.pathReactions:
             for spec in reaction.reactants:
-                if not spec.hasStatMech(): spec.generateStatMech(database)
+                if not spec.hasStatMech(): spec.generateStatMech()
         # While we don't need the frequencies for product channels, we do need
         # the E0, so create a conformer object with the E0 for the product
         # channel species if necessary

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -449,7 +449,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         for product in products:
             self.products.append(Configuration(*product))
 
-    def update(self, reactionModel, database, pdepSettings):
+    def update(self, reactionModel, pdepSettings):
         """
         Regenerate the :math:`k(T,P)` values for this partial network if the
         network is marked as invalid.

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -459,30 +459,18 @@ class Species(object):
         from rmgpy.thermo.thermoengine import submit
         
         if self.thermo:
-            self.thermo = self.getData()
+            if isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
+                return self.thermo
+            else:
+                return self.thermo.result()
         else:
             submit(self)
-            self.thermo = self.getData()
+            if isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
+                return self.thermo
+            else:
+                return self.thermo.result()
 
         return self.thermo       
-
-    def getData(self):
-        """
-        Returns the data, i.e. the thermo data associated with this
-        Species.
-
-        The thermo data can either be an already computed thermo data
-        object (NASA, Wilhoit, ThermoData), or it can be a future object
-        that holds a promise to a future object.
-
-        In the latter case, a blocking call is made to the future to retrieve
-        the thermo data object.
-        """
-        if isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
-            return self.thermo
-        else:
-            return self.thermo.result()
-
             
     def generateTransportData(self):
         """

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -49,6 +49,8 @@ import logging
 import rmgpy.quantity as quantity
 from rmgpy.molecule import Molecule
 
+from rmgpy.pdep import SingleExponentialDown
+from rmgpy.statmech.conformer import Conformer
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
 
 #: This dictionary is used to add multiplicity to species label
@@ -498,6 +500,30 @@ class Species(object):
             self.generateTransportData()
 
         return self.transportData
+
+    def generateStatMech(self):
+        """
+        Generate molecular degree of freedom data for the species. You must
+        have already provided a thermodynamics model using e.g.
+        :meth:`generateThermoData()`.
+        """
+
+        from rmgpy.data.rmg import getDB
+        try:
+            statmechDB = getDB('statmech')        
+            if not statmechDB: raise Exception
+        except Exception, e:
+            logging.debug('Could not obtain the stat. mech database. Not generating stat. mech...')
+            raise e
+
+        molecule = self.molecule[0]
+        conformer = statmechDB.getStatmechData(molecule, self.getThermoData())
+        
+        if self.conformer is None:
+            self.conformer = Conformer()
+        self.conformer.E0 = self.getThermoData().E0
+        self.conformer.modes = conformer.modes
+        self.conformer.spinMultiplicity = conformer.spinMultiplicity
         
 ################################################################################
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -500,6 +500,17 @@ class Species(object):
         self.transportData = transportDB.getTransportProperties(self)[0]
 
 
+    def getTransportData(self):
+        """
+        Returns the transport data associated with this species, and
+        calculates it if it is not yet available.
+        """
+
+        if not self.transportData:
+            self.generateTransportData()
+
+        return self.transportData
+        
 ################################################################################
 
 class TransitionState():

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -518,13 +518,23 @@ class Species(object):
 
         molecule = self.molecule[0]
         conformer = statmechDB.getStatmechData(molecule, self.getThermoData())
-        
+
         if self.conformer is None:
             self.conformer = Conformer()
         self.conformer.E0 = self.getThermoData().E0
         self.conformer.modes = conformer.modes
         self.conformer.spinMultiplicity = conformer.spinMultiplicity
         
+    def generateEnergyTransferModel(self):
+        """
+        Generate the collisional energy transfer model parameters for the
+        species. This "algorithm" is *very* much in need of improvement.
+        """
+        self.energyTransferModel = SingleExponentialDown(
+            alpha0 = (300*0.011962,"kJ/mol"),
+            T0 = (300,"K"),
+            n = 0.85,
+        ) 
 ################################################################################
 
 class TransitionState():

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -44,6 +44,7 @@ transition states (first-order saddle points on a potential energy surface).
 
 import numpy
 import cython
+import logging
 
 import rmgpy.quantity as quantity
 from rmgpy.molecule import Molecule
@@ -482,6 +483,21 @@ class Species(object):
         else:
             return self.thermo.result()
 
+            
+    def generateTransportData(self):
+        """
+        Generate the transportData parameters for the species.
+        """
+        from rmgpy.data.rmg import getDB
+        try:
+            transportDB = getDB('transport')        
+            if not transportDB: raise Exception
+        except Exception, e:
+            logging.debug('Could not obtain the transport database. Not generating transport...')
+            raise e
+
+        #count = sum([1 for atom in self.molecule[0].vertices if atom.isNonHydrogen()])
+        self.transportData = transportDB.getTransportProperties(self)[0]
 
 
 ################################################################################

--- a/rmgpy/speciesTest.py
+++ b/rmgpy/speciesTest.py
@@ -197,6 +197,15 @@ Thermo library: primaryThermoLibrary
         self.assertEqual(type(rmg_ctSpecies.thermo), type(ctSpecies.thermo))
         self.assertEqual(type(rmg_ctSpecies.transport), type(ctSpecies.transport))
 
+    def testGetTransportData(self):
+        """
+        Test that transport data can be retrieved correctly via the getTransportData method.
+        """
+
+        spc = Species(label="Ar", molecule=[Molecule(SMILES="[Ar]")], transportData=TransportData(shapeIndex=0, epsilon=(1134.93,'J/mol'), sigma=(3.33,'angstrom'), dipoleMoment=(2,'De'), polarizability=(1,'angstrom^3'), rotrelaxcollnum=15.0, comment="""GRI-Mech"""))
+
+        self.assertTrue(spc.getTransportData() is spc.transportData)
+
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a bug (cf. #718 ) that results in empty transport data files (`tran.dat`) after the recent merge of the `thermo_engine` branch. Transport data is also needed for p-dep simulations, so they would have crashed as well.

This PR replaces access of `spc.transportData` by method calls `spc.getTransportData()`. The latter checks if the transport data is available, and if not calculates the transport data on the spot.

In terms of code, I moved `generateTransportData` from `rmgpy.rmg.model.Species` to `rmgpy.species.Species`, where it really belongs. This way, `rmgpy.rmg.model.Species` becomes even more empty; only methods for stat. mech and solvent are still part of that class.

I added a unit test for the `getTransportData()` method.
