### PR TITLE
A more deterministic way of bicyclic decompostion

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -418,8 +418,8 @@ def bicyclicDecompositionForPolyring(polyring):
     """
 
     submol, _ = convertRingToSubMolecule(polyring)
-    SSSR = submol.getSmallestSetOfSmallestRings()
-    
+    SSSR = submol.getDeterministicSmallestSetOfSmallestRings()
+
     ringPairWithCommonAtomsList = []
     ringOccurancesDict = {}
     

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -207,3 +207,5 @@ cdef class Molecule(Graph):
     cpdef list generateResonanceIsomers(self)
 
     cpdef list getAromaticSSSR(Molecule mol)
+
+    cpdef list getDeterministicSmallestSetOfSmallestRings(self)

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1698,6 +1698,98 @@ multiplicity 2
         sssr5_sizes_expected = [6, 6, 6]
         self.assertEqual(sssr5_sizes, sssr5_sizes_expected)
     
+    def testGetDeterministicSmallestSetOfSmallestRingsCase1(self):
+        """
+        Test fused tricyclic can be decomposed into single rings more 
+        deterministically
+        """
+        smiles = 'C1C2C3C=CCCC2C13'
+
+        previous_num_shared_atoms_list = None
+        # repeat 100 time to test non-deterministic behavior
+        for _ in range(100):
+            mol =  Molecule().fromSMILES(smiles)
+            sssr_det = mol.getDeterministicSmallestSetOfSmallestRings()
+
+            
+            num_shared_atoms_list = []
+            for i, ring_i in enumerate(sssr_det):
+                for j in range(i+1, len(sssr_det)):
+                    ring_j = sssr_det[j]
+                    num_shared_atoms = len(set(ring_i).intersection(ring_j))
+
+                    num_shared_atoms_list.append(num_shared_atoms)
+
+            num_shared_atoms_list = sorted(num_shared_atoms_list)
+            
+            if previous_num_shared_atoms_list is None:
+                previous_num_shared_atoms_list = num_shared_atoms_list
+                continue
+            self.assertEqual(num_shared_atoms_list, previous_num_shared_atoms_list)
+            previous_num_shared_atoms_list = num_shared_atoms_list
+
+    def testGetDeterministicSmallestSetOfSmallestRingsCase2(self):
+        """
+        Test if two possible smallest rings can join the smallest set
+        the method can pick one of them deterministically using sum of 
+        atomic numbers along the rings.
+        In this test case and with currect method setup, ring (CCSCCCCC)
+        will be picked rather than ring(CCCOCC).
+        """
+
+        smiles = 'C1=CC2C3CSC(CO3)C2C1'
+
+        previous_atom_symbols_list = None
+        # repeat 100 time to test non-deterministic behavior
+        for _ in range(100):
+            mol =  Molecule().fromSMILES(smiles)
+            sssr_det = mol.getDeterministicSmallestSetOfSmallestRings()
+
+            atom_symbols_list = []
+            for ring in sssr_det:
+                atom_symbols = sorted([a.element.symbol for a in ring])
+                atom_symbols_list.append(atom_symbols)
+
+            atom_symbols_list = sorted(atom_symbols_list)
+
+            if previous_atom_symbols_list is None:
+                previous_atom_symbols_list = atom_symbols_list
+                continue
+            self.assertEqual(atom_symbols_list, previous_atom_symbols_list)
+            previous_atom_symbols_list = atom_symbols_list
+
+    @work_in_progress
+    def testGetDeterministicSmallestSetOfSmallestRingsCase3(self):
+        """
+        Test if two possible smallest rings can join the smallest set
+        the method can pick one of them deterministically when their
+        sum of atomic numbers along the rings are also equal to each other.
+        
+        To break the tie, one option we have is to consider adding contributions
+        from other parts of the molecule, such as atomic number weighted connectivity
+        value and differentiate bond orders when calculating connectivity values.
+        """
+        smiles = 'C=1CC2C3CSC(O[Si]3)C2C1'
+
+        previous_atom_symbols_list = None
+        # repeat 100 time to test non-deterministic behavior
+        for _ in range(100):
+            mol =  Molecule().fromSMILES(smiles)
+            sssr_det = mol.getDeterministicSmallestSetOfSmallestRings()
+
+            atom_symbols_list = []
+            for ring in sssr_det:
+                atom_symbols = sorted([a.element.symbol for a in ring])
+                atom_symbols_list.append(atom_symbols)
+
+            atom_symbols_list = sorted(atom_symbols_list)
+
+            if previous_atom_symbols_list is None:
+                previous_atom_symbols_list = atom_symbols_list
+                continue
+            self.assertEqual(atom_symbols_list, previous_atom_symbols_list)
+            previous_atom_symbols_list = atom_symbols_list
+
     def testToGroup(self):
         """
         Test if we can convert a Molecule object into a Group object.


### PR DESCRIPTION
Previous bicyclic decomposition works well on most large polycyclics. But the algorithm gets confused by some interesting examples listed below.

![image](https://cloud.githubusercontent.com/assets/2739496/21956801/aa6e47d6-da56-11e6-95a5-394ba51ff138.png)
![image](https://cloud.githubusercontent.com/assets/2739496/21956807/b47e0266-da56-11e6-90eb-db3b740ecf8c.png)

In the first example, will the 5-member ring go with the 6-member ring containing O or go with 6-member ring containing S? 
In the second example, will the 4-member ring sharing 2 atoms with the 7-member ring get picked or the one sharing 3 atoms with the 7-member ring?

The previous algorithm cannot deal with these two well and give bicyclic decomposition results non-deterministically.

This root problem with this is that the method of `getSSSR` has non-deterministic behaviors, which is also mentioned by the authors of [this method](http://pubs.acs.org/doi/abs/10.1021/ci00015a002). Simply put, if the algorithm finds two candidate rings, both of them have same and smallest sizes, the algorithm will choose one of them non-deterministically.

So what this patch does is to provide more sorting keys to break ties, which makes smallest ring set more deterministically. So far two sorting keys are deployed in this patch: sum of atomic number of the atoms along the rings, original connectivity value.

This patch won't affect other parts where getSSSR is used since a new method called `getDeterministicSSSR` is created and only used by `bicyclicDecomposition`.