### PR TITLE
Change product template duplicate testing from isIsomorphic to isIden…

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -851,7 +851,7 @@ class KineticsFamily(Database):
             for i, struct in enumerate(productStructure):
                 for s in productStructureList[i]:
                     try:
-                        if s.isIsomorphic(struct): break
+                        if s.isIdentical(struct): break
                     except KeyError:
                         print struct.toAdjacencyList()
                         print s.toAdjacencyList()


### PR DESCRIPTION
…tical

Previously we used isIsomorphic to delete duplicate product templates, when we really should be using isIdentical which does not respect wildcards. This make it so that we could potentially lose product templates like R u1 if C u1 was added first.

This push may make RMG find many more reverse reactions for family's that are not their own reverse.