### PR TITLE
Fix and re-add verbose comments back to RMG

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1037,13 +1037,13 @@ class KineticsFamily(Database):
         else:
             return self.groups.top
     
-    def fillKineticsRulesByAveragingUp(self):
+    def fillKineticsRulesByAveragingUp(self, verbose=False):
         """
         Fill in gaps in the kinetics rate rules by averaging child nodes
         recursively starting from the top level root template.
         """
         
-        self.rules.fillRulesByAveragingUp(self.getRootTemplate(), {})
+        self.rules.fillRulesByAveragingUp(self.getRootTemplate(), {}, verbose)
         
         
 

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -636,6 +636,13 @@ class KineticsRules(Database):
                 else:
                     # We found one or more results! Let's average them together
                     kinetics = self.__getAverageKinetics([k for k, t in kineticsList])
+                    # Unlike in the case of a single rule, the verbose comments for averaging are lost unless they are 
+                    # appended in the following lines.  Verbose comments are filtered out in 
+                    # rmgpy.rmg.model.CoreEdgeReactionModel.generateKinetics
+                    kinetics.comment = 'Average of ({0})'.format(
+                         ' + '.join(k.comment if k.comment != '' else ';'.join(g.label for g in t) for k, t in kineticsList))
+                    kinetics.comment +='\n'
+                    # Append standard portion of kinetics comments that appear in non-verbose mode.
                     kinetics.comment += 'Estimated using average of templates {0}'.format(
                         ' + '.join([getTemplateLabel(t) for k, t in kineticsList]),
                     )

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -440,9 +440,11 @@ class KineticsRules(Database):
         
         return entries
 
-    def fillRulesByAveragingUp(self, rootTemplate, alreadyDone):
+    def fillRulesByAveragingUp(self, rootTemplate, alreadyDone, verbose=False):
         """
         Fill in gaps in the kinetics rate rules by averaging child nodes.
+        If verbose is set to True, then exact sources of kinetics are saved in the kinetics comments
+        (warning: this uses up a lot of memory due to the extensively long comments)
         """
         rootLabel = ';'.join([g.label for g in rootTemplate])
         
@@ -472,7 +474,7 @@ class KineticsRules(Database):
             if label in alreadyDone:
                 kinetics = alreadyDone[label]
             else:
-                kinetics = self.fillRulesByAveragingUp(template, alreadyDone)
+                kinetics = self.fillRulesByAveragingUp(template, alreadyDone, verbose)
             
             if kinetics is not None:
                 kineticsList.append([kinetics, template])
@@ -494,26 +496,27 @@ class KineticsRules(Database):
             if len(kineticsList) > 1:
                 # We found one or more results! Let's average them together
                 kinetics = self.__getAverageKinetics([k for k, t in kineticsList])
-                kinetics.comment = 'Average of ({0})'.format(
-                     ' + '.join(';'.join(g.label for g in t) for k, t in kineticsList))
                 
-                # For debug mode: uncomment the following kinetics commenting
-                # lines and use them instead of the lines above. Caution: large memory usage.
-
-                # kinetics.comment += 'Average of ({0})'.format(
-                #     ' + '.join(k.comment if k.comment != '' else ';'.join(g.label for g in t) for k, t in kineticsList))
+                if verbose:
+                    kinetics.comment = 'Average of ({0})'.format(
+                         ' + '.join(k.comment if k.comment != '' else ';'.join(g.label for g in t) for k, t in kineticsList))
+                
+                else:
+                    kinetics.comment = 'Average of ({0})'.format(
+                     ' + '.join(';'.join(g.label for g in t) for k, t in kineticsList))
 
             else:
                 k,t = kineticsList[0]
                 kinetics = deepcopy(k)
                 # Even though we are using just a single set of kinetics, it's still considered
                 # an average.  It just happens that the other distance 1 children had no data.
-                kinetics.comment = 'Average of ({0})'.format(';'.join(g.label for g in t))
                 
-                # For debug mode: uncomment the following kinetics commenting
-                # lines and use them instead of the lines above. Caution: large memory usage.
+                if verbose:
+                    kinetics.comment = 'Average of ({0})'.format(k.comment if k.comment != '' else ';'.join(g.label for g in t))
+                else:
+                    kinetics.comment = 'Average of ({0})'.format(';'.join(g.label for g in t))
+                
 
-                # kinetics.comment += 'Average of ({0}).format(k.comment if k.comment != '' else ';'.join(g.label for g in t))
             
             entry = Entry(
                 index = 0,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -322,7 +322,7 @@ class RMG(util.Subject):
                 logging.info('Training set explicitly not added to rate rules in kinetics families...')
             logging.info('Filling in rate rules in kinetics families by averaging...')
             for family in self.database.kinetics.families.values():
-                family.fillKineticsRulesByAveragingUp()
+                family.fillKineticsRulesByAveragingUp(verbose=self.verboseComments)
     
     def initialize(self, **kwargs):
         """


### PR DESCRIPTION
After https://github.com/ReactionMechanismGenerator/RMG-Py/pull/713, we removed true verbose comments due to high memory usage.  Turns out the memory consumption was partially due to incorrect kinetic comments.  These commits try to fix the verbose comments for kinetics (turned on when the `input.py` file contains `options(verboseComments=True)`.)  This should print out all the original rule rules which actually contain data.  

Turning on `verboseComments` starts out with memory usage around 1 GB, and with it off the memory usage starts at around 300 MB.

