### PR TITLE
Log the species RMG crashes on if atomType doesn't exist

### DIFF
--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -198,7 +198,7 @@ cdef class Molecule(Graph):
 
     cpdef double calculateCpInf(self) except -1
     
-    cpdef updateAtomTypes(self)
+    cpdef updateAtomTypes(self, logSpecies=?)
     
     cpdef bint isRadical(self) except -2
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -939,7 +939,7 @@ class Molecule(Graph):
                 atom.atomType = getAtomType(atom, atom.edges)
             except:
                 logging.error("Problematic species: {}".format(self))
-                atom.atomType = getAtomType(atom, atom.edges)
+                raise
             
     def updateMultiplicity(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -51,7 +51,7 @@ except:
 from rdkit import Chem
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 import rmgpy.molecule.group as gr
-from .atomtype import AtomType, atomTypes, getAtomType
+from .atomtype import AtomType, atomTypes, getAtomType, AtomTypeError
 import rmgpy.constants as constants
 import rmgpy.molecule.parser as parser
 import rmgpy.molecule.generator as generator
@@ -928,7 +928,7 @@ class Molecule(Graph):
                     self.addBond(bond)
         self.updateAtomTypes()
         
-    def updateAtomTypes(self,printFlag=1):
+    def updateAtomTypes(self, logSpecies=True):
         """
         Iterate through the atoms in the structure, checking their atom types
         to ensure they are correct (i.e. accurately describe their local bond
@@ -937,9 +937,9 @@ class Molecule(Graph):
         for atom in self.vertices:
             try:
                 atom.atomType = getAtomType(atom, atom.edges)
-            except:
-                if printFlag == 1:
-                    logging.error("Problematic species: {}".format(self))
+            except AtomTypeError:
+                if logSpecies:
+                    logging.error("Could not update atomtypes for {0}.\n{1}".format(self, self.toAdjacencyList()))
                 raise
             
     def updateMultiplicity(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -935,7 +935,11 @@ class Molecule(Graph):
         environment) and complete (i.e. are as detailed as possible).
         """
         for atom in self.vertices:
-            atom.atomType = getAtomType(atom, atom.edges)
+            try:
+                atom.atomType = getAtomType(atom, atom.edges)
+            except:
+                logging.error("Problematic species: {}".format(self))
+                atom.atomType = getAtomType(atom, atom.edges)
             
     def updateMultiplicity(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -928,7 +928,7 @@ class Molecule(Graph):
                     self.addBond(bond)
         self.updateAtomTypes()
         
-    def updateAtomTypes(self):
+    def updateAtomTypes(self,printFlag=1):
         """
         Iterate through the atoms in the structure, checking their atom types
         to ensure they are correct (i.e. accurately describe their local bond
@@ -938,7 +938,8 @@ class Molecule(Graph):
             try:
                 atom.atomType = getAtomType(atom, atom.edges)
             except:
-                logging.error("Problematic species: {}".format(self))
+                if printFlag == 1:
+                    logging.error("Problematic species: {}".format(self))
                 raise
             
     def updateMultiplicity(self):

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -76,7 +76,7 @@ def generateAdjacentResonanceIsomers(mol):
                 bond12.decrementOrder()
                 bond23.incrementOrder()
                 # Append to isomer list if unique
-                isomer.updateAtomTypes()
+                isomer.updateAtomTypes(logSpecies=False)
                 isomers.append(isomer)
 
     return isomers
@@ -123,7 +123,7 @@ def generateLonePairRadicalResonanceIsomers(mol):
                 atom2.incrementLonePairs()
                 atom2.updateCharge()
                 # Append to isomer list if unique
-                isomer.updateAtomTypes()
+                isomer.updateAtomTypes(logSpecies=False)
                 isomers.append(isomer)
 
     return isomers
@@ -173,7 +173,7 @@ def generateN5dd_N5tsResonanceIsomers(mol):
                 atom2.updateCharge()
                 atom3.updateCharge()
                 # Append to isomer list if unique
-                isomer.updateAtomTypes()
+                isomer.updateAtomTypes(logSpecies=False)
                 isomers.append(isomer)
             
             # from N5ts to N5dd
@@ -206,7 +206,7 @@ def generateN5dd_N5tsResonanceIsomers(mol):
                 atom2.updateCharge()
                 atom3.updateCharge()
                 # Append to isomer list if unique
-                isomer.updateAtomTypes()
+                isomer.updateAtomTypes(logSpecies=False)
                 isomers.append(isomer)
                 
     return isomers
@@ -259,7 +259,7 @@ def generateAromaticResonanceIsomers(mol):
 
     if aromatic:
         try:
-            molecule.updateAtomTypes()
+            molecule.updateAtomTypes(logSpecies=False)
         except:
             # Something incorrect has happened, ie. 2 double bonds on a Cb atomtype
             # Do not add the new isomer since it is malformed
@@ -289,7 +289,7 @@ def generateKekulizedResonanceIsomers(mol):
         isomer = parser.fromRDKitMol(Molecule(), rdkitmol)  # This step Kekulizes the molecule
     except ValueError:
         return []
-    isomer.updateAtomTypes()
+    isomer.updateAtomTypes(logSpecies=False)
     return [isomer]
 
 def generate_isomorphic_isomers(mol):


### PR DESCRIPTION
Logging the species RMG crashes on when an unknown atomType is discovered. Important for debugging when modifying atom types, see issue #809.
For now I only saw a need to add this fix to molecule.py, and not to adjlist.py (where `getAtomType` is also being called).