### PR TITLE
Smart polycyclic thermo

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -372,6 +372,25 @@ def combineTwoRingsIntoSubMolecule(ring1, ring2):
                     mol0.addBond(Bond(atomsMapping[atom],atomsMapping[bondedAtom],order=bond.order))
     
     return mol0, atomsMapping
+
+def getCopyForOneRing(ring):
+
+    _, atomsMapping = convertRingToSubMolecule(ring)
+
+    ringCopy = [atomsMapping[atom] for atom in ring]
+    
+    return ringCopy
+
+
+def getCopyFromTwoRingsWithCommonAtoms(ring1, ring2):
+
+    mergedRing, atomsMapping = combineTwoRingsIntoSubMolecule(ring1, ring2)
+
+    ring1Copy = [atomsMapping[atom] for atom in ring1]
+    ring2Copy = [atomsMapping[atom] for atom in ring2]
+    
+    return ring1Copy, ring2Copy, mergedRing
+
 ################################################################################
 
 class ThermoDepository(Database):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -391,6 +391,23 @@ def getCopyFromTwoRingsWithCommonAtoms(ring1, ring2):
     
     return ring1Copy, ring2Copy, mergedRing
 
+def isPolyringPartialMatched(polyring, matched_group):
+    """
+    An example of polyring partial match is tricyclic polyring is matched by a bicyclic group
+    usually because of not enough data in polycyclic tree. The method takes a matched group 
+    returned from descendTree and the polyring (a list of non-hydrogen atoms in the polyring)
+    """
+
+    if len(polyring) != len(matched_group.atoms):
+        return True
+    else:
+        submol_polyring, _ = convertRingToSubMolecule(polyring)
+        sssr = submol_polyring.getSmallestSetOfSmallestRings()
+        sssr_grp = matched_group.getSmallestSetOfSmallestRings()
+        if sorted([len(sr) for sr in sssr]) == sorted([len(sr_grp) for sr_grp in sssr_grp]):
+            return False
+        else:
+            return True
 ################################################################################
 
 class ThermoDepository(Database):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -206,7 +206,7 @@ def addThermoData(thermoData1, thermoData2, groupAdditivity=False):
             
         return thermoData1
     
-def removeThermoData(thermoData1, thermoData2):
+def removeThermoData(thermoData1, thermoData2, groupAdditivity=False):
     """
     Remove the thermodynamic data `thermoData2` from the data `thermoData1`,
     and return `thermoData1`.
@@ -219,6 +219,11 @@ def removeThermoData(thermoData1, thermoData2):
     thermoData1.H298.value_si -= thermoData2.H298.value_si
     thermoData1.S298.value_si -= thermoData2.S298.value_si
 
+    if groupAdditivity:
+        if thermoData1.comment:
+            thermoData1.comment += ' - {0}'.format(thermoData2.comment)
+        else:
+            thermoData1.comment = 'Thermo group additivity estimation: ' + ' - {0}'.format(thermoData2.comment)
     return thermoData1
 
 def averageThermoData(thermoDataList=None):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1422,17 +1422,17 @@ class ThermoDatabase(object):
                 # Make a temporary structure containing only the atoms in the ring
                 # NB. if any of the ring corrections depend on ligands not in the ring, they will not be found!
                 try:
-                    self.__addRingCorrectionThermoData(thermoData, self.groups['ring'], molecule, ring)
+                    self.__addRingCorrectionThermoDataFromTree(thermoData, self.groups['ring'], molecule, ring)
                 except KeyError:
                     logging.error("Couldn't find a match in the monocyclic ring database even though monocyclic rings were found.")
                     logging.error(molecule)
                     logging.error(molecule.toAdjacencyList())
                     raise
-            for ring in polyrings:
+            for polyring in polyrings:
                 # Make a temporary structure containing only the atoms in the ring
                 # NB. if any of the ring corrections depend on ligands not in the ring, they will not be found!
                 try:
-                    self.__addRingCorrectionThermoData(thermoData, self.groups['polycyclic'], molecule, ring)
+                    self.__addRingCorrectionThermoDataFromTree(thermoData, self.groups['polycyclic'], molecule, polyring)
                 except KeyError:
                     logging.error("Couldn't find a match in the polycyclic ring database even though polycyclic rings were found.")
                     logging.error(molecule)
@@ -1442,10 +1442,12 @@ class ThermoDatabase(object):
         return thermoData
 
     def __addRingCorrectionThermoData(self, thermoData, ring_database, molecule, ring):
+    def __addRingCorrectionThermoDataFromTree(self, thermoData, ring_database, molecule, ring):
         """
         Determine the ring correction group additivity thermodynamic data for the given
          `ring` in the `molecule`, and add it to the existing thermo data
         `thermoData`.
