### PR TITLE
Resonance Part 1: Clar Structure Generation

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -13,6 +13,7 @@ dependencies:
   - rdkit >=2015.09.2
   - pydas >=1.0.1
   - pydqed >=1.0.0
+  - lpsolve55
   - quantities
   - scipy
   - xlwt

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -13,6 +13,7 @@ dependencies:
   - rdkit >=2015.09.2
   - pydas >=1.0.1
   - pydqed >=1.0.0
+  - lpsolve55
   - quantities
   - scipy
   - xlwt

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -11,6 +11,7 @@ dependencies:
   - cython ==0.21
   - matplotlib >=1.5
   - rdkit >=2015.09.2
+  - lpsolve55
   - quantities
   - scipy
   - xlwt

--- a/meta.yaml
+++ b/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - jinja2
     - libgcc # [unix]
     - libgfortran ==1.0 # [linux] You may need to comment this out for mac osx
+    - lpsolve55
     - markupsafe
     - matplotlib >=1.5
     - nose
@@ -57,6 +58,7 @@ requirements:
     - jinja2
     - libgcc # [unix]
     - libgfortran ==1.0 # [linux] You may need to comment this out for mac osx
+    - lpsolve55
     - markupsafe
     - matplotlib >=1.5
     - mopac

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -205,3 +205,5 @@ cdef class Molecule(Graph):
     cpdef int calculateSymmetryNumber(self) except -1
 
     cpdef list generateResonanceIsomers(self)
+
+    cpdef list getAromaticSSSR(Molecule mol)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1621,4 +1621,48 @@ class Molecule(Graph):
         
         return group
 
+    def getAromaticSSSR(self):
+        """
+        Returns the smallest set of smallest aromatic rings
 
+        Identifies rings using `Graph.getSmallestSetOfSmallestRings()`, then uses RDKit to perceive aromaticity.
+        RDKit uses an atom-based pi-electron counting algorithm to check aromaticity based on Huckel's Rule.
+        Therefore, this method identifies "true" aromaticity, rather than simply the RMG bond type.
+
+        The method currently restricts aromaticity to six-membered carbon-only rings. This is a limitation imposed
+        by RMG, and not by RDKit.
+        """
+        cython.declare(rdAtomIndices=dict, aromaticRings=list, aromaticBonds=list)
+        cython.declare(rings=list, ring0=list, i=cython.int, atom1=Atom, atom2=Atom)
+
+        from rdkit.Chem.rdchem import BondType
+
+        AROMATIC = BondType.AROMATIC
+
+        rings = [ring0 for ring0 in self.getSmallestSetOfSmallestRings() if len(ring0) == 6]
+        if not rings:
+            return []
+
+        try:
+            rdkitmol, rdAtomIndices = generator.toRDKitMol(self, removeHs=False, returnMapping=True)
+        except ValueError:
+            return []
+
+        aromaticRings = []
+        for ring0 in rings:
+            aromaticBonds = []
+            # Figure out which atoms and bonds are aromatic and reassign appropriately:
+            for i, atom1 in enumerate(ring0):
+                if not atom1.isCarbon():
+                    # all atoms in the ring must be carbon in RMG for our definition of aromatic
+                    break
+                for atom2 in ring0[i + 1:]:
+                    if self.hasBond(atom1, atom2):
+                        if rdkitmol.GetBondBetweenAtoms(rdAtomIndices[atom1],
+                                                        rdAtomIndices[atom2]).GetBondType() is AROMATIC:
+                            aromaticBonds.append(self.getBond(atom1, atom2))
+            else:  # didn't break so all atoms are carbon
+                if len(aromaticBonds) == 6:
+                    aromaticRings.append(ring0)
+
+        return aromaticRings

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1827,6 +1827,37 @@ multiplicity 2
         
         self.assertTrue(exp.isIsomorphic(calc))
 
