### PR TITLE
Fix lone pair thermo

### DIFF
--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -237,6 +237,41 @@ class TestThermoDatabase(unittest.TestCase):
         self.assertEqual(source['GAV']['ring'][0][1],-1)  # the weight of benzene contribution should be -1
         self.assertEqual(source['GAV']['group'][0][1],2)  # weight of the group(Cs-CsCsHH) conbtribution should be 2
         
+    def testLonePairThermoGeneration(self):
+        """
+        Test that for the biradical and lone pair form of the same molecule, we
+        are getting the same thermo data by transforming the lone pair into a biradical.
+        """
+        spc1 = Species(molecule=[Molecule().fromAdjacencyList("""
+        multiplicity 3
+        1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+        2 C u0 p0 c0 {1,S} {3,S} {6,S} {7,S}
+        3 C u2 p0 c0 {1,S} {2,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {2,S}
+        7 H u0 p0 c0 {2,S}
+        """
+        )])
+
+        spc2 = Species(molecule=[Molecule().fromAdjacencyList("""
+        1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+        2 C u0 p0 c0 {1,S} {3,S} {6,S} {7,S}
+        3 C u0 p1 c0 {1,S} {2,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {2,S}
+        7 H u0 p0 c0 {2,S}
+        """
+        )])
+
+        spc1.generateResonanceIsomers()
+        spc2.generateResonanceIsomers()
+        thermo1 = self.database.getThermoDataFromGroups(spc1)
+        thermo2 = self.database.getThermoDataFromGroups(spc2)
+
+        self.assertEqual(thermo1.getEnthalpy(298), thermo2.getEnthalpy(298))
+
 class TestThermoDatabaseAromatics(TestThermoDatabase):
     """
     Test only Aromatic species.

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1563,6 +1563,55 @@ class Molecule(Graph):
             charge += atom.charge
         return charge
 
+    def transformLonePairs(self):
+        """
+        Changes lone pairs in a molecule to two radicals for purposes of finding
+        solute data or thermo data via group additivity. Transformed for each atom
+        based on valency.
+        """
+        saturatedStruct = self.copy(deep=True)
+        addedToPairs = {}
+
+        for atom in saturatedStruct.atoms:
+            addedToPairs[atom] = 0
+            if atom.lonePairs > 0:
+                charge = atom.charge # Record this so we can conserve it when checking
+                bonds = saturatedStruct.getBonds(atom)
+                sumBondOrders = 0
+                for key, bond in bonds.iteritems():
+                    if bond.order == 'S': sumBondOrders += 1
+                    if bond.order == 'D': sumBondOrders += 2
+                    if bond.order == 'T': sumBondOrders += 3
+                    if bond.order == 'B': sumBondOrders += 1.5 # We should always have 2 'B' bonds (but what about Cbf?)
+                if atomTypes['Val4'] in atom.atomType.generic: # Carbon, Silicon
+                    while(atom.radicalElectrons + charge + sumBondOrders < 4):
+                        atom.decrementLonePairs()
+                        atom.incrementRadical()
+                        atom.incrementRadical()
+                        addedToPairs[atom] += 1
+                if atomTypes['Val5'] in atom.atomType.generic: # Nitrogen
+                    while(atom.radicalElectrons + charge + sumBondOrders < 3):
+                        atom.decrementLonePairs()
+                        atom.incrementRadical()
+                        atom.incrementRadical()
+                        addedToPairs[atom] += 1
+                if atomTypes['Val6'] in atom.atomType.generic: # Oxygen, sulfur
+                    while(atom.radicalElectrons + charge + sumBondOrders < 2):
+                        atom.decrementLonePairs()
+                        atom.incrementRadical()
+                        atom.incrementRadical()
+                        addedToPairs[atom] += 1
+                if atomTypes['Val7'] in atom.atomType.generic: # Chlorine
+                    while(atom.radicalElectrons + charge + sumBondOrders < 1):
+                        atom.decrementLonePairs()
+                        atom.incrementRadical()
+                        atom.incrementRadical()
+                        addedToPairs[atom] += 1
+
+        saturatedStruct.update()
+        saturatedStruct.updateLonePairs()
+
+        return saturatedStruct, addedToPairs
     def saturate(self):
         """
         Saturate the molecule by replacing all radicals with bonds to hydrogen atoms.  Changes self molecule object.  


### PR DESCRIPTION
This pull request fixes #792. Now RMG will convert lone pairs to biradicals for the purpose of finding thermo via group additivity. 

There are no Benson groups for the lone pair atoms, so we end up falling up the thermo group tree to inappropriate groups since they are neither radicals nor are they attached to hydrogens. This is the same thing we decided to do for solvation in #364, since there are no Platts groups for the lone pair species. The better thing would be to add groups for these or put some of these molecules in a library, but for Carbon, we may not encounter many of these molecules anyway. 

Now there is no Cp discontinuity when searching for the problematic molecule - this is what I get when I run the website with this version of RMG-Py for cyclopropane with a lone pair on two of the carbons:
<img width="548" alt="cp" src="https://cloud.githubusercontent.com/assets/2792693/19908757/0a8967c6-a05b-11e6-91cf-e9a45bb4eb22.png">
