### PR TITLE
Entry accessibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ before_install:
   - conda update --yes conda
   - cd ..
   - git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
-  - cd RMG-Py
+  - cd RMG-database
+  - git checkout unimol_accessibility
+  - cd ../RMG-Py
 
 install:
   - conda env create -f environment_linux.yml

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -235,7 +235,7 @@ atomTypes['R']    = AtomType(label='R', generic=[], specific=[
     'O','Os','Od','Oa','Ot',
     'Ne',
     'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf',
-    'S','Ss','Sd','Sa',
+    'S','Ss','Sd','Sa','St',
     'Cl','Ar']
 )
 atomTypes['R!H']  = AtomType(label='R!H', generic=['R'], specific=[
@@ -247,7 +247,7 @@ atomTypes['R!H']  = AtomType(label='R!H', generic=['R'], specific=[
     'O','Os','Od','Oa','Ot',
     'Ne',
     'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf',
-    'S','Ss','Sd','Sa',
+    'S','Ss','Sd','Sa','St',
     'Cl','Ar'])
 
 atomTypes['Val4'] = AtomType(label='Val4', generic=['R','R!H'], specific=[
@@ -259,7 +259,7 @@ atomTypes['Val5'] = AtomType(label='Val5', generic=['R','R!H'], specific=[
 
 atomTypes['Val6'] = AtomType(label='Val6', generic=['R','R!H'], specific=[
     'O','Os','Od','Oa','Ot',
-    'S','Ss','Sd','Sa'])
+    'S','Ss','Sd','Sa', 'St'])
 
 atomTypes['Val7'] = AtomType(label='Val7', generic=['R','R!H'], specific=[
     'Cl'])
@@ -342,13 +342,16 @@ atomTypes['Sib' ] = AtomType('Sib',  generic=['R','R!H','Si','Val4'], specific=[
 atomTypes['Sibf'] = AtomType('Sibf', generic=['R','R!H','Si','Val4'], specific=[],
                              single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[3])
 
-atomTypes['S'   ] = AtomType('S',    generic=['R','R!H','Val6'],      specific=['Ss','Sd','Sa'])
+atomTypes['S'   ] = AtomType('S',    generic=['R','R!H','Val6'],      specific=['Ss','Sd','Sa','St'])
 atomTypes['Ss'  ] = AtomType('Ss',   generic=['R','R!H','S','Val6'],  specific=[],
                              single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
 atomTypes['Sd'  ] = AtomType('Sd',   generic=['R','R!H','S','Val6'],  specific=[],
                              single=[], allDouble=[1], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
 atomTypes['Sa'  ] = AtomType('Sa',   generic=['R','R!H','S','Val6'],  specific=[],
                              single=[0], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[0], benzene=[0])
+atomTypes['St'  ] = AtomType('St',   generic=['R','R!H','S','Val6'],  specific=[],
+                             single=[], allDouble=[0], rDouble=[], oDouble=[], sDouble=[], triple=[1], benzene=[0])
+
 
 atomTypes['Cl'  ] = AtomType('Cl',   generic=['R','R!H','Val7'],      specific=[])
 
@@ -409,6 +412,8 @@ atomTypes['S'   ].setActions(incrementBond=['S'],            decrementBond=['S']
 atomTypes['Ss'  ].setActions(incrementBond=['Sd'],           decrementBond=[],               formBond=['Ss'],        breakBond=['Ss'],        incrementRadical=['Ss'],   decrementRadical=['Ss'],   incrementLonePair=['Ss'],  decrementLonePair=['Ss'])
 atomTypes['Sd'  ].setActions(incrementBond=[],               decrementBond=['Ss'],           formBond=[],            breakBond=[],            incrementRadical=[],       decrementRadical=[],       incrementLonePair=['Sd'],  decrementLonePair=['Sd'])
 atomTypes['Sa'  ].setActions(incrementBond=[],               decrementBond=[],               formBond=[],            breakBond=[],            incrementRadical=[],       decrementRadical=[],       incrementLonePair=[],      decrementLonePair=[])
+atomTypes['St'  ].setActions(incrementBond=[],               decrementBond=['Sd'],           formBond=[],            breakBond=[],            incrementRadical=[],       decrementRadical=[],       incrementLonePair=['St'],  decrementLonePair=['St'])
+
 
 atomTypes['Cl'  ].setActions(incrementBond=[],               decrementBond=['Cl'],           formBond=['Cl'],        breakBond=['Cl'],        incrementRadical=['Cl'],   decrementRadical=['Cl'],   incrementLonePair=[],      decrementLonePair=[])
 

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -422,6 +422,12 @@ atomTypes['Ar'  ].setActions(incrementBond=[],               decrementBond=[],  
 #list of elements that do not have more specific atomTypes
 allElements=['H', 'He', 'C', 'O', 'N', 'Si', 'S', 'Ne','Cl', 'Ar', ]
 nonSpecifics=['H', 'He', 'Ne', 'Cl', 'Ar',]
+#define list of aromaticAtomTypes
+aromaticAtomtypes = []
+for label, atomtype in atomTypes.iteritems():
+    requiredBenzene = atomtype.getFeatures()[6]
+    if requiredBenzene and 0 not in requiredBenzene:
+        aromaticAtomtypes.append(atomtype)
 
 for atomType in atomTypes.values():
     for items in [atomType.generic, atomType.specific,
@@ -429,6 +435,7 @@ for atomType in atomTypes.values():
       atomType.breakBond, atomType.incrementRadical, atomType.decrementRadical, atomType.incrementLonePair, atomType.decrementLonePair]:
         for index in range(len(items)):
             items[index] = atomTypes[items[index]]
+
 
 def getFeatures(atom, bonds):
     """

--- a/rmgpy/molecule/atomtypeTest.py
+++ b/rmgpy/molecule/atomtypeTest.py
@@ -181,9 +181,16 @@ class TestGetAtomType(unittest.TestCase):
                                                      9  H u0 p0 {3,S}
                                                      10 H u0 p0 {4,S}
                                                      11 H u0 p0 {5,S}''')
-        self.mol19 = Molecule().fromSMILES('C=S')
-        
-    
+
+        self.mol19 = Molecule().fromAdjacencyList('''1 C u0 p0 c0 {2,D} {3,S} {4,S}
+                                                     2 S u0 p2 c0 {1,D}
+                                                     3 H u0 p0 c0 {1,S}
+                                                     4 H u0 p0 c0 {1,S}''')
+
+        self.mol20 = Molecule().fromSMILES('[C-]#[O+]')
+
+        self.mol21 = Molecule().fromSMILES('[C-]#[S+]')
+
     def atomType(self, mol, atomID):
         atom = mol.atoms[atomID]
         type = getAtomType(atom, mol.getBonds(atom))
@@ -234,6 +241,7 @@ class TestGetAtomType(unittest.TestCase):
         """
         self.assertEqual(self.atomType(self.mol1, 1), 'Os')
         self.assertEqual(self.atomType(self.mol1, 3), 'Od')
+        self.assertEqual(self.atomType(self.mol20, 1), 'Ot')
     
     def testSiliconTypes(self):
         """
@@ -251,6 +259,7 @@ class TestGetAtomType(unittest.TestCase):
         """
         self.assertEqual(self.atomType(self.mol4, 8), 'Ss')
         self.assertEqual(self.atomType(self.mol4, 10), 'Sd')
+        self.assertEqual(self.atomType(self.mol21, 1), 'St')
     
     def testOtherTypes(self):
         """

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -89,6 +89,8 @@ cdef class Graph:
     
     cpdef Graph copy(self, bint deep=?)
 
+    cpdef dict copyAndMap(self)
+
     cpdef Graph merge(self, Graph other)
 
     cpdef list split(self)

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -321,13 +321,41 @@ cdef class Graph:
                     other.addEdge(edge)
         return other
 
+    cpdef dict copyAndMap(self):
+        """
+        Create a deep copy of the current graph, and return the dict
+        'mapping'. Method was modified from Graph.copy() method
+        """
+        cdef Graph other
+        cdef Vertex vertex, vertex1, vertex2
+        cdef Edge edge
+        cdef dict edges, mapping
+        cdef list vertices
+        cdef int index1, index2
+
+        other = Graph()
+        vertices = self.vertices
+        mapping = {}
+        for vertex in vertices:
+            vertex2 = other.addVertex(vertex.copy())
+            mapping[vertex] = vertex2
+
+        for vertex1 in vertices:
+            for vertex2 in vertex1.edges:
+                edge = vertex1.edges[vertex2]
+                edge = edge.copy()
+                edge.vertex1 = mapping[vertex1]
+                edge.vertex2 = mapping[vertex2]
+                other.addEdge(edge)
+        return mapping
+
     cpdef Graph merge(self, Graph other):
         """
         Merge two graphs so as to store them in a single Graph object.
         """
         cdef Graph new
         cdef Vertex vertex, vertex1, vertex2
-        
+
         # Create output graph
         new = Graph()
 

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -530,14 +530,14 @@ class GroupAtom(Vertex):
         #Based on git history, it is probably because RDKit requires a number instead of None
         #Instead we will set it to 0 here
 
-        if newAtom.lonePairs == -100:
-            if atomtype in [atomTypes[x] for x in ['N5d', 'N5dd', 'N5t', 'N5b', 'N5s']]:
-                newAtom.lonePairs = 0
-                newAtom.charge = 1
-            elif atomtype is atomTypes['N1d']:
-                newAtom.charge = -1
-            else:
-                newAtom.lonePairs = defaultLonePairs[newAtom.symbol]
+        #Hard code charge for a few atomtypes
+        if atomtype in [atomTypes[x] for x in ['N5d', 'N5dd', 'N5t', 'N5b', 'N5s']]:
+            newAtom.lonePairs = 0
+            newAtom.charge = 1
+        elif atomtype in [atomTypes[x] for x in ['N1d']]:
+            newAtom.charge = -1
+        elif newAtom.lonePairs == -100:
+            newAtom.lonePairs = defaultLonePairs[newAtom.symbol]
 
         return newAtom
 
@@ -1774,43 +1774,43 @@ class Group(Graph):
         Returns: A sample class :Molecule: from the group
         """
 
-        # print self
-        # print self.atoms
-
         #Add implicit atoms
         modifiedGroup = self.addImplicitAtomsFromAtomType()
         #Add implicit benzene rings
         modifiedGroup = modifiedGroup.addImplicitBenzene()
-        #Make dictionary of :GroupAtoms: to :Atoms:
-        atomDict = {}
+        #Make dictionary of :GroupAtoms: to :Atoms: and vice versa
+        groupToMol = {}
+        molToGroup = {}
         for atom in modifiedGroup.atoms:
-            atomDict[atom] = atom.makeSampleAtom()
+            molAtom = atom.makeSampleAtom()
+            groupToMol[atom] = molAtom
+            molToGroup[molAtom] = atom
 
         #create the molecule
-        newMolecule = mol.Molecule(atoms = atomDict.values())
+        newMolecule = mol.Molecule(atoms = groupToMol.values())
+            
         #Add explicit bonds to :Atoms:
         for atom1 in modifiedGroup.atoms:
             for atom2, bond12 in atom1.bonds.iteritems():
-                bond12.makeBond(newMolecule, atomDict[atom1], atomDict[atom2])
-
+                bond12.makeBond(newMolecule, groupToMol[atom1], groupToMol[atom2])
 
         #Saturate up to expected valency
-        for atom in newMolecule.atoms:
-            statedCharge = atom.charge
-            atom.updateCharge()
-            if atom.charge - statedCharge:
-                hydrogenNeeded = atom.charge - statedCharge
+        for molAtom in newMolecule.atoms:
+            statedCharge = molAtom.charge
+            molAtom.updateCharge()
+            if molAtom.charge - statedCharge:
+                hydrogenNeeded = molAtom.charge - statedCharge
+                if molAtom in molToGroup and molToGroup[molAtom].atomType[0].single:
+                    maxSingle = max(molToGroup[molAtom].atomType[0].single)
+                    if hydrogenNeeded > maxSingle: hydrogenNeeded = maxSingle
                 for x in range(hydrogenNeeded):
                     newH = mol.Atom('H', radicalElectrons=0, lonePairs=0, charge=0)
-                    newBond = mol.Bond(atom, newH, 1)
+                    newBond = mol.Bond(molAtom, newH, 1)
                     newMolecule.addAtom(newH)
                     newMolecule.addBond(newBond)
-                atom.updateCharge()
-            # print statedCharge, atom.charge, type(atom.charge)
+                molAtom.updateCharge()
 
         newMolecule.update()
-        # print newMolecule.atoms
-
 
         return newMolecule
 

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -36,7 +36,7 @@ reaction sites).
 import cython
 
 from .graph import Vertex, Edge, Graph
-from .atomtype import atomTypes, allElements, nonSpecifics, getFeatures
+from .atomtype import atomTypes, allElements, nonSpecifics, getFeatures, aromaticAtomtypes
 from .element import PeriodicSystem
 import rmgpy.molecule.molecule as mol
 from copy import deepcopy, copy
@@ -1778,11 +1778,21 @@ class Group(Graph):
         modifiedGroup = self.copy(deep = True)
         for atom in modifiedGroup.atoms:
             atom.atomType=[atom.atomType[0]]
+            print atom
             for atom2, bond12 in atom.bonds.iteritems():
-                bond12.order=[bond12.order[0]]
+                # print atom.atomType, atom2.atomType
+                if atom.atomType[0] in aromaticAtomtypes or atom2.atomType[0] in aromaticAtomtypes:
+                    if 1.5 in bond12.order:
+                        bond12.order = [1.5]
+                    else: bond12.order = [bond12.order[0]]
+                else:
+                    bond12.order = [bond12.order[0]]
 
         # print "initial"
         # print self.toAdjacencyList()
+        #
+        # print "after eliminating wildcards"
+        # print modifiedGroup.toAdjacencyList()
 
         #Add implicit atoms
         modifiedGroup = modifiedGroup.addImplicitAtomsFromAtomType()

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1425,7 +1425,7 @@ class Group(Graph):
 
         for atom in self.atoms:
             if not atom.atomType[0].label in labelsOfCarbonAtomTypes: continue
-            elif atom.atomType[0].label in ['Cb', 'N3b']: #Make Cb and N3b into normal cb atoms
+            elif atom.atomType[0].label in ['Cb', 'N5b', 'N3b']: #Make Cb and N3b into normal cb atoms
                 cbAtomList.append(atom)
             elif atom.atomType[0].label == 'Cbf':
                 cbfAtomList.append(atom)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1781,9 +1781,14 @@ class Group(Graph):
             for atom2, bond12 in atom.bonds.iteritems():
                 bond12.order=[bond12.order[0]]
 
+        # print "initial"
+        # print self.toAdjacencyList()
+
         #Add implicit atoms
         modifiedGroup = modifiedGroup.addImplicitAtomsFromAtomType()
 
+        # print "after implicit"
+        # print modifiedGroup.toAdjacencyList()
 
         #Add implicit benzene rings
         modifiedGroup = modifiedGroup.addImplicitBenzene()
@@ -1803,6 +1808,8 @@ class Group(Graph):
             for atom2, bond12 in atom1.bonds.iteritems():
                 bond12.makeBond(newMolecule, groupToMol[atom1], groupToMol[atom2])
 
+        # print "first molecule"
+        # print newMolecule.toAdjacencyList()
 
         #Saturate up to expected valency
         for molAtom in newMolecule.atoms:
@@ -1821,6 +1828,9 @@ class Group(Graph):
                     newMolecule.addAtom(newH)
                     newMolecule.addBond(newBond)
                 molAtom.updateCharge()
+
+        # print "after saturated"
+        # print newMolecule.toAdjacencyList()
 
         newMolecule.update()
         return newMolecule

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -1073,18 +1073,21 @@ class TestGroup(unittest.TestCase):
         Test the Group.makeSampleMolecule method
         """
 
-        # result = self.group.makeSampleMolecule()
-        # print result.multiplicity
-        # self.assertTrue(result.isIsomorphic(Molecule().fromSMILES('OCC')))
-
+        def performSampMoleComparison(adjlist, answer_smiles):
+            """
+            Creates a sample molecule from the adjlist and returns if it is isomorphic to a molecule created from
+            the inputted smiles
+            """
+            group = Group().fromAdjacencyList(adjlist)
+            result = group.makeSampleMolecule()
+            return (result.isIsomorphic(Molecule().fromSMILES(answer_smiles)))
+########################################################################################################################
         #tests adding implicit atoms
-        adjlist1 = """
+        adjlist = """
 1  *1 Cd u0
             """
-
-        group1 = Group().fromAdjacencyList(adjlist1)
-        result1 = group1.makeSampleMolecule()
-        self.assertTrue(result1.isIsomorphic(Molecule().fromSMILES('C=C')))
+        answer_smiles = 'C=C'
+        self.assertTrue(performSampMoleComparison(adjlist, answer_smiles))
 
         #test creating implicit benzene atoms
         adjlist2 = """
@@ -1098,24 +1101,29 @@ class TestGroup(unittest.TestCase):
         resonanceList2=naphthaleneMolecule.generateResonanceIsomers()
         self.assertTrue(any([result2.isIsomorphic(x) for x in resonanceList2]))
 
-        #test the creation of a charged species
-        adjlist3 = """
+        #test the creation of a positively charged species
+        adjlist = """
 1  *1 N5s u0
         """
+        answer_smiles = '[NH4+]'
+        self.assertTrue(performSampMoleComparison(adjlist, answer_smiles))
 
-        group3 = Group().fromAdjacencyList(adjlist3)
-        result3 = group3.makeSampleMolecule()
-        self.assertTrue(result3.isIsomorphic(Molecule().fromSMILES('[NH4+]')))
+        #test the creation of a negatively charged species
+        #commented out until new nitrogen atom types added in
+#         adjlist = """
+# 1  *1 N2s u0
+#         """
+#         answer_smiles = '[NH2-]'
+#         self.assertTrue(performSampMoleComparison(adjlist, answer_smiles))
 
         #test creation of charged species when some single bonds present
-        adjlist4 = """
+        adjlist = """
 1 *2 [N5s,N5d] u0 {2,S} {3,S}
 2 *3 R!H       u1 {1,S}
 3 *4 H         u0 {1,S}
 """
-        group4 = Group().fromAdjacencyList(adjlist4)
-        result4 = group4.makeSampleMolecule()
-        self.assertTrue(result4.isIsomorphic(Molecule().fromSMILES('[NH3+][CH2]')))
+        answer_smiles = '[NH3+][CH2]'
+        self.assertTrue(performSampMoleComparison(adjlist, answer_smiles))
 
     def testIsBenzeneExplicit(self):
         """

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -1125,6 +1125,22 @@ class TestGroup(unittest.TestCase):
         answer_smiles = '[NH3+][CH2]'
         self.assertTrue(performSampMoleComparison(adjlist, answer_smiles))
 
+        #test that Cb/Cbf atoms with [D,B] chooses [B] instead of [D] bonds
+        adjlist5 = """
+1 *1 R!H       u1 {2,[D,B]}
+2 *4 [Cbf,Cdd] u0 {1,[D,B]} {3,[D,B]}
+3 *5 [Cb,Cd]   u0 {2,[D,B]} {4,S}
+4 *2 R!H       u0 {3,S} {5,S}
+5 *3 H         u0 {4,S}
+"""
+        group5 = Group().fromAdjacencyList(adjlist5)
+        result5 = group5.makeSampleMolecule()
+        atom1 = result5.getLabeledAtom("*1")
+        atom4 = result5.getLabeledAtom("*4")
+        atom5 = result5.getLabeledAtom("*5")
+        self.assertTrue(atom1.bonds[atom4].isBenzene())
+        self.assertTrue(atom5.bonds[atom4].isBenzene())
+
     def testIsBenzeneExplicit(self):
         """
         Test the Group.isBenzeneExplicit method

--- a/rmgpy/molecule/parser.pxd
+++ b/rmgpy/molecule/parser.pxd
@@ -21,6 +21,8 @@ cdef Molecule __fromSMILES(Molecule mol, str smilesstr, str backend)
 
 cdef Molecule __fromInChI(Molecule mol, str inchistr, str backend)
 
+cdef Molecule __fromSMARTS(Molecule mol, str identifier, str backend)
+
 cdef Molecule __parse(Molecule mol, str identifier, str type_identifier, str backend)
 
 cpdef Molecule parse_openbabel(Molecule mol, str identifier, str type_identifier)
@@ -29,7 +31,7 @@ cpdef Molecule fromInChI(Molecule mol, str inchistr, backend=*)
 
 cpdef Molecule fromSMILES(Molecule mol, str smilesstr, str backend=*)
 
-cpdef Molecule fromSMARTS(Molecule mol, str smartsstr)
+cpdef Molecule fromSMARTS(Molecule mol, str smartsstr, str backend=*)
 
 cpdef Molecule fromAugmentedInChI(Molecule mol, aug_inchi)
     

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -104,6 +104,7 @@ def __parse(mol, identifier, type_identifier, backend):
 
     if __lookup(mol, identifier, type_identifier) is not None:
         if isCorrectlyParsed(mol, identifier):
+            mol.updateAtomTypes()
             return mol
 
     for _backend in (BACKENDS if backend=='try-all' else [backend]):
@@ -117,6 +118,7 @@ def __parse(mol, identifier, type_identifier, backend):
             raise NotImplementedError("Unknown identifier type {0}".format(type_identifier))
 
         if isCorrectlyParsed(mol, identifier):
+            mol.updateAtomTypes()
             return mol
         else:
             logging.debug('Backend %s is not able to parse identifier %s', _backend, identifier)

--- a/rmgpy/molecule/parserTest.py
+++ b/rmgpy/molecule/parserTest.py
@@ -3,6 +3,7 @@ import unittest
 from rmgpy.molecule.molecule import Molecule
 
 from rmgpy.molecule.parser import *
+from rmgpy.molecule.atomtype import atomTypes
 
 class ParserTest(unittest.TestCase):
 
@@ -41,10 +42,20 @@ class ParserTest(unittest.TestCase):
         mol = fromSMILES(Molecule(), smiles)
         self.assertTrue(mol.isIsomorphic(self.methane))
 
+        #Test that atomtypes that rely on lone pairs for identity are typed correctly
+        smiles = 'CN'
+        mol = fromSMILES(Molecule(), smiles)
+        self.assertEquals(mol.atoms[1].atomType, atomTypes['N3s'] )
+
     def test_fromInChI(self):
         inchi = 'InChI=1S/CH4/h1H4'
         mol = fromInChI(Molecule(), inchi)
         self.assertTrue(mol.isIsomorphic(self.methane))
+
+        #Test that atomtypes that rely on lone pairs for identity are typed correctly
+        inchi = "InChI=1S/CH5N/c1-2/h2H2,1H3"
+        mol = fromInChI(Molecule(), inchi)
+        self.assertEquals(mol.atoms[1].atomType, atomTypes['N3s'] )
 
     #Commented out because current implementation of SMARTS is broken
     # def test_fromSMARTS(self):

--- a/rmgpy/molecule/parserTest.py
+++ b/rmgpy/molecule/parserTest.py
@@ -2,18 +2,55 @@ import unittest
 
 from rmgpy.molecule.molecule import Molecule
 
-from .parser import *
+from rmgpy.molecule.parser import *
 
 class ParserTest(unittest.TestCase):
+
+    def setUp(self):
+
+        self.methane = Molecule().fromAdjacencyList("""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+""")
+        self.methylamine = Molecule().fromAdjacencyList("""
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+""")
 
     def test_fromAugmentedInChI(self):
         aug_inchi = 'InChI=1S/CH4/h1H4'
         mol = fromAugmentedInChI(Molecule(), aug_inchi)
         self.assertTrue(not mol.InChI == '')
+        self.assertTrue(mol.isIsomorphic(self.methane))
 
         aug_inchi = 'InChI=1/CH4/h1H4'
         mol = fromAugmentedInChI(Molecule(), aug_inchi)
         self.assertTrue(not mol.InChI == '')
+        self.assertTrue(mol.isIsomorphic(self.methane))
+
+    def test_fromSMILES(self):
+        smiles = 'C'
+        mol = fromSMILES(Molecule(), smiles)
+        self.assertTrue(mol.isIsomorphic(self.methane))
+
+    def test_fromInChI(self):
+        inchi = 'InChI=1S/CH4/h1H4'
+        mol = fromInChI(Molecule(), inchi)
+        self.assertTrue(mol.isIsomorphic(self.methane))
+
+    #Commented out because current implementation of SMARTS is broken
+    # def test_fromSMARTS(self):
+    #     smarts = '[CH4]'
+    #     mol = fromSMARTS(Molecule(), smarts)
+    #     self.assertTrue(mol.isIsomorphic(self.methane))
 
     def test_toRDKitMol(self):
         """

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -80,12 +80,11 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             self.compat_func_name = test_name
             yield test, family_name
 
-            # this patch of code is commented out till the kinetics database is ready for proper testing
-            # test = lambda x: self.kinetics_checkSampleDescendsToGroup(family_name)
-            # test_name = "Kinetics family {0}: Entry is accessible?".format(family_name)
-            # test.description = test_name
-            # self.compat_func_name = test_name
-            # yield test, family_name
+            test = lambda x: self.kinetics_checkSampleDescendsToGroup(family_name)
+            test_name = "Kinetics family {0}: Entry is accessible?".format(family_name)
+            test.description = test_name
+            self.compat_func_name = test_name
+            yield test, family_name
 
             for depository in family.depositories:
 
@@ -477,12 +476,10 @@ The following adjList may have atoms in a different ordering than the input file
         """
         This test first creates a sample :class:Molecule from a :class:Group. Then it checks
         that this molecule hits the original group or a child when it descends down the tree.
-        
-        this test is not currently called. It will be used when the kinetics database is fixed
-        to allow for biomolecular reaction finding effectively.
         """
         family = self.database.kinetics.families[family_name]
 
+        #ignore any products
         ignore=[]
         if not family.ownReverse:
             for product in family.forwardTemplate.products:
@@ -490,14 +487,20 @@ The following adjList may have atoms in a different ordering than the input file
                 ignore.extend(product.children)
         else: ignore=[]
 
+        #Do not perform test if family is unimolecular or (more generally) backbone archetype
+        roots = family.groups.top
+        if len(roots) > len(family.forwardTemplate.reactants):
+            return
+
         for entryName, entry in family.groups.entries.iteritems():
-            print entryName
             if entry in ignore: continue
             elif isinstance(entry.item, Group):
-                # print entryName
+                ancestors=family.ancestors(entry)
+                if ancestors: root = ancestors[-1]
+                else: root = entry
                 sampleMolecule = entry.item.makeSampleMolecule()
                 atoms = sampleMolecule.getLabeledAtoms()
-                match = family.groups.descendTree(sampleMolecule, atoms, strict=True)
+                match = family.groups.descendTree(sampleMolecule, atoms, strict=True, root = root)
 
                 assert entry in [match]+family.groups.ancestors(match), """In group {0}, a sample molecule made from node {1} returns node {2} when descending the tree.
 Sample molecule AdjList:
@@ -508,8 +511,7 @@ Origin Group AdjList:
 
 Matched group AdjList:
 {5}
-                                           """.format(family_name, entry, match, sampleMolecule.toAdjacencyList(), entry.item.toAdjacencyList(),match.item.toAdjacencyList())
-
+""".format(family_name, entry, match, sampleMolecule.toAdjacencyList(), entry.item.toAdjacencyList(),match.item.toAdjacencyList())
 
     def general_checkNodesFoundInTree(self, group_name, group):
         """
@@ -649,7 +651,7 @@ Origin Group AdjList:
 
 Matched group AdjList:
 {5}
-                                           """.format(group_name, entry, match, sampleMolecule.toAdjacencyList(), entry.item.toAdjacencyList(),match.item.toAdjacencyList())
+""".format(group_name, entry, match, sampleMolecule.toAdjacencyList(), entry.item.toAdjacencyList(),match.item.toAdjacencyList())
 
 if __name__ == '__main__':
     nose.run(argv=[__file__, '-v', '--nologcapture'], defaultTest=__name__)

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -634,6 +634,12 @@ The following adjList may have atoms in a different ordering than the input file
             for x in E:
                 s += '\n'+str(x)
             nose.tools.assert_true(False,s)
+    def kinetics_checkSampleDescendsToGroup(self, family_name):
+        """
+        This test first creates a sample :class:Molecule from a :class:Group. Then it checks
+        that this molecule hits the original group or a child when it descends down the tree.
+        """
+        family = self.database.kinetics.families[family_name]
 
         #ignore any products
         ignore=[]

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -9,7 +9,8 @@ from rmgpy.data.rmg import RMGDatabase
 from copy import copy, deepcopy
 from rmgpy.data.base import LogicOr
 from rmgpy.molecule import Group
-from rmgpy.molecule.atomtype import atomTypes, AtomTypeError
+from rmgpy.molecule.atomtype import atomTypes
+from rmgpy.molecule.pathfinder import find_shortest_path
 
 import nose
 import nose.tools
@@ -80,6 +81,13 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             self.compat_func_name = test_name
             yield test, family_name
 
+            if len(family.forwardTemplate.reactants) < len(family.groups.top) and family_name != 'Diels_alder_addition':
+                test = lambda x: self.kinetics_checkUnimolecularGroups(family_name)
+                test_name = "Kinetics family {0} check that unimolecular group is formatted correctly?".format(family_name)
+                test.description = test_name
+                self.compat_func_name = test_name
+                yield test, family_name
+                
             test = lambda x: self.kinetics_checkSampleDescendsToGroup(family_name)
             test_name = "Kinetics family {0}: Entry is accessible?".format(family_name)
             test.description = test_name
@@ -472,12 +480,160 @@ The following adjList may have atoms in a different ordering than the input file
 {4}
                                             """.format(family_name, entry, correctAtom, index+1, entry.item.toAdjacencyList()))
 
-    def kinetics_checkSampleDescendsToGroup(self, family_name):
+    def kinetics_checkUnimolecularGroups(self,family_name):
         """
-        This test first creates a sample :class:Molecule from a :class:Group. Then it checks
-        that this molecule hits the original group or a child when it descends down the tree.
+        This test goes through all unimolecular groups that have more than one top level, top level groups
+        that overlap with family.reactant are assumed to be backbones(contains the whole reactant molecule)
+        and the other top levels are assumedto be endgroups
+
+        the following are format requirements are checked:
+        1)endgroup entries hav exactly the same labels as their top level entry
+        2)backbone groups have all labels that endgroups have
+        3)backbone groups have labels tracing between the endgroups that follow the shortest path
+        4)The end subgraph inside each backbone is exactly the same as the top level of the correspodning end tree
         """
+
+        def getEndFromBackbone(backbone, endLabels):
+            """
+            :param backbone: :class: Entry for a backbone of molecule
+            :param endLabels: Labels in the end groups
+            :return: A subgraph representing the end group of the molecule
+            """
+            #make copy for manipulation
+            copyGroup = backbone.item.copy(True)
+
+            #Find the endGroup atoms
+            for atom in copyGroup.atoms:
+                if atom.label in endLabels:
+                    midAtom = atom
+                    break
+
+            #find the bonds to break
+            bondsToBreak = []
+            for atom2, bond in midAtom.bonds.iteritems():
+                if atom2.label is None or atom2.label not in endLabels: #
+                    bondsToBreak.append(bond)
+
+
+            for bond in bondsToBreak:
+                copyGroup.removeBond(bond)
+
+            #split group into end and backbone fragment
+            groups = copyGroup.split()
+
+            #verify group was split correctly and identify the correct end group
+            endLabels = set(endLabels)
+            for group in groups:
+                groupLabels = set(atom.label for atom in group.atoms)
+                groupLabels.discard('')
+                if endLabels == groupLabels:
+                    break
+            else:
+                print(endLabels)
+                print(groupLabels)
+                for group in groups:
+                    print(group.toAdjacencyList(label=backbone.label))
+                raise Exception("Group {0} not split correctly".format(backbone.label))
+
+            return group
+        #################################################################################
         family = self.database.kinetics.families[family_name]
+        print family
+
+        backbone =  family.getBackboneRoots()[0]
+
+        endGroups = family.getEndRoots()
+
+        endLabels = {}
+        for endGroup in endGroups:
+            labels = []
+            for atom in endGroup.item.atoms:
+                if atom.label:
+                    labels.append(atom.label)
+            endLabels[endGroup] = set(labels)
+
+        #get boundary atoms to test that backbones have labels between end groups
+        nose.tools.assert_is_not_none(family.boundaryAtoms)
+
+        # set of all end_labels should be backbone label
+        backboneLabel = set([])
+        for end, end_label in endLabels.iteritems():
+            for label in end_label:
+                backboneLabel.add(label)
+
+        #define types of errors
+        A = [] #end groups have too many labels
+        B = [] #end group lacks necessary label
+        C = [] #backbone missing end group labels
+        D = [] #backbone missing labels in between groups
+        E = [] #backbone tries to define atoms inside end groups
+        for group_name, entry in family.groups.entries.iteritems():
+            if isinstance(entry.item, Group):
+                group = entry.item
+                if backbone in family.ancestors(entry):
+                    for atom in group.atoms:
+                        if atom.label: presentLabels.add(atom.label)
+                    #Check C
+                    for endGroup, labels in endLabels.iteritems():
+                        if not labels.issubset(presentLabels):
+                            C.append([endGroup, entry])
+                    #check D
+                    midAtoms = [group.getLabeledAtom(x) for x in family.boundaryAtoms]
+                    pathAtoms = find_shortest_path(midAtoms[0], midAtoms[1])
+                    for atom in pathAtoms:
+                        if not atom.label:
+                            D.append([backbone, entry])
+                            break
+                    #check E
+                    for endGroup, labels in endLabels.iteritems():
+                        endFromBackbone = getEndFromBackbone(entry, labels)
+                        presentLabels = endFromBackbone.getLabeledAtoms()
+                        presentLabels = set(presentLabels.keys())
+                        if labels == presentLabels:
+                            if not endGroup.item.isIdentical(endFromBackbone):
+                                E.append([endGroup, entry])
+                        else: raise Exception("Group {0} has split into end group {1}, but does not match any root".format(entry.label, endFromBackbone.toAdjacencyList()))
+
+                else:
+                    presentLabels = set([])
+                    for endNode, labelledAtoms in endLabels.iteritems():
+                        if endNode in family.ancestors(entry):
+                            for atom in group.atoms:
+                                if atom.label: presentLabels.add(atom.label)
+                            #Check A
+                            if not presentLabels.issubset(labelledAtoms):
+                                A.append([endNode, entry])
+                            #Check B
+                            if not labelledAtoms.issubset(presentLabels):
+                                B.append([endNode, entry])
+
+
+        #print outputs
+        if A != []:
+            s = "These end groups have extra labels that their top level end group do not have:"+"\n [root group, error group]"
+            for x in A:
+                s += '\n'+str(x)
+            nose.tools.assert_true(False,s)
+        if B != []:
+            s = "These end groups are missing labels that their top level end group have:"+"\n [root group, error group]"
+            for x in B:
+                s += '\n'+str(x)
+            nose.tools.assert_true(False,s)
+        if C != []:
+            s = "These backbone groups are missing labels that are in the end groups:"+"\n [root group, error group]"
+            for x in C:
+                s += '\n'+str(x)
+            nose.tools.assert_true(False,s)
+        if D != []:
+            s = "These backbone groups are missing labels along the path atoms:"+"\n [root group, error group]"
+            for x in D:
+                s += '\n'+str(x)
+            nose.tools.assert_true(False,s)
+        if E != []:
+            s = "These backbone have end subgraphs that don't match a root:"+"\n [root group, error group]"
+            for x in E:
+                s += '\n'+str(x)
+            nose.tools.assert_true(False,s)
 
         #ignore any products
         ignore=[]


### PR DESCRIPTION
Making this pull request as a place to write down work that still needs to be done. This is not ready to be merged.

This pull request addresses the issue of entry accessibility unit tests for the RMG-database. The main testDatabases other than kinetics are almost complete, and should probably go into their own pull request. Work that still needs to be done on these:
1. Functions and unit tests dealing with addImplicitBenzene. Right now it does too much and doesn't do those things right. I shouldn't try to handle Cbf3 as its more complicated than anything in the database and phenalene (my simple test case for Cbf3) is not actually fully aromatic on every ring. 
2. Refactor valency in standardizeAtomTypes method to use methods from #769  
3. Finish making a method to test that either a group has either <3 Cbf atoms or has all Cb/Cbf atoms in explicit rings. Otherwise we shouldn't allow these groups in the database because it is too hard to make sample molecules (by hand or by code)

I also want to use some of these commits to fix entry accessibility in kinetics, which will probably make a second pull request. There is still a lot of work to do for that:
1. Problem of conflicting ends and backbones. Some unimolecular kinetics families follow the paradigm of having a 'backbone' subtree describing the overall shape of the molecule and 'end' groups describing the reactive sites. We need to refactor the backbone entries to be orthogonal to the end entries. That is, any labelled atom overlapping between an end Group and backbone Group should be as general as the top of the end subtree. In the backbone, we only describe atoms not accounted for in the end groups (non-overlapping), or the bonding between non-overlapping atoms and overlapping atoms. This will make organization of the groups better as well as fix difficulties in making sample atoms.
2. To make sample atoms to descend the tree, backbone groups are the same as thermo groups, but end groups need to be merged with a general backbone before creating the molecule. This is partially implemented, but does not work well for backbones that are cyclic (e.g. entry R3H_SS_12cy3 i intra_H_migration)
3. Diels_alder_addition is a special case of having a pseudo-backbone/end paradigm. It is not actually unimolecule, but one of the reactants has backbone/end subtrees. It is a little more complicated, because usually the ends are terminal from non-reacting backbone labelled atoms: i.e. end1-nonOverlappingBackboneAtoms-end2. However diels alder actually has the "end" sandwiched in the middle of the backbone. This special case needs to be handled differently
4. I briefly discussed a problem of subtree leakage with Kehang and Richard, but further testing makes it look like it is actually already handled correctly. RMG labels all atoms on the backbone before descending the trees, matching with strict = True. Might want to confirm this after fixing above problems.
5. Once test is working and backbone/end is cleaned up. We still need to use the database test to find real non-accessible entries like we did for thermo. 
