### PR TITLE
Improve flexibility of Molecule and Group drawing algorithms

### DIFF
--- a/rmgpy/molecule/drawTest.py
+++ b/rmgpy/molecule/drawTest.py
@@ -37,7 +37,7 @@ class TestMoleculeDrawer(unittest.TestCase):
         path = 'test_molecule.png'
         if os.path.exists(path):
             os.unlink(path)
-        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='png', path=path)
+        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='png', target=path)
         self.assertTrue(os.path.exists(path), "File doesn't exist")
         os.unlink(path)
         self.assertIsInstance(surface, ImageSurface)
@@ -53,7 +53,7 @@ class TestMoleculeDrawer(unittest.TestCase):
         path = 'test_molecule.pdf'
         if os.path.exists(path):
             os.unlink(path)
-        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='pdf', path=path)
+        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='pdf', target=path)
         self.assertIsInstance(surface, PDFSurface)
         self.assertGreater(width, height)
         os.unlink(path)
@@ -70,7 +70,7 @@ class TestMoleculeDrawer(unittest.TestCase):
         if os.path.exists(path):
             os.unlink(path)
         polycycle = Molecule(SMILES="C123CC4CC1COCC2CCC34")
-        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='pdf', path=path)
+        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='pdf', target=path)
         self.assertIsInstance(surface, PDFSurface)
         self.assertGreater(width, height)
         os.unlink(path)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -792,8 +792,15 @@ class Group(Graph):
         """
         Return a png picture of the group, useful for ipython-qtconsole.
         """
+        return self.draw('png')
+
+    def draw(self, format):
+        """
+        Use pydot to draw a basic graph of the group.
+
+        Use format to specify the desired output format, eg. 'png', 'svg', 'ps', 'pdf', 'plain', etc.
+        """
         import pydot
-        import os
 
         graph = pydot.Dot(graph_type='graph', dpi="52")
         for index, atom in enumerate(self.atoms):
@@ -810,7 +817,7 @@ class Group(Graph):
                     bondType = '"' + bondType + '"'
                     graph.add_edge(pydot.Edge(src=str(index1 + 1), dst=str(index2 + 1), label=bondType, fontname="Helvetica", fontsize="16"))
 
-        img = graph.create_png(prog='neato')
+        img = graph.create(prog='neato', format=format)
         return img
 
     def __getAtoms(self): return self.vertices

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -1151,6 +1151,46 @@ class TestGroup(unittest.TestCase):
         result = group._repr_png_()
         self.assertIsNotNone(result)
 
+    def testDrawGroup(self):
+        """Test that the draw method returns the expected pydot graph."""
+        adjlist = """
+1 *1 [C,Cd,Ct,CO,CS,Cb] u1 {2,[S,D,T,B]}
+2 *2 [C,Cd,Ct,CO,CS,Cb] u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *3 [C,Cd,Ct,CO,CS,Cb] u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *4 [C,Cd,Ct,CO,CS,Cb] u0 {3,[S,D,T,B]}
+        """
+        # Use of tabs in the expected string is intentional
+        expected = """
+graph G {
+	graph [dpi=52];
+	node [label="\N"];
+	1	 [fontname=Helvetica,
+		fontsize=16,
+		label="*1 C,Cd,Ct,CO,CS,Cb"];
+	2	 [fontname=Helvetica,
+		fontsize=16,
+		label="*2 C,Cd,Ct,CO,CS,Cb"];
+	1 -- 2	 [fontname=Helvetica,
+		fontsize=16,
+		label="S,D,T,B"];
+	3	 [fontname=Helvetica,
+		fontsize=16,
+		label="*3 C,Cd,Ct,CO,CS,Cb"];
+	2 -- 3	 [fontname=Helvetica,
+		fontsize=16,
+		label="S,D,T,B"];
+	4	 [fontname=Helvetica,
+		fontsize=16,
+		label="*4 C,Cd,Ct,CO,CS,Cb"];
+	3 -- 4	 [fontname=Helvetica,
+		fontsize=16,
+		label="S,D,T,B"];
+}
+        """
+        group = Group().fromAdjacencyList(adjlist)
+        result = group.draw('canon')
+        self.assertEqual(''.join(result.split()), ''.join(expected.split()))
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1225,7 +1225,7 @@ class Molecule(Graph):
         """
         from .draw import MoleculeDrawer
         format = os.path.splitext(path)[-1][1:].lower()
-        MoleculeDrawer().draw(self, format, path=path)
+        MoleculeDrawer().draw(self, format, target=path)
     
     def _repr_png_(self):
         """

--- a/rmgpy/pdep/draw.py
+++ b/rmgpy/pdep/draw.py
@@ -362,7 +362,7 @@ class NetworkDrawer:
         width = max([rect[2]+rect[0] for rect in wellRects]) - min([rect[0] for rect in wellRects]) + 2 * padding
         
         # Draw to the final surface
-        surface = createNewSurface(format=format, path=path, width=width, height=height)
+        surface = createNewSurface(format=format, target=path, width=width, height=height)
         cr = cairo.Context(surface)
         
         # Some global settings


### PR DESCRIPTION
This PR contains minor refactoring of `MoleculeDrawer` and `Group._repr_png_()` to give more flexibility in creating drawings. The motivation for these changes is to allow the website to display svg images instead of png images.

MoleculeDrawer has been refactored to allow saving to file-like objects, which enables writing the drawing to an HTML response object or a string buffer.

The main drawing algorithm in `Group._repr_png()` has been separated into a new function `Group.draw()` which accepts an additional format argument. `Group._repr_png()` now calls `Group.draw()` with 'png' as the format specifier.