### PR TITLE
Thermo library existence checking when loading database

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -751,18 +751,30 @@ class ThermoDatabase(object):
         points to the top-level folder of the thermo database.
         """
         self.libraries = {}; self.libraryOrder = []
-        for (root, dirs, files) in os.walk(os.path.join(path)):
-            for f in files:
-                name, ext = os.path.splitext(f)
-                if ext.lower() == '.py' and (libraries is None or name in libraries):
-                    logging.info('Loading thermodynamics library from {0} in {1}...'.format(f, root))
+        if libraries is None:
+            for (root, dirs, files) in os.walk(os.path.join(path)):
+                for f in files:
+                    name, ext = os.path.splitext(f)
+                    if ext.lower() == '.py':
+                        logging.info('Loading thermodynamics library from {0} in {1}...'.format(f, root))
+                        library = ThermoLibrary()
+                        library.load(os.path.join(root, f), self.local_context, self.global_context)
+                        library.label = os.path.splitext(f)[0]
+                        self.libraries[library.label] = library
+                        self.libraryOrder.append(library.label)
+
+        else:
+            for libraryName in libraries:
+                f = libraryName + '.py'
+                if os.path.exists(os.path.join(path, f)):
+                    logging.info('Loading thermodynamics library from {0} in {1}...'.format(f, path))
                     library = ThermoLibrary()
-                    library.load(os.path.join(root, f), self.local_context, self.global_context)
+                    library.load(os.path.join(path, f), self.local_context, self.global_context)
                     library.label = os.path.splitext(f)[0]
                     self.libraries[library.label] = library
                     self.libraryOrder.append(library.label)
-        if libraries is not None:
-            self.libraryOrder = libraries
+                else:
+                    logging.warning('Library {} not found in {}...'.format(libraryName, path))
 
     def loadGroups(self, path):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -774,7 +774,7 @@ class ThermoDatabase(object):
                     self.libraries[library.label] = library
                     self.libraryOrder.append(library.label)
                 else:
-                    logging.warning('Library {} not found in {}...'.format(libraryName, path))
+                    raise Exception('Library {} not found in {}...Please check if your library is correctly placed'.format(libraryName, path))
 
     def loadGroups(self, path):
         """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -15,6 +15,19 @@ import rmgpy
 
 ################################################################################
 
+class TestThermoDatabaseLoading(unittest.TestCase):
+
+    def testLoadingThermoLibraries(self):
+
+        database = ThermoDatabase()
+        libraries = ['primaryThermoLibrary', 'GRI-Mech3.0', 'I am a library not existing in official RMG']
+        path = os.path.join(settings['database.directory'], 'thermo')
+        
+        database.loadLibraries(os.path.join(path, 'libraries'), libraries)
+
+        self.assertEqual(len(database.libraries), 2)
+        self.assertEqual(len(database.libraryOrder), 2)
+
 class TestThermoDatabase(unittest.TestCase):
     """
     Contains unit tests of the ThermoDatabase class.

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -17,16 +17,14 @@ import rmgpy
 
 class TestThermoDatabaseLoading(unittest.TestCase):
 
-    def testLoadingThermoLibraries(self):
+    def testFailingLoadsThermoLibraries(self):
 
         database = ThermoDatabase()
         libraries = ['primaryThermoLibrary', 'GRI-Mech3.0', 'I am a library not existing in official RMG']
         path = os.path.join(settings['database.directory'], 'thermo')
         
-        database.loadLibraries(os.path.join(path, 'libraries'), libraries)
-
-        self.assertEqual(len(database.libraries), 2)
-        self.assertEqual(len(database.libraryOrder), 2)
+        with self.assertRaises(Exception):
+            database.loadLibraries(os.path.join(path, 'libraries'), libraries)
 
 class TestThermoDatabase(unittest.TestCase):
     """


### PR DESCRIPTION
This PR is mainly to address the issue #611 

- checks thermo library existence when loading database instead of crashing after job starts

- adds an unit test for the change method `loadLibraries` in `thermo.py`