### PR TITLE
New criterion

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -225,12 +225,14 @@ def solvation(solvent):
         raise InputError("solvent should be a string like 'water'")
     rmg.solvent = solvent
 
-def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=numpy.inf, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
+def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=numpy.inf, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
     by default this criterion is turned off
     Other parameters are optional and control the pruning.
+    ignoreOverallFluxCriterion=True will cause the toleranceMoveToCore to be only applied
+    to the pressure dependent network expansion and not movement of species from edge to core
     """
     if toleranceMoveToCore is None:
         raise InputError("You must provide a toleranceMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
@@ -246,6 +248,7 @@ def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,tolera
     rmg.minCoreSizeForPrune = minCoreSizeForPrune
     rmg.minSpeciesExistIterationsForPrune = minSpeciesExistIterationsForPrune
     rmg.filterReactions = filterReactions
+    rmg.ignoreOverallFluxCriterion=ignoreOverallFluxCriterion
 
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -224,7 +224,7 @@ def solvation(solvent):
         raise InputError("solvent should be a string like 'water'")
     rmg.solvent = solvent
 
-def model(toleranceMoveToCore=None, toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
+def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=None,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=1.0, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. Other parameters are optional and control the pruning.
     """
@@ -232,9 +232,15 @@ def model(toleranceMoveToCore=None, toleranceKeepInEdge=0.0, toleranceInterruptS
         raise InputError("You must provide a toleranceMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
     if toleranceMoveToCore > toleranceInterruptSimulation:
         raise InputError("toleranceMoveToCore must be less than or equal to toleranceInterruptSimulation, which is currently {0}".format(toleranceInterruptSimulation))
-
+    if toleranceMoveReactionToCore is None:
+        raise InputError("You must provide a toleranceInternalMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
+    if toleranceMoveReactionToCore > toleranceReactionInterruptSimulation:
+        raise InputError("toleranceInternalMoveToCore must be less than or equal to toleranceInterruptSimulation, which is currently {0}".format(toleranceInterruptSimulation))
+    
     rmg.fluxToleranceKeepInEdge = toleranceKeepInEdge
     rmg.fluxToleranceMoveToCore = toleranceMoveToCore
+    rmg.reactionToleranceMoveToCore = toleranceMoveReactionToCore
+    rmg.reactionToleranceInterrupt = toleranceReactionInterruptSimulation
     rmg.fluxToleranceInterrupt = toleranceInterruptSimulation
     rmg.maximumEdgeSpecies = maximumEdgeSpecies
     rmg.minCoreSizeForPrune = minCoreSizeForPrune

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -31,6 +31,7 @@
 import logging
 import quantities
 import os
+import numpy
 
 from rmgpy import settings
 
@@ -224,18 +225,17 @@ def solvation(solvent):
         raise InputError("solvent should be a string like 'water'")
     rmg.solvent = solvent
 
-def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=None,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=1.0, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
+def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=numpy.inf, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
     """
-    How to generate the model. `toleranceMoveToCore` must be specified. Other parameters are optional and control the pruning.
+    How to generate the model. `toleranceMoveToCore` must be specified. 
+    toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
+    by default this criterion is turned off
+    Other parameters are optional and control the pruning.
     """
     if toleranceMoveToCore is None:
         raise InputError("You must provide a toleranceMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
     if toleranceMoveToCore > toleranceInterruptSimulation:
         raise InputError("toleranceMoveToCore must be less than or equal to toleranceInterruptSimulation, which is currently {0}".format(toleranceInterruptSimulation))
-    if toleranceMoveReactionToCore is None:
-        raise InputError("You must provide a toleranceInternalMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
-    if toleranceMoveReactionToCore > toleranceReactionInterruptSimulation:
-        raise InputError("toleranceInternalMoveToCore must be less than or equal to toleranceInterruptSimulation, which is currently {0}".format(toleranceInterruptSimulation))
     
     rmg.fluxToleranceKeepInEdge = toleranceKeepInEdge
     rmg.fluxToleranceMoveToCore = toleranceMoveToCore

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -55,6 +55,7 @@ from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.kinetics.diffusionLimited import diffusionLimiter
 
 from model import Species, CoreEdgeReactionModel
+from rmgpy.reaction import Reaction
 from pdep import PDepNetwork
 import rmgpy.util as util
 
@@ -606,7 +607,10 @@ class RMG(util.Subject):
                     elif isinstance(obj, Species):
                         objectsToEnlarge.append(obj)
                     elif isinstance(obj,Reaction):
-                        objectsToEnlarge.extend(filter(lambda x: not (x in coreSpecies), Reaction.reactants+Reaction.products))
+                        potentialSpcs = obj.reactants+obj.products
+                        filterFcn = lambda x: not (x in self.reactionModel.core.species)
+                        neededSpcs = filter(filterFcn,potentialSpcs)
+                        objectsToEnlarge.extend(neededSpcs)
                     self.done = False
     
     

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -167,6 +167,7 @@ class RMG(util.Subject):
         self.fluxToleranceInterrupt = 1.0
         self.reactionToleranceMoveToCore = numpy.inf
         self.reactionToleranceInterrupt = numpy.inf
+        self.ignoreOverallFluxCriterion=False
         
         self.absoluteTolerance = 1.0e-8
         self.relativeTolerance = 1.0e-4
@@ -589,6 +590,7 @@ class RMG(util.Subject):
                     toleranceInterruptSimulation = self.fluxToleranceInterrupt if prune else self.fluxToleranceMoveToCore,
                     toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt if prune else self.reactionToleranceMoveToCore,
                     pdepNetworks = self.reactionModel.networkList,
+                    ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
                     absoluteTolerance = self.absoluteTolerance,
                     relativeTolerance = self.relativeTolerance,
                     filterReactions=False,
@@ -610,8 +612,11 @@ class RMG(util.Subject):
                         assert len(objectsToEnlarge)>0
                     elif isinstance(obj,Reaction):
                         potentialSpcs = obj.reactants+obj.products
-                        filterFcn = lambda x: not (x in self.reactionModel.core.species)
+                        filterFcn = lambda x: not ((x in self.reactionModel.core.species)) #remove species already in core
                         neededSpcs = filter(filterFcn,potentialSpcs)
+                        for i in range(len(neededSpcs)): #remove duplicate species
+                            if neededSpcs.index(neededSpcs[i]) != i:
+                                del neededSpcs[i]
                         objectsToEnlarge.extend(neededSpcs)
                     self.done = False
     
@@ -656,6 +661,7 @@ class RMG(util.Subject):
                                 toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
                                 toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt,
                                 pdepNetworks = self.reactionModel.networkList,
+                                ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
                                 absoluteTolerance = self.absoluteTolerance,
                                 relativeTolerance = self.relativeTolerance,
                                 filterReactions=True,
@@ -709,8 +715,11 @@ class RMG(util.Subject):
                     edgeReactions = self.reactionModel.edge.reactions,
                     toleranceKeepInEdge = self.fluxToleranceKeepInEdge,
                     toleranceMoveToCore = self.fluxToleranceMoveToCore,
-                    toleranceInterruptSimulation = self.fluxToleranceInterrupt,
+                    toleranceReactionMoveToCore = self.reactionToleranceMoveToCore,
+                    toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
+                    toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt,
                     pdepNetworks = self.reactionModel.networkList,
+                    ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
                     absoluteTolerance = self.absoluteTolerance,
                     relativeTolerance = self.relativeTolerance,
                     sensitivity = True,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -164,6 +164,9 @@ class RMG(util.Subject):
         self.fluxToleranceKeepInEdge = 0.0
         self.fluxToleranceMoveToCore = 1.0
         self.fluxToleranceInterrupt = 1.0
+        self.reactionToleranceMoveToCore = numpy.inf
+        self.reactionToleranceInterrupt = numpy.inf
+        
         self.absoluteTolerance = 1.0e-8
         self.relativeTolerance = 1.0e-4
         self.sensitivityAbsoluteTolerance = 1.0e-6
@@ -581,7 +584,9 @@ class RMG(util.Subject):
                     edgeReactions = self.reactionModel.edge.reactions,
                     toleranceKeepInEdge = self.fluxToleranceKeepInEdge if prune else 0,
                     toleranceMoveToCore = self.fluxToleranceMoveToCore,
+                    toleranceReactionMoveToCore = self.reactionToleranceMoveToCore,
                     toleranceInterruptSimulation = self.fluxToleranceInterrupt if prune else self.fluxToleranceMoveToCore,
+                    toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt if prune else self.reactionToleranceMoveToCore,
                     pdepNetworks = self.reactionModel.networkList,
                     absoluteTolerance = self.absoluteTolerance,
                     relativeTolerance = self.relativeTolerance,
@@ -598,7 +603,10 @@ class RMG(util.Subject):
                         # We do this here because we need a temperature and pressure
                         # Store the maximum leak species along with the associated network
                         obj = (obj, obj.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si))
-                    objectsToEnlarge.append(obj)
+                    elif isinstance(obj, Species):
+                        objectsToEnlarge.append(obj)
+                    elif isinstance(obj,Reaction):
+                        objectsToEnlarge.extend(filter(lambda x: not (x in coreSpecies), Reaction.reactants+Reaction.products))
                     self.done = False
     
     
@@ -638,7 +646,9 @@ class RMG(util.Subject):
                                 edgeReactions = [],
                                 toleranceKeepInEdge = 0,
                                 toleranceMoveToCore = self.fluxToleranceMoveToCore,
+                                toleranceReactionMoveToCore = self.reactionToleranceMoveToCore,
                                 toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
+                                toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt,
                                 pdepNetworks = self.reactionModel.networkList,
                                 absoluteTolerance = self.absoluteTolerance,
                                 relativeTolerance = self.relativeTolerance,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -604,8 +604,10 @@ class RMG(util.Subject):
                         # We do this here because we need a temperature and pressure
                         # Store the maximum leak species along with the associated network
                         obj = (obj, obj.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si))
+                        objectsToEnlarge.append(obj)
                     elif isinstance(obj, Species):
                         objectsToEnlarge.append(obj)
+                        assert len(objectsToEnlarge)>0
                     elif isinstance(obj,Reaction):
                         potentialSpcs = obj.reactants+obj.products
                         filterFcn = lambda x: not (x in self.reactionModel.core.species)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -108,7 +108,7 @@ cdef class ReactionSystem(DASx):
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
         double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,double toleranceReactionMoveToCore=?,double toleranceReactionInterruptSimulation=?,
-        list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
+        list pdepNetworks=?,ignoreOverallFluxCriterion=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
         sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
         filterReactions=?)
 

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -107,7 +107,7 @@ cdef class ReactionSystem(DASx):
         list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?, filterReactions=?)
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
+        double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,double toleranceReactionMoveToCore=?,double toleranceReactionInterruptSimulation=?,
         list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
         sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
         filterReactions=?)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -108,10 +108,10 @@ cdef class ReactionSystem(DASx):
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
         double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
