### PR TITLE
fix memory logging

### DIFF
--- a/cantherm.py
+++ b/cantherm.py
@@ -63,7 +63,7 @@ cantherm.execute()
 try:
     import psutil
     process = psutil.Process(os.getpid())
-    rss, vms = process.memory_info()
-    logging.info('Memory used: %.2f MB' % (rss / 1024.0 / 1024.0))
+    memory_info = process.memory_info()
+    logging.info('Memory used: %.2f MB' % (memory_info.rss / 1024.0 / 1024.0))
 except ImportError:
     logging.info('Optional package dependency "psutil" not found; memory profiling information will not be saved.')

--- a/rmgpy/stats.py
+++ b/rmgpy/stats.py
@@ -103,8 +103,8 @@ class ExecutionStatsWriter(object):
         try:
             import psutil
             process = psutil.Process(os.getpid())
-            rss, vms = process.memory_info()
-            self.memoryUse.append(rss / 1.0e6)
+            memory_info = process.memory_info()
+            self.memoryUse.append(memory_info.rss / 1.0e6)
             logging.info('    Memory used: %.2f MB' % (self.memoryUse[-1]))
         except:
             logging.info('    Memory used: memory usage was unable to be logged')


### PR DESCRIPTION
It's been a long time RMG cannot print out right memory info; it's always showing 
`Memory used: memory usage was unable to be logged`

Since `process.memory_info()` is returning an object instead of a tuple any more, this PR makes sure memory info is parsed properly.