### PR TITLE
update environment yaml to allow pkgs (numpy, rdkit, cantera) upgrade

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -32,5 +32,5 @@ dependencies:
   - mopac
   - graphviz
   - scoop
-  - libgfortran ==1.0 # You may need to comment this out for mac osx
+  - libgfortran >=1.0 # You may need to comment this out for mac osx
   - ffmpeg


### PR DESCRIPTION
This PR relaxes the requirement for version of libgfrotran to be higher or equal to 1.0, so that numpy and rdkit and cantera can be upgraded, finally will fix issues like #796 