+    def testAromaticityPerceptionBenzene(self):
+        """Test aromaticity perception via getAromaticSSSR for benzene."""
+        mol = Molecule(SMILES='c1ccccc1')
+        asssr = mol.getAromaticSSSR()
+        self.assertEqual(len(asssr), 1)
+
+    def testAromaticityPerceptionTetralin(self):
+        """Test aromaticity perception via getAromaticSSSR for tetralin."""
+        mol = Molecule(SMILES='c1ccc2c(c1)CCCC2')
+        asssr = mol.getAromaticSSSR()
+        self.assertEqual(len(asssr), 1)
+
+    def testAromaticityPerceptionBiphenyl(self):
+        """Test aromaticity perception via getAromaticSSSR for biphenyl."""
+        mol = Molecule(SMILES='c1ccc(cc1)c2ccccc2')
+        asssr = mol.getAromaticSSSR()
+        self.assertEqual(len(asssr), 2)
+
+    def testAromaticityPerceptionAzulene(self):
+        """Test aromaticity perception via getAromaticSSSR for azulene."""
+        mol = Molecule(SMILES='c1cccc2cccc2c1')
+        asssr = mol.getAromaticSSSR()
+        self.assertEqual(len(asssr), 0)
+
+    def testAromaticityPerceptionFuran(self):
+        """Test aromaticity perception via getAromaticSSSR for furan."""
+        mol = Molecule(SMILES='c1ccoc1')
+        asssr = mol.getAromaticSSSR()
+        self.assertEqual(len(asssr), 0)
+
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -15,3 +15,5 @@ cpdef list generate_isomorphic_isomers(Molecule mol)
 
 cpdef list generateKekulizedResonanceIsomers(Molecule mol)
 
+cpdef list clarOptimization(Molecule mol, list constraints=?, maxNum=?)
+

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -15,6 +15,8 @@ cpdef list generate_isomorphic_isomers(Molecule mol)
 
 cpdef list generateKekulizedResonanceIsomers(Molecule mol)
 
+cpdef list generateClarStructures(Molecule mol)
+
 cpdef list clarOptimization(Molecule mol, list constraints=?, maxNum=?)
 
 cpdef list clarTransformation(Molecule mol, list ring)

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -1,6 +1,8 @@
 from .graph cimport Vertex, Edge, Graph
 from .molecule cimport Atom, Bond, Molecule
 
+cpdef tuple populate_resonance_generation_algorithm()
+
 cpdef list generateResonanceIsomers(Molecule mol)
 
 cpdef list generateAdjacentResonanceIsomers(Molecule mol)
@@ -13,4 +15,3 @@ cpdef list generate_isomorphic_isomers(Molecule mol)
 
 cpdef list generateKekulizedResonanceIsomers(Molecule mol)
 
-cpdef tuple populate_resonance_generation_algorithm()

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -17,3 +17,4 @@ cpdef list generateKekulizedResonanceIsomers(Molecule mol)
 
 cpdef list clarOptimization(Molecule mol, list constraints=?, maxNum=?)
 
+cpdef list clarTransformation(Molecule mol, list ring)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -519,6 +519,29 @@ def clarOptimization(mol, constraints=None, maxNum=None):
     return innerSolutions + [(molecule, asssr, bonds, solution)]
 
 
+def clarTransformation(mol, aromaticRing):
+    """
+    Performs Clar transformation for given ring in a molecule, ie. conversion to aromatic sextet.
+
+    Args:
+        mol             a :class:`Molecule` object
+        aromaticRing    a list of :class:`Atom` objects corresponding to an aromatic ring in mol
+
+    This function directly modifies the input molecule and does not return anything.
+    """
+    cython.declare(bondList=list, i=cython.int, atom1=Atom, atom2=Atom, bond=Bond)
+
+    bondList = []
+
+    for i, atom1 in enumerate(aromaticRing):
+        for atom2 in aromaticRing[i + 1:]:
+            if mol.hasBond(atom1, atom2):
+                bondList.append(mol.getBond(atom1, atom2))
+
+    for bond in bondList:
+        bond.order = 'B'
+
+
 class ILPSolutionError(Exception):
     """
     An exception to be raised when solving an integer linear programming problem if a solution

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -1,3 +1,36 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2009-2011 by the RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This module contains methods for generation of resonance isomers of molecules.
+"""
+
 import cython
 
 import rmgpy.molecule.generator as generator
@@ -6,6 +39,20 @@ import rmgpy.molecule.parser as parser
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 from .molecule import Atom, Bond, Molecule
 import rmgpy.molecule.pathfinder as pathfinder
