### PR TITLE
Changes to Wilhoit, NASA, ThermoData

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -869,7 +869,7 @@ class ThermoDatabase(object):
                 thermo0 = self.getThermoDataFromGroups(species)
                 
         # Make sure to calculate Cp0 and CpInf if it wasn't done already
-        self.findCp0andCpInf(species, thermo0)
+        findCp0andCpInf(species, thermo0)
 
         # Return the resulting thermo parameters
         return thermo0
@@ -926,24 +926,7 @@ class ThermoDatabase(object):
                     thermoData[0].comment += 'Thermo library: ' + label
                 return thermoData
 
-        return None
-    
-    def findCp0andCpInf(self, species, thermoData):
-        """
-        Calculate the Cp0 and CpInf values, and add them to the thermoData object.
-        
-        Modifies thermoData in place and doesn't return anything
-        """
-        if not isinstance(thermoData,ThermoData):
-            return # Just skip it
-            raise Exception("Trying to add Cp0 to something that's not a ThermoData: {0!r}".format(thermoData))
-        if thermoData.Cp0 is None:
-            Cp0 = species.calculateCp0()
-            thermoData.Cp0 = (Cp0,"J/(mol*K)")
-        if thermoData.CpInf is None:
-            CpInf = species.calculateCpInf()  
-            thermoData.CpInf = (CpInf,"J/(mol*K)")
-                
+        return None                
                 
     def getAllThermoData(self, species):
         """
@@ -1009,7 +992,7 @@ class ThermoDatabase(object):
             for molecule in species.molecule:
                 if molecule.isIsomorphic(entry.item) and entry.data is not None:
                     thermoData = deepcopy(entry.data)
-                    self.findCp0andCpInf(species, thermoData)
+                    findCp0andCpInf(species, thermoData)
                     return (thermoData, library, entry)
         return None
 
@@ -1037,7 +1020,7 @@ class ThermoDatabase(object):
         species.molecule = [species.molecule[ind] for ind in indices]
         
         thermoData = thermo[indices[0]]
-        self.findCp0andCpInf(species, thermoData)
+        findCp0andCpInf(species, thermoData)
         return thermoData
 
     def prioritizeThermo(self, species, thermoDataList):
@@ -1356,3 +1339,19 @@ class ThermoDatabase(object):
                 groupLabel = splitTokens[1]
                 polycyclicGroups.append(self.groups['polycyclic'].entries[groupLabel])
         return ringGroups, polycyclicGroups
+
+def findCp0andCpInf(species, thermoData):
+    """
+    Calculate the Cp0 and CpInf values, and add them to the thermoData object.
+    
+    Modifies thermoData in place and doesn't return anything
+    """
+    if not isinstance(thermoData,ThermoData):
+        return # Just skip it
+        raise Exception("Trying to add Cp0 to something that's not a ThermoData: {0!r}".format(thermoData))
+    if thermoData.Cp0 is None:
+        Cp0 = species.calculateCp0()
+        thermoData.Cp0 = (Cp0,"J/(mol*K)")
+    if thermoData.CpInf is None:
+        CpInf = species.calculateCpInf()  
+        thermoData.CpInf = (CpInf,"J/(mol*K)")

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1340,18 +1340,13 @@ class ThermoDatabase(object):
                 polycyclicGroups.append(self.groups['polycyclic'].entries[groupLabel])
         return ringGroups, polycyclicGroups
 
-def findCp0andCpInf(species, thermoData):
+def findCp0andCpInf(species, heatCap):
     """
-    Calculate the Cp0 and CpInf values, and add them to the thermoData object.
-    
-    Modifies thermoData in place and doesn't return anything
+    Calculate the Cp0 and CpInf values, and add them to the HeatCapacityModel object.
     """
-    if not isinstance(thermoData,ThermoData):
-        return # Just skip it
-        raise Exception("Trying to add Cp0 to something that's not a ThermoData: {0!r}".format(thermoData))
-    if thermoData.Cp0 is None:
+    if heatCap.Cp0 is None:
         Cp0 = species.calculateCp0()
-        thermoData.Cp0 = (Cp0,"J/(mol*K)")
-    if thermoData.CpInf is None:
+        heatCap.Cp0 = (Cp0,"J/(mol*K)")
+    if heatCap.CpInf is None:
         CpInf = species.calculateCpInf()  
-        thermoData.CpInf = (CpInf,"J/(mol*K)")
+        heatCap.CpInf = (CpInf,"J/(mol*K)")

--- a/rmgpy/thermo/convertTest.py
+++ b/rmgpy/thermo/convertTest.py
@@ -72,6 +72,8 @@ class TestConverter(unittest.TestCase):
             Tmin = (10,"K"),
             Tmax = (3000,"K"),
             E0 = (-93.6077,'kJ/mol'),
+            Cp0 = (4.0*constants.R,"J/(mol*K)"),
+            CpInf = (21.5*constants.R,"J/(mol*K)"),
             comment = 'C2H6',
         )
         self.thermodata = ThermoData(
@@ -131,7 +133,7 @@ class TestConverter(unittest.TestCase):
         Test the conversion of a NASA model to a Wilhoit model.
         """
         nasa = self.nasa
