### PR TITLE
Enable matching tricyclics stored in polycyclic.py

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1536,6 +1536,11 @@ class ThermoDatabase(object):
         if matchedRingEntries is []:
             raise KeyError('Node not found in database.')
         # Decide which group to keep
+        completeMatchedGroups = [entry for entry in matchedRingEntries if not isRingPartialMatched(ring, entry.item)]
+
+        if completeMatchedGroups:
+            matchedRingEntries = completeMatchedGroups
+
         depthList = [len(ring_database.ancestors(entry)) for entry in matchedRingEntries]
         mostSpecificMatchIndices = [i for i, x in enumerate(depthList) if x == max(depthList)]
         

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -391,18 +391,19 @@ def getCopyFromTwoRingsWithCommonAtoms(ring1, ring2):
     
     return ring1Copy, ring2Copy, mergedRing
 
-def isPolyringPartialMatched(polyring, matched_group):
+def isRingPartialMatched(ring, matched_group):
     """
-    An example of polyring partial match is tricyclic polyring is matched by a bicyclic group
+    An example of ring partial match is tricyclic ring is matched by a bicyclic group
     usually because of not enough data in polycyclic tree. The method takes a matched group 
-    returned from descendTree and the polyring (a list of non-hydrogen atoms in the polyring)
+    returned from descendTree and the ring (a list of non-hydrogen atoms in the ring)
     """
-
-    if len(polyring) != len(matched_group.atoms):
+    # if matched group has less atoms than the target ring
+    # it's surely a partial match
+    if len(ring) > len(matched_group.atoms):
         return True
     else:
-        submol_polyring, _ = convertRingToSubMolecule(polyring)
-        sssr = submol_polyring.getSmallestSetOfSmallestRings()
+        submol_ring, _ = convertRingToSubMolecule(ring)
+        sssr = submol_ring.getSmallestSetOfSmallestRings()
         sssr_grp = matched_group.getSmallestSetOfSmallestRings()
         if sorted([len(sr) for sr in sssr]) == sorted([len(sr_grp) for sr_grp in sssr_grp]):
             return False

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -436,7 +436,7 @@ class TestCyclicThermo(unittest.TestCase):
         polyring = mol.getDisparateRings()[1][0]
 
         poly_groups = self.database.groups['polycyclic']
-        _, matched_entry = self.database._ThermoDatabase__addRingCorrectionThermoDataFromTree(None, poly_groups, mol, polyring)
+        _, matched_entry, _ = self.database._ThermoDatabase__addRingCorrectionThermoDataFromTree(None, poly_groups, mol, polyring)
 
         self.assertEqual(matched_entry.label, 's2-3_5_5_5_ane')
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -413,7 +413,7 @@ class TestCyclicThermo(unittest.TestCase):
         self.assertTrue(groupToRemove2.parent.data.getEntropy(298) == groupToRemove2.data.getEntropy(298))
         self.assertFalse(False in [groupToRemove2.parent.data.getHeatCapacity(x) == groupToRemove2.data.getHeatCapacity(x) for x in Tlist])
 
-    def testIsPolyringPartialMatched(self):
+    def testIsRingPartialMatched(self):
         
         # create testing molecule
         smiles = 'C1CC2CCCC3CCCC(C1)C23'
@@ -424,7 +424,7 @@ class TestCyclicThermo(unittest.TestCase):
         matched_group = self.database.groups['polycyclic'].entries['PolycyclicRing'].item
         
         # test
-        self.assertTrue(isPolyringPartialMatched(polyring, matched_group))
+        self.assertTrue(isRingPartialMatched(polyring, matched_group))
 
     def testAddRingCorrectionThermoDataFromTreeForExistingTricyclic(self):
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -426,6 +426,20 @@ class TestCyclicThermo(unittest.TestCase):
         # test
         self.assertTrue(isPolyringPartialMatched(polyring, matched_group))
 
+    def testAddRingCorrectionThermoDataFromTreeForExistingTricyclic(self):
+
+        # create testing molecule: C1CC2C3CCC(C3)C2C1
+        # this tricyclic molecule is already in polycyclic database
+        # so algorithm should give complete match: s2-3_5_5_5_ane
+        smiles = 'C1CC2C3CCC(C3)C2C1'
+        mol = Molecule().fromSMILES(smiles)
+        polyring = mol.getDisparateRings()[1][0]
+
+        poly_groups = self.database.groups['polycyclic']
+        _, matched_entry = self.database._ThermoDatabase__addRingCorrectionThermoDataFromTree(None, poly_groups, mol, polyring)
+
+        self.assertEqual(matched_entry.label, 's2-3_5_5_5_ane')
+
     def testAddPolyRingCorrectionThermoDataFromHeuristicUsingPyrene(self):
 
         # create testing molecule: Pyrene with two ring of aromatic version


### PR DESCRIPTION
`polycyclic.py` mainly contains bicyclic entries so that most large cyclics can decompose into bicyclics and use some tested formula to estimate their ring corrections. But we also include some important tricyclics so that if target molecules match one of the included tricyclics, it doesn't have to go through bicyclic decomposition.

@zjburas recently reported the issue where tricyclics in `polycyclic.py` cannot be matched directly. The reason is we put our limited number of tricyclics in the second level of tree, the algorithm will pick the entry with deepest level if multiple entries are matched. So what's really happening for tricyclics is although exact match can be found but it's second level, RMG will consider some partial match with deeper levels.

This is fixed by this PR by checking whether it's exact match before going through depth comparison.