### PR TITLE
Possible fix for the duplicate training reactions problem

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -395,8 +395,8 @@ class CoreEdgeReactionModel:
                 else:
                     if areIdenticalSpeciesReferences(rxn, rxn0):
                         return True, rxn0
-            
-            if isinstance(familyObj, KineticsFamily) and familyObj.ownReverse:
+            if isinstance(familyObj, KineticsFamily):
+                
                 if (rxn_id == rxn_id0[::-1]):
                     if areIdenticalSpeciesReferences(rxn, rxn0):
                         return True, rxn0
@@ -1573,7 +1573,7 @@ class CoreEdgeReactionModel:
             
         family = getFamilyLibraryObject(family_label)       
         # if the family is its own reverse (H-Abstraction) then check the other direction
-        if isinstance(family,KineticsFamily) and family.ownReverse: # (family may be a KineticsLibrary)
+        if isinstance(family,KineticsFamily): 
 
             # Get the short-list of reactions with the same family, product1 and product2
             family_label, r1_rev, r2_rev = generateReactionKey(rxn, useProducts=True)


### PR DESCRIPTION
Bug was found where reaction 2 in  R_Addition_MultipleBond/training
C2H3O3 <=> C2H2O + HO2
was getting duplicated in the final model.  It appears
that we fail the checkForExistingReaction check because we typically
only check in reverse direction when the family is its ownReverse.
However, this forgets that there are some training reactions that
are in fact in the reverse direction!

Therefore we should more expand the searchRetrieveReactions()
function to generate reverse direction reactions for all families.
This may slow things down, leave optimization till later.