### PR TITLE
Degeneracy fix for identical reactants

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1404,13 +1404,6 @@ class KineticsFamily(Database):
         # original
         reactants = [reactant if isinstance(reactant, list) else [reactant] for reactant in reactants]
 
-        sameReactants = False
-        if len(reactants) == 2 and len(reactants[0]) == len(reactants[1]):
-            reactantA = reactants[0][0]
-            for reactantB in reactants[1]:
-                if reactantA.isIsomorphic(reactantB):
-                    sameReactants = True
-                    break
                     
         if forward:
             template = self.forwardTemplate
@@ -1564,9 +1557,7 @@ class KineticsFamily(Database):
         # For R_Recombination reactions, the degeneracy is twice what it should
         # be, so divide those by two
         # This is hardcoding of reaction families!
-        # For reactions of the form A + A -> products, the degeneracy is twice
-        # what it should be, so divide those by two
-        if sameReactants or self.label.lower().startswith('r_recombination'):
+        if self.label.lower().startswith('r_recombination'):
             for rxn in rxnList:
                 assert(rxn.degeneracy % 2 == 0)
                 rxn.degeneracy /= 2

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1736,11 +1736,11 @@ class KineticsFamily(Database):
         kineticsList.sort(key=lambda x: (x[1].rank, x[1].index))
         return kineticsList[0]
         
