### PR TITLE
Bond order fix

### DIFF
--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -96,7 +96,7 @@ class ConsistencyChecker(object):
                              radicals=atom.radicalElectrons,
                              lonePairs=atom.lonePairs,
                              charge=atom.charge,
-                             bonds=','.join([bond.order for bond in atom.bonds.values()])
+                             bonds=','.join([str(bond.order) for bond in atom.bonds.values()])
                             ))
 
     @staticmethod

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -459,7 +459,7 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
                     elif num_of_Dbonds == 1:
                         for ligand, bond in atom.bonds.iteritems():
                             #Ignore ligands that are not double bonded
-                            if 'D' in bond.order:
+                            if any([abs(2-order) < 1e-7 for order in bond.order]):
                                 for ligAtomType in ligand.atomType:
                                     if ligand.atomType[0].isSpecificCaseOf(atomTypes['O']): correctAtomList.append('CO')
                                     elif ligand.atomType[0].isSpecificCaseOf(atomTypes['S']): correctAtomList.append('CS')
@@ -612,7 +612,7 @@ Matched group AdjList:
                     elif num_of_Dbonds == 1:
                         for ligand, bond in atom.bonds.iteritems():
                             #Ignore ligands that are not double bonded
-                            if 'D' in bond.order:
+                            if any([abs(2-order) < 1e-7 for order in bond.order]):
                                 for ligAtomType in ligand.atomType:
                                     if ligand.atomType[0].isSpecificCaseOf(atomTypes['O']): correctAtomList.append('CO')
                                     elif ligand.atomType[0].isSpecificCaseOf(atomTypes['S']): correctAtomList.append('CS')


### PR DESCRIPTION
I checked for all instances of `bond.order` in rmgpy, as requested by @mjliu and found two discrepancies, one of which was alluded to in #898 and #899. The other one improves the robustness of databaseTest. 