### PR TITLE
Including a notice that KlippensteinH2O2 thermo library was deleted

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -775,6 +775,9 @@ class ThermoDatabase(object):
                     self.libraries[library.label] = library
                     self.libraryOrder.append(library.label)
                 else:
+                    if libraryName == "KlippensteinH2O2":
+                        logging.info("""\n** Note: The thermo library KlippensteinH2O2 was replaced and is no longer available in RMG.
+                        For H2 combustion chemistry consider using the BurkeH2O2 library instead\n""")
                     raise Exception('Library {} not found in {}...Please check if your library is correctly placed'.format(libraryName, path))
 
     def loadGroups(self, path):


### PR DESCRIPTION
Including a notice that the KlippensteinH2O2 thermo library was deleted
and replaced by BurkeH2O2, for people whose old input
files were using it, so that they get a more helpful error message if
they try to request it once it's gone.

This is complementary to a similar note we already added for the kinetic KlippensteinH2O2 library.