-        list pdepNetworks=None, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
-        sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
-        filterReactions=False)
+        list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
+        sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
+        filterReactions=?)
 
-    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum object network, double networkRate):
+    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum, object network, double networkRate)
      
     cpdef logConversions(self, speciesIndex, y0)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -112,6 +112,6 @@ cdef class ReactionSystem(DASx):
         sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
         filterReactions=False)
 
-    cpdef logRates(self, double charRate, object species, double speciesRate, object network, double networkRate)
-
+    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum object network, double networkRate):
+     
     cpdef logConversions(self, speciesIndex, y0)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -69,7 +69,8 @@ cdef class ReactionSystem(DASx):
     # The reaction and species rates at the current time (in mol/m^3*s)
     cdef public numpy.ndarray coreSpeciesRates
     cdef public numpy.ndarray coreReactionRates
-
+    cdef public numpy.ndarray coreSpeciesProductionRates
+    cdef public numpy.ndarray coreSpeciesConsumptionRates
     cdef public numpy.ndarray edgeSpeciesRates
     cdef public numpy.ndarray edgeReactionRates
 
@@ -106,9 +107,10 @@ cdef class ReactionSystem(DASx):
         list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?, filterReactions=?)
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,
-        list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, sensitivityAbsoluteTolerance=?, 
-        sensitivityRelativeTolerance=?, sensWorksheet=?, filterReactions=?)
+        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
+        list pdepNetworks=None, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
+        sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
+        filterReactions=False)
 
     cpdef logRates(self, double charRate, object species, double speciesRate, object network, double networkRate)
 

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -73,7 +73,7 @@ cdef class ReactionSystem(DASx):
         self.numEdgeSpecies = -1
         self.numEdgeReactions = -1
         self.numPdepNetworks = -1