-        wilhoit = nasa.toWilhoit(Cp0=self.wilhoit.Cp0.value_si, CpInf=self.wilhoit.CpInf.value_si)
+        wilhoit = nasa.toWilhoit()
         Tlist = numpy.arange(10, 3000, 10)
         for T in Tlist:
             Cp_wilhoit = wilhoit.getHeatCapacity(T)
@@ -211,7 +213,7 @@ class TestConverter(unittest.TestCase):
         """
         wilhoit1 = self.wilhoit
         nasa = wilhoit1.toNASA(Tmin=10, Tmax=3000, Tint=1000)
-        wilhoit2 = nasa.toWilhoit(Cp0=self.wilhoit.Cp0.value_si, CpInf=self.wilhoit.CpInf.value_si)
+        wilhoit2 = nasa.toWilhoit()
         Tlist = numpy.arange(10, 3000, 10)
         for T in Tlist:
             Cp_1 = wilhoit1.getHeatCapacity(T)

--- a/rmgpy/thermo/convertTest.py
+++ b/rmgpy/thermo/convertTest.py
@@ -150,7 +150,7 @@ class TestConverter(unittest.TestCase):
         Test the conversion of a NASA model to a ThermoData model.
         """
         nasa = self.nasa
-        thermodata = nasa.toThermoData(Cp0=self.thermodata.Cp0.value_si, CpInf=self.thermodata.CpInf.value_si)
+        thermodata = nasa.toThermoData()
         Tlist = numpy.array([300,400,500,600,800,1000,1500])
         for T in Tlist:
             Cp_thermodata = thermodata.getHeatCapacity(T)

--- a/rmgpy/thermo/model.pxd
+++ b/rmgpy/thermo/model.pxd
@@ -29,7 +29,7 @@ from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 
 cdef class HeatCapacityModel:
     
-    cdef public ScalarQuantity _Tmin, _Tmax, _E0
+    cdef public ScalarQuantity _Tmin, _Tmax, _E0, _Cp0, _CpInf
     cdef public str comment
     
     cpdef bint isTemperatureValid(self, double T) except -2

--- a/rmgpy/thermo/model.pyx
+++ b/rmgpy/thermo/model.pyx
@@ -47,15 +47,19 @@ cdef class HeatCapacityModel:
     `Tmin`          The minimum temperature at which the model is valid, or ``None`` if unknown or undefined
     `Tmax`          The maximum temperature at which the model is valid, or ``None`` if unknown or undefined
     `E0`            The energy at zero Kelvin (including zero point energy)
+    `Cp0`           The heat capacity at zero Kelvin
+    `CpInf`         The heat capacity at infinity
     `comment`       Information about the model (e.g. its source)
     =============== ============================================================
 
     """
     
-    def __init__(self, Tmin=None, Tmax=None, E0=None, comment=''):
+    def __init__(self, Tmin=None, Tmax=None, E0=None, Cp0=None, CpInf=None, comment=''):
         self.Tmin = Tmin
         self.Tmax = Tmax
         self.E0 = E0
+        self.Cp0 = Cp0
+        self.CpInf = CpInf
         self.comment = comment
         
     def __repr__(self):
@@ -63,13 +67,13 @@ cdef class HeatCapacityModel:
         Return a string representation that can be used to reconstruct the
         HeatCapacityModel object.
         """
-        return 'HeatCapacityModel(Tmin={0!r}, Tmax={1!r}, E0={2!r}, comment="""{3}""")'.format(self.Tmin, self.Tmax, self.E0, self.comment)
+        return 'HeatCapacityModel(Tmin={0!r}, Tmax={1!r}, E0={2!r}, Cp0={3!r}, Cp0={4!r}, comment="""{5}""")'.format(self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.comment)
 
     def __reduce__(self):
         """
         A helper function used when pickling a HeatCapacityModel object.
         """
