### PR TITLE
Bond and GroupBond store bond order as float

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -235,7 +235,7 @@ class ReactionRecipe:
                 elif (action[0] == 'FORM_BOND' and doForward) or (action[0] == 'BREAK_BOND' and not doForward):
                     if struct.hasBond(atom1, atom2):
                         raise InvalidActionError('Attempted to create an existing bond.')
-                    bond = GroupBond(atom1, atom2, order=['S']) if pattern else Bond(atom1, atom2, order='S')
+                    bond = GroupBond(atom1, atom2, order=[1]) if pattern else Bond(atom1, atom2, order=1)
                     struct.addBond(bond)
                     atom1.applyAction(['FORM_BOND', label1, info, label2])
                     atom2.applyAction(['FORM_BOND', label1, info, label2])

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -717,10 +717,7 @@ class SolvationDatabase(object):
                 bonds = saturatedStruct.getBonds(atom)
                 sumBondOrders = 0
                 for key, bond in bonds.iteritems():
-                    if bond.order == 'S': sumBondOrders += 1
-                    if bond.order == 'D': sumBondOrders += 2
-                    if bond.order == 'T': sumBondOrders += 3
-                    if bond.order == 'B': sumBondOrders += 1.5 # We should always have 2 'B' bonds (but what about Cbf?)
+                    sumBondOrders += bond.order# We should always have 2 'B' bonds (but what about Cbf?)
                 if atomTypes['Val4'] in atom.atomType.generic: # Carbon, Silicon
                     while(atom.radicalElectrons + charge + sumBondOrders < 4):
                         atom.decrementLonePairs()

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -454,11 +454,11 @@ def bicyclicDecompositionForPolyring(polyring):
         elif (not isA_aromatic and not isB_aromatic):
             aromaticBonds_inA = findAromaticBondsFromSubMolecule(submolA)
             for aromaticBond_inA in aromaticBonds_inA:
-                aromaticBond_inA.order = 'S'
+                aromaticBond_inA.setOrderNum(1)
 
             aromaticBonds_inB = findAromaticBondsFromSubMolecule(submolB)
             for aromaticBond_inB in aromaticBonds_inB:
-                aromaticBond_inB.order = 'S'
+                aromaticBond_inB.setOrderNum(1)
         elif isA_aromatic:
             aromaticBonds_inB = findAromaticBondsFromSubMolecule(submolB)
             for aromaticBond_inB in aromaticBonds_inB:
@@ -467,14 +467,14 @@ def bicyclicDecompositionForPolyring(polyring):
                 if (aromaticBond_inB.atom1 in submolA.atoms) and (aromaticBond_inB.atom2 in submolA.atoms) and (submolA.hasBond(aromaticBond_inB.atom1, aromaticBond_inB.atom2)):
                     pass
                 else:
-                    aromaticBond_inB.order = 'S'
+                    aromaticBond_inB.setOrderNum(1)
         else:
             aromaticBonds_inA = findAromaticBondsFromSubMolecule(submolA)
             for aromaticBond_inA in aromaticBonds_inA:
                 if (aromaticBond_inA.atom1 in submolB.atoms) and (aromaticBond_inA.atom2 in submolB.atoms) and (submolB.hasBond(aromaticBond_inA.atom1, aromaticBond_inA.atom2)):
                     pass
                 else:
-                    aromaticBond_inA.order = 'S'
+                    aromaticBond_inA.setOrderNum(1)
         mergedRing.update()#
         bicyclicsMergedFromRingPair.append(mergedRing)
 
@@ -1505,7 +1505,7 @@ class ThermoDatabase(object):
                 if not isAromaticRing(submol):
                     aromaticBonds = findAromaticBondsFromSubMolecule(submol)
                     for aromaticBond in aromaticBonds:
