### PR TITLE
Enable RMG to produce benzene through propargyl radical recombination

### DIFF
--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -677,7 +677,13 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
     elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'DFT_G03_b3lyp','B3LYP/6-311+G(3df,2p)']:
         bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
             'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44, 
-            'C#N': 0.22, 'C-S': -2.35, 'S=O': -5.19, 'S-H': -0.52, }    
+            'C#N': 0.22, 'C-S': -2.35, 'S=O': -5.19, 'S-H': -0.52, }
+    # BAC corrections for Klip_3 method (RQCISD(T)/cc-PV(infinity)(Q)Z) from Table 2 in Goldsmith, C. F.; Magoon, G. R.; Green, W. H.,
+    # Database of Small Molecule Thermochemistry for Combustion. J. Phys. Chem. A 2012, 116, 9033-9057.
+    # http://dx.doi.org/10.1021/jp303819e
+    elif modelChemistry == 'Klip_3':
+        bondEnergies = {'C-H': -0.03, 'C-C': -0.36, 'C=C': -0.96, 'C#C': -1.41,
+                        'O-H': 0.21, 'C-O': 0.09, 'C=O': 0.11, 'O-O': -0.58,}
     else:
         
         logging.warning('No bond energy correction found for model chemistry: {0}'.format(modelChemistry))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1128,12 +1128,19 @@ class KineticsFamily(Database):
                     for i in range(4,highest+1):
                         atomLabels['*{0:d}'.format(i)].label = '*{0:d}'.format(4+highest-i)
                         
-            elif label == 'H_shift_cyclopentadiene':
+            elif label == 'Intra_ene_reaction':
                 # Labels for nodes are swapped
                 atomLabels['*1'].label = '*2'
                 atomLabels['*2'].label = '*1'
                 atomLabels['*3'].label = '*5'
                 atomLabels['*5'].label = '*3'
+
+            elif label == '6_membered_central_C-C_shift':
+                # Labels for nodes are swapped
+                atomLabels['*1'].label = '*3'
+                atomLabels['*3'].label = '*1'
+                atomLabels['*4'].label = '*6'
+                atomLabels['*6'].label = '*4'
 
         if not forward: template = self.reverseTemplate
         else:           template = self.forwardTemplate

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -141,7 +141,7 @@ class GroupAtom(Vertex):
         Return a deep copy of the :class:`GroupAtom` object. Modifying the
         attributes of the copy will not affect the original.
         """
-        return GroupAtom(self.atomType[:], self.radicalElectrons[:], self.charge[:], self.label)
+        return GroupAtom(self.atomType[:], self.radicalElectrons[:], self.charge[:], self.label, self.lonePairs[:])
 
     def __changeBond(self, order):
         """

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -236,11 +236,11 @@ class GroupAtom(Vertex):
 
         #Add a lone pair to a group atom with none
         if not self.lonePairs:
-            self.lonePairs.append(pair)
+            self.lonePairs = [1,2,3,4] #set to a wildcard of any number greater than 0
         #Add a lone pair to a group atom that already has at least one lone pair
         else:
-            for lonePairs in zip(self.lonePairs):
-                lonePairs.append(lonePairs + pair)
+            for x in self.lonePairs:
+                lonePairs.append(x + pair)
             # Set the new lone electron pair count
             self.lonePairs = lonePairs
         
@@ -252,12 +252,16 @@ class GroupAtom(Vertex):
         lonePairs = []
         if any([len(atomType.decrementLonePair) == 0 for atomType in self.atomType]):
             raise ActionError('Unable to update GroupAtom due to LOSE_PAIR action: Unknown atom type produced from set "{0}".'.format(self.atomType))
-        for lonePairs in zip(self.lonePairs):
-            if lonePairs - pair < 0:
-                raise ActionError('Unable to update GroupAtom due to LOSE_PAIR action: Invalid lone electron pairs set "{0}".'.format(self.lonePairs))
-            lonePairs.append(lonePairs - pair)
-        # Set the new lone electron pair count
-        self.lonePairs = lonePairs
+
+        if not self.lonePairs:
+            self.lonePairs = [0,1,2,3] #set to a wildcard of any number fewer than 4
+        else:
+            for x in self.lonePairs:
+                if x - pair < 0:
+                    raise ActionError('Unable to update GroupAtom due to LOSE_PAIR action: Invalid lone electron pairs set "{0}".'.format(self.lonePairs))
+                lonePairs.append(x - pair)
+            # Set the new lone electron pair count
+            self.lonePairs = lonePairs
 
     def applyAction(self, action):
         """

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -233,10 +233,16 @@ class GroupAtom(Vertex):
         lonePairs = []
         if any([len(atomType.incrementLonePair) == 0 for atomType in self.atomType]):
             raise ActionError('Unable to update GroupAtom due to GAIN_PAIR action: Unknown atom type produced from set "{0}".'.format(self.atomType))
-        for lonePairs in zip(self.lonePairs):
-            lonePairs.append(lonePairs + pair)
-        # Set the new lone electron pair count
-        self.lonePairs = lonePairs
+
+        #Add a lone pair to a group atom with none
+        if not self.lonePairs:
+            self.lonePairs.append(pair)
+        #Add a lone pair to a group atom that already has at least one lone pair
+        else:
+            for lonePairs in zip(self.lonePairs):
+                lonePairs.append(lonePairs + pair)
+            # Set the new lone electron pair count
+            self.lonePairs = lonePairs
         
     def __losePair(self, pair):
         """


### PR DESCRIPTION
Companion PR to RMG-database PR 161. The following changes in RMG-Py are necessary in order for RMG to form benzene from propargyl radical recombination:

1. Because many of the new reaction families use the GAIN_PAIR and LOSE_PAIR actions, in order for them to work the recently discovered bug in these actions needs to be fixed. Therefore, this PR builds on #868.

2. The 2 new reaction families that are their own reverse are hardcoded in rmgpy/data/kinetics/family.py, where the switching of atom labels in reversing the reaction direction are defined.

Also, added the Bond Additivity Corrections (BAC's) of Goldsmith et al. to Cantherm for the following quantum method (Goldsmith, C. F.; Magoon, G. R.; Green, W. H., Database of Small Molecule Thermochemistry for Combustion. J. Phys. Chem. A 2012, 116, 9033-9057.):

RQCISD(T)/cc-PV(infinity)(Q)Z

This method is simply called "Klip_3" in Cantherm currently.