### PR TITLE
Unimol format tests

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -612,7 +612,6 @@ class KineticsFamily(Database):
             self.depositories.append(depository)
         
 
-            
     def loadTemplate(self, reactants, products, ownReverse=False):
         """
         Load information about the reaction template.
@@ -2143,3 +2142,43 @@ class KineticsFamily(Database):
 
         # Source of the kinetics is from rate rules
         return False, [self.label, sourceDict]
+
+    def getBackboneRoots(self):
+        """
+        Returns: the top level backbone node in a unimolecular family.
+        """
+
+        backboneRoots = [entry for entry in self.groups.top if entry in self.forwardTemplate.reactants]
+        return backboneRoots
+
+    def getEndRoots(self):
+        """
+        Returns: A list of top level end nodes in a unimolecular family
+        """
+
+        endRoots = [entry for entry in self.groups.top if entry not in self.forwardTemplate.reactants]
+        return endRoots
+
+    def getTopLevelGroups(self, root):
+        """
+        Returns a list of group nodes that are the highest in the tree starting at node "root".
+        If "root" is a group node, then it will return a single-element list with "root".
+        Otherwise, for every child of root, we descend until we find no nodes with logic
+        nodes. We then return a list of all group nodes found along the way.
+        """
+
+        groupList = [root]
+        allGroups = False
+
+        while not allGroups:
+            newGroupList = []
+            for entry in groupList:
+                if isinstance(entry.item,Group):
+                    newGroupList.append(entry)
+                else:
+                    newGroupList.extend(entry.children)
+            groupList = newGroupList
+            allGroups = all([isinstance(entry.item, Group) for entry in groupList])
+
+        return groupList
+

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -317,6 +317,7 @@ class KineticsFamily(Database):
     `reverseRecipe`     :class:`ReactionRecipe`         The steps to take when applying the reverse reaction to a set of reactants
     `forbidden`         :class:`ForbiddenStructures`    (Optional) Forbidden product structures in either direction
     `ownReverse`        `Boolean`                       It's its own reverse?
+    'boundaryAtoms'     list                            Labels which define the boundaries of end groups in backbone/end families
     ------------------- ------------------------------- ------------------------
     `groups`            :class:`KineticsGroups`         The set of kinetics group additivity values
     `rules`             :class:`KineticsRules`          The set of kinetics rate rules from RMG-Java
@@ -340,7 +341,8 @@ class KineticsFamily(Database):
                  forwardRecipe=None,
                  reverseTemplate=None,
                  reverseRecipe=None,
-                 forbidden=None
+                 forbidden=None,
+                 boundaryAtoms = None
                  ):
         Database.__init__(self, entries, top, label, name, shortDesc, longDesc)
         self.reverse = reverse
@@ -350,6 +352,7 @@ class KineticsFamily(Database):
         self.reverseRecipe = reverseRecipe
         self.forbidden = forbidden
         self.ownReverse = forwardTemplate is not None and reverseTemplate is None
+        self.boundaryAtoms = boundaryAtoms
         # Kinetics depositories of training and test data
         self.groups = None
         self.rules = None
@@ -530,11 +533,14 @@ class KineticsFamily(Database):
         local_context['True'] = True
         local_context['False'] = False
         local_context['reverse'] = None
+        local_context['boundaryAtoms'] = None
+
         self.groups = KineticsGroups(label='{0}/groups'.format(self.label))
         logging.debug("Loading kinetics family groups from {0}".format(os.path.join(path, 'groups.py')))
         Database.load(self.groups, os.path.join(path, 'groups.py'), local_context, global_context)
         self.name = self.label
-        
+        self.boundaryAtoms = local_context.get('boundaryAtoms', None)
+
         # Generate the reverse template if necessary
         self.forwardTemplate.reactants = [self.groups.entries[label] for label in self.forwardTemplate.reactants]
         if self.ownReverse:

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -1,0 +1,60 @@
+import unittest
+from rmgpy.data.kinetics.database import KineticsDatabase
+import os.path
+from rmgpy import settings
+
+###################################################
+
+class TestFamily(unittest.TestCase):
+
+
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        # Set up a dummy database
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        self.database = KineticsDatabase()
+        self.database.loadFamilies(os.path.join(dir_path,"family_test_data"), families=['intra_H_migration'])
+        self.family = self.database.families['intra_H_migration']
+
+    def testGetBackboneRoots(self):
+        """
+        Test the getBackboneRoots() function
+        """
+        backbones = self.family.getBackboneRoots()
+        self.assertEquals(backbones[0].label, "RnH")
+
+    def testGetEndRoots(self):
+        """
+        Test the getEndRoots() function
+        """
+        ends = self.family.getEndRoots()
+        self.assertEquals(len(ends), 2)
+        self.assertIn(self.family.groups.entries["Y_rad_out"], ends)
+        self.assertIn(self.family.groups.entries["XH_out"], ends)
+
+    def testGetTopLevelGroups(self):
+        """
+        Test the getTopLevelGroups() function
+        """
+        topGroups = self.family.getTopLevelGroups(self.family.groups.entries["RnH"])
+        self.assertEquals(len(topGroups), 2)
+        self.assertIn(self.family.groups.entries["R5Hall"], topGroups)
+        self.assertIn(self.family.groups.entries["R6Hall"], topGroups)
+
+    # def testLoadFamilies(self):
+    #     """
+    #     Test that the loadFamilies function raises the correct exceptions
+    #     """
+    #     path = os.path.join(settings['database.directory'],'kinetics','families')
+    #     database = KineticsDatabase()
+    #
+    #     with self.assertRaises(DatabaseError):
+    #         database.loadFamilies(path, families='random')
+    #     with self.assertRaises(DatabaseError):
+    #         database.loadFamilies(path, families=['!H_Abstraction','Disproportionation'])
+    #     with self.assertRaises(DatabaseError):
+    #         database.loadFamilies(path, families=['fake_family'])
+    #     with self.assertRaises(DatabaseError):
+    #         database.loadFamilies(path, families=[])

