### PR TITLE
Nodal distances

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -98,6 +98,7 @@ class Entry(object):
                  shortDesc='',
                  longDesc='',
                  rank=None,
+                 nodalDistance=None,
                  ):
         self.index = index
         self.label = label
@@ -110,6 +111,7 @@ class Entry(object):
         self._shortDesc = unicode(shortDesc)
         self._longDesc = unicode(longDesc)
         self.rank = rank
+        self.nodalDistance=nodalDistance
 
     def __str__(self):
         return self.label

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -82,6 +82,7 @@ class Entry(object):
     `shortDesc`         A brief (one-line) description of the data
     `longDesc`          A long, verbose description of the data
     `rank`              An integer indicating the degree of confidence in the entry data, or ``None`` if not used
+    `nodalDistance`     A float representing the distance of a given entry from it's parent entry
     =================== ========================================================
 
     """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -393,8 +393,11 @@ class KineticsFamily(Database):
         self.ownReverse = forwardTemplate is not None and reverseTemplate is None
         self.boundaryAtoms = boundaryAtoms
         self.treeDistances = treeDistances
+        
         if self.treeDistances is None:
             self.treeDistances = np.ones(len(self.top))
+        else:
+            assert len(self.treeDistances) == len(self.top), 'treeDistances must be the same length as the number of trees in the family'
         # Kinetics depositories of training and test data
         self.groups = None
         self.rules = None
@@ -576,13 +579,13 @@ class KineticsFamily(Database):
         local_context['False'] = False
         local_context['reverse'] = None
         local_context['boundaryAtoms'] = None
-
+        local_context['treeDistances'] = None
         self.groups = KineticsGroups(label='{0}/groups'.format(self.label))
         logging.debug("Loading kinetics family groups from {0}".format(os.path.join(path, 'groups.py')))
         Database.load(self.groups, os.path.join(path, 'groups.py'), local_context, global_context)
         self.name = self.label
         self.boundaryAtoms = local_context.get('boundaryAtoms', None)
-
+        self.treeDistances = local_context.get('treeDistances',np.ones(len(self.top)))
         # Generate the reverse template if necessary
         self.forwardTemplate.reactants = [self.groups.entries[label] for label in self.forwardTemplate.reactants]
         if self.ownReverse:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -563,7 +563,11 @@ class KineticsFamily(Database):
         if not already entered with the value from treeDistances associated
         with the tree the entry comes from
         """
+        treeDistances = self.treeDistances
         toplabels = [i.label for i in self.groups.top]
+        
+        assert len(toplabels) == len(treeDistances), 'treeDistances does not have the same number of entries as there are top nodes in the family'
+        
         for entryName,entry in self.groups.entries.iteritems():
             topentry = entry
             while not (topentry.parent is None): #get the top for the tree entry is in
@@ -571,7 +575,7 @@ class KineticsFamily(Database):
             if topentry.label in toplabels: #not exactly sure where the ones that don't match come from, they aren't in the trees, so this should be ok
                 ind = toplabels.index(topentry.label)
                 if entry.nodalDistance is None:
-                    entry.nodalDistance = self.treeDistances[ind]
+                    entry.nodalDistance = treeDistances[ind]
                 
     def load(self, path, local_context=None, global_context=None, depositoryLabels=None):
         """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -633,6 +633,12 @@ class KineticsFamily(Database):
                 entry.item = reaction
         self.depositories = []
         
+        if self.treeDistances is None:
+            self.treeDistances = np.ones(len(self.groups.top))
+        else:
+            self.treeDistances = np.array(self.treeDistances,np.float64)
+        self.distributeTreeDistances()
+            
         if depositoryLabels=='all':
             # Load everything. This option is generally used for working with the database
             # load all the remaining depositories, in order returned by os.walk
@@ -648,11 +654,6 @@ class KineticsFamily(Database):
                     depository.load(fpath, local_context, global_context)
                     self.depositories.append(depository)
                     
-            if self.treeDistances is None:
-                self.treeDistances = np.ones(len(self.groups.top))
-            else:
-                self.treeDistances = np.array(self.treeDistances,np.float64)
-            self.distributeTreeDistances()
             return
                     
         if not depositoryLabels:
@@ -681,11 +682,6 @@ class KineticsFamily(Database):
             depository.load(fpath, local_context, global_context)
             self.depositories.append(depository)
             
-        if self.treeDistances is None:
-            self.treeDistances = np.ones(len(self.groups.top))
-        else:
-            self.treeDistances = np.array(self.treeDistances,np.float64)
-        self.distributeTreeDistances()
         
     def loadTemplate(self, reactants, products, ownReverse=False):
         """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -37,6 +37,7 @@ import logging
 import codecs
 from copy import deepcopy
 import itertools