-        return (HeatCapacityModel, (self.Tmin, self.Tmax, self.E0, self.comment))
+        return (HeatCapacityModel, (self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.comment))
 
     property E0:
         """The ground state energy (J/mol) at zero Kelvin, including zero point energy, or ``None`` if not yet specified."""
@@ -91,6 +95,20 @@ cdef class HeatCapacityModel:
             return self._Tmax
         def __set__(self, value):
             self._Tmax = quantity.Temperature(value)
+
+    property Cp0:
+        """The heat capacity at zero temperature."""
+        def __get__(self):
+            return self._Cp0
+        def __set__(self, value):
+            self._Cp0 = quantity.HeatCapacity(value)
+
+    property CpInf:
+        """The heat capacity at infinite temperature."""
+        def __get__(self):
+            return self._CpInf
+        def __set__(self, value):
+            self._CpInf = quantity.HeatCapacity(value)
 
     cpdef bint isTemperatureValid(self, double T) except -2:
         """

--- a/rmgpy/thermo/nasa.pxd
+++ b/rmgpy/thermo/nasa.pxd
@@ -65,7 +65,7 @@ cdef class NASA(HeatCapacityModel):
 
     cpdef double getFreeEnergy(self, double T) except 1000000000
 
-    cpdef ThermoData toThermoData(self, double Cp0=?, double CpInf=?)
+    cpdef ThermoData toThermoData(self)
 
     cpdef Wilhoit toWilhoit(self, double Cp0, double CpInf)
     

--- a/rmgpy/thermo/nasa.pxd
+++ b/rmgpy/thermo/nasa.pxd
@@ -67,6 +67,6 @@ cdef class NASA(HeatCapacityModel):
 
     cpdef ThermoData toThermoData(self)
 
-    cpdef Wilhoit toWilhoit(self, double Cp0, double CpInf)
+    cpdef Wilhoit toWilhoit(self)
     
     cpdef NASA changeBaseEnthalpy(self, double deltaH)

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -289,7 +289,7 @@ cdef class NASA(HeatCapacityModel):
         """
         return self.selectPolynomial(T).getFreeEnergy(T)
 
-    cpdef ThermoData toThermoData(self, double Cp0=0.0, double CpInf=0.0):
+    cpdef ThermoData toThermoData(self):
         """
         Convert the Wilhoit model to a :class:`ThermoData` object.
         """
@@ -303,8 +303,8 @@ cdef class NASA(HeatCapacityModel):
             Cpdata = (Cpdata,"J/(mol*K)"),
             H298 = (self.getEnthalpy(298)*0.001,"kJ/mol"),
             S298 = (self.getEntropy(298),"J/(mol*K)"),
-            Cp0 = (Cp0,"J/(mol*K)"),
-            CpInf = (CpInf,"J/(mol*K)"),
+            Cp0 = self.Cp0,
+            CpInf = self.CpInf,
             E0 = self.E0,
             comment = self.comment
         )

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -200,8 +200,8 @@ cdef class NASA(HeatCapacityModel):
 
     """
     
-    def __init__(self, polynomials=None, Tmin=None, Tmax=None, E0=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, comment=comment)
+    def __init__(self, polynomials=None, Tmin=None, Tmax=None, E0=None, Cp0=None, CpInf=None, comment=''):
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, Cp0=Cp0, CpInf=CpInf, comment=comment)
         self.polynomials = polynomials
     
     def __repr__(self):
@@ -214,6 +214,8 @@ cdef class NASA(HeatCapacityModel):
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
         if self.E0 is not None: string += ', E0={0!r}'.format(self.E0)
+        if self.Cp0 is not None: string += ', Cp0={0!r}'.format(self.Cp0)
+        if self.CpInf is not None: string += ', CpInf={0!r}'.format(self.CpInf)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -222,7 +224,7 @@ cdef class NASA(HeatCapacityModel):
         """
         A helper function used when pickling an object.
         """
-        return (NASA, (self.polynomials, self.Tmin, self.Tmax, self.E0, self.comment))
+        return (NASA, (self.polynomials, self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.comment))
 
     property polynomials:
         """The set of one, two, or three NASA polynomials."""

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -310,7 +310,7 @@ cdef class NASA(HeatCapacityModel):
         )
 
     @cython.boundscheck(False)
-    cpdef Wilhoit toWilhoit(self, double Cp0, double CpInf):
+    cpdef Wilhoit toWilhoit(self):
         """
         Convert a :class:`MultiNASA` object `multiNASA` to a :class:`Wilhoit` 
         object. You must specify the linearity of the molecule `linear`, the number
