### PR TITLE
Fix Group._repr_png_()

### DIFF
--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -765,7 +765,7 @@ class Group(Graph):
                 index1 = self.atoms.index(atom1)
                 index2 = self.atoms.index(atom2)
                 if index1 < index2:
-                    bondType = ','.join([order for order in bond.order])
+                    bondType = ','.join([order for order in bond.getOrderStr()])
                     bondType = '"' + bondType + '"'
                     graph.add_edge(pydot.Edge(src=str(index1 + 1), dst=str(index2 + 1), label=bondType, fontname="Helvetica", fontsize="16"))
 

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -1026,6 +1026,18 @@ class TestGroup(unittest.TestCase):
         benzene = Group().fromAdjacencyList(benzene)
         self.assertTrue(benzene.isBenzeneExplicit())
 
+    def test_repr_png(self):
+        """Test that a png representation can be created."""
+        adjlist = """
+1 *1 [C,Cd,Ct,CO,CS,Cb] u1 {2,[S,D,T,B]}
+2 *2 [C,Cd,Ct,CO,CS,Cb] u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *3 [C,Cd,Ct,CO,CS,Cb] u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *4 [C,Cd,Ct,CO,CS,Cb] u0 {3,[S,D,T,B]}
+        """
+        group = Group().fromAdjacencyList(adjlist)
+        result = group._repr_png_()
+        self.assertIsNotNone(result)
+
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
This method needed to be updated following the switch to floats for bond orders.