### PR TITLE
Support for isotope information in chemkin files

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -52,6 +52,7 @@ from rmgpy.data.kinetics.library import LibraryReaction
 from rmgpy.data.kinetics.family import TemplateReaction
 from rmgpy.rmg.pdep import PDepNetwork
 from rmgpy.molecule import Molecule
+from rmgpy.molecule.util import retrieveElementCount
 from rmgpy.transport import TransportData
 
 __chemkin_reaction_count = None
@@ -1349,23 +1350,7 @@ def writeThermoEntry(species, verbose = True):
     assert thermo.polynomials[1].cm2 == 0 and thermo.polynomials[1].cm1 == 0
 
     # Determine the number of each type of element in the molecule
-    elements = ['C','H','N','O']; elementCounts = [0,0,0,0]
-    for atom in species.molecule[0].atoms:
-        # The atom itself
-        symbol = atom.element.symbol
-        if symbol not in elements:
-            elements.append(symbol)
-            elementCounts.append(1)
-        else:
-            elementCounts[elements.index(symbol)] += 1
-    # Remove elements with zero count
-    index = 0
-    while index < len(elementCounts):
-        if elementCounts[index] == 0:
-            del elements[index]
-            del elementCounts[index]
-        else:
-            index += 1
+    elementCounts = retrieveElementCount(species.molecule[0])
     
     string = ''
     # Write thermo comments
@@ -1381,20 +1366,30 @@ def writeThermoEntry(species, verbose = True):
 
     # Line 1
     string += '{0:<16}        '.format(getSpeciesIdentifier(species))
-    if len(elements) <= 4:
+    if len(elementCounts) <= 4:
         # Use the original Chemkin syntax for the element counts
-        for symbol, count in zip(elements, elementCounts):
-            string += '{0!s:<2}{1:<3d}'.format(symbol, count)
-        string += '     ' * (4 - len(elements))
+        for key, count in elementCounts.iteritems():
+            if isinstance(key, tuple):
+                symbol, isotope = key
+                chemkinName = getElement(symbol, isotope=isotope).chemkinName
+            else:
+                chemkinName = key
+            string += '{0!s:<2}{1:<3d}'.format(chemkinName, count)
+        string += '     ' * (4 - len(elementCounts))
     else:
         string += '     ' * 4
     string += 'G{0:<10.3f}{1:<10.3f}{2:<8.2f}      1'.format(thermo.polynomials[0].Tmin.value_si, thermo.polynomials[1].Tmax.value_si, thermo.polynomials[0].Tmax.value_si)
-    if len(elements) > 4:
+    if len(elementCounts) > 4:
         string += '&\n'
         # Use the new-style Chemkin syntax for the element counts
         # This will only be recognized by Chemkin 4 or later
-        for symbol, count in zip(elements, elementCounts):
-            string += '{0!s:<2}{1:<3d}'.format(symbol, count)
+        for key, count in elementCounts.iteritems():
+            if isinstance(key, tuple):
+                symbol, isotope = key
+                chemkinName = getElement(symbol, isotope=isotope).chemkinName
+            else:
+                chemkinName = key
+            string += '{0!s:<2}{1:<3d}'.format(chemkinName, count)
     string += '\n'
 
     # Line 2

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -39,6 +39,7 @@ import os.path
 import numpy
 
 import rmgpy.kinetics as _kinetics
+from rmgpy.molecule.element import getElement
 from rmgpy.reaction import Reaction
 #from species import Species
 from rmgpy.rmg.model import Species