+import numpy as np
 
 from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.data.base import Database, Entry, LogicNode, LogicOr, ForbiddenStructures,\
@@ -379,7 +380,8 @@ class KineticsFamily(Database):
                  reverseTemplate=None,
                  reverseRecipe=None,
                  forbidden=None,
-                 boundaryAtoms = None
+                 boundaryAtoms = None,
+                 treeDistances = None
                  ):
         Database.__init__(self, entries, top, label, name, shortDesc, longDesc)
         self.reverse = reverse
@@ -390,6 +392,9 @@ class KineticsFamily(Database):
         self.forbidden = forbidden
         self.ownReverse = forwardTemplate is not None and reverseTemplate is None
         self.boundaryAtoms = boundaryAtoms
+        self.treeDistances = treeDistances
+        if self.treeDistances is None:
+            self.treeDistances = np.ones(len(self.top))
         # Kinetics depositories of training and test data
         self.groups = None
         self.rules = None

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -356,6 +356,7 @@ class KineticsFamily(Database):
     `forbidden`         :class:`ForbiddenStructures`    (Optional) Forbidden product structures in either direction
     `ownReverse`        `Boolean`                       It's its own reverse?
     'boundaryAtoms'     list                            Labels which define the boundaries of end groups in backbone/end families
+    `treeDistances`     numpy.ndarray                   The default distance from parent along each tree
     ------------------- ------------------------------- ------------------------
     `groups`            :class:`KineticsGroups`         The set of kinetics group additivity values
     `rules`             :class:`KineticsRules`          The set of kinetics rate rules from RMG-Java

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -71,7 +71,7 @@ class KineticsGroups(Database):
     def __repr__(self):
         return '<KineticsGroups "{0}">'.format(self.label)
 
-    def loadEntry(self, index, label, group, kinetics, reference=None, referenceType='', shortDesc='', longDesc=''):
+    def loadEntry(self, index, label, group, kinetics, reference=None, referenceType='', shortDesc='', longDesc='',nodalDistance=None):
         if group[0:3].upper() == 'OR{' or group[0:4].upper() == 'AND{' or group[0:7].upper() == 'NOT OR{' or group[0:8].upper() == 'NOT AND{':
             item = makeLogicNode(group)
         else:
@@ -88,6 +88,7 @@ class KineticsGroups(Database):
             referenceType = referenceType,
             shortDesc = shortDesc,
             longDesc = longDesc.strip(),
+            nodalDistance=nodalDistance
         )
 
     def getReactionTemplate(self, reaction):

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -72,6 +72,9 @@ class KineticsGroups(Database):
         return '<KineticsGroups "{0}">'.format(self.label)
 
     def loadEntry(self, index, label, group, kinetics, reference=None, referenceType='', shortDesc='', longDesc='',nodalDistance=None):
+        """
+        nodalDistance is the distance between a given entry and its parent specified by a float
+        """
         if group[0:3].upper() == 'OR{' or group[0:4].upper() == 'AND{' or group[0:7].upper() == 'NOT OR{' or group[0:8].upper() == 'NOT AND{':
             item = makeLogicNode(group)
         else:

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -591,10 +591,11 @@ class KineticsRules(Database):
         import numpy
         depth = numpy.array([node.level for node in template])
         otherDepth = numpy.array([otherNode.level for otherNode in otherTemplate])
-
+        weights = numpy.array([self.treeDistances[i] if template[i].nodalDistance is None else template[i].nodalDistance for i in range(len(template))])
         distance = numpy.array(depth-otherDepth)