-
+        
         """
         The number of differential equations that will 
         be solved simulatenously by the solver.
@@ -128,7 +128,8 @@ cdef class ReactionSystem(DASx):
         # The reaction and species rates at the current time (in mol/m^3*s)
         self.coreSpeciesRates = None
         self.coreReactionRates = None
-
+        self.coreSpeciesProductionRates = None
+        self.coreSpeciesConsumptionRates = None
         self.edgeSpeciesRates = None
         self.edgeReactionRates = None
 
@@ -200,6 +201,8 @@ cdef class ReactionSystem(DASx):
         self.generate_reactant_product_indices(coreReactions, edgeReactions)
 
         self.coreSpeciesConcentrations = numpy.zeros((self.numCoreSpecies), numpy.float64)
+        self.coreSpeciesProductionRates = numpy.zeros((self.numCoreSpecies), numpy.float64)
+        self.coreSpeciesConsumptionRates = numpy.zeros((self.numCoreSpecies), numpy.float64)
         self.coreReactionRates = numpy.zeros((self.numCoreReactions), numpy.float64)
         self.edgeReactionRates = numpy.zeros((self.numEdgeReactions), numpy.float64)
         self.coreSpeciesRates = numpy.zeros((self.numCoreSpecies), numpy.float64)
@@ -344,7 +347,7 @@ cdef class ReactionSystem(DASx):
 
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,
+        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
         list pdepNetworks=None, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
         sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
         filterReactions=False):
@@ -361,18 +364,20 @@ cdef class ReactionSystem(DASx):
 
         cdef dict speciesIndex
         cdef list row
-        cdef int index, maxSpeciesIndex, maxNetworkIndex
+        cdef int index, spcIndex, maxSpeciesIndex, maxNetworkIndex
         cdef int numCoreSpecies, numEdgeSpecies, numPdepNetworks, numCoreReactions
         cdef double stepTime, charRate, maxSpeciesRate, maxNetworkRate
         cdef numpy.ndarray[numpy.float64_t, ndim=1] y0 #: Vector containing the number of moles of each species
-        cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesRates, edgeSpeciesRates, networkLeakRates
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesRates, edgeSpeciesRates, networkLeakRates, coreSpeciesProductionRates, coreSpeciesConsumptionRates, totalDivAccumNums
         cdef numpy.ndarray[numpy.float64_t, ndim=1] maxCoreSpeciesRates, maxEdgeSpeciesRates, maxNetworkLeakRates,maxEdgeSpeciesRateRatios, maxNetworkLeakRateRatios
         cdef bint terminated
-        cdef object maxSpecies, maxNetwork
+        cdef object maxSpecies, maxNetwork, 
         cdef int i, j, k
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
         cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
         
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] edgeReactionRates
+        cdef double reactionRate, production, consumption
         # cython declations for sensitivity analysis
         cdef numpy.ndarray[numpy.int_t, ndim=1] sensSpeciesIndices
         cdef numpy.ndarray[numpy.float64_t, ndim=1] moleSens, dVdk, normSens
@@ -458,8 +463,11 @@ cdef class ReactionSystem(DASx):
 
             # Get the characteristic flux
             charRate = sqrt(numpy.sum(self.coreSpeciesRates * self.coreSpeciesRates))
-
+            
             coreSpeciesRates = numpy.abs(self.coreSpeciesRates)
+            edgeReactionRates = self.edgeReactionRates
+            coreSpeciesConsumptionRates = self.coreSpeciesConsumptionRates
+            coreSpeciesProductionRates = self.coreSpeciesProductionRates
             edgeSpeciesRates = numpy.abs(self.edgeSpeciesRates)
             networkLeakRates = numpy.abs(self.networkLeakRates)
             edgeSpeciesRateRatios = numpy.abs(self.edgeSpeciesRates/charRate)
@@ -481,7 +489,31 @@ cdef class ReactionSystem(DASx):
             for index in xrange(numPdepNetworks):
                 if maxNetworkLeakRateRatios[index] < networkLeakRateRatios[index]:
                     maxNetworkLeakRateRatios[index] = networkLeakRateRatios[index]
-
+            
+            #get abs(delta(Ln(total accumulation numbers))) (accumulation number=Production/Consumption)
+            #(the natural log operation is avoided until after the maximum accumulation number is found)
+            totalDivAccumNums = numpy.ones((numEdgeReactions,))
+            for index in xrange(numEdgeReactions):
+                reactionRate = edgeReactionRates[index]
+                for spcIndex in self.reactantIndicies[index+numCoreReactions,:]:
+                    if spcIndex != -1:
+                        consumption = coreSpeciesConsumptionRates[spcIndex]
+                        totalDivAccumNums[index] *= (reactionRate+consumption)/consumption
+                for spcIndex in self.productIndicies[index+numCoreReactions,:]:
+                    if spcIndex != -1:
+                        production = coreSpeciesProductionRates[spcIndex]
+                        totalDivAccumNums[index] *= (reactionRate+production)/production 
+            
+            #Get edge reaction with greatest total difference in Ln(accumulation number)
+            if numEdgeSpecies > 0:
+                maxAccumReactionIndex = numpy.argmax(totalDivAccumNums)
+                maxAccumReaction = edgeReactions[maxReactionIndex]
+                maxDifLnAccumNum = numpy.log(totalDivAccumNums[maxAccumReactionIndex])
+            else:
+                maxAccumReactionIndex = -1
+                maxAccumReaction = None
+                maxAccumReactionRate = 0.0
+                
             # Get the edge species with the highest flux
             if numEdgeSpecies > 0:
                 maxSpeciesIndex = numpy.argmax(edgeSpeciesRates)
@@ -514,29 +546,41 @@ cdef class ReactionSystem(DASx):
                         if not bimolecularThreshold[i,j]:
                             if coreSpeciesConcentrations[i]*coreSpeciesConcentrations[j] > bimolecularThresholdVal:
                                 bimolecularThreshold[i,j] = True
-
+                                                    
             # Interrupt simulation if that flux exceeds the characteristic rate times a tolerance
             if maxSpeciesRate > toleranceMoveToCore * charRate and not invalidObject:
                 logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for moving to model core'.format(self.t, maxSpecies))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxNetwork, maxNetworkRate)
+                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                 self.logConversions(speciesIndex, y0)
                 invalidObject = maxSpecies
             if maxSpeciesRate > toleranceInterruptSimulation * charRate:
                 logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for simulation interruption'.format(self.t, maxSpecies))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxNetwork, maxNetworkRate)
+                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                 self.logConversions(speciesIndex, y0)
                 break
-
+            
+            #Interrupt simulation if the difference in natural log of total accumulation number exceeds tolerance
+            if maxDifLnAccumNum > toleranceReactionMoveToCore and not invalidObject:
+                logging.info('At time {0:10.4e} s, Reaction {1} exceeded the minimum difference in total log(accumulation number) for moving to model core'.format(self.t, maxAccumReaction))
+                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
+                self.logConversions(speciesIndex, y0)
+                invalidObject = maxAccumReaction
+            if maxDifLnAccumNum > toleranceReactionInterruptSimulation:
+                logging.info('At time {0:10.4e} s, Reaction {1} exceeded the minimum difference in total log(accumulation number) for simulation interruption'.format(self.t, maxAccumReaction))
+                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
+                self.logConversions(speciesIndex, y0)
+                break
+            
             # If pressure dependence, also check the network leak fluxes
             if pdepNetworks:
                 if maxNetworkRate > toleranceMoveToCore * charRate and not invalidObject:
                     logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} exceeded the minimum rate for exploring'.format(self.t, maxNetwork.index))
-                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxNetwork, maxNetworkRate)
+                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                     self.logConversions(speciesIndex, y0)
                     invalidObject = maxNetwork
                 if maxNetworkRate > toleranceInterruptSimulation * charRate:
                     logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} exceeded the minimum rate for simulation interruption'.format(self.t, maxNetwork.index))
-                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxNetwork, maxNetworkRate)
+                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                     self.logConversions(speciesIndex, y0)
                     break
 
@@ -598,11 +642,12 @@ cdef class ReactionSystem(DASx):
         # (if the simulation was valid)
         return terminated, invalidObject
 
-    cpdef logRates(self, double charRate, object species, double speciesRate, object network, double networkRate):
+    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum object network, double networkRate):
         """
         Log information about the current maximum species and network rates.
         """
         logging.info('    Characteristic rate: {0:10.4e} mol/m^3*s'.format(charRate))
+        logging.info('    Max(Dif(Ln(accumulation number))):  {0:10.4e}'.format(maxDifLnAccumNum))
         if charRate == 0.0:
             logging.info('    {0} rate: {1:10.4e} mol/m^3*s'.format(species, speciesRate))
             if network is not None:
@@ -611,7 +656,7 @@ cdef class ReactionSystem(DASx):
             logging.info('    {0} rate: {1:10.4e} mol/m^3*s ({2:.4g})'.format(species, speciesRate, speciesRate / charRate))
             if network is not None:
                 logging.info('    PDepNetwork #{0:d} leak rate: {1:10.4e} mol/m^3*s ({2:.4g})'.format(network.index, networkRate, networkRate / charRate))
-
+                
     cpdef logConversions(self, speciesIndex, y0):
         """
         Log information about the current conversion values.

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -364,9 +364,9 @@ cdef class ReactionSystem(DASx):
 
         cdef dict speciesIndex
         cdef list row
