### PR TITLE
adds jupyter as RMG's denpendency

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -35,3 +35,4 @@ dependencies:
   - scoop
   - libgfortran >=1.0 # You may need to comment this out for mac osx
   - ffmpeg
+  - jupyter

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -34,3 +34,4 @@ dependencies:
   - graphviz
   - scoop
   - ffmpeg
+  - jupyter

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -33,3 +33,4 @@ dependencies:
   - graphviz
   - scoop
   - ffmpeg
+  - jupyter


### PR DESCRIPTION
We've been adding lots of jupyter notebooks in RMG for functionality demos, but haven't added `jupyter` as RMG's dependency, which requires users to install `jupyter` within the `rmg_env` manually. Sometimes it creates unnecessary confusions. 

This PR is to officially add jupyter as RMG's dependency and eliminate jupyter installation confusion.