### PR TITLE
fix restart file generation

### DIFF
--- a/documentation/source/users/rmg/running.rst
+++ b/documentation/source/users/rmg/running.rst
@@ -3,10 +3,20 @@
 *************
 Running a Job
 *************
- 
-Submitting a job is easy ::
+
+Running RMG job is easy and under different situations you might want add additional flag as the following examples.
+
+Basic run::
 
 	python rmg.py input.py
+
+Run with a restart file (restart file should be located in same folder as input.py)::
+
+    python rmg.py input.py -r
+
+Run with CPU profiling::
+
+    python rmg.py input.py -p
 
 We recommend you make a job-specific directory for each RMG simulation. Some jobs can take quite a while to complete, so we also recommend using a job scheduler (if working in an linux environment). 
 

--- a/rmgpy/restart.py
+++ b/rmgpy/restart.py
@@ -37,14 +37,14 @@ import time
 def save(rmg):
     # Save the restart file if desired
     if rmg.saveRestartPeriod or rmg.done:
-        saveRestartFile( os.path.join(rmg.outputDirectory,'restart.pkl'),
-                              rmg.reactionModel,
+        saveRestartFile( os.path.join(rmg.outputDirectory, 'restart.pkl'),
+                              rmg,
                               delay=0 if rmg.done else rmg.saveRestartPeriod.value_si
                             )
 
         
         
-def saveRestartFile(path, reactionModel, delay=0):
+def saveRestartFile(path, rmg, delay=0):
     """
     Save a restart file to `path` on disk containing the contents of the
     provided `reactionModel`. The `delay` parameter is a time in seconds; if
@@ -61,8 +61,18 @@ def saveRestartFile(path, reactionModel, delay=0):
     # Pickle the reaction model to the specified file
     # We also compress the restart file to save space (and lower the disk read/write time)
     logging.info('Saving restart file...')
+
+    from rmgpy.rmg.main import RMG
+    rmg_restart = RMG()
+    rmg_restart.reactionModel = rmg.reactionModel
+    rmg_restart.unimolecularReact = rmg.unimolecularReact
+    rmg_restart.bimolecularReact = rmg.bimolecularReact
+    if rmg.filterReactions:
+        rmg_restart.unimolecularThreshold = rmg.unimolecularThreshold
+        rmg_restart.bimolecularThreshold = rmg.bimolecularThreshold
+    
     f = open(path, 'wb')
-    cPickle.dump(reactionModel, f, cPickle.HIGHEST_PROTOCOL)
+    cPickle.dump(rmg_restart, f, cPickle.HIGHEST_PROTOCOL)
     f.close()
 
 class RestartWriter(object):

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -896,12 +896,20 @@ class RMG(util.Subject):
         """
     
         import cPickle
+        from rmgpy.rmg.model import getFamilyLibraryObject
     
         # Unpickle the reaction model from the specified restart file
         logging.info('Loading previous restart file...')
         f = open(path, 'rb')
-        self.reactionModel = cPickle.load(f)
+        rmg_restart = cPickle.load(f)
         f.close()
+
+        self.reactionModel = rmg_restart.reactionModel
+        self.unimolecularReact = rmg_restart.unimolecularReact
+        self.bimolecularReact = rmg_restart.bimolecularReact
+        if self.filterReactions:
+            self.unimolecularThreshold = rmg_restart.unimolecularThreshold
+            self.bimolecularThreshold = rmg_restart.bimolecularThreshold
     
         # A few things still point to the species in the input file, so update
         # those to point to the equivalent species loaded from the restart file

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -924,42 +924,43 @@ class RMG(util.Subject):
         # The reactions and reactionDict still point to the old reaction families
         reactionDict = {}
         oldFamilies = self.reactionModel.reactionDict.keys()
-        for family0 in self.reactionModel.reactionDict:
+        for family0_label in self.reactionModel.reactionDict:
     
             # Find the equivalent library or family in the newly-loaded kinetics database
-            family = None
-            if isinstance(family0, KineticsLibrary):
+            family_label = None
+            family0_obj = getFamilyLibraryObject(family0_label)
+            if isinstance(family0_obj, KineticsLibrary):
                 for label, database in self.database.kinetics.libraries.iteritems():
-                    if database.label == family0.label:
-                        family = database
+                    if database.label == family0_label:
+                        family_label = database.label
                         break
-            elif isinstance(family0, KineticsFamily):
+            elif isinstance(family0_obj, KineticsFamily):
                 for label, database in self.database.kinetics.families.iteritems():
-                    if database.label == family0.label:
-                        family = database
+                    if database.label == family0_label:
+                        family_label = database.label
                         break    
             else:
                 import pdb; pdb.set_trace()
-            if family is None:
-                raise Exception("Unable to find matching reaction family for %s" % family0.label)
+            if family_label is None:
+                raise Exception("Unable to find matching reaction family for %s" % family0_label)
     
             # Update each affected reaction to point to that new family
             # Also use that new family in a duplicate reactionDict
-            reactionDict[family] = {}
-            for reactant1 in self.reactionModel.reactionDict[family0]:
-                reactionDict[family][reactant1] = {}
-                for reactant2 in self.reactionModel.reactionDict[family0][reactant1]:
-                    reactionDict[family][reactant1][reactant2] = []
-                    if isinstance(family0, KineticsLibrary):
-                        for rxn in self.reactionModel.reactionDict[family0][reactant1][reactant2]:
+            reactionDict[family_label] = {}
+            for reactant1 in self.reactionModel.reactionDict[family0_label]:
+                reactionDict[family_label][reactant1] = {}
+                for reactant2 in self.reactionModel.reactionDict[family0_label][reactant1]:
+                    reactionDict[family_label][reactant1][reactant2] = []
+                    if isinstance(family0_obj, KineticsLibrary):
+                        for rxn in self.reactionModel.reactionDict[family0_label][reactant1][reactant2]:
                             assert isinstance(rxn, LibraryReaction)
-                            rxn.library = family.label
-                            reactionDict[family][reactant1][reactant2].append(rxn)
-                    elif isinstance(family0, KineticsFamily):
-                        for rxn in self.reactionModel.reactionDict[family0][reactant1][reactant2]:
+                            rxn.library = family_label
+                            reactionDict[family_label][reactant1][reactant2].append(rxn)
+                    elif isinstance(family0_obj, KineticsFamily):
+                        for rxn in self.reactionModel.reactionDict[family0_label][reactant1][reactant2]:
                             assert isinstance(rxn, TemplateReaction)
-                            rxn.family = family.label
-                            reactionDict[family][reactant1][reactant2].append(rxn)
+                            rxn.family_label = family_label
+                            reactionDict[family_label][reactant1][reactant2].append(rxn)
         
         self.reactionModel.reactionDict = reactionDict
         

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -652,7 +652,7 @@ class CoreEdgeReactionModel:
                         if not isForward:
                             reaction.template = reaction.reverse.template
                         # We're done with the "reverse" attribute, so delete it to save a bit of memory
-                        delattr(reaction,'reverse')
+                        reaction.reverse = None
                     
         # For new reactions, convert ArrheniusEP to Arrhenius, and fix barrier heights.
         # self.newReactionList only contains *actually* new reactions, all in the forward direction.


### PR DESCRIPTION
This PR fixes the issue of restart file generation failure caused by `reaction.reverse` being deleted #822 . The patch 

- replaces `delattr(reaction, 'reverse')` with `reaction.reverse = None`

- adds a unit test for restart file generation

- adds restart documentation to address issue #877 