### PR TITLE
Remove guppy and symmetry packages

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -23,7 +23,6 @@ dependencies:
   - pydot ==1.2.2
   - nose
   - coverage
-  - guppy
   - gprof2dot
   - cairo
   - cairocffi

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -23,7 +23,6 @@ dependencies:
   - pydot ==1.2.2
   - nose
   - coverage
-  - guppy
   - gprof2dot
   - cairo
   - cairocffi

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -22,7 +22,6 @@ dependencies:
   - pydqed
   - nose
   - coverage
-  - guppy
   - gprof2dot
   #- cairo
   #- cairocffi

--- a/meta.yaml
+++ b/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - gcc # [unix]
     - gcc ==4.8.2 # [linux32]
     - gprof2dot
-    - guppy
     - jinja2
     - libgcc # [unix]
     - libgfortran ==1.0 # [linux] You may need to comment this out for mac osx

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ scipy
 matplotlib
 cython>=0.19
 quantities
-guppy
 psutil
 xlwt
 MarkupSafe # this makes Jinja2 faster

--- a/rmg.py
+++ b/rmg.py
@@ -90,18 +90,6 @@ def parseCommandLineArguments():
 
 if __name__ == '__main__':
 
-    """ GUPPY PROFILING DISABLED FOR NOW
-    # Initialize the memory profiler
-    # It works best if we do this as the very first thing
-    # If the memory profiler package is not installed then carry on
-    try:
-        from guppy import hpy
-        hp = hpy()
-        hp.heap()
-    except ImportError:
-        pass
-    """
-
     # Parse the command-line arguments (requires the argparse module)
     args = parseCommandLineArguments()
 


### PR DESCRIPTION
I removed the dependencies of `guppy` and `symmetry` from requirements file after noticing that they are not being used, nor can they currently function, in RMG. 

I tested if RMG still functioned by running `conda remove guppy symmetry` and then `make test`. All the tests passed. 