+
+def populate_resonance_generation_algorithm():
+    """
+    A list with the current set of resonance generation algorithms.
+    """
+    algorithms = (
+        generateAdjacentResonanceIsomers,
+        generateLonePairRadicalResonanceIsomers,
+        generateN5dd_N5tsResonanceIsomers,
+        generateKekulizedResonanceIsomers,
+        generateAromaticResonanceIsomers,
+    )
+
+    return algorithms
 
 def generateResonanceIsomers(mol):
     """
@@ -341,17 +388,3 @@ def generate_isomorphic_isomers(mol):
 
     return isomorphic_isomers
 
-def populate_resonance_generation_algorithm():
-    """
-    A list with the current set of resonance generation algorithms.
-    """
-    algorithms = (
-        generateAdjacentResonanceIsomers,
-        generateLonePairRadicalResonanceIsomers,
-        generateN5dd_N5tsResonanceIsomers,
-        generateKekulizedResonanceIsomers,
-        generateAromaticResonanceIsomers,
-    )
-
-
-    return algorithms

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -356,3 +356,157 @@ class ClarTest(unittest.TestCase):
 
             # Check that we only assign 1 aromatic sextet
             self.assertEqual(sum(y), 1)
+
+    def testPhenanthrene(self):
+        """
+        Test phenanthrene, which is a basic case that should work.
+        """
+        mol = Molecule().fromSMILES('C1=CC=C2C(C=CC3=CC=CC=C32)=C1')
+        newmol = generateClarStructures(mol)
+
+        struct = Molecule().fromAdjacencyList("""1  C u0 p0 c0 {2,S} {3,B} {5,B}
+2  C u0 p0 c0 {1,S} {4,B} {9,B}
+3  C u0 p0 c0 {1,B} {6,S} {10,B}
+4  C u0 p0 c0 {2,B} {7,S} {8,B}
+5  C u0 p0 c0 {1,B} {12,B} {17,S}
+6  C u0 p0 c0 {3,S} {7,D} {18,S}
+7  C u0 p0 c0 {4,S} {6,D} {19,S}
+8  C u0 p0 c0 {4,B} {13,B} {20,S}
+9  C u0 p0 c0 {2,B} {14,B} {23,S}
+10 C u0 p0 c0 {3,B} {11,B} {24,S}
+11 C u0 p0 c0 {10,B} {12,B} {15,S}
+12 C u0 p0 c0 {5,B} {11,B} {16,S}
+13 C u0 p0 c0 {8,B} {14,B} {21,S}
+14 C u0 p0 c0 {9,B} {13,B} {22,S}
+15 H u0 p0 c0 {11,S}
+16 H u0 p0 c0 {12,S}
+17 H u0 p0 c0 {5,S}
+18 H u0 p0 c0 {6,S}
+19 H u0 p0 c0 {7,S}
+20 H u0 p0 c0 {8,S}
+21 H u0 p0 c0 {13,S}
+22 H u0 p0 c0 {14,S}
+23 H u0 p0 c0 {9,S}
+24 H u0 p0 c0 {10,S}
+""")
+
+        self.assertEqual(len(newmol), 1)
+        self.assertTrue(newmol[0].isIsomorphic(struct))
+
+    def testPhenalene(self):
+        """
+        Test phenalene, which currently does not have feasible starting point.
+        """
+        mol = Molecule().fromSMILES('C1=CC2=CC=CC3CC=CC(=C1)C=32')
+        newmol = generateClarStructures(mol)
+
+        struct1 = Molecule().fromAdjacencyList("""1  C u0 p0 c0 {2,S} {6,S} {14,S} {15,S}
+2  C u0 p0 c0 {1,S} {3,S} {7,D}
+3  C u0 p0 c0 {2,S} {4,B} {5,B}
+4  C u0 p0 c0 {3,B} {9,B} {10,S}
+5  C u0 p0 c0 {3,B} {8,S} {11,B}
+6  C u0 p0 c0 {1,S} {8,D} {16,S}
+7  C u0 p0 c0 {2,D} {13,S} {21,S}
+8  C u0 p0 c0 {5,S} {6,D} {22,S}
+9  C u0 p0 c0 {4,B} {12,B} {18,S}
+10 C u0 p0 c0 {4,S} {13,D} {19,S}
+11 C u0 p0 c0 {5,B} {12,B} {23,S}
+12 C u0 p0 c0 {9,B} {11,B} {17,S}
+13 C u0 p0 c0 {7,S} {10,D} {20,S}
+14 H u0 p0 c0 {1,S}
+15 H u0 p0 c0 {1,S}
+16 H u0 p0 c0 {6,S}
+17 H u0 p0 c0 {12,S}
+18 H u0 p0 c0 {9,S}
+19 H u0 p0 c0 {10,S}
+20 H u0 p0 c0 {13,S}
+21 H u0 p0 c0 {7,S}
+22 H u0 p0 c0 {8,S}
+23 H u0 p0 c0 {11,S}
+""")
+        struct2 = Molecule().fromAdjacencyList("""1  C u0 p0 c0 {2,S} {6,S} {14,S} {15,S}
+2  C u0 p0 c0 {1,S} {3,B} {7,B}
+3  C u0 p0 c0 {2,B} {4,B} {5,S}
+4  C u0 p0 c0 {3,B} {9,S} {10,B}
+5  C u0 p0 c0 {3,S} {8,S} {11,D}
+6  C u0 p0 c0 {1,S} {8,D} {16,S}
+7  C u0 p0 c0 {2,B} {13,B} {21,S}
+8  C u0 p0 c0 {5,S} {6,D} {22,S}
+9  C u0 p0 c0 {4,S} {12,D} {18,S}
+10 C u0 p0 c0 {4,B} {13,B} {19,S}
+11 C u0 p0 c0 {5,D} {12,S} {23,S}
+12 C u0 p0 c0 {9,D} {11,S} {17,S}
+13 C u0 p0 c0 {7,B} {10,B} {20,S}
+14 H u0 p0 c0 {1,S}
+15 H u0 p0 c0 {1,S}
+16 H u0 p0 c0 {6,S}
+17 H u0 p0 c0 {12,S}
+18 H u0 p0 c0 {9,S}
+19 H u0 p0 c0 {10,S}
+20 H u0 p0 c0 {13,S}
+21 H u0 p0 c0 {7,S}
+22 H u0 p0 c0 {8,S}
+23 H u0 p0 c0 {11,S}
+""")
+
+        self.assertEqual(len(newmol), 2)
+        self.assertTrue(newmol[0].isIsomorphic(struct1) or newmol[0].isIsomorphic(struct2))
+        self.assertTrue(newmol[1].isIsomorphic(struct2) or newmol[0].isIsomorphic(struct1))
+        self.assertFalse(newmol[0].isIsomorphic(newmol[1]))
+
+    def testCorannulene(self):
+        """
+        Test corannulene, which does not give integer results after initial optimization.
+        """
+        mol = Molecule().fromSMILES('C1=CC2=CC=C3C=CC4=C5C6=C(C2=C35)C1=CC=C6C=C4')
+        newmol = generateClarStructures(mol)
+
+        struct = Molecule().fromAdjacencyList("""1  C u0 p0 c0 {2,S} {5,B} {8,B}
+2  C u0 p0 c0 {1,S} {3,B} {10,B}
+3  C u0 p0 c0 {2,B} {4,S} {9,B}
+4  C u0 p0 c0 {3,S} {5,S} {6,D}
+5  C u0 p0 c0 {1,B} {4,S} {7,B}
+6  C u0 p0 c0 {4,D} {12,S} {13,S}
+7  C u0 p0 c0 {5,B} {14,S} {15,B}
+8  C u0 p0 c0 {1,B} {16,B} {20,S}
+9  C u0 p0 c0 {3,B} {11,S} {17,B}
+10 C u0 p0 c0 {2,B} {18,B} {19,S}
+11 C u0 p0 c0 {9,S} {12,D} {21,S}
+12 C u0 p0 c0 {6,S} {11,D} {22,S}
+13 C u0 p0 c0 {6,S} {14,D} {23,S}
+14 C u0 p0 c0 {7,S} {13,D} {24,S}
+15 C u0 p0 c0 {7,B} {16,B} {25,S}
+16 C u0 p0 c0 {8,B} {15,B} {26,S}
+17 C u0 p0 c0 {9,B} {18,B} {27,S}
+18 C u0 p0 c0 {10,B} {17,B} {28,S}
+19 C u0 p0 c0 {10,S} {20,D} {29,S}
+20 C u0 p0 c0 {8,S} {19,D} {30,S}
+21 H u0 p0 c0 {11,S}
+22 H u0 p0 c0 {12,S}
+23 H u0 p0 c0 {13,S}
+24 H u0 p0 c0 {14,S}
+25 H u0 p0 c0 {15,S}
+26 H u0 p0 c0 {16,S}
+27 H u0 p0 c0 {17,S}
+28 H u0 p0 c0 {18,S}
+29 H u0 p0 c0 {19,S}
+30 H u0 p0 c0 {20,S}
+""")
+
+        self.assertEqual(len(newmol), 5)
+        self.assertTrue(newmol[0].isIsomorphic(struct))
+        self.assertTrue(newmol[1].isIsomorphic(struct))
+        self.assertTrue(newmol[2].isIsomorphic(struct))
+        self.assertTrue(newmol[3].isIsomorphic(struct))
+        self.assertTrue(newmol[4].isIsomorphic(struct))
+
+    def testExocyclicDB(self):
+        """Test that Clar structure generation doesn't modify exocyclic double bonds
+
+        Important for cases where RDKit considers rings to be aromatic by counting pi-electron contributions
+        from exocyclic double bonds, while they don't actually contribute to aromaticity"""
+
+        mol = Molecule(SMILES="C=C1C=CC=CC1=C")
+        newmol = generateClarStructures(mol)
+
+        self.assertEquals(len(newmol), 0)


