### PR TITLE
Fix getThermoData bug for radical species: Use correct thermo prioritization for the saturated species

### DIFF
--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -251,6 +251,13 @@ class TestCyclicThermo(unittest.TestCase):
         # therefore is not selected.  Note that this unit test will have to change if the correction is fixed later.
         self.assertEqual(polycyclicGroups[0].label, 'PolycyclicRing')
         self.assertEqual(selected_polycyclicGroups[0].label, 'C12CCC=C1CC=C2')
+        
+        
+        # Check that the same result occurs when we retrieve thermo from getThermoData
+        selected_thermo2 = self.database.getThermoData(spec)
+        
+        selected2_ringGroups, selected2_polycyclicGroups = self.database.getRingGroupsFromComments(selected_thermo2)
+        self.assertEqual(selected2_polycyclicGroups[0].label, 'C12CCC=C1CC=C2')
     
 
     def testGetRingGroupsFromComments(self):


### PR DESCRIPTION
Like for saturated species, use thermo rank to pick out the thermo and then sort by enthalpy.  Looks like the old code only fixed the saturated thermo, but still relied on the most stable enthalpy for sorting the
radical thermo which uses HBI corrections.   This would likely use the wrong thing when we calculate a polycyclic radical's thermo..