### PR TITLE
Always use the same temp range 294-2000K to fit reverse kinetics

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -707,10 +707,7 @@ class Reaction:
         cython.declare(Tlist=numpy.ndarray, klist=numpy.ndarray, i=cython.int)
         kf = kForward
         assert isinstance(kf, Arrhenius), "Only reverses Arrhenius rates"
-        if kf.Tmin is not None and kf.Tmax is not None:
-            Tlist = 1.0/numpy.linspace(1.0/kf.Tmax.value_si, 1.0/kf.Tmin.value_si, 50)
-        else:
-            Tlist = 1.0 / numpy.arange(0.0005, 0.0034, 0.0001)  # 294 K to 2000 K
+        Tlist = 1.0 / numpy.arange(0.0005, 0.0034, 0.0001)  # 294 K to 2000 K
         # Determine the values of the reverse rate coefficient k_r(T) at each temperature
         klist = numpy.zeros_like(Tlist)
         for i in range(len(Tlist)):


### PR DESCRIPTION
The temperature range given in kinetics entries are often arbitrary
and dictated by the user.  Sometimes these temperature ranges are
very narrow.  Sometimes they fail because NASA polynomials cannot
even be evaluated at Tmin.  Fitting in a narrow range doesn't work well
because RMG will always use the kinetics if its available, even
if we are outside the temperature range.  It makes more sense
to fit to a standard temperature range.