@@ -318,7 +318,7 @@ cdef class NASA(HeatCapacityModel):
         `Nrotors` so the algorithm can determine the appropriate heat capacity
         limits at zero and infinite temperature.
         """
-        cdef double Tmin, Tmax, dT, H298, S298
+        cdef double Tmin, Tmax, dT, H298, S298, Cp0, CpInf
         cdef numpy.ndarray[numpy.float64_t, ndim=1] Tdata, Cpdata
         cdef int i
         
@@ -326,6 +326,8 @@ cdef class NASA(HeatCapacityModel):
         
         Tmin = self.Tmin.value_si
         Tmax = self.Tmax.value_si
+        Cp0 = self.Cp0.value_si
+        CpInf = self.CpInf.value_si
         dT = min(50.0, (Tmax - Tmin) / 100.)
         
         Tdata = numpy.arange(Tmin, Tmax, dT)

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -333,7 +333,7 @@ cdef class NASA(HeatCapacityModel):
         H298 = self.getEnthalpy(298)
         S298 = self.getEntropy(298)
         
-        return Wilhoit().fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
+        return Wilhoit(comment=self.comment).fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
     
     cpdef NASA changeBaseEnthalpy(self, double deltaH):
         """

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -304,6 +304,7 @@ cdef class NASA(HeatCapacityModel):
             Cp0 = (Cp0,"J/(mol*K)"),
             CpInf = (CpInf,"J/(mol*K)"),
             E0 = self.E0,
+            comment = self.comment
         )
 
     @cython.boundscheck(False)

--- a/rmgpy/thermo/nasaTest.py
+++ b/rmgpy/thermo/nasaTest.py
@@ -245,7 +245,7 @@ class TestNASA(unittest.TestCase):
 
         # Load databases
         database = RMGDatabase()
-        database.loadThermo(os.path.join(settings['database.directory'], 'thermo'))
+        database.loadThermo(os.path.join(settings['database.directory'], 'thermo'),thermoLibraries=['Narayanaswamy'])
         database.loadSolvation(os.path.join(settings['database.directory'], 'solvation'))
 
         spc = Species().fromSMILES('CC')
@@ -261,9 +261,22 @@ class TestNASA(unittest.TestCase):
         Std = td.getEntropy(T)
 
         self.assertAlmostEqual(Snasa, Std, -1)
+        self.assertEqual(td.comment,nasa.comment)
+
 
         # thermodata to nasa
-        nasa = td.toNASA(500., 1500., 1000.)
+        nasa = td.toNASA(Tmin=100.0, Tmax=5000.0, Tint=1000.0)
         Snasa = nasa.getEntropy(T)
 
         self.assertAlmostEqual(Snasa, Std, -1)
+        self.assertEqual(td.comment,nasa.comment)
+
+        # wilhoit to nasa
+        wilhoit=nasa.toWilhoit()
+        nasa = wilhoit.toNASA(Tmin=100.0, Tmax=5000.0, Tint=1000.0)
+        Snasa = nasa.getEntropy(T)
+
+        self.assertAlmostEqual(Snasa, Std, -1)
+        self.assertEqual(wilhoit.comment,nasa.comment)
+
+        # nasa to wilhoi performed in wilhoitTest

--- a/rmgpy/thermo/thermodata.pxd
+++ b/rmgpy/thermo/thermodata.pxd
@@ -38,7 +38,6 @@ cdef class ThermoData(HeatCapacityModel):
     
     cdef public ScalarQuantity _H298, _S298
     cdef public ArrayQuantity _Tdata, _Cpdata
-    cdef public ScalarQuantity _Cp0, _CpInf
     
     cpdef double getHeatCapacity(self, double T) except -1000000000
 

--- a/rmgpy/thermo/thermodata.pxd
+++ b/rmgpy/thermo/thermodata.pxd
@@ -48,6 +48,6 @@ cdef class ThermoData(HeatCapacityModel):
 
     cpdef double getFreeEnergy(self, double T) except 1000000000
 
