### PR TITLE
fix gaussian tests being out of date

### DIFF
--- a/rmgpy/qm/gaussianTest.py
+++ b/rmgpy/qm/gaussianTest.py
@@ -8,6 +8,7 @@ import itertools
 import logging
 import numpy as np
 import os
+import shutil
 
 from rmgpy import getPath
 from rmgpy.qm.main import QMCalculator


### PR DESCRIPTION
This PR is trying to address issue #775. 

The reason why the first two tests fail is they lack shutil import. The third one needs `g09` installed so that `pm6` can be run. 

Code reviewer can test them on pharos slave node (head node doesn't allow normal users to `mkdir` under /scratch), but since pharos has no `g09`, error like `Segmentation fault` will be observed when you run the third test.
