### PR TITLE
fix getThermoData method of species.Species

### DIFF
--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -461,16 +461,12 @@ class Species(object):
         from rmgpy.thermo.thermoengine import submit
         
         if self.thermo:
-            if isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
-                return self.thermo
-            else:
-                return self.thermo.result()
+            if not isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
+                self.thermo = self.thermo.result()
         else:
             submit(self)
-            if isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
-                return self.thermo
-            else:
-                return self.thermo.result()
+            if not isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
+                self.thermo = self.thermo.result()
 
         return self.thermo       
             


### PR DESCRIPTION
this PR fixes a bug introduced in d227a597e9424fd96797d337cef3b2077784f156 after merging two methods into one.

The bug only occurs in parallel runs, and was caught in the RMG-tests Travis CI builds, but not in the unit tests of this repo. It only emphasizes the importance of having unit tests with scoop enabled also working for this repo, cf. #663 (WIP). If not, the parallel functionality will be broken in no time...