-    cpdef Wilhoit toWilhoit(self)
+    cpdef Wilhoit toWilhoit(self, object B=?)
 
     cpdef NASA toNASA(self, double Tmin, double Tmax, double Tint, bint fixedTint=?, bint weighting=?, int continuity=?)

--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -353,11 +353,13 @@ cdef class ThermoData(HeatCapacityModel):
 
         return self.getEnthalpy(T) - T * self.getEntropy(T)
 
-    cpdef Wilhoit toWilhoit(self):
+    cpdef Wilhoit toWilhoit(self, B=None):
         """
         Convert the Benson model to a Wilhoit model. For the conversion to
         succeed, you must have set the `Cp0` and `CpInf` attributes of the
         Benson model.
+
+        B: the characteristic temperature in Kelvin.
         """
         if 0.0 in [self.Cp0.value_si, self.CpInf.value_si]:
             raise Exception('Cannot convert Benson model to Wilhoit model; first specify Cp0 and CpInf.')
@@ -370,7 +372,10 @@ cdef class ThermoData(HeatCapacityModel):
         Cp0 = self._Cp0.value_si
         CpInf = self._CpInf.value_si
         
-        return Wilhoit().fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
+        if B:
+            return Wilhoit(comment=self.comment).fitToDataForConstantB(Tdata, Cpdata, Cp0, CpInf, H298, S298, B=B)
+        else:
+            return Wilhoit(comment=self.comment).fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
 
     cpdef NASA toNASA(self, double Tmin, double Tmax, double Tint, bint fixedTint=False, bint weighting=True, int continuity=3):
         """

--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -359,7 +359,7 @@ cdef class ThermoData(HeatCapacityModel):
         succeed, you must have set the `Cp0` and `CpInf` attributes of the
         Benson model.
         """
-        if self.Cp0 == 0.0 or self.CpInf == 0.0:
+        if 0.0 in [self.Cp0.value_si, self.CpInf.value_si]:
             raise Exception('Cannot convert Benson model to Wilhoit model; first specify Cp0 and CpInf.')
         from rmgpy.thermo.wilhoit import Wilhoit
         

--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -48,8 +48,6 @@ cdef class ThermoData(HeatCapacityModel):
     `Cpdata`        An array of heat capacities at the given temperatures
     `H298`          The standard enthalpy of formation at 298 K
     `S298`          The standard entropy at 298 K
-    `Cp0`           The heat capacity at zero temperature
-    `CpInf`         The heat capacity at infinite temperature
     `Tmin`          The minimum temperature at which the model is valid, or zero if unknown or undefined
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `E0`            The energy at zero Kelvin (including zero point energy)
@@ -59,13 +57,11 @@ cdef class ThermoData(HeatCapacityModel):
     """
 
     def __init__(self, Tdata=None, Cpdata=None, H298=None, S298=None, Cp0=None, CpInf=None, Tmin=None, Tmax=None, E0=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, comment=comment)
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, Cp0=Cp0, CpInf=CpInf, comment=comment)
         self.H298 = H298
         self.S298 = S298
         self.Tdata = Tdata
         self.Cpdata = Cpdata
-        self.Cp0 = Cp0
-        self.CpInf = CpInf
     
     def __repr__(self):
         """
@@ -115,20 +111,6 @@ cdef class ThermoData(HeatCapacityModel):
             return self._S298
         def __set__(self, value):
             self._S298 = quantity.Entropy(value)
-
-    property Cp0:
-        """The heat capacity at zero temperature."""
-        def __get__(self):
-            return self._Cp0
-        def __set__(self, value):
-            self._Cp0 = quantity.HeatCapacity(value)
-
-    property CpInf:
-        """The heat capacity at infinite temperature."""
-        def __get__(self):
-            return self._CpInf
-        def __set__(self, value):
-            self._CpInf = quantity.HeatCapacity(value)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/rmgpy/thermo/thermoengine.py
+++ b/rmgpy/thermo/thermoengine.py
@@ -29,7 +29,6 @@ def processThermoData(spc, thermo0, thermoClass=NASA):
         wilhoit = thermo0.toWilhoit(B=1000.)
     else:
         wilhoit = thermo0.toWilhoit()
-    wilhoit.comment = thermo0.comment
 
     # Add on solvation correction
     if Species.solventData and not "Liquid thermo library" in thermo0.comment:

