### PR TITLE
Restart code refactor and parsing test

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -409,7 +409,7 @@ class RMG(util.Subject):
 
         # Initialize reaction model
         if restart:
-            self.loadRestartFile(os.path.join(self.outputDirectory,'restart.pkl'))
+            self.initializeRestartRun(os.path.join(self.outputDirectory,'restart.pkl'))
         else:
     
             # Seed mechanisms: add species and reactions from seed mechanism
@@ -889,28 +889,13 @@ class RMG(util.Subject):
                 logging.log(level, databaseCondaPackage)
                 logging.log(level,'')
 
-    
-    def loadRestartFile(self, path):
-        """
-        Load a restart file at `path` on disk.
-        """
-    
-        import cPickle
-        from rmgpy.rmg.model import getFamilyLibraryObject
-    
-        # Unpickle the reaction model from the specified restart file
-        logging.info('Loading previous restart file...')
-        f = open(path, 'rb')
-        rmg_restart = cPickle.load(f)
-        f.close()
+    def initializeRestartRun(self, path):
 
-        self.reactionModel = rmg_restart.reactionModel
-        self.unimolecularReact = rmg_restart.unimolecularReact
-        self.bimolecularReact = rmg_restart.bimolecularReact
-        if self.filterReactions:
-            self.unimolecularThreshold = rmg_restart.unimolecularThreshold
-            self.bimolecularThreshold = rmg_restart.bimolecularThreshold
-    
+        from rmgpy.rmg.model import getFamilyLibraryObject
+
+        # read restart file
+        self.loadRestartFile(path)
+
         # A few things still point to the species in the input file, so update
         # those to point to the equivalent species loaded from the restart file
     
@@ -971,6 +956,25 @@ class RMG(util.Subject):
                             reactionDict[family_label][reactant1][reactant2].append(rxn)
         
         self.reactionModel.reactionDict = reactionDict
+    
+    def loadRestartFile(self, path):
+        """
+        Load a restart file at `path` on disk.
+        """
+        import cPickle
+    
+        # Unpickle the reaction model from the specified restart file
+        logging.info('Loading previous restart file...')
+        f = open(path, 'rb')
+        rmg_restart = cPickle.load(f)
+        f.close()
+
+        self.reactionModel = rmg_restart.reactionModel
+        self.unimolecularReact = rmg_restart.unimolecularReact
+        self.bimolecularReact = rmg_restart.bimolecularReact
+        if self.filterReactions:
+            self.unimolecularThreshold = rmg_restart.unimolecularThreshold
+            self.bimolecularThreshold = rmg_restart.bimolecularThreshold
         
     def loadRMGJavaInput(self, path):
         """

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -170,6 +170,27 @@ class TestRMGWorkFlow(unittest.TestCase):
         restart_path = os.path.join(restart_folder, 'restart.pkl')
         saveRestartFile(restart_path, self.rmg)
 
+        # load the generated restart file
+        rmg_load = RMG()
+        rmg_load.loadRestartFile(restart_path)
+
+        core_species_num_orig = len(self.rmg.reactionModel.core.species)
+        core_rxn_num_orig = len(self.rmg.reactionModel.core.reactions)
+        core_species_num_load = len(rmg_load.reactionModel.core.species)
+        core_rxn_num_load = len(rmg_load.reactionModel.core.reactions)
+
+        edge_species_num_orig = len(self.rmg.reactionModel.edge.species)
+        edge_rxn_num_orig = len(self.rmg.reactionModel.edge.reactions)
+        edge_species_num_load = len(rmg_load.reactionModel.edge.species)
+        edge_rxn_num_load = len(rmg_load.reactionModel.edge.reactions)
+
+        self.assertEqual(core_species_num_orig, core_species_num_load)
+        self.assertEqual(core_rxn_num_orig, core_rxn_num_load)
+
+        self.assertEqual(edge_species_num_orig, edge_species_num_load)
+        self.assertEqual(edge_rxn_num_orig, edge_rxn_num_load)
+
+
 def findTargetRxnsContaining(mol1, mol2, reactions):
     target_rxns = []
     for rxn in reactions:


### PR DESCRIPTION
This PR address the follow-up request from #878 that parsing the generated restart file needs to be tested. So it 

- extends the previous restart unit test with additional parsing step

- refactors restart code to be more modulized (divides original loadRestartFile into two parts: reading and integrating into runtime RMG object)