### PR TITLE
Always use scaled harmonic oscillator (HO) frequencies for calculating ZPE in Cantherm

### DIFF
--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -393,13 +393,6 @@ class StatMechJob:
                        
             logging.debug('    Determining frequencies from reduced force constant matrix...')
             frequencies = numpy.array(projectRotors(conformer, F, rotors, linear, TS))
-            
-            # The frequencies have changed after projection, hence we need to recompute the ZPE
-            # We might need to multiply the scaling factor to the frequencies 
-            ZPE = self.getZPEfromfrequencies(frequencies)
-            E0_withZPE = E0 + ZPE
-            # Reset the E0 of the conformer
-            conformer.E0 = (E0_withZPE*0.001,"kJ/mol")
 
         elif len(conformer.modes) > 2:
             frequencies = conformer.modes[2].frequencies.value_si


### PR DESCRIPTION
Currently, if hindered rotors are included in a Cantherm statmech job, the ZPE will be calculated based on the projected frequencies after the frequency(ies) corresponding to the internal rotation have been removed. As pointed out by @shamelmerchant when he originally [made this change](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/ac5e31735ffe70f3701110a9576cb630028c686a), ideally the HO and projected frequencies should not differ much except for the removal of hindered rotor mode in the latter case. However, in cases with strong coupling between modes (e.g. hydrogen bonding) the projected frequencies can be significantly different from  the HO frequencies, resulting in ZPE's that can differ by kcals, which has a proportional effect on thermo calculations, and potentially an exponential effect on kinetics.

As an example, I've been trying to use QM calculations (CCSD(T)-F12/cc-pVDZ-F12//M06) + Cantherm to match experimental measurements of the overall kinetics of phenyl + ketene:

![image](https://cloud.githubusercontent.com/assets/12465817/23828351/2aec92c4-069d-11e7-9f4b-7d412ede2e12.png) + ![image](https://cloud.githubusercontent.com/assets/12465817/23828359/37e50f24-069d-11e7-8854-58319ac548f8.png) = 
![image](https://cloud.githubusercontent.com/assets/12465817/23828366/525b5cb4-069d-11e7-8b94-972820d74c8a.png)
and
![image](https://cloud.githubusercontent.com/assets/12465817/23828373/5d806fbc-069d-11e7-9857-4f49055f14c6.png)

In both cases above (terminal and central addition) the TS's and products have a hindered rotor that the reactants don't (rotation  around the new bond being formed). Additionally, in both cases there is noticeable hydrogen bonding between the O and ortho-H, causing the projected frequencies to differ significantly from the HO frequencies. This results in a ~2 kcal decrease in the ZPE's and a corresponding  ~2 kcal decrease in the reaction barrier heights, which has a huge effect on the predicted kinetics as shown below:

![image](https://cloud.githubusercontent.com/assets/12465817/23828400/2da65904-069e-11e7-95a6-ceedbca4c86e.png)

If the projected frequencies are used to calculate ZPE, Cantherm largely overpredicts the experimental measurements. However, if hindered rotors are included, but the ZPE is calculated from the HO frequencies, Cantherm is much closer to experiment and the remaining discrepancy can be resolved  by small adjustments in the electronic energy (< 1 kcal). 

In contrast, for the analogous central addition product of phenyl + allene:

![image](https://cloud.githubusercontent.com/assets/12465817/23828425/09a2beac-069f-11e7-80aa-23c7fe931b3c.png)

the projected and HO frequencies are nearly identical, resulting in a ZPE difference of only ~0.1 kcal, corresponding to the one removed frequency. In other words, for species without strong coupling between vibrations (i.e., without hydrogen bonding, like hydrocarbons), the assumption made by @shamelmerchant seems to be valid. Fortunately, up to this point I think Cantherm has mostly been used for hydrocarbons anyway.

Nonetheless, because the ZPE represents the internal energy from the lowest possible vibrational modes [n=0 in E_vib = h*(n+1)/2*SUM(nu)] in the limit of 0 K, it is reasonable at that condition to model all vibrations as HO's, including modes corresponding to internal rotation. Therefore, I think the HO frequencies should always be used to calculate ZPE, which is what the current pull request does.