@@ -1786,7 +1787,7 @@ def saveChemkinFile(path, species, reactions, verbose = True, checkForDuplicates
     sorted_species = sorted(species, key=lambda species: species.index)
 
     # Elements section
-    f.write('ELEMENTS H C O N Ne Ar He Si S Cl END\n\n')
+    writeElementsSection(f)
 
     # Species section
     f.write('SPECIES\n')
@@ -1922,6 +1923,29 @@ def saveChemkinFiles(rmg):
         if os.path.exists(latest_chemkin_path):
             os.unlink(latest_chemkin_path)
         shutil.copy2(this_chemkin_path,latest_chemkin_path)
+
+def writeElementsSection(f):
+    """
+    Write the ELEMENTS section of the chemkin file.    
+    """
+
+    s = 'ELEMENTS\n'
+
+    # map of isotope elements with chemkin-compatible element representation:
+
+    elements = ('H', 'C', ('C', 13), 'O', 'N', 'Ne', 'Ar', 'He', 'Si', 'S', 'Cl')
+    for el in elements:
+        if isinstance(el, tuple):
+            symbol, isotope = el
+            chemkinName = getElement(symbol, isotope=isotope).chemkinName
+            mass = 1000 * getElement(symbol, isotope=isotope).mass
+            s += '\t' + chemkinName + ' /' +  '{0:.3f}'.format(mass) + '/' + '\n'
+        else:
+            s += '\t' + el + '\n'
+    s += 'END\n\n'
+
+    f.write(s)
+
 
 class ChemkinWriter(object):
     """

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1921,14 +1921,16 @@ def saveChemkinFiles(rmg):
 
 def writeElementsSection(f):
     """
-    Write the ELEMENTS section of the chemkin file.    
+    Write the ELEMENTS section of the chemkin file.  This file currently lists
+    all elements and isotopes available in RMG. It may become useful in the future
+    to only include elements/isotopes present in the current RMG run. 
     """
 
     s = 'ELEMENTS\n'
 
     # map of isotope elements with chemkin-compatible element representation:
 
-    elements = ('H', 'C', ('C', 13), 'O', 'N', 'Ne', 'Ar', 'He', 'Si', 'S', 'Cl')
+    elements = ('H', ('H', 2), ('H',3), 'C', ('C', 13), 'O', ('O',18), 'N', 'Ne', 'Ar', 'He', 'Si', 'S', 'Cl')
     for el in elements:
         if isinstance(el, tuple):
             symbol, isotope = el

--- a/rmgpy/molecule/element.pxd
+++ b/rmgpy/molecule/element.pxd
@@ -32,5 +32,6 @@ cdef class Element:
     cdef public float mass
     cdef public float covRadius
     cdef public int isotope
+    cdef public str chemkinName
 
 cpdef Element getElement(value, int isotope=?)

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -68,18 +68,20 @@ class Element:
     `mass`      ``float``       The mass of the element in kg/mol
     `covRadius` ``float``       Covalent bond radius in Angstrom
     `isotope`   ``int``         The isotope integer of the element
+    `chemkinName` ``str``       The chemkin compatible representation of the element
     =========== =============== ================================================
     
     This class is specifically for properties that all atoms of the same element
     share. Ideally there is only one instance of this class for each element.
     """
     
-    def __init__(self, number, symbol, name, mass, isotope=-1):
+    def __init__(self, number, symbol, name, mass, isotope=-1, chemkinName=None):
         self.number = number
         self.symbol = intern(symbol)
         self.name = name
         self.mass = mass
         self.isotope = isotope
+        self.chemkinName = chemkinName or self.name
         try:
             self.covRadius = _rdkit_periodic_table.GetRcovalent(symbol)
         except RuntimeError:
@@ -164,8 +166,8 @@ def getElement(value, isotope=-1):
 # Period 1
 #: Hydrogen
 H  = Element(1,   'H' , 'hydrogen'      , 0.00100794)
-D  = Element(1,   'H' , 'deuterium'     , 0.002014101, 2)
-T  = Element(1,   'H' , 'tritium'       , 0.003016049, 3)
+D  = Element(1,   'H' , 'deuterium'     , 0.002014101, 2, 'D')
+T  = Element(1,   'H' , 'tritium'       , 0.003016049, 3, 'T')
 He = Element(2,   'He', 'helium'        , 0.004002602)
 
 # Period 2
@@ -173,10 +175,10 @@ Li = Element(3,   'Li', 'lithium'       , 0.006941)
 Be = Element(4,   'Be', 'beryllium'     , 0.009012182)
 B  = Element(5,   'B',  'boron'         , 0.010811)
 C  = Element(6,   'C' , 'carbon'        , 0.0120107)
-C13= Element(6,   'C' , 'carbon-13'     , 0.0130033, 13)
+C13= Element(6,   'C' , 'carbon-13'     , 0.0130033, 13, 'CI')
 N  = Element(7,   'N' , 'nitrogen'      , 0.01400674)
 O  = Element(8,   'O' , 'oxygen'        , 0.0159994)
-O18= Element(8,   'O' , 'oxygen-18'     , 0.0179999, 18)
+O18= Element(8,   'O' , 'oxygen-18'     , 0.0179999, 18, 'OI')
 F  = Element(9,   'F' , 'fluorine'      , 0.018998403)
 Ne = Element(10,  'Ne', 'neon'          , 0.0201797)
 

--- a/rmgpy/molecule/elementTest.py
+++ b/rmgpy/molecule/elementTest.py
@@ -52,6 +52,26 @@ class TestElement(unittest.TestCase):
         """
         self.assertTrue(rmgpy.molecule.element.getElement(6) is self.element)
         self.assertTrue(rmgpy.molecule.element.getElement('C') is self.element)
+
+    def testGetElementIsotope(self):
+        """
+        Test that the rmgpy.elements.getElement() method works for isotopes.
+        """
+        self.assertTrue(isinstance(rmgpy.molecule.element.getElement('C', isotope=13), Element))
+        self.assertTrue(isinstance(rmgpy.molecule.element.getElement(6, isotope=13), Element))
+
+    def testChemkinName(self):
+        """
+        Test that retrieving the chemkin name of an element works.
+        """
+        d = rmgpy.molecule.element.getElement('H', isotope=2)
+        self.assertEqual(d.chemkinName, 'D')
+
+        c13 = rmgpy.molecule.element.getElement('C', isotope=13)
+        self.assertEqual(c13.chemkinName, 'CI')
+
+        o18 = rmgpy.molecule.element.getElement('O', isotope=18)
+        self.assertEqual(o18.chemkinName, 'OI')
         
 ################################################################################
 

--- a/rmgpy/molecule/util.py
+++ b/rmgpy/molecule/util.py
@@ -23,12 +23,14 @@ def retrieveElementCount(obj):
     
     elif isinstance(obj, Molecule):
         for atom in obj.atoms:
-            element = atom.element.symbol
-            if element in element_count:
-                updated_count = element_count[element] + 1
-                element_count[element] = updated_count 
+            symbol = atom.element.symbol
+            isotope = atom.element.isotope
+            key = symbol if isotope == -1 else (symbol, isotope)
+            if key in element_count:
+                updated_count = element_count[key] + 1
+                element_count[key] = updated_count 
             else:
-                element_count[element] = 1
+                element_count[key] = 1
         return element_count
 
     else:


### PR DESCRIPTION
This PR adds support for isotope information in chemkin files.

Specifically:

- a new attribute `chemkinName` in the Element class ensures that chemkin-compatible element symbols are written. Chemkin only allows up names of to two characters long, so alternative had to be provided for longer, more straightforward names like "C-13".
- Writing the elements section of the chemkin file is refactored in its own function. However, rather than searching for all unique elements (and isotopes) among the species of the model, the elements are still hard-coded, for efficiency reasons. 
- the utility function `retrieveElementCount` of the `rmgpy.molecule.util` module now supports isotopes as well. That is, non-normal isotopes like C-13 will not be counted as a normal carbon atom, but as a separate key in the returned dictionary.
- the `writeThermoEntry ` function of the `rmgpy.chemkin` module now correctly writes the elements of the compound. It does this by removing the hard-coded heuristic, by a more thorough search via `retrieveElementCount`.