### PR TITLE
make standard last commit msg for RMG-tests

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -72,7 +72,7 @@ git checkout $RMGTESTSBRANCH
 
 # create an empty commit with the SHA-ID of the 
 # tested commit of the RMG-Py branch:
-git commit --allow-empty -m $REV
+git commit --allow-empty -m rmgpy-$REV
 
 # push to the branch to the RMG/RMG-tests repo:
 git push -f $REPO $RMGTESTSBRANCH > /dev/null


### PR DESCRIPTION
last commit msg will be used for triggering RMG-tests, RMG-database has the format of last commit msg as `rmgdb-SHA`, to be more consistent, make same style for deployment from RMG-Py.