--- a/rmgpy/data/kinetics/family_test_data/intra_H_migration/groups.py
+++ b/rmgpy/data/kinetics/family_test_data/intra_H_migration/groups.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "intra_H_migration/groups"
+shortDesc = u""
+longDesc = u"""
+
+"""
+
+template(reactants=["RnH"], products=["RnH"], ownReverse=True)
+
+recipe(actions=[
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['GAIN_RADICAL', '*2', '1'],
+    ['LOSE_RADICAL', '*1', '1'],
+])
+
+entry(
+    index = 1,
+    label = "RnH",
+    group = "OR{R2Hall, R3Hall, R4Hall, R5Hall, R6Hall, R7Hall}",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "Y_rad_out",
+    group = 
+"""
+1 *1 R!H u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
+    label = "XH_out",
+    group = 
+"""
+1 *2 R!H u0 {2,S}
+2 *3 H   u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 74,
+    label = "R5Hall",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 75,
+    label = "R5HJ_1",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u1 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 76,
+    label = "R5HJ_2",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u1 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 77,
+    label = "R5HJ_3",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u1 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 78,
+    label = "R5H",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 131,
+    label = "R6Hall",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H ux {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 132,
+    label = "R6HJ_1",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u1 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 133,
+    label = "R6HJ_2",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u1 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 134,
+    label = "R6HJ_3",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u1 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 135,
+    label = "R6HJ_4",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u1 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 136,
+    label = "R6H",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 188,
+    label = "O_rad_out",
+    group = 
+"""
+1 *1 O u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 190,
+    label = "Cd_rad_out",
+    group = 
+"""
+1 *1 Cd u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 199,
+    label = "C_rad_out_single",
+    group = 
+"""
+1 *1 C u1 {2,S} {3,S}
+2    R u0 {1,S}
+3    R u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 219,
+    label = "O_H_out",
+    group = 
+"""
+1 *2 O u0 {2,S}
+2 *3 H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 223,
+    label = "Cd_H_out_double",
+    group = 
+"""
+1 *2 Cd         u0 {2,S} {3,D}
+2 *3 H          u0 {1,S}
+3    [Cd,Cdd,O] u0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 226,
+    label = "Cd_H_out_single",
+    group = 
+"""
+1 *2 Cd u0 {2,S} {3,S}
+2 *3 H  u0 {1,S}
+3    R  u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 230,
+    label = "Cs_H_out",
+    group = 
+"""
+1 *2 Cs u0 {2,S} {3,S} {4,S}
+2 *3 H  u0 {1,S}
+3    R  u0 {1,S}
+4    R  u0 {1,S}
+""",
+    kinetics = None,
+)
+
+tree(
+"""
+L1: RnH
+    L2: R5Hall
+        L3: R5HJ_1
+        L3: R5HJ_2
+        L3: R5HJ_3
+        L3: R5H
+    L2: R6Hall
+        L3: R6HJ_1
+        L3: R6HJ_2
+        L3: R6HJ_3
+        L3: R6HJ_4
+        L3: R6H
+L1: Y_rad_out
+    L2: O_rad_out
+    L2: Cd_rad_out
+    L2: C_rad_out_single
+L1: XH_out
+    L2: O_H_out
+    L2: Cd_H_out_double
+    L2: Cd_H_out_single
+    L2: Cs_H_out
+"""
+)
+
+forbidden(
+    label = "[CH2]C1=CC(C)CC=C1_1",
+    group = 
+"""
+1 *5 C u0 {2,S} {3,S} {8,S}
+2 *2 C u0 {1,S} {9,S}
+3    C u0 {1,S} {4,S}
+4    C u0 {3,S} {5,D}
+5    C u0 {4,D} {6,S}
+6 *4 C u0 {5,S} {7,S} {8,D}
+7 *1 C u1 {6,S}
+8 *6 C u0 {1,S} {6,D}
+9 *3 H u0 {2,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "[CH2]C1=CC(C)CC=C1_2",
+    group = 
+"""
+1 *5 C u0 {2,S} {3,S} {8,S}
+2    C u0 {1,S}
+3 *2 C u0 {1,S} {4,S} {9,S}
+4    C u0 {3,S} {5,D}
+5    C u0 {4,D} {6,S}
+6 *4 C u0 {5,S} {7,S} {8,D}
+7 *1 C u1 {6,S}
+8 *6 C u0 {1,S} {6,D}
+9 *3 H u0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "[CH2]C1=CC(C)CC=C1_3",
+    group = 
+"""
+1    C u0 {2,S} {3,S} {8,S}
+2    C u0 {1,S}
+3 *2 C u0 {1,S} {4,S} {9,S}
+4 *5 C u0 {3,S} {5,D}
+5 *6 C u0 {4,D} {6,S}
+6 *4 C u0 {5,S} {7,S} {8,D}
+7 *1 C u1 {6,S}
+8    C u0 {1,S} {6,D}
+9 *3 H u0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "bridged56_1243",
+    group = 
+"""
+1 *1 C u1 {2,S} {6,S}
+2 *4 C u0 {1,S} {3,S} {7,S}
+3 *2 C u0 {2,S} {4,S} {8,S}
+4 *5 C u0 {3,S} {5,S}
+5    C u0 {4,S} {6,S} {7,S}
+6    C u0 {1,S} {5,S}
+7    C u0 {2,S} {5,S}
+8 *3 H u0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "bridged56_1254",
+    group = 
+"""
+1 *1 C u1 {2,S} {6,S}
+2 *4 C u0 {1,S} {3,S} {7,S}
+3    C u0 {2,S} {4,S}
+4 *2 C u0 {3,S} {5,S} {8,S}
+5 *5 C u0 {4,S} {6,S} {7,S}
+6    C u0 {1,S} {5,S}
+7    C u0 {2,S} {5,S}
+8 *3 H u0 {4,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+

--- a/rmgpy/data/kinetics/family_test_data/intra_H_migration/rules.py
+++ b/rmgpy/data/kinetics/family_test_data/intra_H_migration/rules.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "intra_H_migration/rules"
+shortDesc = u""
+longDesc = u"""
+
+"""
+entry(
+    index = 614,
+    label = "RnH;Y_rad_out;XH_out",
+    kinetics = ArrheniusEP(
+        A = (1e+10, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (25, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""default""",
+)
+
+entry(
+    index = 615,
+    label = "R6H;C_rad_out_single;Cs_H_out",
+    kinetics = ArrheniusEP(
+        A = (5.48e+08, 's^-1'),
+        n = 1.62,
+        alpha = 0,
+        E0 = (38.76, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Currans's estimation [5] in his reaction type 5.""",
+    longDesc = 
+u"""
+Test case with modified group from database. This data is definitly not
+scientifically accurate, so do not use it in model generation!!!"
+""",
+)

--- a/rmgpy/data/kinetics/family_test_data/intra_H_migration/training/reactions.py
+++ b/rmgpy/data/kinetics/family_test_data/intra_H_migration/training/reactions.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "intra_H_migration/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""
+

--- a/rmgpy/molecule/pathfinder.pxd
+++ b/rmgpy/molecule/pathfinder.pxd
@@ -1,4 +1,5 @@
 from .molecule cimport Atom, Bond, Molecule
+from .graph cimport Vertex, Edge
 
 cpdef list find_butadiene(Atom start, Atom end)
 
@@ -6,7 +7,7 @@ cpdef list find_butadiene_end_with_charge(Atom start)
 
 cpdef list find_allyl_end_with_charge(Atom start)
 
-cpdef list find_shortest_path(Atom start, Atom end, list path=*)
+cpdef list find_shortest_path(Vertex start, Vertex end, list path=*)
 
 cpdef list add_unsaturated_bonds(list path)
 

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -118,7 +118,7 @@ def find_shortest_path(start, end, path=None):
         return path
 
     shortest = None
-    for node,_ in start.bonds.iteritems():
+    for node,_ in start.edges.iteritems():
         if node not in path:
             newpath = find_shortest_path(node, end, path)
             if newpath:


### PR DESCRIPTION
This pull request introduces some new functions which will be used in database tests for unimolecular families requiring them to adhere to stricter rules about their formatting. 

Specifically, families that use a backbone/end groups like structure will have the following features:

1. End groups must have all the labels of their root entries
2. Backbones must have all the labels of connected end groups
3. Backbones must use the generic root entries as end groups, such that they are not both defining the backbone and ends
4. Backbones must label all atoms along the shortest path between end groups