-        distance *= numpy.array(self.treeDistances) #need to take values from template if available
+        distance *= weights #need to take values from template if available
         norm = numpy.dot(distance,distance)
+        assert False
         return norm
         
     def estimateKinetics(self, template, degeneracy=1):

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -72,6 +72,7 @@ class KineticsRules(Database):
                   shortDesc='',
                   longDesc='',
                   rank=None,
+                  nodalDistance=None,
                   ):
             
         entry = Entry(
@@ -84,6 +85,7 @@ class KineticsRules(Database):
             shortDesc = shortDesc,
             longDesc = longDesc.strip(),
             rank = rank,
+            nodalDistance=nodalDistance,
         )
         try:
             self.entries[label].append(entry)
@@ -591,6 +593,7 @@ class KineticsRules(Database):
         otherDepth = numpy.array([otherNode.level for otherNode in otherTemplate])
 
         distance = numpy.array(depth-otherDepth)
+        distance *= numpy.array(self.treeDistances) #need to take values from template if available
         norm = numpy.dot(distance,distance)
         return norm
         

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -698,13 +698,14 @@ class KineticsRules(Database):
                         ' + '.join([getTemplateLabel(t) for k, t in kineticsList]),
                     )
                 
-        kinetics.comment +=  ' for rate rule ' + originalLeaves
+        kinetics.comment += ' for rate rule ' + originalLeaves
+        kinetics.comment += ' Euclidian distance = {}.'.format(minNorm)
         kinetics.A.value_si *= degeneracy
         if degeneracy > 1:
             kinetics.comment += "\n"
             kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
 
-        return kinetics, entry if 'Exact' in kinetics.comment else None
+        return kinetics, (entry if 'Exact' in kinetics.comment else None)
 
 def removeIdenticalKinetics(kList):
     """

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -73,6 +73,7 @@ class KineticsRules(Database):
                   longDesc='',
                   rank=None,
                   nodalDistance=None,
+                  treeDistances=None
                   ):
             
         entry = Entry(
@@ -591,11 +592,10 @@ class KineticsRules(Database):
         import numpy
         depth = numpy.array([node.level for node in template])
         otherDepth = numpy.array([otherNode.level for otherNode in otherTemplate])
-        weights = numpy.array([self.treeDistances[i] if template[i].nodalDistance is None else template[i].nodalDistance for i in range(len(template))])
-        distance = numpy.array(depth-otherDepth)
-        distance *= weights #need to take values from template if available
+        weights = numpy.array([template[i].nodalDistance for i in range(len(template))]) #we weigh the nodes based on nodalDistance (distance specified between an entry and its parent)
+        distance = numpy.array(depth-otherDepth,numpy.float64)
+        distance *= weights 
         norm = numpy.dot(distance,distance)
-        assert False
         return norm
         
     def estimateKinetics(self, template, degeneracy=1):

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -460,13 +460,19 @@ class KineticsRules(Database):
         # If a particular node has no children, it is skipped from the children expansion altogether.
 
         childrenList = []
+        distanceList = []
         for i, parent in enumerate(rootTemplate):
             # Start with the root template, and replace the ith member with its children
             if parent.children:
                 childrenSet = [[group] for group in rootTemplate]
                 childrenSet[i] = parent.children
                 childrenList.extend(getAllCombinations(childrenSet))
-
+                distanceList.extend([k.nodalDistance for k in parent.children])
+        
+        minDist = min(distanceList) #average the minimum distance neighbors
+        
+        childrenList = [childrenList[i] for i in xrange(len(childrenList)) if distanceList[i]==minDist]
+        
         kineticsList = []
         for template in childrenList:
             label = ';'.join([g.label for g in template])
@@ -478,10 +484,11 @@ class KineticsRules(Database):
             
             if kinetics is not None:
                 kineticsList.append([kinetics, template])
-                
+        
         # See if we already have a rate rule for this exact template instead
         # and return it now that we have finished searching its children
         entry = self.getRule(rootTemplate)
+        
         if entry is not None and entry.rank > 0:
             # We already have a rate rule for this exact template
             # If the entry has rank of zero, then we have so little faith

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -592,10 +592,6 @@ class KineticsRules(Database):
         entry used to determine the kinetics only if it is an exact match,
         and is None if some averaging or use of a parent node took place.
         """
