### PR TITLE
Improve Chemkin output from Cantherm jobs

### DIFF
--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -46,6 +46,7 @@ from rmgpy.reaction import Reaction
 from rmgpy.kinetics.tunneling import Wigner, Eckart
 
 from rmgpy.cantherm.output import prettify
+from rmgpy.chemkin import writeKineticsEntry
 
 ################################################################################
 
@@ -445,42 +446,8 @@ class PressureDependenceJob(object):
             for reac in range(Nreac):
                 if reac == prod: continue
                 reaction = self.network.netReactions[count]
-                kinetics = reaction.kinetics
                 count += 1
-                
-                string = '{0!s:51} 1.0 0.0 0.0\n'.format(reaction)
-                
-                if isinstance(kinetics, PDepArrhenius):
-                    for P, arrhenius in zip(kinetics.pressures.value_si, kinetics.arrhenius):
-                        string += 'PLOG/ {0:<9.3f} {1:<11.3e} {2:<8.2f} {3:<8.2f}/\n'.format(P / 101325.,
-                            arrhenius.A.value_si / (arrhenius.T0.value_si ** arrhenius.n.value_si) * 1e6 ** (len(reaction.reactants) - 1),
-                            arrhenius.n.value_si,
-                            arrhenius.Ea.value_si / 4184.
-                        )
-                        
-                elif isinstance(kinetics, Chebyshev):
-                    coeffs = kinetics.coeffs.value_si.copy()
-                    coeffs[0,0] += 6 * (len(reaction.reactants) - 1)
-                    string += 'TCHEB/ {0:<9.3f} {1:<9.3f}/\n'.format(kinetics.Tmin.value_si, kinetics.Tmax.value_si)
-                    string += 'PCHEB/ {0:<9.3f} {1:<9.3f}/\n'.format(kinetics.Pmin.value_si / 101325., kinetics.Pmax.value_si / 101325.)
-                    string += 'CHEB/ {0:d} {1:d}/\n'.format(kinetics.degreeT, kinetics.degreeP)
-                    if kinetics.degreeP < 6:
-                        for i in range(kinetics.degreeT):
-                            string += 'CHEB/'
-                            for j in range(kinetics.degreeP):
-                                string += ' {0:<12.3e}'.format(coeffs[i,j])
-                            string += '/\n'
-                    else:
-                        coeffs_list = []
-                        for i in range(kinetics.degreeT):
-                            for j in range(kinetics.degreeP):
-                                coeffs_list.append(coeffs[i,j])
-                        coeffs_list[0] += 6 * (numReactants - 1)
-                        for i in range(len(coeffs_list)):
-                            if i % 5 == 0: string += '    CHEB/'
-                            string += ' {0:<12.3e}'.format(coeffs_list[i])
-                            if i % 5 == 4: string += '/\n'  
-
+                string = writeKineticsEntry(reaction, speciesList=None, verbose=False)
                 f.write('{0}\n'.format(string))
             
         f.close()

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -222,6 +222,8 @@ class StatMechJob:
             atoms = local_context['atoms']
         except KeyError:
             raise InputError('Required attribute "atoms" not found in species file {0!r}.'.format(path))
+        else:
+            self.species.props['elementCounts'] = atoms
         
         try:
             bonds = local_context['bonds']

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1384,11 +1384,11 @@ def writeThermoEntry(species, verbose = True):
                 chemkinName = getElement(symbol, isotope=isotope).chemkinName
             else:
                 chemkinName = key
-            string += '{0!s:<2}{1:<3d}'.format(chemkinName, count)
+            string += '{0!s:<2}{1:>3d}'.format(chemkinName, count)
         string += '     ' * (4 - len(elementCounts))
     else:
         string += '     ' * 4
-    string += 'G{0:<10.3f}{1:<10.3f}{2:<8.2f}      1'.format(thermo.polynomials[0].Tmin.value_si, thermo.polynomials[1].Tmax.value_si, thermo.polynomials[0].Tmax.value_si)
+    string += 'G{0:>10.3f}{1:>10.3f}{2:>8.2f}      1'.format(thermo.polynomials[0].Tmin.value_si, thermo.polynomials[1].Tmax.value_si, thermo.polynomials[0].Tmax.value_si)
     if len(elementCounts) > 4:
         string += '&\n'
         # Use the new-style Chemkin syntax for the element counts
@@ -1399,7 +1399,7 @@ def writeThermoEntry(species, verbose = True):
                 chemkinName = getElement(symbol, isotope=isotope).chemkinName
             else:
                 chemkinName = key
-            string += '{0!s:<2}{1:<3d}'.format(chemkinName, count)
+            string += '{0!s:<2}{1:>3d}'.format(chemkinName, count)
     string += '\n'
 
     # Line 2

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1340,7 +1340,7 @@ def getSpeciesIdentifier(species):
 
 ################################################################################
 
-def writeThermoEntry(species, verbose = True):
+def writeThermoEntry(species, elementCounts=None, verbose=True):
     """
     Return a string representation of the NASA model readable by Chemkin.
     To use this method you must have exactly two NASA polynomials in your
@@ -1360,7 +1360,8 @@ def writeThermoEntry(species, verbose = True):
     assert thermo.polynomials[1].cm2 == 0 and thermo.polynomials[1].cm1 == 0
 
     # Determine the number of each type of element in the molecule
-    elementCounts = retrieveElementCount(species.molecule[0])
+    if elementCounts is None:
+        elementCounts = retrieveElementCount(species.molecule[0])
     
     string = ''
     # Write thermo comments


### PR DESCRIPTION
Addresses #789 

Eliminate standalone Chemkin output writing scripts in Cantherm and use the more robust scripts in `rmgpy.chemkin`. In order to write element counts, atom information from StatmechJob is saved to `species.prop`, then used when writing the thermo output.

Also includes some minor alignment changes when writing Chemkin thermo blocks. The alignment was changed in this commit (e1374f3378473dfbca126299abcf63e44717ccb4), but the original alignment matches Chemkin documentation better. The output has been tested in Chemkin to be extra sure that it still works fine.

Before:

```
C2H4                    H 4  C 2            G10.000    3000.000  764.98        1
```

After:

```
C2H4                    H   4C   2          G    10.000  3000.000  764.98      1
```