+        Also returns the matched ring group from the database from which the data originated.
         """
         matchedRingEntries = []
         # label each atom in the ring individually to try to match the group
@@ -1489,13 +1491,14 @@ class ThermoDatabase(object):
                 if entry.label == data:
                     data = entry.data
                     comment = entry.label
+                    node = entry
                     break
         data.comment = '{0}({1})'.format(ring_database.label, comment)
         
         if thermoData is None:
-            return data
+            return data, node
         else:
-            return addThermoData(thermoData, data, groupAdditivity=True)
+            return addThermoData(thermoData, data, groupAdditivity=True), node
 
     def __averageChildrenThermo(self, node):
         """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -338,6 +338,19 @@ class TestCyclicThermo(unittest.TestCase):
         self.assertTrue(groupToRemove2.parent.data.getEntropy(298) == groupToRemove2.data.getEntropy(298))
         self.assertFalse(False in [groupToRemove2.parent.data.getHeatCapacity(x) == groupToRemove2.data.getHeatCapacity(x) for x in Tlist])
 
+    def testIsPolyringPartialMatched(self):
+        
+        # create testing molecule
+        smiles = 'C1CC2CCCC3CCCC(C1)C23'
+        mol = Molecule().fromSMILES(smiles)
+        polyring = [atom for atom in mol.atoms if atom.isNonHydrogen()]
+
+        # create matched group
+        matched_group = self.database.groups['polycyclic'].entries['PolycyclicRing'].item
+        
+        # test
+        self.assertTrue(isPolyringPartialMatched(polyring, matched_group))
+
 class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
     """
     Contains unit tests for methods of molecular manipulations for thermo estimation

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -218,47 +218,10 @@ class TestCyclicThermo(unittest.TestCase):
         expected_matchedRings = [self.database.groups['ring'].entries[label] for label in expected_matchedRingsLabels]
         self.assertEqual(set(ringGroups), set(expected_matchedRings))
         
-        expected_matchedPolyringsLabels = ['norbornane']
+        expected_matchedPolyringsLabels = ['s3_5_5_ane']
         expected_matchedPolyrings = [self.database.groups['polycyclic'].entries[label] for label in expected_matchedPolyringsLabels]
 
         self.assertEqual(set(polycyclicGroups), set(expected_matchedPolyrings))
-    
-    def testPolycyclicPicksBestThermo(self):
-        """
-        Test that RMG prioritizes thermo correctly and chooses the thermo from the isomer which
-        has a non generic polycyclic ring correction
-        """
-        
-        spec = Species().fromSMILES('C1=C[C]2CCC=C2C1')
-        spec.generateResonanceIsomers()
-        
-        thermoDataList = []
-        for molecule in spec.molecule:
-            thermo = self.database.estimateRadicalThermoViaHBI(molecule, self.database.computeGroupAdditivityThermo)
-            thermoDataList.append(thermo)
-            
-        thermoDataList.sort(key=lambda x: x.getEnthalpy(298))
-        most_stable_thermo = thermoDataList[0]
-        ringGroups, polycyclicGroups = self.database.getRingGroupsFromComments(most_stable_thermo)
-        
-        selected_thermo = self.database.getThermoDataFromGroups(spec)
-        
-        self.assertNotEqual(selected_thermo, thermoDataList)
-        
-        selected_ringGroups, selected_polycyclicGroups = self.database.getRingGroupsFromComments(selected_thermo)
-        
-        # The group used to estimate the most stable thermo is the generic polycyclic group and
-        # therefore is not selected.  Note that this unit test will have to change if the correction is fixed later.
-        self.assertEqual(polycyclicGroups[0].label, 'PolycyclicRing')
-        self.assertEqual(selected_polycyclicGroups[0].label, 'C12CCC=C1CC=C2')
-        
-        
-        # Check that the same result occurs when we retrieve thermo from getThermoData
-        selected_thermo2 = self.database.getThermoData(spec)
-        
-        selected2_ringGroups, selected2_polycyclicGroups = self.database.getRingGroupsFromComments(selected_thermo2)
-        self.assertEqual(selected2_polycyclicGroups[0].label, 'C12CCC=C1CC=C2')
-    
 
     def testGetRingGroupsFromComments(self):
         """

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -116,11 +116,12 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             self.compat_func_name = test_name
             yield test, group_name
 