### PR DESCRIPTION
This PR is not ready for merging yet, but I'm opening the request so it can start being reviewed.

This is the first part of an overhaul of resonance structure generation in RMG. This PR does not actually affect any functionality. It only adds methods for Clar structure generation that will be actually integrated into the resonance algorithm in the second part.
### Clar Structures

The motivation behind using Clar structures is the lack of a consistent and deterministic resonance structures for polycyclic aromatic compounds. We currently have a fully delocalized structure, where all bonds in rings are benzene bonds. This works well for thermo estimation because it's consistent with Benson group additivity, but it is not great for kinetics since bonds in PAHs can have different reactivity depending on location in the molecule.

The basis of Clar structures is a more rigid electron counting system, wherein sets of 6 pi-electrons are assigned to specific rings. As a result, not all rings in a PAH will have a sextet assigned to them, and any leftover pi-electrons are kept as double bonds. The Clar structure(s) are defined as the structures with the greatest number of assigned sextets. A basic example is phenanthrene, shown here:
![image](https://cloud.githubusercontent.com/assets/10817103/19816160/3847f852-9d14-11e6-8f66-8ac04f4babc1.png)
Phenanthrene has a total of 14 pi-electrons, which allows the assignment of two sextets and one double bond. Experiments show that the double bond in the Clar structure is the most reactive to addition reactions, and is also the shortest bond in the molecule.

The intent is to use Clar structures to fully replace Kekule structures because Clar structures are easier to enumerate, there are fewer Clar structures than Kekule structures for any PAH, and they provide a more chemically accurate representation of reactivity.
### Implementation

The Clar structure generation algorithm implemented here is based on a optimization algorithm proposed by Hansen and Zheng (J. Math. Chem. 1994). The task is formulated as an integer linear programming problem, where the number of sextets is maximized, subject to the constraint that each atom can only be part of one sextet or one double bond (ie. an atom valency constraint). There are two sets of binary variables, one set corresponding to whether or not each ring contains a sextet, and the other corresponding to whether or not each bond is a double bond. The objective function is simply the sum of the sextet variables.

All Clar structures are enumerated by repeating the optimization after adding a constraint that eliminates the already found solution as a feasible solution. The algorithm terminates when there are no more feasible solutions or when the objective value decreases, indicating that fewer sextets are being assigned.
### To Do

The open source GNU Linear Programming Kit was used to perform the optimization step, in conjunction with the PyGLPK wrapper. Anaconda packages exist for Linux and Mac, but not Windows. This is also complicated by the fact that PyGLPK is not under active development anymore, so it is only compatible with GLPK <v4.52.

I'm planning on making a Windows package for both GLPK and PyGLPK, and have it ready before this is merged into master. However, if anyone has suggestions for a better (faster?) solver/python binding combination, we can also switch to something else. I've looked at PuLP, but it creates input files for various solvers and runs them via command line, which seems sub-optimal. I also looked at PySCIPOpt, which is a wrapper for SCIP (supposedly the fastest non-commercial solver currently), but had difficulty getting it working. It also does not seem to support Windows at this time, and it's distributed under a unique ZIB Academic License.
