### PR TITLE
Changed assertion message when library rxn isn't unique (minor fix)

### DIFF
--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -294,7 +294,7 @@ class KineticsLibrary(Database):
 #        if not rxn.isBalanced():
 #            raise DatabaseError('Reaction {0} in kinetics library {1} was not balanced! Please reformulate.'.format(rxn, self.label))        
 #        label = str(rxn)
-        assert index not in self.entries, "Reaction {0} already present!".format(label)
+        assert index not in self.entries, "Index of reaction {0} is not unique!".format(label)
         self.entries[index] = Entry(
             index = index,
             label = label,


### PR DESCRIPTION
We're checking that the index number of each library reaction is unique,
but we output a misleading message suggesting that the reaction itself isn't unique.
This minor PR fixes the assertion error message.
Might speed-up debugging when creating new libraries.