-            test = lambda x: self.general_checkSiblingsForParents(group_name, group)
-            test_name = "Thermo groups {0}: sibling relationships are correct?".format(group_name)
-            test.description = test_name
-            self.compat_func_name = test_name
-            yield test, group_name
+            if group_name != 'polycyclic':
+                test = lambda x: self.general_checkSiblingsForParents(group_name, group)
+                test_name = "Thermo groups {0}: sibling relationships are correct?".format(group_name)
+                test.description = test_name
+                self.compat_func_name = test_name
+                yield test, group_name
 
             test = lambda x: self.general_checkCdAtomType(group_name, group)
             test_name = "Thermo groups {0}: Cd atomtype used correctly?".format(group_name)


### PR DESCRIPTION
# New polycyclic thermo estimator

## Motivation
It's always been a limitation for RMG to estimate polycyclic thermo both quickly and accurately. Previously we have developed QMTP, which partially mitigated the issue, but still too time-consuming for cases where you have thousands of edge polycyclic species. This PR (together RMG-database `smart_polycyclic_thermo` branch) is to continue pursuing the most affordable way: group additivity method, and make specific improvements for polycyclics both data-wise (`RMG-databse`) and algorithmically (`RMG-Py`). 

Two outstanding issues of polycyclic estimation in current version of RMG:
1. not enough data: lots of species cannot find exact matches in database
2. not using available data smartly: 