-        cdef int index, spcIndex, maxSpeciesIndex, maxNetworkIndex
+        cdef int index, spcIndex, maxSpeciesIndex, maxNetworkIndex, infAccumNumIndex
         cdef int numCoreSpecies, numEdgeSpecies, numPdepNetworks, numCoreReactions
-        cdef double stepTime, charRate, maxSpeciesRate, maxNetworkRate
+        cdef double stepTime, charRate, maxSpeciesRate, maxNetworkRate, maxEdgeReactionAccum
         cdef numpy.ndarray[numpy.float64_t, ndim=1] y0 #: Vector containing the number of moles of each species
         cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesRates, edgeSpeciesRates, networkLeakRates, coreSpeciesProductionRates, coreSpeciesConsumptionRates, totalDivAccumNums
         cdef numpy.ndarray[numpy.float64_t, ndim=1] maxCoreSpeciesRates, maxEdgeSpeciesRates, maxNetworkLeakRates,maxEdgeSpeciesRateRatios, maxNetworkLeakRateRatios
@@ -375,7 +375,7 @@ cdef class ReactionSystem(DASx):
         cdef int i, j, k
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
         cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
-        
+        cdef bool zeroProduction, zeroConsumption
         cdef numpy.ndarray[numpy.float64_t, ndim=1] edgeReactionRates
         cdef double reactionRate, production, consumption
         # cython declations for sensitivity analysis
