### PR TITLE
Fix and speed up test_liquidInputReading

### DIFF
--- a/rmgpy/solver/files/liquid_phase_constSPC/input.py
+++ b/rmgpy/solver/files/liquid_phase_constSPC/input.py
@@ -1,0 +1,66 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = [],
+    kineticsFamilies = 'none',
+    kineticsEstimator = 'rate rules',
+)
+
+# Constraints on generated species
+generatedSpeciesConstraints(
+    maximumRadicalElectrons = 3,
+)
+
+# List of species
+species(
+    label='octane',
+    reactive=True,
+    structure=SMILES("C(CCCCC)CC"),
+)
+
+species(
+    label='oxygen',
+    reactive=True,
+    structure=SMILES("[O][O]"),
+)
+
+# Reaction systems
+liquidReactor(
+    temperature=(450,'K'),
+    initialConcentrations={
+        "octane": (6.154e-3,'mol/cm^3'),
+        "oxygen": (4.953e-6,'mol/cm^3'),
+    },
+#    terminationTime=(300,'s'),
+    terminationConversion={'octane': 0.9},
+    constantSpecies=['oxygen']
+)
+
+solvation(
+	solvent='octane'
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=1E-20,
+    toleranceMoveToCore=0.5,
+    toleranceInterruptSimulation=0.7,
+    maximumEdgeSpecies=50000
+)
+
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveEdgeSpecies=False,
+    saveSimulationProfiles=False,
+)
+

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -263,23 +263,17 @@ class LiquidReactorCheck(unittest.TestCase):
         From input file reading to information storage in liquid reactor object.
         """
         rmg = RMG()
-
-        ##use the liquid phase example to load every input parameters
-        inp = os.path.join("examples","rmg","liquid_phase_constSPC","input.py") #In order to work on every system, use of os.path
-        rmg.inputFile = inp
-
+        rmg.inputFile = os.path.join('rmgpy', 'solver', 'files', 'liquid_phase_constSPC', 'input.py')
         rmg.initialize()
             
-        if rmg.solvent is not None:
-            ##call the function to identify indices in the solver
-            for index, reactionSystem in enumerate(rmg.reactionSystems):
-                    if reactionSystem.constSPCNames is not None: #if no constant species provided do nothing
-                        reactionSystem.get_constSPCIndices(rmg.reactionModel.core.species)        
-                   
         for index, reactionSystem in enumerate(rmg.reactionSystems):
-            self.assertIsNotNone(reactionSystem.constSPCNames,"""this input \"{0} \" contain constant SPC, reactor should contain its name and its indices after few steps""")
-            self.assertIsNotNone(reactionSystem.constSPCIndices,"""this input \"{0} \" contain constant SPC, reactor should contain its corresponding indices in the core species array""")
-            self.assertIs(reactionSystem.constSPCNames[0],rmg.reactionModel.core.species[reactionSystem.constSPCIndices[0]].label,"The constant species name from reaction model and constantSPCnames has to be equals")            
+            self.assertIsNotNone(reactionSystem.constSPCNames,
+                                 'Reactor should contain constant species name and indices after few steps')
+            self.assertIsNotNone(reactionSystem.constSPCIndices,
+                                 'Reactor should contain constant species indices in the core species array')
+            self.assertIs(reactionSystem.constSPCNames[0],
+                          rmg.reactionModel.core.species[reactionSystem.constSPCIndices[0]].label,
+                          'The constant species name from the reaction model and constantSPCnames should be equal')
             
     def test_corespeciesRate(self):
         "Test if a specific core species rate is equal to 0 over time"    


### PR DESCRIPTION
Remove some redundant code in from the test method so that we actually test `initialize()`. Previously, the test would have continued to pass even if `initialize()` were to be modified.

Also switch to use a reduced input file that does not load kinetics families, which greatly reduces test time. Testing on my computer (in a VM) showed a reduction in time from ~170 to ~120 s for the entire test suite. However, I'm not really sure how that happened, since running the original test by itself only took ~20 s. (Possibly due to overhead from using nose and coverage?)

Addresses #786 