### PR TITLE
Fix signal handling after calling lpsolve

### DIFF
--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -680,6 +680,10 @@ def _clarOptimization(mol, constraints=None, maxNum=None):
                    a=list, objective=list, status=cython.int, solution=list, innerSolutions=list)
 
     from lpsolve55 import lpsolve
+    import signal
+
+    # Save the current signal handler
+    sig = signal.getsignal(signal.SIGINT)
 
     # Make a copy of the molecule so we don't destroy the original
     molecule = mol.copy(deep=True)
@@ -752,6 +756,9 @@ def _clarOptimization(mol, constraints=None, maxNum=None):
     status = lpsolve('solve', lp)
     objVal, solution = lpsolve('get_solution', lp)[0:2]
     lpsolve('delete_lp', lp)  # Delete the LP problem to clear up memory
+
+    # Reset signal handling since lpsolve changed it
+    signal.signal(signal.SIGINT, sig)
 
     # Check that optimization was successful
     if status != 0:


### PR DESCRIPTION
The lpsolve module redirects interrupt signals to a custom handler, and this change is persistent in python until another change is made. This fix resets the handler to the one that was in use prior to calling lpsolve.

This restores the ability to send KeyboardInterrupt signals to stop an RMG job.