@@ -383,6 +383,8 @@ cdef class ReactionSystem(DASx):
         cdef numpy.ndarray[numpy.float64_t, ndim=1] moleSens, dVdk, normSens
         cdef list time_array, normSens_array 
         
+        zeroProduction = False
+        zeroConsumption = False
         pdepNetworks = pdepNetworks or []
 
         numCoreSpecies = len(coreSpecies)
@@ -472,7 +474,8 @@ cdef class ReactionSystem(DASx):
             networkLeakRates = numpy.abs(self.networkLeakRates)
             edgeSpeciesRateRatios = numpy.abs(self.edgeSpeciesRates/charRate)
             networkLeakRateRatios = numpy.abs(self.networkLeakRates/charRate)
-
+            numEdgeReactions = self.numEdgeReactions
+            
             # Update the maximum species rate and maximum network leak rate arrays
             for index in xrange(numCoreSpecies):
                 if maxCoreSpeciesRates[index] < coreSpeciesRates[index]:
@@ -492,23 +495,60 @@ cdef class ReactionSystem(DASx):
             
             #get abs(delta(Ln(total accumulation numbers))) (accumulation number=Production/Consumption)
             #(the natural log operation is avoided until after the maximum accumulation number is found)
-            totalDivAccumNums = numpy.ones((numEdgeReactions,))
+            totalDivAccumNums = numpy.ones(numEdgeReactions)
             for index in xrange(numEdgeReactions):
                 reactionRate = edgeReactionRates[index]
-                for spcIndex in self.reactantIndicies[index+numCoreReactions,:]:
-                    if spcIndex != -1:
+                for spcIndex in self.reactantIndices[index+numCoreReactions,:]:
+                    if spcIndex != -1 and spcIndex<numCoreSpecies:
                         consumption = coreSpeciesConsumptionRates[spcIndex]
