### PR TITLE
fix the order of returned values from diff_models.execute

### DIFF
--- a/scripts/checkModels.py
+++ b/scripts/checkModels.py
@@ -88,7 +88,7 @@ def check(name, benchChemkin, benchSpeciesDict, testChemkin, testSpeciesDict):
         }
 
     testThermo, benchThermo = None, None
-    commonSpecies, uniqueSpeciesTest, uniqueSpeciesOrig, commonReactions, uniqueReactionsTest, uniqueReactionsOrig = \
+    commonSpecies, uniqueSpeciesOrig, uniqueSpeciesTest, commonReactions, uniqueReactionsOrig, uniqueReactionsTest = \
     execute(benchChemkin, benchSpeciesDict, benchThermo, testChemkin, testSpeciesDict, testThermo, **kwargs)
 
     errorModel = checkModel(commonSpecies, uniqueSpeciesTest, uniqueSpeciesOrig, commonReactions, uniqueReactionsTest, uniqueReactionsOrig)


### PR DESCRIPTION
This PR fixes the order of returned values from `diff_models.execute()` used in `checkModels.py`, which RMG-tests relies on.