- e.g., RMG gives appropriate ring correction for ![image](https://cloud.githubusercontent.com/assets/2739496/17685847/bcb95234-6335-11e6-9e1b-b0a6c1c16bcf.png), but matches a similar molecule ![image](https://cloud.githubusercontent.com/assets/2739496/17685845/b60f05dc-6335-11e6-9fa0-9c16ec7d61b9.png) to a generic node, indicating not using sibling data smartly.

- e.g., RMG partially matches a tricyclic molecule ![image](https://cloud.githubusercontent.com/assets/2739496/17685840/aa203de0-6335-11e6-8b23-7b65f832ee13.png) to a bicyclic group ![image](https://cloud.githubusercontent.com/assets/2739496/17685830/8dea6646-6335-11e6-8d93-1d813365710f.png), indicating RMG lacks of data and strategy of dealing with large polycyclics.

This PR and together with the corresponding PR in RMG-database will address the above two issues; add more data by quantum calculations, reorganize polycyclic tree to enable RMG to use sibling data, design and implement a new strategy of estimating large polycyclics.

## Data

All the data is a merged result of old polycylic tree and new quantum calculations at M06-2X level. For more information, please check out RMG-database `smart_polycyclic_thermo` branch and https://github.com/ReactionMechanismGenerator/RMG-database/pull/122

## Algorithm Design
The new polycyclic estimator is to use bicyclics as building blocks to estimate thermo of large polycyclics (we are currently writing a paper about the estimating method, you can find more details in RMG-Py code as well). So the database is trying to contain as many bicyclics as possible, and this PR contains a heuristic algorithm for estimating large polycyclics using bicyclics.

### workflow
 A schematic for the algorithm can be found below. Once a polycyclic molecule is input for thermo estimation, RMG will first extract all the disperate polycyclics in that molecule then try to apply polycyclic correction one by one. If can be found in polycyclic tree, the corresponding entry will be retrieved. If a submolecule not in the tree (e.g., some complicated tricyclic), the submolecule will be splitted into a combination of bicyclics and unicyclics (bycyclic-core decomposition, see next section for more detail). Finally using a heuristic formula, the polycyclic estimator is able to give reasonably accurate estimates.
![image](https://cloud.githubusercontent.com/assets/2739496/17746794/c636d0f2-647f-11e6-93d6-8c29271cb0f9.png)


### bicyclic-core decomposition
we noticed polycyclic ring correction is not simply the sum of single ring corrections; the fused part between two single rings can create additional ring strain. After testing lots of heurist formulas, we found a better way to do is bicyclic-core decomposition, say, a tricyclic ABC (A, B, C stands for single rings in that tricyclic) can be estimated as AB + BC - B. For instance, 
![image](https://cloud.githubusercontent.com/assets/2739496/17746800/cf101a94-647f-11e6-95c9-bbcbf3577776.png) will be estimated as ![image](https://cloud.githubusercontent.com/assets/2739496/17746806/dcd8f48e-647f-11e6-95e1-bbbd71cebaa9.png) + ![image](https://cloud.githubusercontent.com/assets/2739496/17746810/e461b7d6-647f-11e6-9719-888c428f29c9.png) - ![image](https://cloud.githubusercontent.com/assets/2739496/17746837/0ef60650-6480-11e6-935e-125d68189b52.png). For those small components, we make sure our polycyclic tree contain them. So theoretically by this way, RMG can estimate all kinds of polycyclics. 

Please find testing results in following sections.
 
## Test

### tricyclic library
we calculated 180 tricyclics (not included in the new tree, they are ranging from alkane, alkene, diene, aromatics), which forms a testing library. 
Here is the histogram of discrepancy between library values and group additivity values using current `master` RMG-database and RMG-Py. (Average discrepancy is 41 kcal/mol)
![image](https://cloud.githubusercontent.com/assets/2739496/17685797/583afa4c-6335-11e6-903d-3987d1514b99.png)

Here is the histogram of discrepancy between library values and group additivity values using `smart_polycyclic_thermo` RMG-database and RMG-Py. (Average discrepancy is 11 kcal/mol)
![image](https://cloud.githubusercontent.com/assets/2739496/17685793/5486c0ac-6335-11e6-95eb-fa9b85ed16c3.png)

### burcat polycylics
Please see and compare [`master` performance](https://github.com/KEHANG/RMG-database/blob/polycyclic_testing/input/thermo/groups/testing/burcat/VisualizeTestDataset-pyMaster-dbMaster.ipynb)   and [`smart_polycyclic_thermo` performance](https://github.com/KEHANG/RMG-database/blob/polycyclic_testing/input/thermo/groups/testing/burcat/VisualizeTestDataset-pyPoly-dbPoly.ipynb). 

> Note: burcat library doesn't have too many polycyclic entries, most of polycyclics are naphthalene-based, so as long as tree has naphthalene, the two estimations shouldn't be too different.

### PAH library
Please see and compare [`master` performance](https://github.com/KEHANG/RMG-database/blob/polycyclic_testing/input/thermo/groups/testing/PAHLibrary/VisualizeTestDataset-pyPoly-dbPoly.ipynb)   and [`smart_polycyclic_thermo` performance](https://github.com/KEHANG/RMG-database/blob/polycyclic_testing/input/thermo/groups/testing/PAHLibrary/VisualizeTestDataset-pyPoly-dbPoly.ipynb).

> Note: PAH library doesn't have too many polycyclic entries either, most of polycyclics are naphthalene, indene-based, so as long as tree has two entries, the two estimations shouldn't be too different.