-                        totalDivAccumNums[index] *= (reactionRate+consumption)/consumption
-                for spcIndex in self.productIndicies[index+numCoreReactions,:]:
-                    if spcIndex != -1:
+                        if consumption != 0:
+                            totalDivAccumNums[index] *= (reactionRate+consumption)/consumption
+                        elif self.coreSpeciesConcentrations[spcIndex] == 0: 
+                            totalDivAccumNums[index] *= 1.0 #if the species concentration is zero ignore
+                        else:
+                            zeroConsumption = True #otherwise include edge reaction with most flux
+                            infAccumNumIndex = spcIndex
+                            break
+                if infAccumNum:
+                    break
+                for spcIndex in self.productIndices[index+numCoreReactions,:]:
+                    if spcIndex != -1 and spcIndex<numCoreSpecies:
                         production = coreSpeciesProductionRates[spcIndex]
-                        totalDivAccumNums[index] *= (reactionRate+production)/production 
-            
+                        if production != 0:
+                            totalDivAccumNums[index] *= (reactionRate+production)/production
+                        elif self.coreSpeciesConcentrations[spcIndex] == 0: 
+                            totalDivAccumNums[index] *= 1.0 #if the species concentration is zero ignore
+                        else:
+                            zeroProduction = True #otherwise include edge reaction with most flux
+                            infAccumNumIndex = spcIndex
+                            break
             #Get edge reaction with greatest total difference in Ln(accumulation number)
             if numEdgeSpecies > 0:
-                maxAccumReactionIndex = numpy.argmax(totalDivAccumNums)
-                maxAccumReaction = edgeReactions[maxReactionIndex]
-                maxDifLnAccumNum = numpy.log(totalDivAccumNums[maxAccumReactionIndex])
+                maxDifLnAccumNum = numpy.inf
+                if zeroConsumption:
+                    for index in xrange(numEdgeReactions):
+                        maxEdgeReactionAccum = 0.0
+                        maxAccumReactionIndex = -1
+                        if infAccumNumIndex in self.reactantIndices[index+numCoreReactions]:
+                            reactionRate = edgeReactionRates[index]
+                            if reactionRate > maxEdgeReactionAccum:
+                                maxEdgeReactionAccum = reactionRate
+                                maxAccumReactionIndex = index
+                    maxAccumReaction = edgeReactions[maxAccumReactionIndex]
+                elif zeroProduction:
+                    for index in xrange(numEdgeReactions):
+                        maxEdgeReactionAccum = 0.0
+                        maxAccumReactionIndex = -1
+                        if infAccumNumIndex in self.productIndices[index+numCoreReactions]:
+                            reactionRate = edgeReactionRates[index]
+                            if reactionRate > maxEdgeReactionAccum:
+                                maxEdgeReactionAccum = reactionRate
+                                maxAccumReactionIndex = index
+                    maxAccumReaction = edgeReactions[maxAccumReactionIndex]
+                else:
+                    maxAccumReactionIndex = numpy.argmax(totalDivAccumNums)
+                    maxAccumReaction = edgeReactions[maxAccumReactionIndex]
+                    maxDifLnAccumNum = numpy.log(totalDivAccumNums[maxAccumReactionIndex])
             else:
                 maxAccumReactionIndex = -1
                 maxAccumReaction = None

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -48,7 +48,7 @@ import cython
 import logging
 import csv
 import itertools
-
+from cpython cimport bool
 from rmgpy.quantity import Quantity
 from rmgpy.chemkin import getSpeciesIdentifier
 
@@ -347,7 +347,7 @@ cdef class ReactionSystem(DASx):
 
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
+        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,double toleranceReactionMoveToCore=numpy.inf, double toleranceReactionInterruptSimulation=numpy.inf,
         list pdepNetworks=None, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
         sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
         filterReactions=False):
@@ -509,7 +509,7 @@ cdef class ReactionSystem(DASx):
                             zeroConsumption = True #otherwise include edge reaction with most flux
                             infAccumNumIndex = spcIndex
                             break
-                if infAccumNum:
+                if zeroConsumption:
                     break
                 for spcIndex in self.productIndices[index+numCoreReactions,:]:
                     if spcIndex != -1 and spcIndex<numCoreSpecies:
@@ -522,8 +522,10 @@ cdef class ReactionSystem(DASx):
                             zeroProduction = True #otherwise include edge reaction with most flux
                             infAccumNumIndex = spcIndex
                             break
+                if zeroProduction:
+                    break
             #Get edge reaction with greatest total difference in Ln(accumulation number)
-            if numEdgeSpecies > 0:
+            if len(totalDivAccumNums) > 0:
                 maxDifLnAccumNum = numpy.inf
                 if zeroConsumption:
                     for index in xrange(numEdgeReactions):
@@ -545,14 +547,14 @@ cdef class ReactionSystem(DASx):
                                 maxEdgeReactionAccum = reactionRate
                                 maxAccumReactionIndex = index
                     maxAccumReaction = edgeReactions[maxAccumReactionIndex]