-    def getKinetics(self, reaction, template, degeneracy=1, estimator='', returnAllKinetics=True):
+    def getKinetics(self, reaction, templateLabels, degeneracy=1, estimator='', returnAllKinetics=True):
         """
         Return the kinetics for the given `reaction` by searching the various
         depositories as well as generating a result using the user-specified `estimator`
-        of either 'group additivity' or 'rate rules.'  Unlike
+        of either 'group additivity' or 'rate rules'.  Unlike
         the regular :meth:`getKinetics()` method, this returns a list of
         results, with each result comprising the kinetics, the source, and
         the entry. If it came from a template estimate, the source and entry
@@ -1751,7 +1751,7 @@ class KineticsFamily(Database):
         
         depositories = self.depositories[:]
 
-        template = self.retrieveTemplate(template)
+        template = self.retrieveTemplate(templateLabels)
         
         # Check the various depositories for kinetics
         for depository in depositories:

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -6,6 +6,9 @@ from rmgpy import settings
 from rmgpy.data.kinetics.database import KineticsDatabase
 from rmgpy.data.base import DatabaseError
 import numpy
+from rmgpy.molecule.molecule import Molecule
+from rmgpy.species import Species
+from rmgpy.data.rmg import RMGDatabase
 ###################################################
 
 class TestKineticsDatabase(unittest.TestCase):
@@ -26,9 +29,367 @@ class TestKineticsDatabase(unittest.TestCase):
         with self.assertRaises(DatabaseError):
             database.loadFamilies(path, families=[])
             
+class TestReactionDegeneracy(unittest.TestCase):
 
+    # load database once for entire class
+    database = RMGDatabase()
+    database.load(path = settings['database.directory'],
+         kineticsFamilies=['R_Recombination', 'Disproportionation','R_Addition_MultipleBond'],
+         depository=True,
+         solvation=True,)
+    for family in database.kinetics.families.values():
+        family.addKineticsRulesFromTrainingSet(thermoDatabase=database.thermo)
+        family.fillKineticsRulesByAveragingUp(verbose=True)
+
+    def test_degeneracy_for_methyl_methyl_recombination(self):
+        """Test that the proper degeneracy is calculated for methyl + methyl recombination"""
+
+        correct_degeneracy = 1
+        rxn_family_str = 'R_Recombination'
+        adj_lists = [
+            """
+            multiplicity 2
+            1 C u1 p0 c0 {2,S} {3,S} {4,S}
+            2 H u0 p0 c0 {1,S}
+            3 H u0 p0 c0 {1,S}
+            4 H u0 p0 c0 {1,S}
+            """,
+            """
+            multiplicity 2
+            1 C u1 p0 c0 {2,S} {3,S} {4,S}
+            2 H u0 p0 c0 {1,S}
+            3 H u0 p0 c0 {1,S}
+            4 H u0 p0 c0 {1,S}
+            """
+        ]
+
+        self.compare_degeneracy_of_reaction(adj_lists,rxn_family_str,correct_degeneracy)
+        
+    def test_degeneracy_for_methyl_labeled_methyl_recombination(self):
+        """Test that the proper degeneracy is calculated for methyl + labeled methyl recombination"""
+
+        correct_degeneracy = 1
+        rxn_family_str = 'R_Recombination'
+        adj_lists = [
+            """
+            multiplicity 2
+            1 C u1 p0 c0 {2,S} {3,S} {4,S}
+            2 H u0 p0 c0 {1,S}
+            3 H u0 p0 c0 {1,S}
+            4 H u0 p0 c0 {1,S}
+            """,
+            """
+            multiplicity 2
+            1 C u1 p0 c0 i13 {2,S} {3,S} {4,S}
+            2 H u0 p0 c0 {1,S}
+            3 H u0 p0 c0 {1,S}
+            4 H u0 p0 c0 {1,S}
+            """
+        ]
+
+        self.compare_degeneracy_of_reaction(adj_lists,rxn_family_str,correct_degeneracy)
+        
+    def test_degeneracy_for_ethyl_ethyl_disproportionation(self):
+        """Test that the proper degeneracy is calculated for ethyl + ethyl disproportionation"""
+
+        correct_degeneracy = 6
+        rxn_family_str = 'Disproportionation'
+        adj_lists = [
+            """
+            multiplicity 2
+            1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+            2 C u1 p0 c0 {1,S} {3,S} {4,S}
+            3 H u0 p0 c0 {2,S}
+            4 H u0 p0 c0 {2,S}
+            5 H u0 p0 c0 {1,S}
+            6 H u0 p0 c0 {1,S}
+            7 H u0 p0 c0 {1,S}
+            """,
+            """
+            multiplicity 2
+            1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+            2 C u1 p0 c0 {1,S} {3,S} {4,S}
+            3 H u0 p0 c0 {2,S}
+            4 H u0 p0 c0 {2,S}
+            5 H u0 p0 c0 {1,S}
+            6 H u0 p0 c0 {1,S}
+            7 H u0 p0 c0 {1,S}
+            """
+        ]
+
+        self.compare_degeneracy_of_reaction(adj_lists,rxn_family_str,correct_degeneracy)
+        
+    def test_degeneracy_for_ethyl_labeled_ethyl_disproportionation(self):
+        """Test that the proper degeneracy is calculated for ethyl + labeled ethyl disproportionation"""
+
+        correct_degeneracy = 3
+        rxn_family_str = 'Disproportionation'
+        adj_lists = [
+            """
+            multiplicity 2
+            1 C u0 p0 c0 i13 {2,S} {5,S} {6,S} {7,S}
+            2 C u1 p0 c0 {1,S} {3,S} {4,S}
+            3 H u0 p0 c0 {2,S}
+            4 H u0 p0 c0 {2,S}
+            5 H u0 p0 c0 {1,S}
+            6 H u0 p0 c0 {1,S}
+            7 H u0 p0 c0 {1,S}
+            """,
+            """
+            multiplicity 2
+            1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+            2 C u1 p0 c0 {1,S} {3,S} {4,S}
+            3 H u0 p0 c0 {2,S}
+            4 H u0 p0 c0 {2,S}
+            5 H u0 p0 c0 {1,S}
+            6 H u0 p0 c0 {1,S}
+            7 H u0 p0 c0 {1,S}
+            """
+        ]
+        expected_products = 2
+        self.compare_degeneracy_of_reaction(adj_lists,rxn_family_str,correct_degeneracy * expected_products,expected_products)
+        
+    def compare_degeneracy_of_reaction(self, reactants_adj_list, 
+                                       rxn_family_str, 
+                                       num_expected_degenerate_products,
+                                       num_independent_reactions = 1):
+        """
+        given: 
+
+        `reactants_adj_list`: a list of adjacency lists (of reactants)
+        `reaction_family_str`: the string representation of the reaction family
+        `num_expected_degenerate_products`: the total number of degenerate reactions
+                        which should be found by generateReactions.
+        `num_independent_rxns`: the number of reaction objects expected from generateReactions
+        
+        performs:
+        
+        a check to ensure that the number of degenerate reactions is what is 
+        expected.
+        """
+        
+        found_degeneracy, reaction = self.find_reaction_degeneracy(reactants_adj_list,rxn_family_str,
+                                 num_independent_reactions)
+        self.assertEqual(found_degeneracy, num_expected_degenerate_products,'degeneracy returned ({0}) is not the correct value ({1}) for reaction {2}'.format(found_degeneracy, num_expected_degenerate_products,reaction)) 
+
+    def find_reaction_degeneracy(self, reactants_adj_list,rxn_family_str,
+                                 num_independent_reactions = 1):
+        """
+        given:
+        
+        reactants_adj_list: a list of adjacency lists of the reactants
+        `reaction_family_str`: the string representation of the reaction family
+        `num_independent_rxns`: the number of reaction objects expected from generateReactions
+        
+        returns:
+        
+        a tuple with the total degeneracy and a list of reaction objects
+        """
+        family = self.database.kinetics.families[rxn_family_str]
+        reactants = [Molecule().fromAdjacencyList(reactants_adj_list[0]),
+                     Molecule().fromAdjacencyList(reactants_adj_list[1])] 
+
+        reactions = family.generateReactions(reactants)
+        self.assertEqual(len(reactions), num_independent_reactions,'only {1} reaction(s) should be produced. Produced reactions {0}'.format(reactions,num_independent_reactions))
+
+        return sum([reaction.degeneracy for reaction in reactions]), reactions
+
+    def test_propyl_propyl_reaction_is_the_same_as_propyl_butyl(self):
+        """
+        test that propyl propyl r-recombination is the same rate as propyl butyl
+        
+        this test assures that r-recombination reactions from the same rate rule
+        have the same reaction rate since they have both symmetrical transition
+        states and reactants, which should cancel out in TST
+        """
+        rxn_family_str = 'R_Recombination'
+        propyl_adj_list = """
+            multiplicity 2
+            1  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+            2  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+            3  C u1 p0 c0 {2,S} {4,S} {5,S}
+            4  H u0 p0 c0 {3,S}
+            5  H u0 p0 c0 {3,S}
+            6  H u0 p0 c0 {1,S}
+            7  H u0 p0 c0 {1,S}
+            8  H u0 p0 c0 {1,S}
+            9  H u0 p0 c0 {2,S}
+            10 H u0 p0 c0 {2,S}
+
+            """
+        butyl_adj_list = """
+            multiplicity 2
+            1  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+            2  C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+            3  C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+            4  C u1 p0 c0 {3,S} {5,S} {6,S}
+            5  H u0 p0 c0 {4,S}
+            6  H u0 p0 c0 {4,S}
+            7  H u0 p0 c0 {1,S}
+            8  H u0 p0 c0 {1,S}
+            9  H u0 p0 c0 {1,S}
+            10 H u0 p0 c0 {2,S}
+            11 H u0 p0 c0 {2,S}
+            12 H u0 p0 c0 {3,S}
+            13 H u0 p0 c0 {3,S}        
+            """
+        
+        family = self.database.kinetics.families[rxn_family_str]
+        
+        # get reaction objects and their degeneracy
+        pp_degeneracy, pp_reactions = self.find_reaction_degeneracy([propyl_adj_list,propyl_adj_list],rxn_family_str)
+        pb_degeneracy, pb_reactions = self.find_reaction_degeneracy([propyl_adj_list,butyl_adj_list],rxn_family_str)
+        
+        # since output is a list of 1
+        pp_reaction = pp_reactions[0]
+        pb_reaction = pb_reactions[0]        
+        
+        # get kinetics for each reaction
+        pp_kinetics_list = family.getKinetics(pp_reaction, pp_reaction.template,
+                                              degeneracy=pp_reaction.degeneracy,
+                                              estimator = 'rate rules')
+        self.assertEqual(len(pp_kinetics_list), 1, 'The propyl and propyl recombination should only return one reaction. It returned {0}. Here is the full kinetics: {1}'.format(len(pp_kinetics_list),pp_kinetics_list))
+        
+        pb_kinetics_list = family.getKinetics(pb_reaction, pb_reaction.template,
+                                              degeneracy=pb_reaction.degeneracy,
+                                              estimator = 'rate rules')
+        self.assertEqual(len(pb_kinetics_list), 1, 'The propyl and butyl recombination should only return one reaction. It returned {0}. Here is the full kinetics: {1}'.format(len(pb_kinetics_list),pb_kinetics_list))
+        
+        # the same reaction group must be found or this test will not work
+        self.assertIn(pp_kinetics_list[0][0].comment,pb_kinetics_list[0][0].comment,
+                         'this test found different kinetics for the two groups, so it will not function as expected\n' + 
+                         str(pp_kinetics_list)+str(pb_kinetics_list))
+        
+        # test that the kinetics are correct
+        self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300), pb_kinetics_list[0][0].getRateCoefficient(300))
+
+    def test_identical_reactants_have_faster_kinetics(self):
+        """
+        tests identical reactants have faster kinetics that different reactants.
+        
+        this test assures that r addition multiple bond reactions from the same 
+        rate rule have the faster reaction rate if the reactants are identicaal 
+        since they have symmetrical reactants, with little change in the 
+        transition state symmetry. This should be more robust than just checking
+        the degeneracy of reactions.
+        """
+        rxn_family_str = 'R_Addition_MultipleBond'
+        butenyl_adj_list = """
+            multiplicity 2
+            1 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+            2 C u0 p0 c0 {1,S} {4,D} {7,S}
+            3 C u1 p0 c0 {1,S} {8,S} {9,S}
+            4 C u0 p0 c0 {2,D} {10,S} {11,S}
+            5 H u0 p0 c0 {1,S}
+            6 H u0 p0 c0 {1,S}
+            7 H u0 p0 c0 {2,S}
+            8 H u0 p0 c0 {3,S}
+            9 H u0 p0 c0 {3,S}
+            10 H u0 p0 c0 {4,S}
+            11 H u0 p0 c0 {4,S}
+            """
+        pentenyl_adj_list = """
+            multiplicity 2
+            1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+            2 C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+            3 C u0 p0 c0 {1,S} {5,D} {10,S}
+            4 C u1 p0 c0 {2,S} {11,S} {12,S}
+            5 C u0 p0 c0 {3,D} {13,S} {14,S}
+            6 H u0 p0 c0 {2,S}
+            7 H u0 p0 c0 {2,S}
+            8 H u0 p0 c0 {1,S}
+            9 H u0 p0 c0 {1,S}
+            10 H u0 p0 c0 {3,S}
+            11 H u0 p0 c0 {4,S}
+            12 H u0 p0 c0 {4,S}
+            13 H u0 p0 c0 {5,S}
+            14 H u0 p0 c0 {5,S}  
+            """
+        
+        family = self.database.kinetics.families[rxn_family_str]
+        
+        # get reaction objects and their degeneracy
+        pp_degeneracy, pp_reactions = self.find_reaction_degeneracy([butenyl_adj_list,butenyl_adj_list],rxn_family_str, num_independent_reactions=2)
+        pb_degeneracy, pb_reactions = self.find_reaction_degeneracy([butenyl_adj_list,pentenyl_adj_list],rxn_family_str, num_independent_reactions=4)
+        
+        # find the correct reaction from the list
+        symmetric_product=Molecule().fromAdjacencyList('''
+            multiplicity 3
+            1 C u0 p0 c0 {2,S} {3,S} {6,S} {9,S}
+            2 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+            3 C u0 p0 c0 {1,S} {7,S} {12,S} {13,S}
+            4 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+            5 C u0 p0 c0 {4,S} {8,D} {16,S}
+            6 C u1 p0 c0 {1,S} {19,S} {20,S}
+            7 C u1 p0 c0 {3,S} {17,S} {18,S}
+            8 C u0 p0 c0 {5,D} {21,S} {22,S}
+            9 H u0 p0 c0 {1,S}
+            10 H u0 p0 c0 {2,S}
+            11 H u0 p0 c0 {2,S}
+            12 H u0 p0 c0 {3,S}
+            13 H u0 p0 c0 {3,S}
+            14 H u0 p0 c0 {4,S}
+            15 H u0 p0 c0 {4,S}
+            16 H u0 p0 c0 {5,S}
+            17 H u0 p0 c0 {7,S}
+            18 H u0 p0 c0 {7,S}
+            19 H u0 p0 c0 {6,S}
+            20 H u0 p0 c0 {6,S}
+            21 H u0 p0 c0 {8,S}
+            22 H u0 p0 c0 {8,S}
+            ''')
+        asymmetric_product = Molecule().fromAdjacencyList('''
+            multiplicity 3
+            1 C u0 p0 c0 {2,S} {3,S} {7,S} {10,S}
+            2 C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
+            3 C u0 p0 c0 {1,S} {4,S} {13,S} {14,S}
+            4 C u0 p0 c0 {3,S} {6,S} {17,S} {18,S}
+            5 C u0 p0 c0 {2,S} {8,S} {15,S} {16,S}
+            6 C u0 p0 c0 {4,S} {9,D} {19,S}
+            7 C u1 p0 c0 {1,S} {22,S} {23,S}
+            8 C u1 p0 c0 {5,S} {20,S} {21,S}
+            9 C u0 p0 c0 {6,D} {24,S} {25,S}
+            10 H u0 p0 c0 {1,S}
+            11 H u0 p0 c0 {2,S}
+            12 H u0 p0 c0 {2,S}
+            13 H u0 p0 c0 {3,S}
+            14 H u0 p0 c0 {3,S}
+            15 H u0 p0 c0 {5,S}
+            16 H u0 p0 c0 {5,S}
+            17 H u0 p0 c0 {4,S}
+            18 H u0 p0 c0 {4,S}
+            19 H u0 p0 c0 {6,S}
+            20 H u0 p0 c0 {8,S}
+            21 H u0 p0 c0 {8,S}
+            22 H u0 p0 c0 {7,S}
+            23 H u0 p0 c0 {7,S}
+            24 H u0 p0 c0 {9,S}
+            25 H u0 p0 c0 {9,S}
+            ''')
+        
+        pp_reaction = next((reaction for reaction in pp_reactions if reaction.products[0].isIsomorphic(symmetric_product)),None)
+        pb_reaction = next((reaction for reaction in pb_reactions if reaction.products[0].isIsomorphic(asymmetric_product)),None)
+        
+        pp_kinetics_list = family.getKinetics(pp_reaction, pp_reaction.template,
+                                              degeneracy=pp_reaction.degeneracy,
+                                              estimator = 'rate rules')
+        self.assertEqual(len(pp_kinetics_list), 1, 'The propyl and propyl recombination should only return one reaction. It returned {0}. Here is the full kinetics: {1}'.format(len(pp_kinetics_list),pp_kinetics_list))
+
+        pb_kinetics_list = family.getKinetics(pb_reaction, pb_reaction.template,
+                                              degeneracy=pb_reaction.degeneracy,
+                                              estimator = 'rate rules')
+        self.assertEqual(len(pb_kinetics_list), 1,  'The propyl and butyl recombination should only return one reaction. It returned {0}. Here is the full kinetics: {1}'.format(len(pb_kinetics_list),pb_kinetics_list))
+        
+        # the same reaction group must be found or this test will not work
+        self.assertIn(pb_kinetics_list[0][0].comment,pp_kinetics_list[0][0].comment,
+                         'this test found different kinetics for the two groups, so it will not function as expected\n' + 
+                         str(pp_kinetics_list)+str(pb_kinetics_list))
+        
+        # test that the kinetics are correct
+        self.assertNotEqual(pp_kinetics_list[0][0].getRateCoefficient(300), pb_kinetics_list[0][0].getRateCoefficient(300))
+        self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300) / 2, pb_kinetics_list[0][0].getRateCoefficient(300))
+        
 class TestKineticsCommentsParsing(unittest.TestCase):
-    from rmgpy.data.rmg import RMGDatabase 
 
     database=RMGDatabase()
     database.load(settings['database.directory'], 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -789,7 +789,7 @@ class CoreEdgeReactionModel:
         family = getFamilyLibraryObject(reaction.family)
 
         # Get the kinetics for the reaction
-        kinetics, source, entry, isForward = family.getKinetics(reaction, template=reaction.template, degeneracy=reaction.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
+        kinetics, source, entry, isForward = family.getKinetics(reaction, templateLabels=reaction.template, degeneracy=reaction.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
         # Get the enthalpy of reaction at 298 K
         H298 = reaction.getEnthalpyOfReaction(298)
         G298 = reaction.getFreeEnergyOfReaction(298)
@@ -800,7 +800,7 @@ class CoreEdgeReactionModel:
                 # The kinetics family is its own reverse, so we could estimate kinetics in either direction
                 
                 # First get the kinetics for the other direction
-                rev_kinetics, rev_source, rev_entry, rev_isForward = family.getKinetics(reaction.reverse, template=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
+                rev_kinetics, rev_source, rev_entry, rev_isForward = family.getKinetics(reaction.reverse, templateLabels=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
                 # Now decide which direction's kinetics to keep
                 keepReverse = False
                 if (entry is not None and rev_entry is None):


### PR DESCRIPTION
Transition state theory asserts that identical reactants should double the symmetry number of a reaction (if not changing transition state geometry), essentially making them twice as fast. See [Fernandez-Ramos et al.](http://link.springer.com/10.1007/s00214-007-0328-0) for a review of reaction symmetry numbers. 

RMG currently doesn't account for this difference. Here is a [symmetrical reaction](http://rmg.mit.edu/database/kinetics/families/R_Addition_MultipleBond/rate_rules/reactant1=multiplicity%202%0A1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B8,S%7D%20%7B9,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B4,S%7D%20%7B6,S%7D%20%7B7,S%7D%0A3%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B5,D%7D%20%7B10,S%7D%0A4%20%20C%20u1%20p0%20c0%20%7B2,S%7D%20%7B11,S%7D%20%7B12,S%7D%0A5%20%20C%20u0%20p0%20c0%20%7B3,D%7D%20%7B13,S%7D%20%7B14,S%7D%0A6%20%20H%20u0%20p0%20c0%20%7B2,S%7D%0A7%20%20H%20u0%20p0%20c0%20%7B2,S%7D%0A8%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A9%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A10%20H%20u0%20p0%20c0%20%7B3,S%7D%0A11%20H%20u0%20p0%20c0%20%7B4,S%7D%0A12%20H%20u0%20p0%20c0%20%7B4,S%7D%0A13%20H%20u0%20p0%20c0%20%7B5,S%7D%0A14%20H%20u0%20p0%20c0%20%7B5,S%7D%0A__reactant2=multiplicity%202%0A1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B5,S%7D%20%7B6,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B4,D%7D%20%7B7,S%7D%0A3%20%20C%20u1%20p0%20c0%20%7B1,S%7D%20%7B8,S%7D%20%7B9,S%7D%0A4%20%20C%20u0%20p0%20c0%20%7B2,D%7D%20%7B10,S%7D%20%7B11,S%7D%0A5%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A6%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A7%20%20H%20u0%20p0%20c0%20%7B2,S%7D%0A8%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0A9%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0A10%20H%20u0%20p0%20c0%20%7B4,S%7D%0A11%20H%20u0%20p0%20c0%20%7B4,S%7D%0A__product1=multiplicity%203%0A1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B7,S%7D%20%7B10,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B5,S%7D%20%7B11,S%7D%20%7B12,S%7D%0A3%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B4,S%7D%20%7B13,S%7D%20%7B14,S%7D%0A4%20%20C%20u0%20p0%20c0%20%7B3,S%7D%20%7B6,S%7D%20%7B17,S%7D%20%7B18,S%7D%0A5%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B8,S%7D%20%7B15,S%7D%20%7B16,S%7D%0A6%20%20C%20u0%20p0%20c0%20%7B4,S%7D%20%7B9,D%7D%20%7B19,S%7D%0A7%20%20C%20u1%20p0%20c0%20%7B1,S%7D%20%7B22,S%7D%20%7B23,S%7D%0A8%20%20C%20u1%20p0%20c0%20%7B5,S%7D%20%7B20,S%7D%20%7B21,S%7D%0A9%20%20C%20u0%20p0%20c0%20%7B6,D%7D%20%7B24,S%7D%20%7B25,S%7D%0A10%20H%20u0%20p0%20c0%20%7B1,S%7D%0A11%20H%20u0%20p0%20c0%20%7B2,S%7D%0A12%20H%20u0%20p0%20c0%20%7B2,S%7D%0A13%20H%20u0%20p0%20c0%20%7B3,S%7D%0A14%20H%20u0%20p0%20c0%20%7B3,S%7D%0A15%20H%20u0%20p0%20c0%20%7B5,S%7D%0A16%20H%20u0%20p0%20c0%20%7B5,S%7D%0A17%20H%20u0%20p0%20c0%20%7B4,S%7D%0A18%20H%20u0%20p0%20c0%20%7B4,S%7D%0A19%20H%20u0%20p0%20c0%20%7B6,S%7D%0A20%20H%20u0%20p0%20c0%20%7B8,S%7D%0A21%20H%20u0%20p0%20c0%20%7B8,S%7D%0A22%20H%20u0%20p0%20c0%20%7B7,S%7D%0A23%20H%20u0%20p0%20c0%20%7B7,S%7D%0A24%20H%20u0%20p0%20c0%20%7B9,S%7D%0A25%20H%20u0%20p0%20c0%20%7B9,S%7D%0A) and an [asymmetrical reaction](http://rmg.mit.edu/database/kinetics/families/R_Addition_MultipleBond/rate_rules/reactant1=multiplicity%202%0A1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B5,S%7D%20%7B6,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B4,D%7D%20%7B7,S%7D%0A3%20%20C%20u1%20p0%20c0%20%7B1,S%7D%20%7B8,S%7D%20%7B9,S%7D%0A4%20%20C%20u0%20p0%20c0%20%7B2,D%7D%20%7B10,S%7D%20%7B11,S%7D%0A5%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A6%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A7%20%20H%20u0%20p0%20c0%20%7B2,S%7D%0A8%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0A9%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0A10%20H%20u0%20p0%20c0%20%7B4,S%7D%0A11%20H%20u0%20p0%20c0%20%7B4,S%7D%0A__reactant2=multiplicity%202%0A1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B5,S%7D%20%7B6,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B4,D%7D%20%7B7,S%7D%0A3%20%20C%20u1%20p0%20c0%20%7B1,S%7D%20%7B8,S%7D%20%7B9,S%7D%0A4%20%20C%20u0%20p0%20c0%20%7B2,D%7D%20%7B10,S%7D%20%7B11,S%7D%0A5%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A6%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A7%20%20H%20u0%20p0%20c0%20%7B2,S%7D%0A8%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0A9%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0A10%20H%20u0%20p0%20c0%20%7B4,S%7D%0A11%20H%20u0%20p0%20c0%20%7B4,S%7D%0A__product1=multiplicity%203%0A1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B6,S%7D%20%7B9,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B4,S%7D%20%7B10,S%7D%20%7B11,S%7D%0A3%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B7,S%7D%20%7B12,S%7D%20%7B13,S%7D%0A4%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B5,S%7D%20%7B14,S%7D%20%7B15,S%7D%0A5%20%20C%20u0%20p0%20c0%20%7B4,S%7D%20%7B8,D%7D%20%7B16,S%7D%0A6%20%20C%20u1%20p0%20c0%20%7B1,S%7D%20%7B19,S%7D%20%7B20,S%7D%0A7%20%20C%20u1%20p0%20c0%20%7B3,S%7D%20%7B17,S%7D%20%7B18,S%7D%0A8%20%20C%20u0%20p0%20c0%20%7B5,D%7D%20%7B21,S%7D%20%7B22,S%7D%0A9%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A10%20H%20u0%20p0%20c0%20%7B2,S%7D%0A11%20H%20u0%20p0%20c0%20%7B2,S%7D%0A12%20H%20u0%20p0%20c0%20%7B3,S%7D%0A13%20H%20u0%20p0%20c0%20%7B3,S%7D%0A14%20H%20u0%20p0%20c0%20%7B4,S%7D%0A15%20H%20u0%20p0%20c0%20%7B4,S%7D%0A16%20H%20u0%20p0%20c0%20%7B5,S%7D%0A17%20H%20u0%20p0%20c0%20%7B7,S%7D%0A18%20H%20u0%20p0%20c0%20%7B7,S%7D%0A19%20H%20u0%20p0%20c0%20%7B6,S%7D%0A20%20H%20u0%20p0%20c0%20%7B6,S%7D%0A21%20H%20u0%20p0%20c0%20%7B8,S%7D%0A22%20H%20u0%20p0%20c0%20%7B8,S%7D%0A) which both involve the R_addition_double_bond family and use the same rate rule. The symmetrical reaction should have twice the rate. This originates from the symmetry term from transition state theory, and also can be explained from how we view degeneracy. One pathway for reaction involves the double bond on the reactant 1 reacting with the radical on reactant 2. The second pathway involves the radical on reactant 1 reacting with the double bond on reactant 2. These two pathways are equivalent, and RMG should be giving a degeneracy of 2 to the symmetrical reaction. 

RMG finds a degeneracy of two for this reaction, and it then reduces the degeneracy because someone thought the higher degeneracy was an overestimation . The [commit](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/d111ef652e55f572ad69aa70a08a0821a766d257) that reduces the degeneracy doesn't give a reason for why the change was made. I may be missing something, but I don't think the previous commit was considering the symmetry effect. The commit might have been made to conform to the rate rule database, but I am not certain about this. 

Just a forewarning that this commit will likely change rate estimates from rate rules but should not effect the rates from training reactions or libraries. 


