### PR TITLE
Allow users to input lists of strings for reactionLibraries

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -82,7 +82,10 @@ are to be used in addition to the Glarborg C3 library::
 	reactionLibraries = [('Glarborg/C3',False)],
 	 	
 The keyword False/True permits user to append all unused reactions (= kept in the edge) from this library to the chemkin file.
-True means those reactions will be appended.
+True means those reactions will be appended. Using just the string inputs would lead to
+a default value of `False`. In the previous example, this would look like::
+
+	reactionLibraries = ['Glarborg/C3'],
 
 The reaction libraries are stored in :file:`$RMG-database/input/kinetics/libraries/`
 and the `Location:` should be specified relative to this path.

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -7,8 +7,11 @@ database(
     thermoLibraries = ['BurkeH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR'],
 	#overrides RMG kinetics estimation if needed in the core of RMG. 
 	#list of libraries found at http://rmg.mit.edu/database/kinetics/libraries/
-	#input each library as a ('library_name',True/False) where a True means that all 
-	#unused reactions will be automatically added to the chemkin file
+	#libraries can be input as either a string or tuple of form ('library_name',True/False) 
+     #where a `True` indicates that all unused reactions will be automatically added 
+	#to the chemkin file at the end of the simulation. Placing just string values
+     #defaults the tuple to `False`. The string input is sufficient in almost
+     #all situations
     reactionLibraries = [],
 	#seed mechanisms are reactionLibraries that are forced into the initial mechanism 
 	#in addition to species listed in this input file.  

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -12,7 +12,7 @@ database(
 	#to the chemkin file at the end of the simulation. Placing just string values
      #defaults the tuple to `False`. The string input is sufficient in almost
      #all situations
-    reactionLibraries = [],
+    reactionLibraries = [('C3', False)],
 	#seed mechanisms are reactionLibraries that are forced into the initial mechanism 
 	#in addition to species listed in this input file.  
 	#This is helpful for reducing run time for species you know will appear in 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -74,6 +74,17 @@ def database(
     rmg.databaseDirectory = settings['database.directory']
     rmg.thermoLibraries = thermoLibraries or []
     rmg.transportLibraries = transportLibraries
+    # Modify reactionLibraries if the user didn't specify tuple input
+    if reactionLibraries:
+        index = 0
+        while index < len(reactionLibraries):
+            if isinstance(reactionLibraries[index],tuple):
+                pass
+            elif isinstance(reactionLibraries[index],str):
+                reactionLibraries[index] = (reactionLibraries[index], False)
+            else:
+                raise TypeError('reaction libraries must be input as tuples or strings')
+            index += 1
     rmg.reactionLibraries = reactionLibraries or []
     rmg.seedMechanisms = seedMechanisms or []
     rmg.statmechLibraries = frequenciesLibraries or []

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -358,6 +358,14 @@ def generatedSpeciesConstraints(**kwargs):
 
 ################################################################################
 
+def setGlobalRMG(rmg0):
+    """
+    sets the global variable rmg to rmg0. This is used to allow for unittesting
+    of above methods
+    """
+    global rmg
+    rmg = rmg0
+
 def readInputFile(path, rmg0):
     """
     Read an RMG input file at `path` on disk into the :class:`RMG` object 
@@ -377,7 +385,7 @@ def readInputFile(path, rmg0):
     logging.info(f.read())
     f.seek(0)# return to beginning of file
 
-    rmg = rmg0
+    setGlobalRMG(rmg0)
     rmg.reactionModel = CoreEdgeReactionModel()
     rmg.initialSpecies = []
     rmg.reactionSystems = []

--- a/rmgpy/rmg/inputTest.py
+++ b/rmgpy/rmg/inputTest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2017 Prof. William H. Green (whgreen@mit.edu) and the
+#   RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import unittest 
+
+from rmgpy.rmg.main import RMG
+from rmgpy.rmg import input as inp
+
+###################################################
+
+def setUpModule(self):
+    """
+    A method that is run before the class.
+    """
+    # set-up RMG object and get global rmg object in input.py file
+    # so methods can be tested
+    global rmg
+    rmg = RMG()
+    inp.setGlobalRMG(rmg)
+
+def tearDownModule(self):
+    # remove RMG object
+    global rmg
+    rmg = None
+
+class TestInputDatabase(unittest.TestCase):
+    """
+    Contains unit tests rmgpy.rmg.input.database
+    """
+
+    def tearDown(self):
+        # remove the reactionLibraries value
+        global rmg
+        rmg.reactionLibraries = None
+
+    def testImportingDatabaseReactionLibrariesFromString(self):
+        """
+        Test that we can import Reaction Libraries using the non-tuple form.
+        """
+        global rmg
+        # add database properties to RMG
+        inp.database(reactionLibraries=['test'])
+        self.assertIsInstance(rmg.reactionLibraries[0], tuple)
+        self.assertFalse(rmg.reactionLibraries[0][1])
+        
+    def testImportingDatabaseReactionLibrariesFromFalseTuple(self):
+        """
+        Test that we can import Reaction Libraries using the Tuple False form.
+        """
+        global rmg
+        # add database properties to RMG
+        inp.database(reactionLibraries=[('test',False)])
+        self.assertIsInstance(rmg.reactionLibraries[0], tuple)
+        self.assertFalse(rmg.reactionLibraries[0][1])
+        
+    def testImportingDatabaseReactionLibrariesFromTrueTuple(self):
+        """
+        Test that we can import Reaction Libraries using the Tuple True form.
+        """
+        global rmg
+        # add database properties to RMG
+        inp.database(reactionLibraries=[('test',True)])
+        self.assertIsInstance(rmg.reactionLibraries[0], tuple)
+        self.assertTrue(rmg.reactionLibraries[0][1])
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR converts a lists of reaction libraries strings to the
`('text',False)` tuples in the `rmgpy/rmg/input.py/database` method.
This allows more intuitive input files to be written and used.