-                else:
+                elif len(totalDivAccumNums)>0:
                     maxAccumReactionIndex = numpy.argmax(totalDivAccumNums)
                     maxAccumReaction = edgeReactions[maxAccumReactionIndex]
                     maxDifLnAccumNum = numpy.log(totalDivAccumNums[maxAccumReactionIndex])
             else:
                 maxAccumReactionIndex = -1
                 maxAccumReaction = None
-                maxAccumReactionRate = 0.0
+                maxDifLnAccumNum = 0.0
                 
             # Get the edge species with the highest flux
             if numEdgeSpecies > 0:

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -642,7 +642,7 @@ cdef class ReactionSystem(DASx):
         # (if the simulation was valid)
         return terminated, invalidObject
 
-    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum object network, double networkRate):
+    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum, object network, double networkRate):
         """
         Log information about the current maximum species and network rates.
         """

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -348,7 +348,7 @@ cdef class ReactionSystem(DASx):
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
         double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,double toleranceReactionMoveToCore=numpy.inf, double toleranceReactionInterruptSimulation=numpy.inf,
-        list pdepNetworks=None, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
+        list pdepNetworks=None, ignoreOverallFluxCriterion=False, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
         sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
         filterReactions=False):
         """
@@ -590,12 +590,12 @@ cdef class ReactionSystem(DASx):
                                 bimolecularThreshold[i,j] = True
                                                     
             # Interrupt simulation if that flux exceeds the characteristic rate times a tolerance
-            if maxSpeciesRate > toleranceMoveToCore * charRate and not invalidObject:
+            if (not ignoreOverallFluxCriterion) and (maxSpeciesRate > toleranceMoveToCore * charRate and not invalidObject):
                 logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for moving to model core'.format(self.t, maxSpecies))
                 self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                 self.logConversions(speciesIndex, y0)
                 invalidObject = maxSpecies
-            if maxSpeciesRate > toleranceInterruptSimulation * charRate:
+            if (not ignoreOverallFluxCriterion) and (maxSpeciesRate > toleranceInterruptSimulation * charRate):
                 logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for simulation interruption'.format(self.t, maxSpecies))
                 self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                 self.logConversions(speciesIndex, y0)

--- a/rmgpy/solver/liquid.pyx
+++ b/rmgpy/solver/liquid.pyx
@@ -212,24 +212,26 @@ cdef class LiquidReactor(ReactionSystem):
         for j in xrange(ir.shape[0]):
             k = kf[j]
             if ir[j,0] >= numCoreSpecies or ir[j,1] >= numCoreSpecies or ir[j,2] >= numCoreSpecies:
-                reactionRate = 0.0
+                fReactionRate = 0.0
             elif ir[j,1] == -1: # only one reactant
-                reactionRate = k * C[ir[j,0]]
+                fReactionRate = k * C[ir[j,0]]
             elif ir[j,2] == -1: # only two reactants
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]]
             else: # three reactants!! (really?)
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
             k = kr[j]
             if ip[j,0] >= numCoreSpecies or ip[j,1] >= numCoreSpecies or ip[j,2] >= numCoreSpecies:
                 pass
             elif ip[j,1] == -1: # only one reactant
-                reactionRate -= k * C[ip[j,0]]
+                revReactionRate = k * C[ip[j,0]]
             elif ip[j,2] == -1: # only two reactants
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]]
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]]
             else: # three reactants!! (really?)
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
-
-           # Set the reaction and species rates
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
+                
+            reactionRate = fReactionRate-revReactionRate
+            
+            # Set the reaction and species rates
             if j < numCoreReactions:
                 # The reaction is a core reaction
                 coreReactionRates[j] = reactionRate
@@ -239,26 +241,32 @@ cdef class LiquidReactor(ReactionSystem):
                 # and products are core species
                 first = ir[j,0]
                 coreSpeciesRates[first] -= reactionRate
-                coreSpeciesConsumptionRates[first] += reactionRate
+                coreSpeciesConsumptionRates[first] += fReactionRate
+                coreSpeciesProductionRates[first] += revReactionRate
                 second = ir[j,1]
                 if second != -1:
                     coreSpeciesRates[second] -= reactionRate
-                    coreSpeciesConsumptionRates[second] += reactionRate
+                    coreSpeciesConsumptionRates[second] += fReactionRate
+                    coreSpeciesProductionRates[second] += revReactionRate
                     third = ir[j,2]
                     if third != -1:
                         coreSpeciesRates[third] -= reactionRate
-                        coreSpeciesConsumptionRates[third] += reactionRate
+                        coreSpeciesConsumptionRates[third] += fReactionRate
+                        coreSpeciesProductionRates[third] += revReactionRate
                 first = ip[j,0]
                 coreSpeciesRates[first] += reactionRate
-                coreSpeciesProductionRates[first] += reactionRate
+                coreSpeciesProductionRates[first] += fReactionRate
+                coreSpeciesConsumptionRates[first] += revReactionRate
                 second = ip[j,1]
                 if second != -1:
                     coreSpeciesRates[second] += reactionRate
-                    coreSpeciesProductionRates[second] += reactionRate
+                    coreSpeciesProductionRates[second] += fReactionRate
+                    coreSpeciesConsumptionRates[second] += revReactionRate
                     third = ip[j,2]
                     if third != -1:
                         coreSpeciesRates[third] += reactionRate
-                        coreSpeciesProductionRates[third] += reactionRate
+                        coreSpeciesProductionRates[third] += fReactionRate
+                        coreSpeciesConsumptionRates[third] += revReactionRate
 
             else:
                 # The reaction is an edge reaction

--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -241,7 +241,7 @@ cdef class SimpleReactor(ReactionSystem):
         cdef numpy.ndarray[numpy.float64_t, ndim=1] res, kf, kr, knet, delta, equilibriumConstants
         cdef int numCoreSpecies, numCoreReactions, numEdgeSpecies, numEdgeReactions, numPdepNetworks
         cdef int i, j, z, first, second, third
-        cdef double k, V, reactionRate, T, P, Peff
+        cdef double k, V, reactionRate, revReactionRate, T, P, Peff
         cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesConcentrations, coreSpeciesRates, coreReactionRates, edgeSpeciesRates, edgeReactionRates, networkLeakRates, coreSpeciesConsumptionRates, coreSpeciesProductionRates
         cdef numpy.ndarray[numpy.float64_t, ndim=1] C, y_coreSpecies
         cdef numpy.ndarray[numpy.float64_t, ndim=2] jacobian, dgdk, colliderEfficiencies
@@ -304,23 +304,25 @@ cdef class SimpleReactor(ReactionSystem):
         for j in xrange(ir.shape[0]):
             k = kf[j]
             if ir[j,0] >= numCoreSpecies or ir[j,1] >= numCoreSpecies or ir[j,2] >= numCoreSpecies:
-                reactionRate = 0.0
+                fReactionRate = 0.0
             elif ir[j,1] == -1: # only one reactant
-                reactionRate = k * C[ir[j,0]]
+                fReactionRate = k * C[ir[j,0]]
             elif ir[j,2] == -1: # only two reactants
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]]
             else: # three reactants!! (really?)
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
             k = kr[j]
             if ip[j,0] >= numCoreSpecies or ip[j,1] >= numCoreSpecies or ip[j,2] >= numCoreSpecies:
                 pass
             elif ip[j,1] == -1: # only one reactant
-                reactionRate -= k * C[ip[j,0]]
+                revReactionRate = k * C[ip[j,0]]
             elif ip[j,2] == -1: # only two reactants
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]]
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]]
             else: # three reactants!! (really?)
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
-
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
+                
+            reactionRate = fReactionRate-revReactionRate
+            
             # Set the reaction and species rates
             if j < numCoreReactions:
                 # The reaction is a core reaction
@@ -331,26 +333,32 @@ cdef class SimpleReactor(ReactionSystem):
                 # and products are core species
                 first = ir[j,0]
                 coreSpeciesRates[first] -= reactionRate
-                coreSpeciesConsumptionRates[first] += reactionRate
+                coreSpeciesConsumptionRates[first] += fReactionRate
+                coreSpeciesProductionRates[first] += revReactionRate
                 second = ir[j,1]
                 if second != -1:
                     coreSpeciesRates[second] -= reactionRate
-                    coreSpeciesConsumptionRates[second] += reactionRate
+                    coreSpeciesConsumptionRates[second] += fReactionRate
+                    coreSpeciesProductionRates[second] += revReactionRate
                     third = ir[j,2]
                     if third != -1:
                         coreSpeciesRates[third] -= reactionRate
-                        coreSpeciesConsumptionRates[third] += reactionRate
+                        coreSpeciesConsumptionRates[third] += fReactionRate
+                        coreSpeciesProductionRates[third] += revReactionRate
                 first = ip[j,0]
                 coreSpeciesRates[first] += reactionRate
-                coreSpeciesProductionRates[first] += reactionRate
+                coreSpeciesProductionRates[first] += fReactionRate
+                coreSpeciesConsumptionRates[first] += revReactionRate
                 second = ip[j,1]
                 if second != -1:
                     coreSpeciesRates[second] += reactionRate
-                    coreSpeciesProductionRates[second] += reactionRate
+                    coreSpeciesProductionRates[second] += fReactionRate
+                    coreSpeciesConsumptionRates[second] += revReactionRate
                     third = ip[j,2]
                     if third != -1:
                         coreSpeciesRates[third] += reactionRate
-                        coreSpeciesProductionRates[third] += reactionRate
+                        coreSpeciesProductionRates[third] += fReactionRate
+                        coreSpeciesConsumptionRates[third] += revReactionRate
 
             else:
                 # The reaction is an edge reaction


### PR DESCRIPTION
This creates a new optional reaction mechanism generation criterion that works alongside the original flux criterion but considers how the edge affects the core rather than how the core affects the edge. The new criterion moves edge reactions (the species in a given reaction) to the core when their estimated effect on the steady state concentration of the involved core species is greater than a given tolerance. 