### PR TITLE
The conda configuration files for the default rmg_env environment hav…

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -36,3 +36,4 @@ dependencies:
   - libgfortran >=1.0 # You may need to comment this out for mac osx
   - ffmpeg
   - jupyter
+  - networkx

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -35,3 +35,4 @@ dependencies:
   - scoop
   - ffmpeg
   - jupyter
+  - networkx

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -34,3 +34,4 @@ dependencies:
   - scoop
   - ffmpeg
   - jupyter
+  - networkx


### PR DESCRIPTION
…e been

updated to include the module 'networkx' as a dependency. This module is
required by the mechanism_analyzer.ipynb script. This addition will prevent
the user from having to use pip install the first time they encounter this
error.