### PR TITLE
Fix CH ground-state representation

### DIFF
--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1042,12 +1042,12 @@ class TestMolecule(unittest.TestCase):
 
     def testRadicalCH(self):
         """
-        Test that the species [CH] has three radical electrons and a spin multiplicity of 4.
+        Test that the species [CH] has one radical electrons and a spin multiplicity of 2.
         """
         molecule = Molecule().fromSMILES('[CH]')
-        self.assertEqual(molecule.atoms[0].radicalElectrons, 3)
-        self.assertEqual(molecule.multiplicity, 4)
-        self.assertEqual(molecule.getRadicalCount(), 3)
+        self.assertEqual(molecule.atoms[0].radicalElectrons, 1)
+        self.assertEqual(molecule.multiplicity, 2)
+        self.assertEqual(molecule.getRadicalCount(), 1)
 
     def testRadicalCH2(self):
         """

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -59,6 +59,12 @@ SMILES_LOOKUPS = {
             multiplicity 3
             1 C u2 p1 c0
             """,
+    '[CH]':  # We'd return the quartet without this
+            """
+            multiplicity 2
+            1 C u1 p1 c0 {2,S}
+            2 H u0 p0 c0 {1,S}
+            """,
 
 }     
 

--- a/rmgpy/molecule/parserTest.py
+++ b/rmgpy/molecule/parserTest.py
@@ -278,11 +278,9 @@ class ParserTest(unittest.TestCase):
         # of methylidyne exists as a mixture of electronic states even at
         # room temperature, giving rise to complex reactions.
         #
-        # Should we make the doublet? For now, this is a regression test,
-        # because we currently make the quartet.
         adjlist = '''
-        multiplicity 4
-        1 C u3 p0 c0 {2,S}
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
         2 H u0 p0 c0 {1,S}
         '''
         smiles = '[CH]'


### PR DESCRIPTION
This PR is just one side of fix for `CH` issue. As mentioned in #949 and RMG-database issue [#172](https://github.com/ReactionMechanismGenerator/RMG-database/issues/172), the major part of the change would be to eliminate the inconsistencies of `CH` in database.

The PR [#175](https://github.com/ReactionMechanismGenerator/RMG-database/pull/175) for RMG-database to be merged with this PR together.