-                        aromaticBond.order = 'S'
+                        aromaticBond.setOrderNum(1)
                     
                     submol.update()
                     singleRingThermodata = self.__addRingCorrectionThermoDataFromTree(None, \

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -849,11 +849,11 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
             # Bond type(s)
             if group:
                 if len(bond.order) == 1:
-                    adjlist += bond.order[0]
+                    adjlist += bond.getOrderStr()[0]
                 else:
-                    adjlist += '[{0}]'.format(','.join(bond.order))
+                    adjlist += '[{0}]'.format(','.join(bond.getOrderStr()))
             else:
-                adjlist += bond.order
+                adjlist += bond.getOrderStr()
             adjlist += '}'
 
         # Each atom begins on a new line
@@ -978,11 +978,11 @@ def toOldAdjacencyList(atoms, multiplicity=None, label=None, group=False, remove
             # Bond type(s)
             if group:
                 if len(bond.order) == 1:
-                    adjlist += bond.order[0]
+                    adjlist += bond.getOrderStr()[0]
                 else:
-                    adjlist += '{{{0}}}'.format(','.join(bond.order))
+                    adjlist += '{{{0}}}'.format(','.join(bond.getOrderStr()))
             else:
-                adjlist += bond.order
+                adjlist += bond.getOrderStr()
             adjlist += '}'
 
         # Each atom begins on a new line

--- a/rmgpy/molecule/adjlistTest.py
+++ b/rmgpy/molecule/adjlistTest.py
@@ -50,8 +50,8 @@ class TestGroupAdjLists(unittest.TestCase):
         self.assertTrue(atom3.atomType[0].label == 'R!H')
         self.assertTrue(atom3.radicalElectrons == [0, 1])
 
-        self.assertTrue(bond12.order == ['S', 'D'])
-        self.assertTrue(bond13.order == ['S'])
+        self.assertTrue(bond12.order == [1,2])
+        self.assertTrue(bond13.isSingle())
 
 
     def testFromAdjacencyList(self):
@@ -86,8 +86,8 @@ class TestGroupAdjLists(unittest.TestCase):
         self.assertTrue(atom3.atomType[0].label == 'R!H')
         self.assertTrue(atom3.radicalElectrons == [0])
 
-        self.assertTrue(bond12.order == ['S', 'D'])
-        self.assertTrue(bond13.order == ['S'])
+        self.assertTrue(bond12.order == [1, 2])
+        self.assertTrue(bond13.isSingle())
 
     def testFromAdjacencyList_multiplicity(self):
         gp = Group().fromAdjacencyList(

--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -273,7 +273,7 @@ def toOBMol(mol):
         a = obmol.NewAtom()
         a.SetAtomicNum(atom.number)
         a.SetFormalCharge(atom.charge)
-    orders = {'S': 1, 'D': 2, 'T': 3, 'B': 5}
+    orders = {1: 1, 2: 2, 3: 3, 1.5: 5}
     for atom1 in mol.vertices:
         for atom2, bond in atom1.edges.iteritems():
             index1 = atoms.index(atom1)
@@ -340,7 +340,7 @@ def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
             rdAtomIndices[atom] = index
     
     rdBonds = Chem.rdchem.BondType
-    orders = {'S': rdBonds.SINGLE, 'D': rdBonds.DOUBLE, 'T': rdBonds.TRIPLE, 'B': rdBonds.AROMATIC}
+    orders = {1: rdBonds.SINGLE, 2: rdBonds.DOUBLE, 3: rdBonds.TRIPLE, 1.5: rdBonds.AROMATIC}
     # Add the bonds
     for atom1 in mol.vertices:
         for atom2, bond in atom1.edges.iteritems():

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -77,6 +77,14 @@ cdef class GroupBond(Edge):
 
     cpdef Edge copy(self)
 
+    cpdef list getOrderStr(self)
+    
+    cpdef setOrderStr(self, list newOrder)
+    
+    cpdef list getOrderNum(self)
+    
+    cpdef setOrderNum(self, list newOrder)
+
     cpdef __changeBond(self, short order)
 
     cpdef bint isSingle(self) except -2

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -42,9 +42,9 @@ cdef class GroupAtom(Vertex):
 
     cpdef __changeBond(self, short order)
 
-    cpdef __formBond(self, str order)
+    cpdef __formBond(self, float order)
 
-    cpdef __breakBond(self, str order)
+    cpdef __breakBond(self, float order)
 
     cpdef __gainRadical(self, short radical)
 

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -68,7 +68,6 @@ cdef class GroupAtom(Vertex):
 
     cpdef mol.Atom makeSampleAtom(self)
 
-    cpdef getBondOrdersForAtom(self)
 ################################################################################
 
 cdef class GroupBond(Edge):

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -570,7 +570,58 @@ class GroupBond(Edge):
         attributes of the copy will not affect the original.
         """
         return GroupBond(self.vertex1, self.vertex2, self.order[:])
-
+        
+    def getOrderStr(self):
+        """
+        returns a string representing the bond order
+        """
+        return self.order
+        
+    def setOrderStr(self, newOrder):
+        """
+        set the bond order using a valid bond-order character
+        """
+        if all[order in ['S','D','T','B'] for order in newOrder]:
+            self.order = newOrder
+        else:
+            raise ValueError("{} is not a valid bond order character".format(newOrder))
+        
+    def getOrderNum(self):
+        """
+        returns the bond order as a number
+        """
+        values = []
+        for value in self.order:
+            if value == 'S':
+                values.append(1)
+            elif value == 'D':
+                values.append(2)
+            elif value == 'T':
+                values.append(3)
+            elif value == 'B':
+                values.append(1.5)
+            else:
+                raise TypeError('Bond order {} is not hardcoded into this method'.format(value))
+        return values
+            
+    def setOrderNum(self, newOrder):
+        """
+        change the bond order with a number
+        """
+        values = []
+        for value in newOrder:
+            if value == 1:
+                values.append('S')
+            elif value == 2:
+                values.append('D')
+            elif value == 3:
+                values.append('T')
+            elif value == 1.5:
+                values.append('B')
+            else:
+                raise TypeError('Bond order {} is not hardcoded into this method'.format(value))
+        self.order = values          
+            
     def isSingle(self):
         """
         Return ``True`` if the bond represents a single bond or ``False`` if

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -512,7 +512,7 @@ class GroupAtom(Vertex):
         num_B_bond = 0
         order = 0
         for _, bond in self.bonds.iteritems():
-            if bond.order == 1.5:
+            if bond.isBenzene():
                 num_B_bond += 1
             else:
                 order += mol.bond_orders[bond.order]

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -694,7 +694,7 @@ class GroupBond(Edge):
             return other.equivalent(self)
         gb = other
         
-        cython.declare(order1=str, order2=str)
+        cython.declare(order1=float, order2=float)
         # Compare two bond groups for equivalence
         # Each atom type in self must have an equivalent in other (and vice versa)
         for order1 in self.order:
@@ -724,7 +724,7 @@ class GroupBond(Edge):
             return other.isSpecificCaseOf(self)
         gb = other
         
-        cython.declare(order1=str, order2=str)
+        cython.declare(order1=float, order2=float)
         # Compare two bond groups for equivalence
         # Each atom type in self must have an equivalent in other
         for order1 in self.order: # all these must match
@@ -1370,7 +1370,7 @@ class Group(Graph):
             while triple < tripleRequired[0]:
                 triple +=1
                 newAtom = GroupAtom(atomType=[atomTypes['C']], radicalElectrons=[0], charge=[], label='', lonePairs=None)
-                newBond = GroupBond(atom1, newAtom, order=[2])
+                newBond = GroupBond(atom1, newAtom, order=[3])
                 implicitAtoms[newAtom] = newBond
 
         for atom, bond in implicitAtoms.iteritems():

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -632,29 +632,32 @@ class GroupBond(Edge):
         """
         Return ``True`` if the bond represents a single bond or ``False`` if
         not. Bonds with any wildcards will return  ``False``.
+        
+        NOTE: we can replace the absolute value relation with math.isclose when
+        we swtich to python 3.5+
         """
-        return self.order[0] == 1 and len(self.order) == 1
+        return abs(self.order[0]-1) <= 1e-9 and len(self.order) == 1
 
     def isDouble(self):
         """
         Return ``True`` if the bond represents a double bond or ``False`` if
         not. Bonds with any wildcards will return  ``False``.
         """
-        return self.order[0] == 2 and len(self.order) == 1
+        return abs(self.order[0]-2) <= 1e-9 and len(self.order) == 1
 
     def isTriple(self):
         """
         Return ``True`` if the bond represents a triple bond or ``False`` if
         not. Bonds with any wildcards will return  ``False``.
         """
-        return self.order[0] == 3 and len(self.order) == 1
+        return abs(self.order[0]-3) <= 1e-9 and len(self.order) == 1
 
     def isBenzene(self):
         """
         Return ``True`` if the bond represents a benzene bond or ``False`` if
         not. Bonds with any wildcards will return  ``False``.
         """
-        return self.order[0] == 1.5 and len(self.order) == 1
+        return abs(self.order[0]-1.5) <= 1e-9 and len(self.order) == 1
 
     def __changeBond(self, order):
         """

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -500,30 +500,6 @@ class GroupAtom(Vertex):
 
         return newAtom
 
-    def getBondOrdersForAtom(self):
-        """
-        This helper function is to help calculate total bond orders for an
-        input atom.
-
-        Some special consideration for the order `B` bond. For atoms having
-        three `B` bonds, the order for each is 4/3.0, while for atoms having other
-        than three `B` bonds, the order for  each is 3/2.0
-        """
-        num_B_bond = 0
-        order = 0
-        for _, bond in self.bonds.iteritems():
-            if bond.isBenzene():
-                num_B_bond += 1
-            else:
-                order += mol.bond_orders[bond.order]
-
-        if num_B_bond == 3:
-            order += num_B_bond * 4/3.0
-        else:
-            order += num_B_bond * 3/2.0
-
-        return order
-
 ################################################################################
 
 class GroupBond(Edge):

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -26,7 +26,7 @@ class TestGroupAtom(unittest.TestCase):
         """
         Test the GroupAtom.applyAction() method for a BREAK_BOND action.
         """
-        action = ['BREAK_BOND', '*1', 'S', '*2']
+        action = ['BREAK_BOND', '*1', 1, '*2']
         for label, atomType in atomTypes.iteritems():
             atom0 = GroupAtom(atomType=[atomType], radicalElectrons=[1], charge=[0], label='*1')
             atom = atom0.copy()
@@ -45,7 +45,7 @@ class TestGroupAtom(unittest.TestCase):
         """
         Test the GroupAtom.applyAction() method for a FORM_BOND action.
         """
-        action = ['FORM_BOND', '*1', 'S', '*2']
+        action = ['FORM_BOND', '*1', 1, '*2']
         for label, atomType in atomTypes.iteritems():
             atom0 = GroupAtom(atomType=[atomType], radicalElectrons=[1], charge=[0], label='*1')
             atom = atom0.copy()
@@ -241,14 +241,14 @@ class TestGroupBond(unittest.TestCase):
         """
         A method called before each unit test in this class.
         """
-        self.bond = GroupBond(None, None, order=['D'])
-        self.orderList = [['S'], ['D'], ['T'], ['B'], ['S','D'], ['D','S'], ['D','T'], ['S','D','T']]
+        self.bond = GroupBond(None, None, order=[2])
+        self.orderList = [[1], [2], [3], [1.5], [1,2], [2,1], [2,3], [1,2,3]]
     
     def testApplyActionBreakBond(self):
         """
         Test the GroupBond.applyAction() method for a BREAK_BOND action.
         """
-        action = ['BREAK_BOND', '*1', 'S', '*2']
+        action = ['BREAK_BOND', '*1', 1, '*2']
         for order0 in self.orderList:
             bond0 = GroupBond(None, None, order=order0)
             bond = bond0.copy()
@@ -262,7 +262,7 @@ class TestGroupBond(unittest.TestCase):
         """
         Test the GroupBond.applyAction() method for a FORM_BOND action.
         """
-        action = ['FORM_BOND', '*1', 'S', '*2']
+        action = ['FORM_BOND', '*1', 1, '*2']
         for order0 in self.orderList:
             bond0 = GroupBond(None, None, order=order0)
             bond = bond0.copy()
@@ -283,7 +283,7 @@ class TestGroupBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue('T' in order0 or 'B' in order0)
+                self.assertTrue(3 in order0 or 1.5 in order0)
                 
     def testApplyActionDecrementBond(self):
         """
@@ -296,7 +296,7 @@ class TestGroupBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue('S' in order0 or 'B' in order0)
+                self.assertTrue(1 in order0 or 1.5 in order0)
             
     def testApplyActionGainRadical(self):
         """
@@ -458,8 +458,8 @@ class TestGroup(unittest.TestCase):
         self.assertTrue(atom3.atomType[0].label == 'R!H')
         self.assertTrue(atom3.radicalElectrons == [0])
 
-        self.assertTrue(bond12.order == ['S','D'])
-        self.assertTrue(bond13.order == ['S'])
+        self.assertTrue(bond12.order == [1,2])
+        self.assertTrue(bond13.isSingle())
 
     def testToAdjacencyList(self):
         """

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -244,6 +244,36 @@ class TestGroupBond(unittest.TestCase):
         self.bond = GroupBond(None, None, order=[2])
         self.orderList = [[1], [2], [3], [1.5], [1,2], [2,1], [2,3], [1,2,3]]
     
+    def testGetOrderStr(self):
+        """
+        test the Bond.getOrderStr() method
+        """
+        bond = GroupBond(None,None,order = [1,2,3,1.5])
+        self.assertEqual(bond.getOrderStr(),['S','D','T','B'])
+        
+    def testSetOrderStr(self):
+        """
+        test the Bond.setOrderStr() method
+        """
+        
+        self.bond.setOrderStr(["B",'T'])
+        self.assertEqual(set(self.bond.order), set([3,1.5]))
+    
+    def testGetOrderNum(self):
+        """
+        test the Bond.getOrderNum() method
+        """
+        self.assertEqual(self.bond.getOrderNum(),[2])
+        
+    def testSetOrderNum(self):
+        """
+        test the Bond.setOrderNum() method
+        """
+        
+        self.bond.setOrderNum([3,1,2])
+        self.assertEqual(self.bond.getOrderStr(),['T','S','D'])
+    
+    
     def testApplyActionBreakBond(self):
         """
         Test the GroupBond.applyAction() method for a BREAK_BOND action.

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -81,11 +81,19 @@ cdef class Atom(Vertex):
     
 cdef class Bond(Edge):
 
-    cdef public str order
+    cdef public float order
 
     cpdef bint equivalent(self, Edge other) except -2
 
     cpdef bint isSpecificCaseOf(self, Edge other) except -2
+
+    cpdef str getOrderStr(self)
+    
+    cpdef setOrderStr(self, str newOrder)
+    
+    cpdef float getOrderNum(self)
+    
+    cpdef setOrderNum(self, float newOrder)
 
     cpdef Edge copy(self)
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -96,6 +96,8 @@ cdef class Bond(Edge):
     cpdef setOrderNum(self, float newOrder)
 
     cpdef Edge copy(self)
+    
+    cpdef bint isOrder(self, float otherOrder)
 
     cpdef bint isSingle(self) except -2
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -413,7 +413,7 @@ class Atom(Vertex):
         num_B_bond = 0
         order = 0
         for _, bond in self.bonds.iteritems():
-            if bond.order == 1.5:
+            if bond.isBenzene():
                 num_B_bond += 1
             else:
                 order += bond.order
@@ -499,13 +499,13 @@ class Bond(Edge):
         """
         returns a string representing the bond order
         """
-        if self.order == 1:
+        if self.isSingle():
             return 'S'
-        elif self.order == 1.5:
+        elif self.isBenzene():
             return 'B'
-        elif self.order == 2:
+        elif self.isDouble():
             return 'D'
-        elif self.order == 3:
+        elif self.isTriple():
             return 'T'
         else:
             raise ValueError("Bond order {} does not have string representation." +  \

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -554,33 +554,44 @@ class Bond(Edge):
         b.order = self.order
         return b
 
+    def isOrder(self, otherOrder):
+        """
+        Return ``True`` if the bond represents a single bond or ``False`` if
+        not. This compares floats that takes into account floating point error
+        
+        NOTE: we can replace the absolute value relation with math.isclose when
+        we swtich to python 3.5+
+        """
+        return abs(self.order - otherOrder) <= 1e-9
+
+        
     def isSingle(self):
         """
         Return ``True`` if the bond represents a single bond or ``False`` if
         not.
         """
-        return self.order == 1
+        return abs(self.order-1) <= 1e-9
 
     def isDouble(self):
         """
         Return ``True`` if the bond represents a double bond or ``False`` if
         not.
         """
-        return self.order == 2
+        return abs(self.order-2) <= 1e-9
 
     def isTriple(self):
         """
         Return ``True`` if the bond represents a triple bond or ``False`` if
         not.
         """
-        return self.order == 3
+        return abs(self.order-3) <= 1e-9
 
     def isBenzene(self):
         """
         Return ``True`` if the bond represents a benzene bond or ``False`` if
         not.
         """
-        return self.order == 1.5
+        return abs(self.order-1.5) <= 1e-9
 
     def incrementOrder(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -59,7 +59,7 @@ import rmgpy.molecule.resonance as resonance
 
 ################################################################################
 
-bond_orders = {'S': 1, 'D': 2, 'T': 3}
+bond_orders = {'S': 1, 'D': 2, 'T': 3, 'B': 1.5}
 
 globals().update({
     'bond_orders': bond_orders,
@@ -413,10 +413,10 @@ class Atom(Vertex):
         num_B_bond = 0
         order = 0
         for _, bond in self.bonds.iteritems():
-            if bond.order == 'B':
+            if bond.order == 1.5:
                 num_B_bond += 1
             else:
-                order += bond_orders[bond.order]
+                order += bond.order
 
         if num_B_bond == 3:
             order += num_B_bond * 4/3.0
@@ -434,20 +434,23 @@ class Bond(Edge):
     =================== =================== ====================================
     Attribute           Type                Description
     =================== =================== ====================================
-    `order`             ``str``             The :ref:`bond type <bond-types>`
+    `order`             ``float``             The :ref:`bond type <bond-types>`
     =================== =================== ====================================
 
     """
 
-    def __init__(self, atom1, atom2, order='S'):
+    def __init__(self, atom1, atom2, order=1):
         Edge.__init__(self, atom1, atom2)
-        self.order = order
+        if isinstance(order, str):
+            self.setOrderStr(order)
+        else:
+            self.order = order
 
     def __str__(self):
         """
         Return a human-readable string representation of the object.
         """
-        return self.order
+        return self.getOrderStr()
 
     def __repr__(self):
         """
@@ -478,10 +481,10 @@ class Bond(Edge):
         cython.declare(bond=Bond, bp=gr.GroupBond)
         if isinstance(other, Bond):
             bond = other
-            return (self.order == bond.order)
+            return (self.getOrderNum() == bond.getOrderNum())
         elif isinstance(other, gr.GroupBond):
             bp = other
-            return (self.order in bp.order)
+            return (self.getOrderNum() in bp.getOrderNum())
 
     def isSpecificCaseOf(self, other):
         """
@@ -492,6 +495,52 @@ class Bond(Edge):
         # There are no generic bond types, so isSpecificCaseOf is the same as equivalent
         return self.equivalent(other)
 
+    def getOrderStr(self):
+        """
+        returns a string representing the bond order
+        """
+        if self.order == 1:
+            return 'S'
+        elif self.order == 1.5:
+            return 'B'
+        elif self.order == 2:
+            return 'D'
+        elif self.order == 3:
+            return 'T'
+        else:
+            raise ValueError("Bond order {} does not have string representation." +  \
+            "".format(self.order))
+        
+    def setOrderStr(self, newOrder):
+        """
+        set the bond order using a valid bond-order character
+        """
+        if newOrder == 'S':
+            self.order = 1
+        elif newOrder == 'D':
+            self.order = 2
+        elif newOrder == 'T':
+            self.order = 3
+        elif newOrder == 'B':
+            self.order = 1.5
+        else:
+            raise TypeError('Bond order {} is not hardcoded into this method'.format(newOrder))
+            
+            
+    def getOrderNum(self):
+        """
+        returns the bond order as a number
+        """
+        
+        return self.order
+            
+    def setOrderNum(self, newOrder):
+        """
+        change the bond order with a number
+        """
+        
+        self.order = newOrder
+        
     def copy(self):
         """
         Generate a deep copy of the current bond. Modifying the
@@ -510,67 +559,60 @@ class Bond(Edge):
         Return ``True`` if the bond represents a single bond or ``False`` if
         not.
         """
-        return self.order == 'S'
+        return self.order == 1
 
     def isDouble(self):
         """
         Return ``True`` if the bond represents a double bond or ``False`` if
         not.
         """
-        return self.order == 'D'
+        return self.order == 2
 
     def isTriple(self):
         """
         Return ``True`` if the bond represents a triple bond or ``False`` if
         not.
         """
-        return self.order == 'T'
+        return self.order == 3
 
     def isBenzene(self):
         """
         Return ``True`` if the bond represents a benzene bond or ``False`` if
         not.
         """
-        return self.order == 'B'
+        return self.order == 1.5
 
     def incrementOrder(self):
         """
         Update the bond as a result of applying a CHANGE_BOND action to
         increase the order by one.
         """
-        if self.order == 'S': self.order = 'D'
-        elif self.order == 'D': self.order = 'T'
+        if self.order <=2: 
+            self.order += 1
         else:
-            raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid bond order "{0}".'.format(self.order))
+            raise gr.ActionError('Unable to increment Bond due to CHANGE_BOND action: '+\
+            'Bond order "{0}" is greater than 2.'.format(self.order))
 
     def decrementOrder(self):
         """
         Update the bond as a result of applying a CHANGE_BOND action to
         decrease the order by one.
         """
-        if self.order == 'D': self.order = 'S'
-        elif self.order == 'T': self.order = 'D'
+        if self.order >=1: 
+            self.order -= 1
         else:
-            raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid bond order "{0}".'.format(self.order))
+            raise gr.ActionError('Unable to decrease Bond due to CHANGE_BOND action: '+\
+            'bond order "{0}" is less than 1.'.format(self.order))
 
     def __changeBond(self, order):
         """
         Update the bond as a result of applying a CHANGE_BOND action,
         where `order` specifies whether the bond is incremented or decremented
-        in bond order, and should be 1 or -1.
+        in bond order, and can be any real number.
         """
-        if order == 1:
-            if self.order == 'S': self.order = 'D'
-            elif self.order == 'D': self.order = 'T'
-            else:
-                raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid bond order "{0}".'.format(self.order))
-        elif order == -1:
-            if self.order == 'D': self.order = 'S'
-            elif self.order == 'T': self.order = 'D'
-            else:
-                raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid bond order "{0}".'.format(self.order))
-        else:
-            raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid order "{0}".'.format(order))
+        self.order += order
+        if self.order < 0 or self.order >3:
+            raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid resulting order "{0}".'.format(self.order))
 
     def applyAction(self, action):
         """
@@ -580,19 +622,20 @@ class Bond(Edge):
         :ref:`here <reaction-recipe-actions>`.
         """
         if action[0].upper() == 'CHANGE_BOND':
-            if action[2] == 1:
-                self.incrementOrder()
-            elif action[2] == -1:
-                self.decrementOrder()
-            elif action[2] == 'B':
-                self.order = 'B'
+            if isinstance(action[2],str):
+                self.setOrderStr(action[2])
             else:
-                raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid order "{0}".'.format(action[2]))
+                try: # try to see if addable
+                   self.__changeBond(action[2])
+                except TypeError:
+                    raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid order "{0}".'.format(action[2]))
         else:
             raise gr.ActionError('Unable to update GroupBond: Invalid action {0}.'.format(action))
+        
 
 #################################################################################
     
+
 class Molecule(Graph):
     """
     A representation of a molecular structure using a graph data type, extending
@@ -925,8 +968,8 @@ class Molecule(Graph):
                 if distanceSquared > criticalDistance or distanceSquared < 0.40:
                     continue
                 else:
-                    # groupBond = GroupBond(atom1, atom2, ['S','D','T','B'])
-                    bond = Bond(atom1, atom2, 'S')
+                    # groupBond = GroupBond(atom1, atom2, [1,2,3,1.5])
+                    bond = Bond(atom1, atom2, 1)
                     self.addBond(bond)
         self.updateAtomTypes()
         
@@ -1276,7 +1319,7 @@ class Molecule(Graph):
     
         for atom1 in atoms:
             for atom2 in atom1.bonds:
-                bond = Bond(mapping[atom1], mapping[atom2], 'S')
+                bond = Bond(mapping[atom1], mapping[atom2], 1)
                 newMol.addBond(bond)
         newMol.updateAtomTypes()
         return newMol
@@ -1568,7 +1611,7 @@ class Molecule(Graph):
         for atom in self.atoms:
             for i in range(atom.radicalElectrons):
                 H = Atom('H', radicalElectrons=0, lonePairs=0, charge=0)
-                bond = Bond(atom, H, 'S')
+                bond = Bond(atom, H, 1)
                 self.addAtom(H)
                 self.addBond(bond)
                 if atom not in added:

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -273,8 +273,47 @@ class TestBond(unittest.TestCase):
         A method called before each unit test in this class.
         """
         self.bond = Bond(atom1=None, atom2=None, order=2)
-        self.orderList = [1,2,3,1.5]
+        self.orderList = [1,2,3,1.5, 0.30000000000000004]
     
+    def testGetOrderStr(self):
+        """
+        test the Bond.getOrderStr() method
+        """
+        
+        self.assertEqual(self.bond.getOrderStr(),'D')
+        
+    def testSetOrderStr(self):
+        """
+        test the Bond.setOrderStr() method
+        """
+        
+        self.bond.setOrderStr("B")
+        self.assertEqual(self.bond.order, 1.5)
+    
+    def testGetOrderNum(self):
+        """
+        test the Bond.getOrderNum() method
+        """
+        self.assertEqual(self.bond.getOrderNum(),2)
+        
+    def testSetOrderNum(self):
+        """
+        test the Bond.setOrderNum() method
+        """
+        
+        self.bond.setOrderNum(3)
+        self.assertEqual(self.bond.getOrderStr(),'T')
+    
+        
+    def testIsOrder(self):
+        """
+        Test the Bond.isOrder() method.
+        """
+        for order in self.orderList:
+            bond = Bond(None, None, order=order)
+            self.assertTrue(bond.isOrder(round(order,2)))
+        
+        
     def testIsSingle(self):
         """
         Test the Bond.isSingle() method.
@@ -286,6 +325,17 @@ class TestBond(unittest.TestCase):
             else:
                 self.assertFalse(bond.isSingle())
     
+    def testIsSingleCanTakeFloatingPointAddition(self):
+        """
+        Test the Bond.isSingle() method with taking floating point addition
+        roundoff errors
+        """
+        new_order = 0.1 + 0.3*3
+        self.assertNotEqual(new_order, 1)
+        
+        self.bond.setOrderNum(new_order)
+        self.assertTrue(self.bond.isSingle())
+        
     def testIsDouble(self):
         """
         Test the Bond.isDouble() method.
@@ -332,7 +382,7 @@ class TestBond(unittest.TestCase):
                 elif order == 2: 
                     self.assertTrue(bond.isTriple())
             except ActionError:
-                self.assertTrue(order in [3,1.5])
+                self.assertTrue(order >= 3)
         
     def testDecrementOrder(self):
         """
@@ -347,7 +397,7 @@ class TestBond(unittest.TestCase):
                 elif order == 3: 
                     self.assertTrue(bond.isDouble())
             except ActionError:
-                self.assertTrue(order in [1,1.5])
+                self.assertTrue(order < 1)
                 
     def testApplyActionBreakBond(self):
         """
@@ -388,7 +438,7 @@ class TestBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue(3 == order0 or 1.5 == order0)
+                self.assertTrue(3 <= order0)
                 
     def testApplyActionDecrementBond(self):
         """
@@ -401,7 +451,7 @@ class TestBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue(1 == order0 or 1.5 == order0)
+                self.assertTrue(order0 < 1)
             
     def testApplyActionGainRadical(self):
         """

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -104,7 +104,7 @@ class TestAtom(unittest.TestCase):
         """
         Test the Atom.applyAction() method for a BREAK_BOND action.
         """
-        action = ['BREAK_BOND', '*1', 'S', '*2']
+        action = ['BREAK_BOND', '*1', 1, '*2']
         for element in elementList:
             atom0 = Atom(element=element, radicalElectrons=1, charge=0, label='*1', lonePairs=0)
             atom = atom0.copy()
@@ -118,7 +118,7 @@ class TestAtom(unittest.TestCase):
         """
         Test the Atom.applyAction() method for a FORM_BOND action.
         """
-        action = ['FORM_BOND', '*1', 'S', '*2']
+        action = ['FORM_BOND', '*1', 1, '*2']
         for element in elementList:
             atom0 = Atom(element=element, radicalElectrons=1, charge=0, label='*1', lonePairs=0)
             atom = atom0.copy()
@@ -248,6 +248,19 @@ class TestAtom(unittest.TestCase):
         self.assertFalse(atom1.equivalent(atom2))
         self.assertTrue(atom1.equivalent(atom3))
 
+    def testGetBondOrdersForAtom(self):
+        """
+        Test Atom.getBondOrdersForAtom for all carbons in naphthalene
+        """
+        
+        m = Molecule().fromSMILES('C12C(C=CC=C1)=CC=CC=2')
+        isomers = m.generateResonanceIsomers()
+        for isomer in isomers:
+            for atom in isomer.atoms:
+                if atom.symbol == 'C':
+                    self.assertEqual(atom.getBondOrdersForAtom(), 4.0)
+
+
 ################################################################################
 
 class TestBond(unittest.TestCase):
@@ -259,8 +272,8 @@ class TestBond(unittest.TestCase):
         """
         A method called before each unit test in this class.
         """
-        self.bond = Bond(atom1=None, atom2=None, order='D')
-        self.orderList = ['S','D','T','B']
+        self.bond = Bond(atom1=None, atom2=None, order=2)
+        self.orderList = [1,2,3,1.5]
     
     def testIsSingle(self):
         """
@@ -268,7 +281,7 @@ class TestBond(unittest.TestCase):
         """
         for order in self.orderList:
             bond = Bond(None, None, order=order)
-            if order == 'S':
+            if order == 1:
                 self.assertTrue(bond.isSingle())
             else:
                 self.assertFalse(bond.isSingle())
@@ -279,7 +292,7 @@ class TestBond(unittest.TestCase):
         """
         for order in self.orderList:
             bond = Bond(None, None, order=order)
-            if order == 'D':
+            if order == 2:
                 self.assertTrue(bond.isDouble())
             else:
                 self.assertFalse(bond.isDouble())
@@ -290,7 +303,7 @@ class TestBond(unittest.TestCase):
         """
         for order in self.orderList:
             bond = Bond(None, None, order=order)
-            if order == 'T':
+            if order == 3:
                 self.assertTrue(bond.isTriple())
             else:
                 self.assertFalse(bond.isTriple())
@@ -301,7 +314,7 @@ class TestBond(unittest.TestCase):
         """
         for order in self.orderList:
             bond = Bond(None, None, order=order)
-            if order == 'B':
+            if order == 1.5:
                 self.assertTrue(bond.isBenzene())
             else:
                 self.assertFalse(bond.isBenzene())
@@ -314,12 +327,12 @@ class TestBond(unittest.TestCase):
             bond = Bond(None, None, order=order)
             try:
                 bond.incrementOrder()
-                if order == 'S': 
+                if order == 1: 
                     self.assertTrue(bond.isDouble())
-                elif order == 'D': 
+                elif order == 2: 
                     self.assertTrue(bond.isTriple())
             except ActionError:
-                self.assertTrue(order in ['T','B'])
+                self.assertTrue(order in [3,1.5])
         
     def testDecrementOrder(self):
         """
@@ -329,18 +342,18 @@ class TestBond(unittest.TestCase):
             bond = Bond(None, None, order=order)
             try:
                 bond.decrementOrder()
-                if order == 'D': 
+                if order == 2: 
                     self.assertTrue(bond.isSingle())
-                elif order == 'T': 
+                elif order == 3: 
                     self.assertTrue(bond.isDouble())
             except ActionError:
-                self.assertTrue(order in ['S','B'])
+                self.assertTrue(order in [1,1.5])
                 
     def testApplyActionBreakBond(self):
         """
         Test the Bond.applyAction() method for a BREAK_BOND action.
         """
-        action = ['BREAK_BOND', '*1', 'S', '*2']
+        action = ['BREAK_BOND', '*1', 1, '*2']
         for order0 in self.orderList:
             bond0 = Bond(None, None, order=order0)
             bond = bond0.copy()
@@ -354,7 +367,7 @@ class TestBond(unittest.TestCase):
         """
         Test the Bond.applyAction() method for a FORM_BOND action.
         """
-        action = ['FORM_BOND', '*1', 'S', '*2']
+        action = ['FORM_BOND', '*1', 1, '*2']
         for order0 in self.orderList:
             bond0 = Bond(None, None, order=order0)
             bond = bond0.copy()
@@ -375,7 +388,7 @@ class TestBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue('T' == order0 or 'B' == order0)
+                self.assertTrue(3 == order0 or 1.5 == order0)
                 
     def testApplyActionDecrementBond(self):
         """
@@ -388,7 +401,7 @@ class TestBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue('S' == order0 or 'B' == order0)
+                self.assertTrue(1 == order0 or 1.5 == order0)
             
     def testApplyActionGainRadical(self):
         """

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -311,7 +311,7 @@ def fromRDKitMol(mol, rdkitmol):
                    charge=cython.int,
                    lonePairs=cython.int,
                    number=cython.int,
-                   order=cython.str,
+                   order=cython.float,
                    atom=Atom,
                    atom1=Atom,
                    atom2=Atom,
@@ -343,14 +343,14 @@ def fromRDKitMol(mol, rdkitmol):
             rdkitatom2 = rdkitmol.GetAtomWithIdx(j + 1)
             rdkitbond = rdkitmol.GetBondBetweenAtoms(i, j)
             if rdkitbond is not None:
-                order = ''
+                order = 0
     
                 # Process bond type
                 rdbondtype = rdkitbond.GetBondType()
-                if rdbondtype.name == 'SINGLE': order = 'S'
-                elif rdbondtype.name == 'DOUBLE': order = 'D'
-                elif rdbondtype.name == 'TRIPLE': order = 'T'
-                elif rdbondtype.name == 'AROMATIC': order = 'B'
+                if rdbondtype.name == 'SINGLE': order = 1
+                elif rdbondtype.name == 'DOUBLE': order = 2
+                elif rdbondtype.name == 'TRIPLE': order = 3
+                elif rdbondtype.name == 'AROMATIC': order = 1.5
     
                 bond = Bond(mol.vertices[i], mol.vertices[j], order)
                 mol.addBond(bond)
@@ -399,15 +399,12 @@ def fromOBMol(mol, obmol):
     
     # iterate through bonds in obmol
     for obbond in openbabel.OBMolBondIter(obmol):
-        order = 0
         # Process bond type
         oborder = obbond.GetBondOrder()
-        if oborder == 1: order = 'S'
-        elif oborder == 2: order = 'D'
-        elif oborder == 3: order = 'T'
-        elif obbond.IsAromatic() : order = 'B'
+        if oborder not in [1,2,3] and obbond.IsAromatic() : 
+            oborder = 1.5
 
-        bond = Bond(mol.vertices[obbond.GetBeginAtomIdx() - 1], mol.vertices[obbond.GetEndAtomIdx() - 1], order)#python array indices start at 0
+        bond = Bond(mol.vertices[obbond.GetBeginAtomIdx() - 1], mol.vertices[obbond.GetEndAtomIdx() - 1], oborder)#python array indices start at 0
         mol.addBond(bond)
 
     

--- a/rmgpy/molecule/parserTest.py
+++ b/rmgpy/molecule/parserTest.py
@@ -19,7 +19,7 @@ class ParserTest(unittest.TestCase):
         """
         Test that toRDKitMol returns correct indices and atom mappings.
         """
-        bondOrderDict = {'SINGLE':'S','DOUBLE':'D','TRIPLE':'T','AROMATIC':'B'}
+        bondOrderDict = {'SINGLE':1,'DOUBLE':2,'TRIPLE':3,'AROMATIC':1.5}
         mol = fromSMILES(Molecule(), 'C1CCC=C1C=O')
         rdkitmol, rdAtomIndices = mol.toRDKitMol(removeHs=False, returnMapping=True, sanitize=True)
         for atom in mol.atoms:

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -303,7 +303,7 @@ def generateAromaticResonanceIsomers(mol):
                 aromatic = True
                 # Only change bonds if there are all 6 are aromatic.  Otherwise don't do anything
                 for bond in aromaticBonds:
-                    bond.order = 'B'
+                    bond.order = 1.5
 
     if aromatic:
         try:
@@ -417,9 +417,9 @@ def generateClarStructures(mol):
         # Apply results to molecule - double bond locations first
         for index, bond in enumerate(bonds):
             if x[index] == 0:
-                bond.order = 'S'
+                bond.order = 1 # single
             elif x[index] == 1:
-                bond.order = 'D'
+                bond.order = 2 # double
             else:
                 raise ValueError('Unaccepted bond value {0} obtained from optimization.'.format(x[index]))
 
@@ -485,7 +485,7 @@ def clarOptimization(mol, constraints=None, maxNum=None):
     exo = []
     for bond in bonds:
         if bond.atom1 not in atoms or bond.atom2 not in atoms:
-            if bond.order == 'D':
+            if bond.isDouble():
                 exo.append(1)
             else:
                 exo.append(0)
@@ -588,7 +588,7 @@ def clarTransformation(mol, aromaticRing):
                 bondList.append(mol.getBond(atom1, atom2))
 
     for bond in bondList:
-        bond.order = 'B'
+        bond.order = 1.5
 
 
 class ILPSolutionError(Exception):

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -342,7 +342,7 @@ class ClarTest(unittest.TestCase):
             # Count pi electrons in molecule
             pi = 0
             for bond in bonds:
-                if bond.order == 'D':
+                if bond.isDouble():
                     pi += 2
 
             # Count pi electrons in solution


### PR DESCRIPTION
This pull request refactors RMG's Bond and GroupBond classes to represent bond order with a float instead of a string. This allows more flexibility with regards to representing bonds and reduces hard-coding of 'S', 'D', 'T', 'B' cases. In addition, I added methods to allow for back conversion if necessary.

This also modified methods that utilizes the order of molecule objects. The reading and writing of adjacency lists still involves string characters, so most of the database is intact and usable. The recipe actions of FORM_BOND, BREAK_BOND, and CHANGE_BOND now involve numbers instead of strings, so an [RMG-database pull request](https://github.com/ReactionMechanismGenerator/RMG-database/pull/156) involves the change of reaction recipes for each reaction family to address this problem. The code will not work without the RMG-database branch `bond_doubles` (which is in the pull request). 

This addresses issue #859 . 