### PR TITLE
Mark core pdep reactions as reversible

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1460,13 +1460,12 @@ class CoreEdgeReactionModel:
         # direction from the list of core reactions
         # Note that well-skipping reactions may not have a reverse if the well
         # that they skip over is not itself in the core
-        for network in updatedNetworks:
-            for reaction in network.netReactions:
-                try:
-                    index = self.core.reactions.index(reaction)
-                except ValueError:
-                    continue
-                for index2, reaction2 in enumerate(self.core.reactions):
+        index = 0
+        coreReactionCount = len(self.core.reactions)
+        while index < coreReactionCount:
+            reaction = self.core.reactions[index]
+            if isinstance(reaction, PDepReaction):
+                for reaction2 in self.core.reactions[index+1:]:
                     if isinstance(reaction2, PDepReaction) and reaction.reactants == reaction2.products and reaction.products == reaction2.reactants:
                         # We've found the PDepReaction for the reverse direction
                         dGrxn = reaction.getFreeEnergyOfReaction(300.)
@@ -1493,10 +1492,13 @@ class CoreEdgeReactionModel:
                             self.core.reactions.remove(reaction2)
                             self.core.reactions.insert(index, reaction2)
                             reaction2.reversible = True
+                        coreReactionCount -= 1
                         # There should be only one reverse, so we can stop searching once we've found it
                         break
                 else:
                     reaction.reversible = True
+            # Move to the next core reaction
+            index += 1
 
 
     def markChemkinDuplicates(self):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1444,7 +1444,7 @@ class CoreEdgeReactionModel:
                         index += 1
 
         count = sum([1 for network in self.networkList if not network.valid and not (len(network.explored) == 0 and len(network.source) > 1)])
-        logging.info('Updating {0:d} modified unimolecular reaction networks...'.format(count))
+        logging.info('Updating {0:d} modified unimolecular reaction networks (out of {1:d})...'.format(count, len(self.networkList)))
         
         # Iterate over all the networks, updating the invalid ones as necessary
         # self = reactionModel object

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -491,6 +491,8 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         if self.valid: return
         # Do nothing if there are no explored wells
         if len(self.explored) == 0 and len(self.source) > 1: return
+        # Log the network being updated
+        logging.info("Updating {0:s}".format(self))
 
         # Generate states data for unimolecular isomers and reactants if necessary
         for isomer in self.isomers:


### PR DESCRIPTION
Instead of looping over net reactions of all pdep networks and checking if they're in the core, loop over all core reactions and check if they're pdep.

Alternative solution for #736.

