### PR TITLE
Including a notice that KlippensteinH2O2 was deleted

### DIFF
--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -209,6 +209,10 @@ class KineticsDatabase(object):
                     library.load(library_file, self.local_context, self.global_context)
                     self.libraries[library.label] = library
                 else:
+                    if library_name == "KlippensteinH2O2":
+                        logging.info("""\n** Note: The KlippensteinH2O2 library was replaced and is no longer available in RMG.
+For H2 combustion chemistry consider using either the BurkeH2inN2 or BurkeH2inArHe
+library instead, depending on the main bath gas (N2 or Ar/He, respectively)\n""")
                     raise IOError("Couldn't find kinetics library {0}".format(library_file))
             # library order should've been set prior to this, with the given seed mechs and reaction libraries
             assert (len(self.libraryOrder) == len(libraries))


### PR DESCRIPTION
Including a notice that the KlippensteinH2O2 kinetic library was deleted
and replaced by BurkeH2inN2 and BurkeH2inArHe, for people whose old input
files were using it, so that they get a more helpful error message if
they try to request it once it's gone.

Related to https://github.com/ReactionMechanismGenerator/RMG-database/pull/168