### PR TITLE
Fix bug when reordering molecules after HBI thermo calculation

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1077,7 +1077,10 @@ class ThermoDatabase(object):
                     for i in range(len(thermo)): 
                         logging.debug("Resonance isomer {0} {1} gives H298={2:.0f} J/mol".format(i+1, thermo[i][1].toSMILES(), thermo[i][0]))
                     # Save resonance isomers reordered by their thermo
-                    species.molecule = [item[1] for item in thermo]
+                    newMolList = [item[1] for item in thermo]
+                    if len(newMolList) < len(species.molecule):
+                        newMolList.extend([mol for mol in species.molecule if mol not in newMolList])
+                    species.molecule = newMolList
                     thermo0 = thermo[0][2]
                     
                 else:

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -237,6 +237,33 @@ class TestThermoDatabase(unittest.TestCase):
         self.assertEqual(source['GAV']['ring'][0][1],-1)  # the weight of benzene contribution should be -1
         self.assertEqual(source['GAV']['group'][0][1],2)  # weight of the group(Cs-CsCsHH) conbtribution should be 2
         
+    def testSpeciesThermoGenerationHBILibrary(self):
+        """Test thermo generation for species objects.
+
+        Ensure that molecule list is only reordered, and not changed after matching library value"""
+        spec = Species().fromSMILES('C[CH]c1ccccc1')
+        spec.generateResonanceIsomers()
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.getThermoData(spec)
+
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue('library' in thermo.comment, 'Thermo not found from library, test purpose not fulfilled.')
+
+    def testSpeciesThermoGenerationHBIGAV(self):
+        """Test thermo generation for species objects.
+
+        Ensure that molecule list is only reordered, and not changed after group additivity"""
+        spec = Species().fromSMILES('CCC[CH]c1ccccc1')
+        spec.generateResonanceIsomers()
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.getThermoData(spec)
+
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue('group additivity' in thermo.comment, 'Thermo not found from GAV, test purpose not fulfilled.')
+
+
 class TestThermoDatabaseAromatics(TestThermoDatabase):
     """
     Test only Aromatic species.

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -754,7 +754,6 @@ class Molecule(Graph):
         cython.declare(hasCarbon=cython.bint, hasHydrogen=cython.bint)
         
         # Count the number of each element in the molecule
-        hasCarbon = False; hasHydrogen = False
         elements = {}
         for atom in self.vertices:
             symbol = atom.element.symbol
@@ -764,11 +763,11 @@ class Molecule(Graph):
         formula = ''
         
         # Carbon and hydrogen always come first if carbon is present
-        if hasCarbon:
+        if 'C' in elements.keys():
             count = elements['C']
             formula += 'C{0:d}'.format(count) if count > 1 else 'C'
             del elements['C']
-            if hasHydrogen:
+            if 'H' in elements.keys():
                 count = elements['H']
                 formula += 'H{0:d}'.format(count) if count > 1 else 'H'
                 del elements['H']


### PR DESCRIPTION
When estimating radical thermo via HBI, RMG will look for the saturated species in libraries. If only some of the saturated molecules are found in a library, then the ones that were not found get dropped from the list when reordering the molecules based on thermo. This leads to failed isomorphism checks and duplicated species, as seen in #577 and #831.

This fixes the issue by adding any non-matched molecules back into the list.