--- a/rmgpy/thermo/thermoengine.py
+++ b/rmgpy/thermo/thermoengine.py
@@ -26,13 +26,7 @@ def processThermoData(spc, thermo0, thermoClass=NASA):
     if isinstance(thermo0, Wilhoit):
         wilhoit = thermo0
     elif isinstance(thermo0, ThermoData):
-        Tdata = thermo0._Tdata.value_si
-        Cpdata = thermo0._Cpdata.value_si
-        H298 = thermo0._H298.value_si
-        S298 = thermo0._S298.value_si
-        Cp0 = thermo0._Cp0.value_si
-        CpInf = thermo0._CpInf.value_si
-        wilhoit = Wilhoit().fitToDataForConstantB(Tdata, Cpdata, Cp0, CpInf, H298, S298, B=1000.0)
+        wilhoit = thermo0.toWilhoit(B=1000.)
     else:
         Cp0 = spc.calculateCp0()
         CpInf = spc.calculateCpInf()

--- a/rmgpy/thermo/thermoengine.py
+++ b/rmgpy/thermo/thermoengine.py
@@ -28,9 +28,7 @@ def processThermoData(spc, thermo0, thermoClass=NASA):
     elif isinstance(thermo0, ThermoData):
         wilhoit = thermo0.toWilhoit(B=1000.)
     else:
-        Cp0 = spc.calculateCp0()
-        CpInf = spc.calculateCpInf()
-        wilhoit = thermo0.toWilhoit(Cp0=Cp0, CpInf=CpInf)
+        wilhoit = thermo0.toWilhoit()
     wilhoit.comment = thermo0.comment
 
     # Add on solvation correction

--- a/rmgpy/thermo/wilhoit.pxd
+++ b/rmgpy/thermo/wilhoit.pxd
@@ -36,7 +36,7 @@ from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 
 cdef class Wilhoit(HeatCapacityModel):
     
-    cdef public ScalarQuantity _Cp0, _CpInf, _B, _H0, _S0
+    cdef public ScalarQuantity _B, _H0, _S0
     cdef public double a0, a1, a2, a3
     
     cpdef double getHeatCapacity(self, double T) except -1000000000

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -481,6 +481,7 @@ cdef class Wilhoit(HeatCapacityModel):
             Cp0 = self.Cp0,
             CpInf = self.CpInf,
             E0 = self.E0,
+            comment = self.comment
         )
     
     cpdef NASA toNASA(self, double Tmin, double Tmax, double Tint, bint fixedTint=False, bint weighting=True, int continuity=3):

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -44,8 +44,6 @@ cdef class Wilhoit(HeatCapacityModel):
     =============== ============================================================
     Attribute       Description
     =============== ============================================================
-    `Cp0`           The heat capacity at zero temperature
-    `CpInf`         The heat capacity at infinite temperature
     `a0`            The zeroth-order Wilhoit polynomial coefficient
     `a1`            The first-order Wilhoit polynomial coefficient
     `a2`            The second-order Wilhoit polynomial coefficient
@@ -62,9 +60,7 @@ cdef class Wilhoit(HeatCapacityModel):
     """
 
     def __init__(self, Cp0=None, CpInf=None, a0=0.0, a1=0.0, a2=0.0, a3=0.0, H0=None, S0=None, B=None, Tmin=None, Tmax=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, comment=comment)
-        self.Cp0 = Cp0
-        self.CpInf = CpInf
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Cp0=Cp0, CpInf=CpInf, comment=comment)
         self.B = B
         self.a0 = a0
         self.a1 = a1
@@ -91,20 +87,6 @@ cdef class Wilhoit(HeatCapacityModel):
         A helper function used when pickling a Wilhoit object.
         """
         return (Wilhoit, (self.Cp0, self.CpInf, self.a0, self.a1, self.a2, self.a3, self.H0, self.S0, self.B, self.Tmin, self.Tmax, self.comment))
-
-    property Cp0:
-        """The heat capacity at zero temperature."""
-        def __get__(self):
-            return self._Cp0
-        def __set__(self, value):
-            self._Cp0 = quantity.HeatCapacity(value)
-
-    property CpInf:
-        """The heat capacity at infinite temperature."""
-        def __get__(self):
-            return self._CpInf
-        def __set__(self, value):
-            self._CpInf = quantity.HeatCapacity(value)
 
     property B:
         """The Wilhoit scaled temperature coefficient."""
