### PR TITLE
Add unit tests to chemkinTest

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -37,3 +37,4 @@ dependencies:
   - ffmpeg
   - jupyter
   - networkx
+  - mock

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -36,3 +36,4 @@ dependencies:
   - ffmpeg
   - jupyter
   - networkx
+  - mock

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -35,3 +35,4 @@ dependencies:
   - ffmpeg
   - jupyter
   - networkx
+  - mock

--- a/meta.yaml
+++ b/meta.yaml
@@ -61,6 +61,7 @@ requirements:
     - lpsolve55
     - markupsafe
     - matplotlib >=1.5
+    - mock
     - mopac
     - nose
     - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,5 @@ pyzmq
 # SCOOP for parallel computing
 git+https://github.com/soravux/scoop.git@0.7.0
 
+# For unit tests
+mock

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -610,14 +610,12 @@ def readReactionComments(reaction, comments, read = True):
                     if reactant.label == reacStr:
                         break
                 else:
-                    import pdb; pdb.set_trace()
                     raise ChemkinError('Unexpected species identifier {0} encountered in flux pairs for reaction {1}.'.format(reacStr, reaction))
                 if prodStr[-1] == ';': prodStr = prodStr[:-1]
                 for product in reaction.products:
                     if product.label == prodStr:
                         break
                 else:
-                    import pdb; pdb.set_trace()
                     raise ChemkinError('Unexpected species identifier {0} encountered in flux pairs for reaction {1}.'.format(prodStr, reaction))
                 reaction.pairs.append((reactant, product))
             assert len(reaction.pairs) == max(len(reaction.reactants), len(reaction.products))

--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -2,121 +2,121 @@ import unittest
 import os
 from chemkin import *
 import rmgpy
+
+
 ###################################################
 
 class ChemkinTest(unittest.TestCase):
+    def testReadTemplateReactionFamilyForMinimalExample(self):
+        """
+        This example is mainly to test if family info can be correctly
+        parsed from comments like '!Template reaction: R_Recombination'.
+        """
+        folder = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data/chemkin/chemkin_py')
 
-	def testReadTemplateReactionFamilyForMinimalExample(self):
-		"""
-		This example is mainly to test if family info can be correctly 
-		parsed from comments like '!Template reaction: R_Recombination'.
-		"""
-		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
-		
-		chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
-		dictionaryPath = os.path.join(folder,'minimal', 'species_dictionary.txt')
+        chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
+        dictionaryPath = os.path.join(folder, 'minimal', 'species_dictionary.txt')
 
-		# loadChemkinFile
-		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath) 
+        # loadChemkinFile
+        species, reactions = loadChemkinFile(chemkinPath, dictionaryPath)
 
-		reaction1 = reactions[0]
-		self.assertEqual(reaction1.family, "R_Recombination")
+        reaction1 = reactions[0]
+        self.assertEqual(reaction1.family, "R_Recombination")
 
-		reaction2 = reactions[1]
-		self.assertEqual(reaction2.family, "H_Abstraction")
-	
-	def testReadTemplateReactionFamilyForPDDExample(self):
-		"""
-		This example is mainly to ensure comments like 
-		'! Kinetics were estimated in this direction instead 
-		of the reverse because:' or '! This direction matched 
-		an entry in H_Abstraction, the other was just an estimate.'
-		won't interfere reaction family info retrival.
-		"""
-		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
-		
-		chemkinPath = os.path.join(folder, 'pdd', 'chem.inp')
-		dictionaryPath = os.path.join(folder,'pdd', 'species_dictionary.txt')
+        reaction2 = reactions[1]
+        self.assertEqual(reaction2.family, "H_Abstraction")
 
-		# loadChemkinFile
-		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath) 
+    def testReadTemplateReactionFamilyForPDDExample(self):
+        """
+        This example is mainly to ensure comments like
+        '! Kinetics were estimated in this direction instead
+        of the reverse because:' or '! This direction matched
+        an entry in H_Abstraction, the other was just an estimate.'
+        won't interfere reaction family info retrival.
+        """
+        folder = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data/chemkin/chemkin_py')
 
-		reaction1 = reactions[0]
-		self.assertEqual(reaction1.family, "H_Abstraction")
+        chemkinPath = os.path.join(folder, 'pdd', 'chem.inp')
+        dictionaryPath = os.path.join(folder, 'pdd', 'species_dictionary.txt')
 
-		reaction2 = reactions[1]
-		self.assertEqual(reaction2.family, "H_Abstraction")
-		
-	def testTransportDataReadAndWrite(self):
-		"""
-		Test that we can write to chemkin and recreate the same transport object
-		"""
-		from rmgpy.species import Species
-		from rmgpy.molecule import Molecule
-		from rmgpy.transport import TransportData
-		
-		Ar = Species(label="Ar", transportData=TransportData(shapeIndex=0, epsilon=(1134.93,'J/mol'), sigma=(3.33,'angstrom'), dipoleMoment=(0,'De'), polarizability=(0,'angstrom^3'), rotrelaxcollnum=0.0, comment="""GRI-Mech"""))
-		
-		Ar_write = Species(label="Ar")
-		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data')
-		
-		tempTransportPath = os.path.join(folder, 'tran_temp.dat')
-		
-		saveTransportFile(tempTransportPath, [Ar])
-		speciesDict = {'Ar': Ar_write}
-		loadTransportFile(tempTransportPath, speciesDict)
-		self.assertEqual(repr(Ar),repr(Ar_write))
-		
-		os.remove(tempTransportPath)
-		
+        # loadChemkinFile
+        species, reactions = loadChemkinFile(chemkinPath, dictionaryPath)
 
