### PR TITLE
Dynamic benzene bond order to fix issue #767

### DIFF
--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -93,7 +93,6 @@ class Saturator(object):
                         - 2* atom.lonePairs - order - atom.charge
             
             '''
-            global bond_orders
             newAtoms = []
             for atom in atoms:
                 try:
@@ -101,9 +100,7 @@ class Saturator(object):
                 except KeyError:
                     raise InvalidAdjacencyListError('Cannot add hydrogens to adjacency list: Unknown orbital for atom "{0}".'.format(atom.symbol))
                 
-                order = 0
-                for _, bond in atom.bonds.items():
-                    order += bond_orders[bond.order]
+                order = getBondOrdersForAtom(atom)
                     
                 number_of_H_to_be_added = max_number_of_valence_electrons - atom.radicalElectrons - 2* atom.lonePairs - int(order) - atom.charge
                 

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -33,7 +33,7 @@ adjacency list format used by Reaction Mechanism Generator (RMG).
 """
 import logging
 import re
-from .molecule import Atom, Bond
+from .molecule import Atom, Bond, getAtomType
 from .group import GroupAtom, GroupBond
 from .element import getElement
 #import chempy.molecule.atomtype as atomtypes
@@ -101,6 +101,9 @@ class ConsistencyChecker(object):
             the theoretical one:
             
             '''
+            if getAtomType(atom, atom.edges).label == 'Cbf':
+                logging.warning("Skipping consistency check for fused benzene atom type")
+                return True
             global bond_orders
             valence = PeriodicSystem.valence_electrons[atom.symbol]
             order = 0
