### PR TITLE
Fix typo in ClarTest.testPhenalene

### DIFF
--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -451,7 +451,7 @@ class ClarTest(unittest.TestCase):
 
         self.assertEqual(len(newmol), 2)
         self.assertTrue(newmol[0].isIsomorphic(struct1) or newmol[0].isIsomorphic(struct2))
-        self.assertTrue(newmol[1].isIsomorphic(struct2) or newmol[0].isIsomorphic(struct1))
+        self.assertTrue(newmol[1].isIsomorphic(struct2) or newmol[1].isIsomorphic(struct1))
         self.assertFalse(newmol[0].isIsomorphic(newmol[1]))
 
     def testCorannulene(self):


### PR DESCRIPTION
For this test, two Clar structures are expected, and were being checked for isomorphism against two test structures. Because the ordering of structures is non-deterministic, the test checks both output molecules against both test molecules, but there was a typo in indexing that caused the test to fail sometimes.