### PR TITLE
Correcting updateLonePairs

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1552,11 +1552,9 @@ class Molecule(Graph):
                         order = order + 3
                     if bond12.isBenzene():
                         order = order + 1.5
-
-                if atom1.isSilicon() or atom1.isCarbon():
-                    atom1.lonePairs = (4 - atom1.radicalElectrons - int(order)) / 2
-                else:     
-                    atom1.lonePairs = 4 - atom1.radicalElectrons - int(order)
+                atom1.lonePairs = (elements.PeriodicSystem.valence_electrons[atom1.symbol] - atom1.radicalElectrons - atom1.charge - int(order)) / 2.0
+                if atom1.lonePairs % 1 > 0 or atom1.lonePairs > 4:
+                    logging.error("Unable to determine the number of lone pairs for element {0} in {1}".format(atom1,self))
             else:
                 atom1.lonePairs = 0
                 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1541,17 +1541,8 @@ class Molecule(Graph):
         """
         cython.declare(atom1=Atom, atom2=Atom, bond12=Bond, order=float)
         for atom1 in self.vertices:
-            order = 0
             if not atom1.isHydrogen():
-                for atom2, bond12 in atom1.edges.items():
-                    if bond12.isSingle():
-                        order = order + 1
-                    if bond12.isDouble():
-                        order = order + 2
-                    if bond12.isTriple():
-                        order = order + 3
-                    if bond12.isBenzene():
-                        order = order + 1.5
+                order = atom1.getBondOrdersForAtom()
                 atom1.lonePairs = (elements.PeriodicSystem.valence_electrons[atom1.symbol] - atom1.radicalElectrons - atom1.charge - int(order)) / 2.0
                 if atom1.lonePairs % 1 > 0 or atom1.lonePairs > 4:
                     logging.error("Unable to determine the number of lone pairs for element {0} in {1}".format(atom1,self))

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -461,6 +461,88 @@ class TestBond(unittest.TestCase):
         import cPickle
         bond = cPickle.loads(cPickle.dumps(self.bond))
         self.assertEqual(self.bond.order, bond.order)
+
+    def testUpdateLonePairs(self):
+        """
+        Test that updateLonePairs works as expected
+        """
+        mol_N1sc_N5t = Molecule().fromAdjacencyList("""
+            1 N u0 p0 c+1 {2,T} {4,S}
+            2 N u0 p0 c+1 {1,T} {3,S}
+            3 N u0 p3 c-2 {2,S}
+            4 H u0 p0 c0 {1,S}""")
+        mol_N1s = Molecule().fromAdjacencyList("""
+            1 N u0 p2 c0 {2,S}
+            2 H u0 p0 c0 {1,S}""")
+        mol_N3s = Molecule().fromAdjacencyList("""
+            multiplicity 3
+            1 N u2 p1 c0 {2,S}
+            2 H u0 p0 c0 {1,S}""")
+        mol_N3b = Molecule().fromAdjacencyList("""
+            1  N u0 p1 c0 {2,D} {6,S}
+            2  C u0 p0 c0 {1,D} {3,S} {7,S}
+            3  C u0 p0 c0 {2,S} {4,D} {8,S}
+            4  C u0 p0 c0 {3,D} {5,S} {9,S}
+            5  C u0 p0 c0 {4,S} {6,D} {10,S}
+            6  C u0 p0 c0 {1,S} {5,D} {11,S}
+            7  H u0 p0 c0 {2,S}
+            8  H u0 p0 c0 {3,S}
+            9  H u0 p0 c0 {4,S}
+            10 H u0 p0 c0 {5,S}
+            11 H u0 p0 c0 {6,S}""")
+        mol_N5s = Molecule().fromAdjacencyList("""
+            multiplicity 2
+            1 N u1 p0 c+1 {2,S} {3,S} {4,S}
+            2 H u0 p0 c0 {1,S}
+            3 H u0 p0 c0 {1,S}
+            4 O u0 p3 c-1 {1,S}""")
+        mol_N5d = Molecule().fromAdjacencyList("""
+            1 N u0 p0 c+1 {2,D} {3,S} {4,S}
+            2 O u0 p2 c0 {1,D}
+            3 O u0 p2 c0 {1,S} {5,S}
+            4 O u0 p3 c-1 {1,S}
+            5 H u0 p0 c0 {3,S}""")
+        mol_N5dd = Molecule().fromAdjacencyList("""
+            1 N u0 p2 c-1 {2,D}
+            2 N u0 p0 c+1 {1,D} {3,D}
+            3 O u0 p2 c0 {2,D}""")
+        mol_CH2_S = Molecule().fromAdjacencyList("""
+            1 C u0 p1 c0 {2,S} {3,S}
+            2 H u0 p0 c0 {1,S}
+            3 H u0 p0 c0 {1,S}""")
+        mol_carbonyl = Molecule().fromAdjacencyList("""
+            1 O u0 p2 c0 {2,D}
+            2 C u0 p0 c0 {1,D} {3,S} {4,S}
+            3 H u0 p0 c0 {2,S}
+            4 H u0 p0 c0 {2,S}""")
+
+        mol_N1sc_N5t.updateLonePairs()
+        mol_N1s.updateLonePairs()
+        mol_N3s.updateLonePairs()
+        mol_N3b.updateLonePairs()
+        mol_N5s.updateLonePairs()
+        mol_N5d.updateLonePairs()
+        mol_N5dd.updateLonePairs()
+        mol_CH2_S.updateLonePairs()
+        mol_carbonyl.updateLonePairs()
+
+        self.assertEqual(mol_N1sc_N5t.atoms[0].lonePairs, 0)
+        self.assertEqual(mol_N1sc_N5t.atoms[2].lonePairs, 3)
+        self.assertEqual(mol_N1s.atoms[0].lonePairs, 2)
+        self.assertEqual(mol_N3s.atoms[0].lonePairs, 1)
+        self.assertEqual(mol_N3b.atoms[0].lonePairs, 1)
+        self.assertEqual(mol_N5s.atoms[0].lonePairs, 0)
+        self.assertEqual(mol_N5s.atoms[3].lonePairs, 3)
+        self.assertEqual(mol_N5d.atoms[0].lonePairs, 0)
+        self.assertEqual(mol_N5d.atoms[1].lonePairs, 2)
+        self.assertEqual(mol_N5d.atoms[2].lonePairs, 2)
+        self.assertEqual(mol_N5d.atoms[3].lonePairs, 3)
+        self.assertEqual(mol_N5dd.atoms[0].lonePairs, 2)
+        self.assertEqual(mol_N5dd.atoms[1].lonePairs, 0)
+        self.assertEqual(mol_N5dd.atoms[2].lonePairs, 2)
+        self.assertEqual(mol_CH2_S.atoms[0].lonePairs, 1)
+        self.assertEqual(mol_carbonyl.atoms[0].lonePairs, 2)
+        self.assertEqual(mol_carbonyl.atoms[1].lonePairs, 0)
         
 ################################################################################
 


### PR DESCRIPTION
The calculation of lone pairs was wrong for the N1s atom type,
and could potentially be worng for some of the new sulfur atom types
which will soon be introduced in RMG.

This PR fixes the calculation of the number of lone pairs by using
the valence electrons of an element. An error will be printed
in case the number of lone pairs isn't an integer.

The previous calculation resulted in 3 lone pairs for N1s (where it should only have 2):
atom1.lonePairs = 4 - atom1.radicalElectrons - int(order) = 4 - 1 = 3
The new calculation will give (5-1)/2 = 2 for N1s.
The new calculation will to be identical for carbon \ oxygen \ silicon.