-	def testUseChemkinNames(self):
-		"""
-		Test that the official chemkin names are used as labels for the created Species objects.
-		"""
+        reaction1 = reactions[0]
+        self.assertEqual(reaction1.family, "H_Abstraction")
 
-		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
-		
-		chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
-		dictionaryPath = os.path.join(folder,'minimal', 'species_dictionary.txt')
+        reaction2 = reactions[1]
+        self.assertEqual(reaction2.family, "H_Abstraction")
 
-		# loadChemkinFile
-		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath, useChemkinNames=True) 
+    def testTransportDataReadAndWrite(self):
+        """
+        Test that we can write to chemkin and recreate the same transport object
+        """
+        from rmgpy.species import Species
+        from rmgpy.molecule import Molecule
+        from rmgpy.transport import TransportData
 
-		expected = [
-			'Ar',
-			'He',
-			'Ne',
-			'N2',
-			'ethane',
-			'CH3',
-			'C2H5',
-			'C'
-		]
+        Ar = Species(label="Ar",
+                     transportData=TransportData(shapeIndex=0, epsilon=(1134.93, 'J/mol'), sigma=(3.33, 'angstrom'),
+                                                 dipoleMoment=(0, 'De'), polarizability=(0, 'angstrom^3'),
+                                                 rotrelaxcollnum=0.0, comment="""GRI-Mech"""))
 
-		for spc, label in zip(species, expected):
-			self.assertEqual(spc.label, label)
+        Ar_write = Species(label="Ar")
+        folder = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data')
 
-	def testReactantN2IsReactiveAndGetsRightSpeciesIdentifier(self):
-		"""
-		Test that after loading chemkin files, species such as N2, which is in the default 
-		inert list of RMG, should be treated as reactive species and given right species
-		Identifier when it's reacting in reactions.
-		"""
-		folder = os.path.join(os.path.dirname(rmgpy.__file__),'test_data/chemkin/chemkin_py')
-		
-		chemkinPath = os.path.join(folder, 'NC', 'chem.inp')
-		dictionaryPath = os.path.join(folder,'NC', 'species_dictionary.txt')
+        tempTransportPath = os.path.join(folder, 'tran_temp.dat')
 
-		# loadChemkinFile
-		species, reactions = loadChemkinFile(chemkinPath, dictionaryPath, useChemkinNames=True) 
+        saveTransportFile(tempTransportPath, [Ar])
+        speciesDict = {'Ar': Ar_write}
+        loadTransportFile(tempTransportPath, speciesDict)
+        self.assertEqual(repr(Ar), repr(Ar_write))
 
-		for n2 in species:
-		    if n2.label == 'N2':
-		        break
-		self.assertTrue(n2.reactive)
+        os.remove(tempTransportPath)
 
-		self.assertEqual(getSpeciesIdentifier(n2), 'N2(35)') 
+    def testUseChemkinNames(self):
+        """
+        Test that the official chemkin names are used as labels for the created Species objects.
+        """
 
-	
+        folder = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data/chemkin/chemkin_py')
 
+        chemkinPath = os.path.join(folder, 'minimal', 'chem.inp')
+        dictionaryPath = os.path.join(folder, 'minimal', 'species_dictionary.txt')
+
+        # loadChemkinFile
+        species, reactions = loadChemkinFile(chemkinPath, dictionaryPath, useChemkinNames=True)
+
+        expected = [
+            'Ar',
+            'He',
+            'Ne',
+            'N2',
+            'ethane',
+            'CH3',
+            'C2H5',
+            'C'
+        ]
+
+        for spc, label in zip(species, expected):
+            self.assertEqual(spc.label, label)
+
+    def testReactantN2IsReactiveAndGetsRightSpeciesIdentifier(self):
+        """
+        Test that after loading chemkin files, species such as N2, which is in the default
+        inert list of RMG, should be treated as reactive species and given right species
+        Identifier when it's reacting in reactions.
+        """
+        folder = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data/chemkin/chemkin_py')
+
+        chemkinPath = os.path.join(folder, 'NC', 'chem.inp')
+        dictionaryPath = os.path.join(folder, 'NC', 'species_dictionary.txt')
+
+        # loadChemkinFile
+        species, reactions = loadChemkinFile(chemkinPath, dictionaryPath, useChemkinNames=True)
+
+        for n2 in species:
+            if n2.label == 'N2':
+                break
+        self.assertTrue(n2.reactive)
+
+        self.assertEqual(getSpeciesIdentifier(n2), 'N2(35)')


### PR DESCRIPTION
I started out trying to write tests for each untested line, but I realized that it wasn't really helping. A major untested part was writing chemkin files, so I added some additional checks to existing tests. The end result was only +6% coverage within chemkin.py. To increase coverage more, we need to test reading and writing the other kinetics formats besides Arrhenius and Chebyshev.