-        def getTemplateLabel(template):
-            # Get string format of the template in the form "(leaf1,leaf2)"
-            return '[{0}]'.format(';'.join([g.label for g in template]))
-        
         entry = self.getRule(template)
         
         originalLeaves = getTemplateLabel(template)
@@ -656,7 +652,7 @@ class KineticsRules(Database):
                     if not template0[index].parent: # We're at the top-level node in this subtreee
                         continue
                     dist = deepcopy(distanceList0[i])
-                    t = deepcopy(template0)
+                    t = template0[:]
                     dist[index] += t[index].nodalDistance
                     t[index] = t[index].parent
                      
@@ -734,4 +730,3 @@ def removeIdenticalKinetics(kList):
 def getTemplateLabel(template):
     # Get string format of the template in the form "(leaf1,leaf2)"
     return '[{0}]'.format(';'.join([g.label for g in template]))
-

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -600,9 +600,10 @@ class KineticsRules(Database):
         minNorm = numpy.inf
         savedKinetics = []
         
-        if not(entry is None) and entry.data:
+        if entry is not None and entry.data:
             savedKinetics = [[deepcopy(entry.data),template]]
             templateList = []
+            minNorm = 0
             
         while len(templateList) > 0:
             
@@ -634,7 +635,7 @@ class KineticsRules(Database):
             distanceList = []
             templateList = []
             
-            if not numpy.isinf(minNorm): #filter out stuff too large to be used
+            if minNorm > 0:  #filter out stuff too large to be used
                 toDelete = []
                 norms = [numpy.linalg.norm(d) for d in distanceList0]
                 for i in range(len(templateList0)):

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -473,9 +473,8 @@ class KineticsRules(Database):
                 childrenList.extend(getAllCombinations(childrenSet))
                 distanceList.extend([k.nodalDistance for k in parent.children])
                 
-        if distanceList != []:
-            minDist = min(distanceList) #average the minimum distance neighbors
-        
+        if distanceList != []: #average the minimum distance neighbors
+            minDist = min(distanceList) 
             closeChildrenList = [childrenList[i] for i in xrange(len(childrenList)) if distanceList[i]==minDist]
         else:
             closeChildrenList = []
@@ -609,8 +608,7 @@ class KineticsRules(Database):
             
             kineticsList = []
             distances = []
-            for i in xrange(len(templateList)):
-                t = templateList[i]
+            for i,t in enumerate(templateList):
                 entry = self.getRule(t)
                 if entry is None: 
                     continue
@@ -630,8 +628,8 @@ class KineticsRules(Database):
                     minNorm = newMinNorm
                     savedKinetics = [pair for pair, norm in zip(kineticsList,norms) if norm == min(norms)]
                 
-            templateList0 = templateList
-            distanceList0 = distanceList
+            templateList0 = templateList #keep the old template list
+            distanceList0 = distanceList #keep thge old distance list
             distanceList = []
             templateList = []
             
@@ -647,8 +645,7 @@ class KineticsRules(Database):
                     del distanceList0[k]
                         
             
-            for i in xrange(len(templateList0)):
-                template0 = templateList0[i]
+            for i,template0 in enumerate(templateList0):
                 for index in xrange(len(template0)):
                     if not template0[index].parent: # We're at the top-level node in this subtreee
                         continue


### PR DESCRIPTION
this enables the assignment of nodalDistance values to the distance between a given node and its parent with the rate rule trees.  Default these values are 1, but in a group file default values for each tree can be set by setting the treeDistances variable 
ex: treeDistances = [1,2,5]
and the values can be directly assigned as inputs to any individual entry
ex:
Entry( .......
nodalDistance=5,
)

Kinetics averaging and estimation have been extended to work with trees where the nodes are different distances apart. 
Nodal averaging is only done between the nodes that are closest to the parent.  But this may be changed later.  

This pull also fixes some issues with the original implementation of the 2-norm (it only compared distances one step out at a time so it would pick [2,0,0] over [1,1,1])