@@ -111,9 +114,10 @@ class ConsistencyChecker(object):
 
             if atom.charge != theoretical:
                 raise InvalidAdjacencyListError(
-                    ('Invalid valency for atom {symbol} with {radicals} unpaired electrons, '
+                    ('Invalid valency for atom {symbol} ({type}) with {radicals} unpaired electrons, '
                     '{lonePairs} pairs of electrons, {charge} charge, and bonds [{bonds}].'
                     ).format(symbol=atom.symbol,
+                             type=getAtomType(atom, atom.edges).label,
                              radicals=atom.radicalElectrons,
                              lonePairs=atom.lonePairs,
                              charge=atom.charge,

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -110,8 +110,15 @@ class ConsistencyChecker(object):
             theoretical = valence - order - atom.radicalElectrons - 2*atom.lonePairs
 
             if atom.charge != theoretical:
-                raise InvalidAdjacencyListError('Invalid valency for atom {symbol} with {radicals} unpaired electrons, {lonePairs} pairs of electrons, and {charge} charge.'
-                                                .format(symbol=atom.symbol, radicals=atom.radicalElectrons, lonePairs=atom.lonePairs, charge=atom.charge))
+                raise InvalidAdjacencyListError(
+                    ('Invalid valency for atom {symbol} with {radicals} unpaired electrons, '
+                    '{lonePairs} pairs of electrons, {charge} charge, and bonds [{bonds}].'
+                    ).format(symbol=atom.symbol,
+                             radicals=atom.radicalElectrons,
+                             lonePairs=atom.lonePairs,
+                             charge=atom.charge,
+                             bonds=','.join([bond.order for bond in atom.bonds.values()])
+                            ))
 
     @staticmethod
     def check_multiplicity(nRad, multiplicity):

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -38,34 +38,6 @@ from .group import GroupAtom, GroupBond
 from .element import getElement
 #import chempy.molecule.atomtype as atomtypes
 
-bond_orders = {'S': 1, 'D': 2, 'T': 3, 'B': 1.5}
-
-def getBondOrdersForAtom(atom):
-    """
-    This helper function is to help calculate total bond orders for an
-    input atom.
-
-    Some special consideration for the order `B` bond. For atoms having 
-    three `B` bonds, the order for each is 4/3.0, while for atoms having other
-    than three `B` bonds, the order for  each is 3/2.0
-    """
-    global bond_orders
-
-    num_B_bond = 0
-    order = 0
-    for _, bond in atom.bonds.items():
-        if bond.order == 'B':
-            num_B_bond += 1
-        else:
-            order += bond_orders[bond.order]
-
-    if num_B_bond == 3:
-        order += num_B_bond * 4/3.0
-    else:
-        order += num_B_bond * 3/2.0
-
-    return order
-
 class PeriodicSystem(object):
     valence_electrons_first_period_elements  = {'H':1, 'He':2}
         
@@ -100,7 +72,7 @@ class Saturator(object):
                 except KeyError:
                     raise InvalidAdjacencyListError('Cannot add hydrogens to adjacency list: Unknown orbital for atom "{0}".'.format(atom.symbol))
                 
-                order = getBondOrdersForAtom(atom)
+                order = atom.getBondOrdersForAtom()
                     
                 number_of_H_to_be_added = max_number_of_valence_electrons - atom.radicalElectrons - 2* atom.lonePairs - int(order) - atom.charge
                 
@@ -125,7 +97,7 @@ class ConsistencyChecker(object):
             
             '''
             valence = PeriodicSystem.valence_electrons[atom.symbol]
-            order = getBondOrdersForAtom(atom)
+            order = atom.getBondOrdersForAtom()
                 
             theoretical = valence - order - atom.radicalElectrons - 2*atom.lonePairs
 
@@ -418,7 +390,7 @@ def fromOldAdjacencyList(adjlist, group=False, saturateH=False):
                     except KeyError:
                         raise InvalidAdjacencyListError('Error in adjacency list:\n{1}\nCannot add hydrogens: Unknown valence for atom "{0}".'.format(atom.symbol, adjlist))
                     radical = atom.radicalElectrons
-                    order = getBondOrdersForAtom(atom)
+                    order = atom.getBondOrdersForAtom()
                     count = valence - radical - int(order) - 2*(atom.lonePairs-standardLonePairs[atom.symbol])
                     for i in range(count):
                         a = Atom(element='H', radicalElectrons=0, charge=0, label='', lonePairs=0)

--- a/rmgpy/molecule/adjlistTest.py
+++ b/rmgpy/molecule/adjlistTest.py
@@ -349,6 +349,55 @@ class TestMoleculeAdjLists(unittest.TestCase):
         self.assertTrue(bond21.isSingle())
         self.assertTrue(bond23.isSingle())
         self.assertTrue(bond24.isDouble())
+
+    def testFromAdjacencyList5(self):
+        """
+        adjlist: Test if fromAdjacencyList works when saturateH is turned on 
+        and test molecule is fused aromatics.
+        """
+        # molecule 5
+        adjlist = """
+1  * C u0 p0 c0 {2,B} {3,B} {4,B}
+2    C u0 p0 c0 {1,B} {5,B} {6,B}
+3    C u0 p0 c0 {1,B} {8,B} {13,S}
+4    C u0 p0 c0 {1,B} {9,B}
+5    C u0 p0 c0 {2,B} {10,B}
+6    C u0 p0 c0 {2,B} {7,B}
+7    C u0 p0 c0 {6,B} {8,B} {11,S}
+8    C u0 p0 c0 {3,B} {7,B} {12,S}
+9    C u0 p0 c0 {4,B} {10,B}
+10   C u0 p0 c0 {5,B} {9,B}
+11   H u0 p0 c0 {7,S}
+12   H u0 p0 c0 {8,S}
+13   H u0 p0 c0 {3,S}
+            """
+        molecule = Molecule().fromAdjacencyList(adjlist, saturateH=True)
+        
+        self.assertTrue(molecule.multiplicity == 1)
+        
+        atom1 = molecule.atoms[0]
+        atom2 = molecule.atoms[1]
+        atom3 = molecule.atoms[2]
+        atom7 = molecule.atoms[6]
+        atom11 = molecule.atoms[10]
+        bond21 = atom2.bonds[atom1]
+        bond13 = atom1.bonds[atom3]
+        bond7_11 = atom7.bonds[atom11]
+
+        self.assertTrue(atom1.label == '*')
+        self.assertTrue(atom1.element.symbol == 'C')
+        self.assertTrue(atom1.radicalElectrons == 0)
+        self.assertTrue(atom1.charge == 0)
+
+        self.assertTrue(atom2.label == '')
+        self.assertTrue(atom2.element.symbol == 'C')
+        self.assertTrue(atom2.radicalElectrons == 0)
+        self.assertTrue(atom2.charge == 0)
+
+        self.assertTrue(bond21.isBenzene())
+        self.assertTrue(bond13.isBenzene())
+        self.assertTrue(bond7_11.isSingle())
+        
     
     def testVariousSpinAdjlists(self):
         """

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -104,6 +104,23 @@ class Element:
         A helper function used when pickling an object.
         """
         return (Element, (self.number, self.symbol, self.name, self.mass, self.isotope))
+
+class PeriodicSystem(object):
+    """
+    Collects hard-coded information of elements in periodic table. 
+
+    Currently it has static attributes:
+    `valences`: the number of bonds an element is able to form around it. 
+    `valence_electrons`: the number of electrons in  the outermost shell of the element that can
+    participate in bond formation. for instance, `S` has 6 outermost electrons (valence_electrons)
+    but 4 of them form lone pairs, the remaining 2 electrons can form bonds so the normal valence 
+    for `S` is 2.
+    `lone_pairs`: the number of lone pairs an element has
+    """
+
+    valences           = {'H': 1, 'He': 0, 'C': 4, 'N': 3, 'O': 2, 'Ne': 0, 'Si': 4, 'S': 2, 'Cl': 1, 'Ar': 0}
+    valence_electrons  = {'H': 1, 'He': 2, 'C': 4, 'N': 5, 'O': 6, 'Ne': 8, 'Si': 4, 'S': 6, 'Cl': 7, 'Ar': 8}
+    lone_pairs         = {'H': 0, 'He': 1, 'C': 0, 'N': 1, 'O': 2, 'Ne': 4, 'Si': 0, 'S': 2, 'Cl': 3, 'Ar': 4}
     
 ################################################################################
 

--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -16,7 +16,7 @@ from .molecule import Atom, Bond, Molecule
 from .pathfinder import compute_atom_distance
 from .util import partition, agglomerate, generate_combo
 
-import rmgpy.molecule.adjlist as adjlist
+import rmgpy.molecule.element as element
 import rmgpy.molecule.inchi as inchiutil
 import rmgpy.molecule.resonance as resonance
 # global variables:
@@ -539,11 +539,11 @@ def has_unexpected_lone_pairs(mol):
 
     for at in mol.atoms:
         try:
-            exp = adjlist.PeriodicSystem.lone_pairs[at.symbol]
+            exp = element.PeriodicSystem.lone_pairs[at.symbol]
         except KeyError:
             raise Exception("Unrecognized element: {}".format(at.symbol))
         else:
-            if at.lonePairs != adjlist.PeriodicSystem.lone_pairs[at.symbol]: return True 
+            if at.lonePairs != element.PeriodicSystem.lone_pairs[at.symbol]: return True 
 
     return False
 
@@ -616,11 +616,11 @@ def create_P_layer(mol, auxinfo):
     p_layer = []
     for i, at in enumerate(mol.atoms):
         try:
-            exp = adjlist.PeriodicSystem.lone_pairs[at.symbol]
+            exp = element.PeriodicSystem.lone_pairs[at.symbol]
         except KeyError:
             raise Exception("Unrecognized element: {}".format(at.symbol))
         else:
-            if at.lonePairs != adjlist.PeriodicSystem.lone_pairs[at.symbol]:
+            if at.lonePairs != element.PeriodicSystem.lone_pairs[at.symbol]:
                 if at.lonePairs == 0:
                     p_layer.append('{}{}'.format(i, '(0)'))
                 else:

--- a/rmgpy/molecule/isomorphismTest.py
+++ b/rmgpy/molecule/isomorphismTest.py
@@ -4,7 +4,7 @@
 
 from nose.tools import assert_equal, assert_true, assert_false
 import logging
-from rmgpy.molecule.adjlist import PeriodicSystem
+from rmgpy.molecule.element import PeriodicSystem
 from rmgpy.molecule.atomtype import atomTypes
 from rmgpy.molecule.atomtypedatabase import create_atom_types 
   

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -32,6 +32,7 @@ cimport rmgpy.constants as constants
 cimport numpy
 
 ################################################################################
+cdef dict bond_orders 
 
 cdef class Atom(Vertex):
 
@@ -73,6 +74,8 @@ cdef class Atom(Vertex):
     cpdef updateCharge(self)
     
     cpdef setSpinMultiplicity(self, int spinMultiplicity)
+
+    cpdef getBondOrdersForAtom(self)
     
 ################################################################################
     

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -356,16 +356,10 @@ class Atom(Vertex):
         Update self.charge, according to the valence, and the 
         number and types of bonds, radicals, and lone pairs.
         """
-        valences = {'H': 1, 'C': 4, 'O': 2, 'N': 3, 'S': 2, 'Si': 4, 'He': 0, 'Ne': 0, 'Ar': 0, 'Cl': 1}
-        orders = {'S': 1, 'D': 2, 'T': 3, 'B': 1.5}
-        valence = valences[self.symbol]
-        order = 0
-        for atom2, bond in self.bonds.items():
-            order += orders[bond.order]
-        if self.symbol == 'H' or self.symbol == 'He':
-            self.charge = 2 - valence - order - self.radicalElectrons - 2*self.lonePairs
-        else:
-            self.charge = 8 - valence - order - self.radicalElectrons - 2*self.lonePairs
+        from .adjlist import getBondOrdersForAtom, PeriodicSystem
+        valence = PeriodicSystem.valence_electrons[self.symbol]
+        order = getBondOrdersForAtom(atom)
+        self.charge = valence - order - self.radicalElectrons - 2*self.lonePairs
         
     def applyAction(self, action):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -362,9 +362,9 @@ class Atom(Vertex):
         Update self.charge, according to the valence, and the 
         number and types of bonds, radicals, and lone pairs.
         """
-        valence = elements.PeriodicSystem.valence_electrons[self.symbol]
+        valence_electron = elements.PeriodicSystem.valence_electrons[self.symbol]
         order = self.getBondOrdersForAtom()
-        self.charge = valence - order - self.radicalElectrons - 2*self.lonePairs
+        self.charge = valence_electron - order - self.radicalElectrons - 2*self.lonePairs
         
     def applyAction(self, action):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -60,6 +60,12 @@ from rmgpy.molecule.group import GroupAtom, GroupBond, Group
 
 ################################################################################
 
+bond_orders = {'S': 1, 'D': 2, 'T': 3}
+
+globals().update({
+    'bond_orders': bond_orders,
+})
+
 class Atom(Vertex):
     """
     An atom. The attributes are:
@@ -356,9 +362,9 @@ class Atom(Vertex):
         Update self.charge, according to the valence, and the 
         number and types of bonds, radicals, and lone pairs.
         """
-        from .adjlist import getBondOrdersForAtom, PeriodicSystem
+        from .adjlist import PeriodicSystem
         valence = PeriodicSystem.valence_electrons[self.symbol]
-        order = getBondOrdersForAtom(atom)
+        order = self.getBondOrdersForAtom()
         self.charge = valence - order - self.radicalElectrons - 2*self.lonePairs
         
     def applyAction(self, action):
@@ -396,6 +402,30 @@ class Atom(Vertex):
         if self.spinMultiplicity < 0:
             raise ActionError('Unable to update Atom due to spin multiplicity : Invalid spin multiplicity set "{0}".'.format(self.spinMultiplicity))
         self.updateCharge()
+
+    def getBondOrdersForAtom(self):
+        """
+        This helper function is to help calculate total bond orders for an
+        input atom.
+
+        Some special consideration for the order `B` bond. For atoms having 
+        three `B` bonds, the order for each is 4/3.0, while for atoms having other
+        than three `B` bonds, the order for  each is 3/2.0
+        """
+        num_B_bond = 0
+        order = 0
+        for _, bond in self.bonds.iteritems():
+            if bond.order == 'B':
+                num_B_bond += 1
+            else:
+                order += bond_orders[bond.order]
+
+        if num_B_bond == 3:
+            order += num_B_bond * 4/3.0
+        else:
+            order += num_B_bond * 3/2.0
+
+        return order
         
 
 ################################################################################

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -362,8 +362,7 @@ class Atom(Vertex):
         Update self.charge, according to the valence, and the 
         number and types of bonds, radicals, and lone pairs.
         """
-        from .adjlist import PeriodicSystem
-        valence = PeriodicSystem.valence_electrons[self.symbol]
+        valence = elements.PeriodicSystem.valence_electrons[self.symbol]
         order = self.getBondOrdersForAtom()
         self.charge = valence - order - self.radicalElectrons - 2*self.lonePairs
         

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1278,7 +1278,7 @@ multiplicity 2
         saturated_molecule.saturate()
         self.assertTrue(saturated_molecule.isIsomorphic(indene))
         
-    def testFusedAromatic(self):
+    def testFusedAromatic1(self):
         """Test we can make aromatic perylene from both adjlist and SMILES"""
         perylene = Molecule().fromAdjacencyList("""
 1  C u0 p0 c0 {3,B} {6,B} {7,B}
@@ -1322,6 +1322,78 @@ multiplicity 2
             self.fail("{} isn't isomorphic with any aromatic forms of {}".format(
                             perylene.toSMILES(),
                             perylene2.toSMILES()
+                        ))
+
+    def testFusedAromatic2(self):
+        """Test we can make aromatic naphthalene from both adjlist and SMILES"""
+        naphthalene = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {3,B} {4,B}
+2  C u0 p0 c0 {1,B} {5,B} {6,B}
+3  C u0 p0 c0 {1,B} {8,B} {13,S}
+4  C u0 p0 c0 {1,B} {9,B} {14,S}
+5  C u0 p0 c0 {2,B} {10,B} {17,S}
+6  C u0 p0 c0 {2,B} {7,B} {18,S}
+7  C u0 p0 c0 {6,B} {8,B} {11,S}
+8  C u0 p0 c0 {3,B} {7,B} {12,S}
+9  C u0 p0 c0 {4,B} {10,B} {15,S}
+10 C u0 p0 c0 {5,B} {9,B} {16,S}
+11 H u0 p0 c0 {7,S}
+12 H u0 p0 c0 {8,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {4,S}
+15 H u0 p0 c0 {9,S}
+16 H u0 p0 c0 {10,S}
+17 H u0 p0 c0 {5,S}
+18 H u0 p0 c0 {6,S}
+""")
+        naphthalene2 = Molecule().fromSMILES('C1=CC=C2C=CC=CC2=C1')
+        for isomer in generateAromaticResonanceIsomers(naphthalene2):
+            if naphthalene.isIsomorphic(isomer):
+                break
+        else:  # didn't break
+            self.fail("{} isn't isomorphic with any aromatic forms of {}".format(
+                            naphthalene.toSMILES(),
+                            naphthalene2.toSMILES()
+                        ))
+
+    def testFusedAromatic3(self):
+        """Test we can make aromatic pyrene_rad from both adjlist and SMILES"""
+        pyrene_rad = Molecule().fromAdjacencyList("""
+multiplicity 2
+1  C u0 p0 c0 {2,B} {3,B} {5,B}
+2  C u0 p0 c0 {1,B} {4,B} {6,S}
+3  C u0 p0 c0 {1,B} {8,B} {9,B}
+4  C u0 p0 c0 {2,B} {10,B} {11,S}
+5  C u0 p0 c0 {1,B} {7,B} {15,S}
+6  C u0 p0 c0 {2,S} {12,S} {16,D}
+7  C u0 p0 c0 {5,B} {13,B} {17,S}
+8  C u0 p0 c0 {3,B} {13,B} {19,S}
+9  C u0 p0 c0 {3,B} {10,B} {20,S}
+10 C u0 p0 c0 {4,B} {9,B} {21,S}
+11 C u1 p0 c0 {4,S} {14,S} {22,S}
+12 C u0 p0 c0 {6,S} {14,D} {24,S}
+13 C u0 p0 c0 {7,B} {8,B} {18,S}
+14 C u0 p0 c0 {11,S} {12,D} {23,S}
+15 C u0 p0 c0 {5,S} {16,D} {25,S}
+16 C u0 p0 c0 {6,D} {15,D}
+17 H u0 p0 c0 {7,S}
+18 H u0 p0 c0 {13,S}
+19 H u0 p0 c0 {8,S}
+20 H u0 p0 c0 {9,S}
+21 H u0 p0 c0 {10,S}
+22 H u0 p0 c0 {11,S}
+23 H u0 p0 c0 {14,S}
+24 H u0 p0 c0 {12,S}
+25 H u0 p0 c0 {15,S}
+""")
+        pyrene_rad2 = Molecule().fromSMILES('[C]1C=C2C=CC=C3C=CC4=CC=CC=1C4=C23')
+        for isomer in pyrene_rad2.generateResonanceIsomers():
+            if pyrene_rad.isIsomorphic(isomer):
+                break
+        else:  # didn't break
+            self.fail("{} isn't isomorphic with any aromatic forms of {}".format(
+                            pyrene_rad.toSMILES(),
+                            pyrene_rad2.toSMILES()
                         ))
 
     def testMalformedAugmentedInChI(self):

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+
 from external.wip import work_in_progress
 from .molecule import Atom, Bond, Molecule, ActionError
 from .group import Group
 from .element import getElement, elementList
 
-################################################################################
 
+################################################################################
 class TestAtom(unittest.TestCase):
     """
     Contains unit tests of the Atom class.
@@ -1313,7 +1314,14 @@ multiplicity 2
 32 H u0 p0 c0 {16,S}
 """)
         perylene2 = Molecule().fromSMILES('c1cc2cccc3c4cccc5cccc(c(c1)c23)c54')
-        self.assertTrue(perylene.isIsomorphic(perylene2))
+        for isomer in perylene2.getAromaticResonanceIsomers():
+            if perylene.isIsomorphic(isomer):
+                break
+        else:  # didn't break
+            self.fail("{} isn't isomorphic with any aromatic forms of {}".format(
+                            perylene.toSMILES(),
+                            perylene2.toSMILES()
+                        ))
 
     def testMalformedAugmentedInChI(self):
         """Test that augmented inchi without InChI layer raises Exception."""

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1276,6 +1276,44 @@ multiplicity 2
         saturated_molecule.saturate()
         self.assertTrue(saturated_molecule.isIsomorphic(indene))
         
+    def testFusedAromatic(self):
+        """Test we can make aromatic perylene from both adjlist and SMILES"""
+        perylene = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {3,B} {6,B} {7,B}
+2  C u0 p0 c0 {4,B} {5,B} {8,B}
+3  C u0 p0 c0 {1,B} {4,B} {11,B}
+4  C u0 p0 c0 {2,B} {3,B} {12,B}
+5  C u0 p0 c0 {2,B} {6,B} {15,B}
+6  C u0 p0 c0 {1,B} {5,B} {16,B}
+7  C u0 p0 c0 {1,B} {9,B} {10,B}
+8  C u0 p0 c0 {2,B} {13,B} {14,B}
+9  C u0 p0 c0 {7,B} {17,B} {22,S}
+10 C u0 p0 c0 {7,B} {18,B} {23,S}
+11 C u0 p0 c0 {3,B} {18,B} {25,S}
+12 C u0 p0 c0 {4,B} {19,B} {26,S}
+13 C u0 p0 c0 {8,B} {19,B} {28,S}
+14 C u0 p0 c0 {8,B} {20,B} {29,S}
+15 C u0 p0 c0 {5,B} {20,B} {31,S}
+16 C u0 p0 c0 {6,B} {17,B} {32,S}
+17 C u0 p0 c0 {9,B} {16,B} {21,S}
+18 C u0 p0 c0 {10,B} {11,B} {24,S}
+19 C u0 p0 c0 {12,B} {13,B} {27,S}
+20 C u0 p0 c0 {14,B} {15,B} {30,S}
+21 H u0 p0 c0 {17,S}
+22 H u0 p0 c0 {9,S}
+23 H u0 p0 c0 {10,S}
+24 H u0 p0 c0 {18,S}
+25 H u0 p0 c0 {11,S}
+26 H u0 p0 c0 {12,S}
+27 H u0 p0 c0 {19,S}
+28 H u0 p0 c0 {13,S}
+29 H u0 p0 c0 {14,S}
+30 H u0 p0 c0 {20,S}
+31 H u0 p0 c0 {15,S}
+32 H u0 p0 c0 {16,S}
+""")
+        perylene2 = Molecule().fromSMILES('c1cc2cccc3c4cccc5cccc(c(c1)c23)c54')
+        self.assertTrue(perylene.isIsomorphic(perylene2))
 
     def testMalformedAugmentedInChI(self):
         """Test that augmented inchi without InChI layer raises Exception."""

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -7,6 +7,7 @@ from external.wip import work_in_progress
 from .molecule import Atom, Bond, Molecule, ActionError
 from .group import Group
 from .element import getElement, elementList
+from .resonance import generateAromaticResonanceIsomers
 
 
 ################################################################################
@@ -1314,7 +1315,7 @@ multiplicity 2
 32 H u0 p0 c0 {16,S}
 """)
         perylene2 = Molecule().fromSMILES('c1cc2cccc3c4cccc5cccc(c(c1)c23)c54')
-        for isomer in perylene2.getAromaticResonanceIsomers():
+        for isomer in generateAromaticResonanceIsomers(perylene2):
             if perylene.isIsomorphic(isomer):
                 break
         else:  # didn't break

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -571,6 +571,7 @@ def convert_3_atom_2_bond_path(start, mol):
     electrons that the molecule should undergo.
     """
     from rmgpy.data.kinetics.family import ReactionRecipe
+    from .molecule import bond_orders
 
     def is_valid(mol):
         """Check if total bond order of oxygen atoms is smaller than 4."""
@@ -768,7 +769,7 @@ def reset_lone_pairs(mol, p_indices):
     or to the default value.
 
     """
-
+    from .molecule import bond_orders
     for at in mol.atoms:
         index = mol.atoms.index(at) + 1 #1-based index
         count = p_indices.count(index)

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -21,7 +21,7 @@ from rdkit import Chem
 
 from rmgpy.molecule import element as elements
 from .molecule import Atom, Bond, Molecule
-from .adjlist import PeriodicSystem, ConsistencyChecker
+from .adjlist import ConsistencyChecker
 
 import rmgpy.molecule.inchi as inchiutil
 import rmgpy.molecule.util as util
@@ -777,7 +777,7 @@ def reset_lone_pairs(mol, p_indices):
             at.lonePairs = count
         else:    
             order = sum([bond_orders[b.order] for _,b in mol.getBonds(at).iteritems()])
-            at.lonePairs = (PeriodicSystem.valence_electrons[at.symbol] - order - at.radicalElectrons - at.charge) / 2
+            at.lonePairs = (elements.PeriodicSystem.valence_electrons[at.symbol] - order - at.radicalElectrons - at.charge) / 2
 
 def fix_unsaturated_bond_to_biradical(mol, inchi, u_indices):
     """

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -571,14 +571,13 @@ def convert_3_atom_2_bond_path(start, mol):
     electrons that the molecule should undergo.
     """
     from rmgpy.data.kinetics.family import ReactionRecipe
-    from .molecule import bond_orders
 
     def is_valid(mol):
         """Check if total bond order of oxygen atoms is smaller than 4."""
 
         for at in mol.atoms:
             if at.number == 8:
-                order = sum([bond_orders[b.order] for _, b in at.bonds.iteritems()])
+                order = at.getBondOrdersForAtom()
                 not_correct = order >= 4
                 if not_correct:
                     return False
@@ -769,14 +768,13 @@ def reset_lone_pairs(mol, p_indices):
     or to the default value.
 
     """
-    from .molecule import bond_orders
     for at in mol.atoms:
         index = mol.atoms.index(at) + 1 #1-based index
         count = p_indices.count(index)
         if count != 0:
             at.lonePairs = count
         else:    
-            order = sum([bond_orders[b.order] for _,b in mol.getBonds(at).iteritems()])
+            order = at.getBondOrdersForAtom()
             at.lonePairs = (elements.PeriodicSystem.valence_electrons[at.symbol] - order - at.radicalElectrons - at.charge) / 2
 
 def fix_unsaturated_bond_to_biradical(mol, inchi, u_indices):

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -21,7 +21,7 @@ from rdkit import Chem
 
 from rmgpy.molecule import element as elements
 from .molecule import Atom, Bond, Molecule
-from .adjlist import PeriodicSystem, bond_orders, ConsistencyChecker
+from .adjlist import PeriodicSystem, ConsistencyChecker
 
 import rmgpy.molecule.inchi as inchiutil
 import rmgpy.molecule.util as util


### PR DESCRIPTION
This PR starts with commits made by @rwest aiming to address the bond order issue for `Cbf`. The detailed issue and solution were recorded [in issue 767] (https://github.com/ReactionMechanismGenerator/RMG-Py/issues/767). 

In summary, we try to modify a little to the current benzene bond order assignment: dynamic bond order depending on how many benzene bonds an atom has; if atom has three benzene bonds, the bond order for each benzene bond is 4/3, while other cases, the benzene bond order stays unchanged. This fix will have fused aromatics parsed correctly from adjacencylist.

In addition, 3 fused aromatics unittests and 1 adjacencylist unittest are added to make sure new changes are valid. so this PR includes

- new way of assigning benzene bond order

- additional unittests for fused aromatics parsing

- code clean-up: moving `bond_orders` to `molecule.py` and `PeriodicSystem` to `element.py`