@@ -582,6 +564,8 @@ cdef class Wilhoit(HeatCapacityModel):
             Tmin = nasa_low.Tmin,
             Tmax = nasa_high.Tmax,
             E0 = self.E0,
+            Cp0 = self.Cp0,
+            CpInf = self.CpInf,
             comment = self.comment,
         )
     

--- a/rmgpy/thermo/wilhoitTest.py
+++ b/rmgpy/thermo/wilhoitTest.py
@@ -34,6 +34,8 @@ This script contains unit tests of the :mod:`rmgpy.thermo.wilhoit` module.
 
 import unittest
 import numpy
+import os.path
+import logging
 
 from rmgpy.thermo.wilhoit import Wilhoit
 import rmgpy.constants as constants
@@ -303,3 +305,39 @@ class TestWilhoit(unittest.TestCase):
         self.assertAlmostEqual(wilhoit.B.value_si, self.wilhoit.B.value_si, 2)
         self.assertAlmostEqual(wilhoit.H0.value_si, self.wilhoit.H0.value_si, 0)
         self.assertAlmostEqual(wilhoit.S0.value_si, self.wilhoit.S0.value_si, 2)
+
+    def testToWilhoit(self):
+        """
+        Test if the entropy computed from other thermo implementations is close to what Wilhoit computes.
+        """
+
+        from rmgpy import settings
+        from rmgpy.data.rmg import RMGDatabase, database
+        from rmgpy.species import Species
+
+        # Load databases
+        database = RMGDatabase()
+        database.loadThermo(os.path.join(settings['database.directory'], 'thermo'))
+
+        spc = Species().fromSMILES('CC')
+        spc.getThermoData()
+
+        T = 1350.# not 298K!
+
+        # nasa to wilhoit
+        nasa = spc.thermo
+        Snasa = nasa.getEntropy(T)
+
+        nasaToWh = nasa.toWilhoit()
+        SnasaToWh = nasaToWh.getEntropy(T)
+
+        self.assertAlmostEqual(Snasa, SnasaToWh, -1)
+
+        # thermo data to wilhoit:
+        td = nasa.toThermoData()
+        Std = td.getEntropy(T)
+
+        wilhoit = td.toWilhoit(B=1000.)        
+        Swh = wilhoit.getEntropy(T)
+
+        self.assertAlmostEqual(Std, Swh, -1)

--- a/rmgpy/thermo/wilhoitTest.py
+++ b/rmgpy/thermo/wilhoitTest.py
@@ -317,7 +317,8 @@ class TestWilhoit(unittest.TestCase):
 
         # Load databases
         database = RMGDatabase()
-        database.loadThermo(os.path.join(settings['database.directory'], 'thermo'))
+        database.loadThermo(os.path.join(settings['database.directory'], 'thermo'), thermoLibraries=['Narayanaswamy'])
+        database.loadSolvation(os.path.join(settings['database.directory'], 'solvation'))
 
         spc = Species().fromSMILES('CC')
         spc.getThermoData()
@@ -332,6 +333,9 @@ class TestWilhoit(unittest.TestCase):
         SnasaToWh = nasaToWh.getEntropy(T)
 
         self.assertAlmostEqual(Snasa, SnasaToWh, -1)
+        self.assertEqual(nasa.comment,nasaToWh.comment)
+
+        # wilhoit to nasa conversion done in nasaTest.py
 
         # thermo data to wilhoit:
         td = nasa.toThermoData()
@@ -341,3 +345,11 @@ class TestWilhoit(unittest.TestCase):
         Swh = wilhoit.getEntropy(T)
 
         self.assertAlmostEqual(Std, Swh, -1)
+        self.assertEqual(td.comment,wilhoit.comment)
+
+        # wilhoit back to thermodata
+        td = wilhoit.toThermoData()
+        Std = td.getEntropy(T)
+
+        self.assertAlmostEqual(Std, Swh, -1)
+        self.assertEqual(td.comment,wilhoit.comment)


### PR DESCRIPTION
This PR attempts to improve the way thermodynamic quantities are exchanged during the conversion between the different HeatCapacityModel implementations: Wilhoit, NASA, and ThermoData.

In doing so, Cp0, and CpInf, the heat capacity at 0K, and infinity have been added as attributes of the superclass, HeatCapacityModel.

Fundamentally, nothing changes in the way these classes compute variables.

The client function, thermoengine.processThermoData that converts different thermo formats becomes less complicated.

