### PR TITLE
Resonance Fixes

### DIFF
--- a/rmgpy/molecule/generator.pxd
+++ b/rmgpy/molecule/generator.pxd
@@ -17,7 +17,7 @@ cpdef str toSMARTS(Molecule mol)
 
 cpdef str toSMILES(Molecule mol)
 
-cpdef toOBMol(Molecule mol)
+cpdef toOBMol(Molecule mol, bint returnMapping=*)
 
 cpdef toRDKitMol(Molecule mol, bint removeHs=*, bint returnMapping=*, bint sanitize=*)
 

--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -261,19 +261,23 @@ def toSMILES(mol):
         return Chem.MolToSmiles(rdkitmol, kekuleSmiles=True)
     return Chem.MolToSmiles(rdkitmol)
 
-def toOBMol(mol):
+def toOBMol(mol, returnMapping=False):
     """
     Convert a molecular structure to an OpenBabel OBMol object. Uses
     `OpenBabel <http://openbabel.org/>`_ to perform the conversion.
     """
 
+    # Sort the atoms to ensure consistent output
+    mol.sortAtoms()
     atoms = mol.vertices
 
+    obAtomIds = {}  # dictionary of OB atom IDs
     obmol = openbabel.OBMol()
     for atom in atoms:
         a = obmol.NewAtom()
         a.SetAtomicNum(atom.number)
         a.SetFormalCharge(atom.charge)
+        obAtomIds[atom] = a.GetId()
     orders = {1: 1, 2: 2, 3: 3, 1.5: 5}
     for atom1 in mol.vertices:
         for atom2, bond in atom1.edges.iteritems():
@@ -284,6 +288,9 @@ def toOBMol(mol):
                 obmol.AddBond(index1+1, index2+1, order)
 
     obmol.AssignSpinMultiplicity(True)
+
+    if returnMapping:
+        return obmol, obAtomIds
 
     return obmol
 

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -129,6 +129,8 @@ cdef class Graph:
 
     cpdef list getAllCyclesOfSize(self, int size)
 
+    cpdef list getAllSimpleCyclesOfSize(self, int size)
+
     cpdef list __exploreCyclesRecursively(self, list chain, list cycles)
 
     cpdef list getSmallestSetOfSmallestRings(self)

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -835,6 +835,30 @@ cdef class Graph:
 
         return cycleSetList
 
+    cpdef list getAllSimpleCyclesOfSize(self, int size):
+        """
+        Return a list of all non-duplicate monocyclic rings with length 'size'.
+
+        Naive approach by eliminating polycyclic rings that are returned by
+        ``getAllCyclicsOfSize``.
+        """
+        cdef list cycleList
+        cdef int i
+        cdef Vertex vertex
+
+        cycleList = self.getAllCyclesOfSize(size)
+
+        i = 0
+        while i < len(cycleList):
+            for vertex in cycleList[i]:
+                internalConnectivity = sum([1 if vertex2 in cycleList[i] else 0 for vertex2 in vertex.edges.iterkeys()])
+                if internalConnectivity > 2:
+                    del cycleList[i]
+                    break
+            else:
+                i += 1
+
+        return cycleList
 
     cpdef list __exploreCyclesRecursively(self, list chain, list cycles):
         """

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -545,6 +545,23 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(len(cycleList[0]), 4)
         self.assertEqual(len(cycleList[1]), 4)
         
+    def test_getAllSimpleCyclesOfSize(self):
+        """
+        Test the Graph.getAllSimpleCyclesOfSize() method.
+        """
+        cycleList = self.graph.getAllCyclesOfSize(6)
+        self.assertEqual(len(cycleList), 0)
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[3])
+        self.graph.addEdge(edge)  # To create a cycle of length 4
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[5])
+        self.graph.addEdge(edge)  # To create a cycle of length 6 and another cycle of length 4
+        cycleList = self.graph.getAllSimpleCyclesOfSize(4)
+        self.assertEqual(len(cycleList), 2)
+        self.assertEqual(len(cycleList[0]), 4)
+        self.assertEqual(len(cycleList[1]), 4)
+        cycleList = self.graph.getAllSimpleCyclesOfSize(6)
+        self.assertEqual(len(cycleList), 0)
+
     def test_getSmallestSetOfSmallestRings(self):
         """
         Test the Graph.getSmallestSetOfSmallestRings() method.

--- a/rmgpy/molecule/kekulize.pyx
+++ b/rmgpy/molecule/kekulize.pyx
@@ -1,0 +1,340 @@
+# encoding: utf-8
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2009-2011 by the RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This module contains functions for kekulization of a aromatic molecule.
+The only function that should be used outside of this module is the main
+`kekulize()` function. The remaining functions and classes are designed only
+to support the kekulization algorithm, and should not be used on their own.
+
+The basic algorithm is as follows:
+1. Identify all aromatic rings in the molecule, based on bond types.
+2. For each ring, identify endocyclic and exocyclic bonds.
+3. Determine if any bonds in the ring are already defined (not benzene bonds).
+4. For the remaining bonds, determine whether or not they can be double bonds.
+5. If a clear determination cannot be made, make heuristic based assumption.
+6. Continue until all bonds in the ring are determined.
+7. Continue until all rings in the molecule are determined.
+
+Here, `endo` refers to bonds that comprise a given ring, while `exo` refers to
+bonds that are connected to atoms in the ring, but not part of the ring itself.
+
+A key part of the algorithm is use of degree of freedom (DOF) analysis in order
+to determine the optimal order to solve the system. Rings and bonds with fewer
+DOFs have fewer ways to be to be kekulized, and are generally easier to solve.
+Each ring or bond that is fixed reduces the DOF of adjacent rings and bonds,
+and the process continues until the entire molecule can be solved.
+"""
+
+from .molecule cimport Atom, Bond, Molecule
+from .element import PeriodicSystem
+
+
+cpdef kekulize(Molecule mol):
+    """
+    Kekulize an aromatic molecule in place. If the molecule cannot be kekulized,
+    an AtomTypeError will be raised. However, the molecule will be left in
+    a semi-kekulized state. Therefore, if the original molecule needs to be kept,
+    it is advisable to create a copy before kekulizing.
+
+    Args: :class:`Molecule` object to be kekulized
+    """
+    cdef list ring, rings, aromaticRings, resolvedRings
+    cdef set endoBonds, exoBonds
+    cdef Atom atom1, atom2, atom
+    cdef Bond bond
+    cdef bint aromatic, successful, bridged
+    cdef int itercount, maxiter
+    cdef AromaticRing aromaticRing
+
+    # Get all potentially aromatic rings
+    rings = mol.getAllCyclesOfSize(6)
+
+    # Identify aromatic rings and categorize endocyclic and exocyclic bonds for each ring
+    aromaticRings = []
+    for ring in rings:
+        endoBonds = set()
+        exoBonds = set()
+        aromatic = True
+        for atom1 in ring:
+            # Check if this is a bridged ring
+            bridged = sum([1 if atom in ring else 0 for atom in atom1.bonds.iterkeys()]) > 2
+            for atom2, bond in atom1.bonds.iteritems():
+                if bridged and sum([1 if atom in ring else 0 for atom in atom2.bonds.iterkeys()]) > 2:
+                    # This atom2 is the other end of the bridging bond, so don't consider it as a part of the ring
+                    exoBonds.add(bond)
+                    continue
+                elif atom2 in ring:
+                    if abs(round(bond.order) - bond.order) < 1e-9:
+                        aromatic = False
+                        break
+                    endoBonds.add(bond)
+                else:
+                    exoBonds.add(bond)
+            if not aromatic:
+                break
+        if aromatic:
+            # Use an AromaticRing object to store the info about this ring
+            aromaticRings.append(AromaticRing(atoms=ring, endoBonds=endoBonds, exoBonds=exoBonds))
+
+    resolvedRings = []
+    itercount = 0
+    maxiter = 2 * len(aromaticRings)
+    while aromaticRings and itercount < maxiter:
+        # Update and sort the remaining rings
+        prioritizeRings(aromaticRings)
+        # Take the next ring off the stack
+        aromaticRing = aromaticRings.pop()
+        # Try to kekulize this ring
+        successful = aromaticRing.kekulize()
+        if successful:
+            resolvedRings.append(aromaticRing)
+        else:
+            # Put it back in the list, which will get resorted by DOF in the next iteration
+            aromaticRings.append(aromaticRing)
+        itercount += 1
+
+    mol.updateAtomTypes(logSpecies=False)
+
+cdef list prioritizeRings(list aromaticList):
+    """Update list of AromaticRing objects, then sort by DOF."""
+    cdef AromaticRing item, x
+    for item in aromaticList:
+        item.update()
+    return aromaticList.sort(key=lambda x: (x.endoDOF, x.exoDOF), reverse=True)
+
+cdef list prioritizeBonds(list aromaticList):
+    """Update list of Aromatic Bond objects, then sort by DOF."""
+    cdef AromaticBond item, x
+    for item in aromaticList:
+        item.update()
+    return aromaticList.sort(key=lambda x: (x.doublePossible, not x.doubleRequired, x.endoDOF, x.exoDOF), reverse=True)
+
+cdef class AromaticRing(object):
+    """
+    Helper class containing information about a single aromatic ring in a molecule.
+
+    DO NOT use outside of this module. This class does not do any aromaticity perception.
+    """
+    cdef list atoms
+    cdef set endoBonds, exoBonds
+    cdef public int endoDOF, exoDOF
+
+    def __init__(self, atoms=None, endoBonds=None, exoBonds=None, endoDOF=-1, exoDOF=-1):
+        self.atoms = atoms
+        self.endoBonds = endoBonds
+        self.exoBonds = exoBonds
+        self.endoDOF = endoDOF
+        self.exoDOF = exoDOF
+
+    cpdef update(self):
+        """
+        Update the degree of freedom information for this aromatic ring.
+
+        `endoDOF` refers to the number of bonds in the ring without fixed bond orders.
+        `exoDOF`  refers to the number of bonds outside the ring without fixed bond orders.
+        """
+        cdef int endoDOF, exoDOF
+        cdef Bond bond
+
+        endoDOF = 0
+        for bond in self.endoBonds:
+            if bond.isBenzene():
+                # Add one dof for each aromatic bond
+                endoDOF += 1
+        exoDOF = 0
+        for bond in self.exoBonds:
+            if bond.isBenzene():
+                # Add one dof for each aromatic bond
+                exoDOF += 1
+        self.endoDOF = endoDOF
+        self.exoDOF = exoDOF
+
+    cpdef tuple processBonds(self):
+        """Create AromaticBond objects for each endocyclic bond."""
+        cdef list resolved, unresolved
+        cdef Bond bond0
+        cdef AromaticBond aromaticBond
+
+        resolved = []
+        unresolved = []
+        for bond0 in self.endoBonds:
+            aromaticBond = AromaticBond(bond=bond0, ringBonds=self.endoBonds)
+
+            if abs(round(bond0.order) - bond0.order) < 1e-9:
+                # Bond has already been assigned, so mark as resolved
+                resolved.append(aromaticBond)
+            elif bond0.isOrder(2.5):
+                # Bond was incremented, so it must be a double bond
+                bond0.order = 2
+                resolved.append(aromaticBond)
+            elif bond0.isOrder(0.5):
+                # Bond was decremented, so it must be a single bond
+                bond0.order = 1
+                resolved.append(aromaticBond)
+            else:
+                unresolved.append(aromaticBond)
+
+        assert len(resolved) + len(unresolved) == len(self.endoBonds)
+
+        return resolved, unresolved
+
+    cpdef bint kekulize(self) except -2:
+        """
+        Attempts to kekulize a single aromatic ring in a molecule.
+
+        Returns True if successful, and False otherwise.
+        """
+        cdef list resolved, unresolved
+        cdef int itercount, maxiter
+        cdef AromaticBond bond
+
+        resolved, unresolved = self.processBonds()
+
+        # Check status
+        if len(unresolved) == 0:
+            return True
+
+        itercount = 0
+        maxiter = 2 * len(unresolved)
+        while unresolved and itercount < maxiter:
+            # Update and sort the unresolved bonds
+            prioritizeBonds(unresolved)
+            # Take the next bond off the stack
+            bond = unresolved.pop()
+
+            if bond.doublePossible and bond.doubleRequired:
+                # This bond must be a double bond to satisfy atom valence
+                bond.bond.order = 2
+                resolved.append(bond)
+                self.endoDOF -= 1
+            elif bond.doublePossible and not bond.doubleRequired:
+                # This could be a double bond, but we don't know for sure
+                # There are a few cases where it's safe to assume that it is a double bond:
+                #   - All exo bonds are defined, and no endo bonds have been defined
+                #   - Exo bonds adjacent to the current bond are defined, and no endo bonds have been defined
+                #   - Exo bonds adjacent to the current bond are not defined, but one adjacent endo bond is defined
+                #   - This is the last undefined endo bond
+                if ((self.endoDOF == 6 and self.exoDOF == 0)
+                        or (self.endoDOF == 6 and bond.exoDOF == 0)
+                        or (bond.endoDOF == 1 and (bond.exoDOF == 1 or bond.exoDOF == 2))
+                        or self.endoDOF == 1):
+                    # Go ahead an assume this bond is double
+                    bond.bond.order = 2
+                    resolved.append(bond)
+                    self.endoDOF -= 1
+                else:
+                    # Come back to this bond later
+                    unresolved.append(bond)
+            else:
+                # Double bond is not possible, so it must be a single bond
+                bond.bond.order = 1
+                resolved.append(bond)
+                self.endoDOF -= 1
+
+            itercount += 1
+
+        if unresolved:
+            # We've hit the iteration limit, but could not solve the ring
+            return False
+
+        return True
+
+cdef class AromaticBond(object):
+    """
+    Helper class containing information about a single aromatic bond in a molecule.
+
+    DO NOT use outside of this module. This class does not do any aromaticity perception.
+    """
+    cdef Bond bond
+    cdef set ringBonds
+    cdef public int endoDOF, exoDOF
+    cdef public bint doublePossible, doubleRequired
+
+    def __init__(self, bond=None, ringBonds=None, endoDOF=-1, exoDOF=-1, doublePossible=True, doubleRequired=False):
+        self.bond = bond
+        self.ringBonds = ringBonds
+        self.endoDOF = endoDOF
+        self.exoDOF = exoDOF
+        self.doublePossible = doublePossible
+        self.doubleRequired = doubleRequired
+
+    cpdef update(self):
+        """
+        Update the local degree of freedom information for this aromatic bond.
+        The DOF counts do not include the bond itself, only its adjacent bonds.
+
+        `endoDOF` refers to the number of adjacent bonds in the ring without fixed bond orders.
+        `exoDOF`  refers to the number of adjacent bonds outside the ring without fixed bond orders.
+        """
+        cdef dict bondOrders, valences
+        cdef Atom atom
+        cdef Bond bond
+        cdef int endoDOF, exoDOF, occupied, uncertain, available
+
+        valences = PeriodicSystem.valences
+
+        endoDOF = 0
+        exoDOF = 0
+        for atom in [self.bond.atom1, self.bond.atom2]:
+            occupied = 0
+            uncertain = 0
+            # Count electrons in bonds
+            for bond in atom.bonds.itervalues():
+                if abs(round(bond.order) - bond.order) < 1e-9:
+                    # This is a fixed bond, either single or double
+                    occupied += int(round(bond.order))
+                elif bond.isBenzene():
+                    # The atom has a benzene bond, so at least one electron is occupied, but there is a second uncertain electron
+                    occupied += 1
+                    uncertain += 1
+                    if bond is not self.bond:
+                        if bond in self.ringBonds:
+                            endoDOF += 1
+                        else:
+                            exoDOF += 1
+                else:
+                    ValueError('Unexpected bond order {0}.'.format(bond.order))
+            # Count radicals and lone pairs
+            occupied += atom.radicalElectrons
+            occupied += 2 * atom.lonePairs
+            # Valence calculation to determine available electrons
+            available = valences[atom.element.symbol] - occupied
+            if available < 0:
+                ValueError('Atom {0} cannot have negative available valence.'.format(atom))
+            elif available == 0:
+                # There are no extra electrons available, so this bond cannot be a double bond
+                self.doublePossible = False
+            elif available == 1 and uncertain == 1:
+                # There is an extra electron available, but the current bond is the only uncertain one,
+                # so it must be a double bond
+                self.doubleRequired = True
+
+        self.endoDOF = endoDOF
+        self.exoDOF = exoDOF
+

--- a/rmgpy/molecule/kekulizeTest.py
+++ b/rmgpy/molecule/kekulizeTest.py
@@ -1,0 +1,54 @@
+import unittest
+from external.wip import work_in_progress
+
+from rmgpy.molecule import Molecule
+from rmgpy.molecule.kekulize import *
+
+class KekulizeTest(unittest.TestCase):
+
+    def setUp(self):
+        """To be run before each test."""
+        molecule = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {6,B} {7,S}
+2  C u0 p0 c0 {1,B} {3,B} {8,S}
+3  C u0 p0 c0 {2,B} {4,B} {9,S}
+4  C u0 p0 c0 {3,B} {5,B} {10,S}
+5  C u0 p0 c0 {4,B} {6,B} {11,S}
+6  C u0 p0 c0 {1,B} {5,B} {12,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""")
+        bonds = set()
+        for atom in molecule.atoms:
+            bonds.update(atom.bonds.values())
+
+        ringAtoms, ringBonds = molecule.getAromaticRings()
+
+        self.aromaticRing = AromaticRing(ringAtoms[0], set(ringBonds[0]), bonds - set(ringBonds[0]))
+
+    def testAromaticRing(self):
+        self.aromaticRing.update()
+
+        self.assertEqual(self.aromaticRing.endoDOF, 6)
+        self.assertEqual(self.aromaticRing.exoDOF, 0)
+
+        result = self.aromaticRing.kekulize()
+
+        self.assertTrue(result)
+
+    def testAromaticBond(self):
+        resolved, unresolved = self.aromaticRing.processBonds()
+
+        self.assertEqual(len(resolved), 0)
+        self.assertEqual(len(unresolved), 6)
+
+        for bond in unresolved:
+            bond.update()
+            self.assertEqual(bond.endoDOF, 2)
+            self.assertEqual(bond.exoDOF, 0)
+            self.assertTrue(bond.doublePossible)
+            self.assertFalse(bond.doubleRequired)

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -210,12 +210,12 @@ cdef class Molecule(Graph):
     
     cpdef bint isRadical(self) except -2
 
-    cpdef bint isArylRadical(self, list ASSSR=?) except -2
+    cpdef bint isArylRadical(self, list aromaticRings=?) except -2
 
     cpdef int calculateSymmetryNumber(self) except -1
 
     cpdef list generateResonanceIsomers(self)
 
-    cpdef tuple getAromaticSSSR(self, list SSSR=?)
+    cpdef tuple getAromaticRings(self, list rings=?)
 
     cpdef list getDeterministicSmallestSetOfSmallestRings(self)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1555,17 +1555,17 @@ class Molecule(Graph):
                 return True
         return False
 
-    def isArylRadical(self, ASSSR=None):
+    def isArylRadical(self, aromaticRings=None):
         """
         Return ``True`` if the molecule only contains aryl radicals,
         ie. radical on an aromatic ring, or ``False`` otherwise.
         """
         cython.declare(atom=Atom, radList=list)
-        if ASSSR is None:
-            ASSSR = self.getAromaticSSSR()[0]
+        if aromaticRings is None:
+            aromaticRings = self.getAromaticRings()[0]
 
         total = self.getRadicalCount()
-        aromaticAtoms = set([atom for atom in itertools.chain.from_iterable(ASSSR)])
+        aromaticAtoms = set([atom for atom in itertools.chain.from_iterable(aromaticRings)])
         aryl = sum([atom.radicalElectrons for atom in aromaticAtoms])
 
         return total == aryl
@@ -1672,9 +1672,9 @@ class Molecule(Graph):
         
         return group
 
-    def getAromaticSSSR(self, SSSR=None):
+    def getAromaticRings(self, rings=None):
         """
-        Returns the smallest set of smallest aromatic rings as a list of atoms and a list of bonds
+        Returns all aromatic rings as a list of atoms and a list of bonds.
 
         Identifies rings using `Graph.getSmallestSetOfSmallestRings()`, then uses RDKit to perceive aromaticity.
         RDKit uses an atom-based pi-electron counting algorithm to check aromaticity based on Huckel's Rule.
@@ -1684,16 +1684,14 @@ class Molecule(Graph):
         by RMG, and not by RDKit.
         """
         cython.declare(rdAtomIndices=dict, aromaticRings=list, aromaticBonds=list)
-        cython.declare(rings=list, ring0=list, i=cython.int, atom1=Atom, atom2=Atom)
+        cython.declare(ring0=list, i=cython.int, atom1=Atom, atom2=Atom)
 
         from rdkit.Chem.rdchem import BondType
 
         AROMATIC = BondType.AROMATIC
 
-        if SSSR is None:
-            SSSR = self.getSmallestSetOfSmallestRings()
-
-        rings = [ring0 for ring0 in SSSR if len(ring0) == 6]
+        if rings is None:
+            rings = self.getAllSimpleCyclesOfSize(6)
         if not rings:
             return [], []
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1947,45 +1947,45 @@ multiplicity 2
         self.assertTrue(exp.isIsomorphic(calc))
 
     def testAromaticityPerceptionBenzene(self):
-        """Test aromaticity perception via getAromaticSSSR for benzene."""
+        """Test aromaticity perception via getAromaticRings for benzene."""
         mol = Molecule(SMILES='c1ccccc1')
-        asssr, aromaticBonds = mol.getAromaticSSSR()
-        self.assertEqual(len(asssr), 1)
+        aromaticAtoms, aromaticBonds = mol.getAromaticRings()
+        self.assertEqual(len(aromaticAtoms), 1)
         self.assertEqual(len(aromaticBonds), 1)
         for bond in aromaticBonds[0]:
-            self.assertTrue(bond.atom1 in asssr[0] and bond.atom2 in asssr[0])
+            self.assertTrue(bond.atom1 in aromaticAtoms[0] and bond.atom2 in aromaticAtoms[0])
 
     def testAromaticityPerceptionTetralin(self):
-        """Test aromaticity perception via getAromaticSSSR for tetralin."""
+        """Test aromaticity perception via getAromaticRings for tetralin."""
         mol = Molecule(SMILES='c1ccc2c(c1)CCCC2')
-        asssr, aromaticBonds = mol.getAromaticSSSR()
-        self.assertEqual(len(asssr), 1)
+        aromaticAtoms, aromaticBonds = mol.getAromaticRings()
+        self.assertEqual(len(aromaticAtoms), 1)
         self.assertEqual(len(aromaticBonds), 1)
         for bond in aromaticBonds[0]:
-            self.assertTrue(bond.atom1 in asssr[0] and bond.atom2 in asssr[0])
+            self.assertTrue(bond.atom1 in aromaticAtoms[0] and bond.atom2 in aromaticAtoms[0])
 
     def testAromaticityPerceptionBiphenyl(self):
-        """Test aromaticity perception via getAromaticSSSR for biphenyl."""
+        """Test aromaticity perception via getAromaticRings for biphenyl."""
         mol = Molecule(SMILES='c1ccc(cc1)c2ccccc2')
-        asssr, aromaticBonds = mol.getAromaticSSSR()
-        self.assertEqual(len(asssr), 2)
+        aromaticAtoms, aromaticBonds = mol.getAromaticRings()
+        self.assertEqual(len(aromaticAtoms), 2)
         self.assertEqual(len(aromaticBonds), 2)
-        for index in range(len(asssr)):
+        for index in range(len(aromaticAtoms)):
             for bond in aromaticBonds[index]:
-                self.assertTrue(bond.atom1 in asssr[index] and bond.atom2 in asssr[index])
+                self.assertTrue(bond.atom1 in aromaticAtoms[index] and bond.atom2 in aromaticAtoms[index])
 
     def testAromaticityPerceptionAzulene(self):
-        """Test aromaticity perception via getAromaticSSSR for azulene."""
+        """Test aromaticity perception via getAromaticRings for azulene."""
         mol = Molecule(SMILES='c1cccc2cccc2c1')
-        asssr, aromaticBonds = mol.getAromaticSSSR()
-        self.assertEqual(len(asssr), 0)
+        aromaticAtoms, aromaticBonds = mol.getAromaticRings()
+        self.assertEqual(len(aromaticAtoms), 0)
         self.assertEqual(len(aromaticBonds), 0)
 
     def testAromaticityPerceptionFuran(self):
-        """Test aromaticity perception via getAromaticSSSR for furan."""
+        """Test aromaticity perception via getAromaticRings for furan."""
         mol = Molecule(SMILES='c1ccoc1')
-        asssr, aromaticBonds = mol.getAromaticSSSR()
-        self.assertEqual(len(asssr), 0)
+        aromaticAtoms, aromaticBonds = mol.getAromaticRings()
+        self.assertEqual(len(aromaticAtoms), 0)
         self.assertEqual(len(aromaticBonds), 0)
 
     def testArylRadicalTrue(self):

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -5,7 +5,7 @@ cpdef list populateResonanceAlgorithms(dict features=?)
 
 cpdef dict analyzeMolecule(Molecule mol)
 
-cpdef list generateResonanceStructures(Molecule mol)
+cpdef list generateResonanceStructures(Molecule mol, bint clarStructures=?)
 
 cpdef list _generateResonanceStructures(list molList, list methodList, bint copy=?)
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -48,11 +48,9 @@ Currently supported resonance types:
 
 import cython
 
-import rmgpy.molecule.generator as generator
-import rmgpy.molecule.parser as parser
-
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 from .molecule import Atom, Bond, Molecule
+from .kekulize import kekulize
 from .atomtype import AtomTypeError
 import rmgpy.molecule.pathfinder as pathfinder
 
@@ -502,20 +500,22 @@ def generateKekuleStructure(mol):
     Returns a single Kekule structure as an element of a list of length 1.
     If there's an error (eg. in RDKit) then it just returns an empty list.
     """
-    cython.declare(atom=Atom)
+    cython.declare(atom=Atom, molecule=Molecule)
+
     for atom in mol.atoms:
         if atom.atomType.label == 'Cb' or atom.atomType.label == 'Cbf':
             break
     else:
         return []
-   
+
+    molecule = mol.copy(deep=True)
+
     try:
-        rdkitmol = generator.toRDKitMol(mol)  # This perceives aromaticity
-        isomer = parser.fromRDKitMol(Molecule(), rdkitmol)  # This step Kekulizes the molecule
-    except ValueError:
+        kekulize(molecule)
+    except AtomTypeError:
         return []
-    isomer.updateAtomTypes(logSpecies=False)
-    return [isomer]
+
+    return [molecule]
 
 def generateOppositeKekuleStructure(mol):
     """

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -660,7 +660,11 @@ def generateClarStructures(mol):
     if not mol.isCyclic():
         return []
 
-    output = _clarOptimization(mol)
+    try:
+        output = _clarOptimization(mol)
+    except ILPSolutionError:
+        # The optimization algorithm did not work on the first iteration
+        return []
 
     molList = []
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -78,14 +78,10 @@ def populateResonanceAlgorithms(features=None):
             generateClarStructures,
         ]
     else:
-        if features['isAromatic']:
-            methodList.append(generateAromaticResonanceStructures)
-            methodList.append(generateKekuleStructure)
-            if features['isPolycyclicAromatic']:
-                methodList.append(generateClarStructures)
-            else:
-                methodList.append(generateOppositeKekuleStructure)
-        if features['isRadical'] and not features['isArylRadical']:
+        # If the molecule is aromatic, then radical resonance has already been considered
+        # If the molecule was falsely identified as aromatic, then isArylRadical will still accurately capture
+        # cases where the radical is in an orbital that is orthogonal to the pi orbitals.
+        if features['isRadical'] and not features['isAromatic'] and not features['isArylRadical']:
             methodList.append(generateAdjacentResonanceStructures)
         if features['hasNitrogen']:
             methodList.append(generateN5dd_N5tsResonanceStructures)
@@ -170,6 +166,7 @@ def generateResonanceStructures(mol):
     else:
         newMolList = []
 
+    # Special handling for aromatic species
     if len(newMolList) > 0:
         if features['isRadical'] and not features['isArylRadical']:
             if features['isPolycyclicAromatic']:
@@ -200,9 +197,10 @@ def generateResonanceStructures(mol):
         # Add the newly generated structures to the original list
         # This is not optimal, but is a temporary measure to ensure compatability until other issues are fixed
         molList.extend(newMolList)
-    else:
-        methodList = populateResonanceAlgorithms(features)
-        _generateResonanceStructures(molList, methodList)
+
+    # Generate remaining resonance structures
+    methodList = populateResonanceAlgorithms(features)
+    _generateResonanceStructures(molList, methodList)
 
     return molList
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -126,7 +126,7 @@ def analyzeMolecule(mol):
 
     return features
 
-def generateResonanceStructures(mol):
+def generateResonanceStructures(mol, clarStructures=True):
     """
     Generate and return all of the resonance structures for the input molecule.
 
@@ -170,17 +170,23 @@ def generateResonanceStructures(mol):
     if len(newMolList) > 0:
         if features['isRadical'] and not features['isArylRadical']:
             if features['isPolycyclicAromatic']:
-                _generateResonanceStructures(newMolList, [generateKekuleStructure])
-                _generateResonanceStructures(newMolList, [generateAdjacentResonanceStructures])
-                _generateResonanceStructures(newMolList, [generateClarStructures])
-                # Remove non-aromatic structures under the assumption that they aren't important resonance contributors
-                newMolList = [m for m in newMolList if m.isAromatic()]
+                if clarStructures:
+                    _generateResonanceStructures(newMolList, [generateKekuleStructure])
+                    _generateResonanceStructures(newMolList, [generateAdjacentResonanceStructures])
+                    _generateResonanceStructures(newMolList, [generateClarStructures])
+                    # Remove non-aromatic structures under the assumption that they aren't important resonance contributors
+                    newMolList = [m for m in newMolList if m.isAromatic()]
+                else:
+                    pass
             else:
                 _generateResonanceStructures(newMolList, [generateKekuleStructure,
                                                           generateOppositeKekuleStructure])
                 _generateResonanceStructures(newMolList, [generateAdjacentResonanceStructures])
         elif features['isPolycyclicAromatic']:
-            _generateResonanceStructures(newMolList, [generateClarStructures])
+            if clarStructures:
+                _generateResonanceStructures(newMolList, [generateClarStructures])
+            else:
+                pass
         else:
             # The molecule is an aryl radical or stable mono-ring aromatic
             # In this case, generate the kekulized form

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -47,6 +47,7 @@ Currently supported resonance types:
 """
 
 import cython
+import logging
 
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 from .molecule import Atom, Bond, Molecule
@@ -751,7 +752,13 @@ def _clarOptimization(mol, constraints=None, maxNum=None):
     # Add constraints to problem if provided
     if constraints is not None:
         for constraint in constraints:
-            lpsolve('add_constraint', lp, constraint[0], '<=', constraint[1])
+            try:
+                lpsolve('add_constraint', lp, constraint[0], '<=', constraint[1])
+            except:
+                logging.error('Unable to add constraint: {0} <= {1}'.format(constraint[0], constraint[1]))
+                logging.error('Cannot complete Clar optimization for {0}.'.format(str(mol)))
+                logging.error(mol.toAdjacencyList())
+                raise
 
     status = lpsolve('solve', lp)
     objVal, solution = lpsolve('get_solution', lp)[0:2]

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -48,6 +48,7 @@ Currently supported resonance types:
 
 import cython
 import logging
+import itertools
 
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 from .molecule import Atom, Bond, Molecule
@@ -427,8 +428,9 @@ def generateAromaticResonanceStructures(mol, features=None):
     In certain cases where multiple forms have the same number of aromatic rings, multiple structures will be returned.
     If there's an error (eg. in RDKit) it just returns an empty list.
     """
-    cython.declare(molecule=Molecule, rings=list, aromaticBonds=list, kekuleList=list,
-                   maxNum=cython.int, molList=list, newMolList=list, ring=list, bond=Bond)
+    cython.declare(molecule=Molecule, rings=list, aromaticBonds=list, kekuleList=list, maxNum=cython.int, molList=list,
+                   newMolList=list, ring=list, bond=Bond, order=float, originalBonds=list, originalOrder=list,
+                   i=cython.int, counter=cython.int)
 
     if features is None:
         features = analyzeMolecule(mol)
@@ -475,6 +477,14 @@ def generateAromaticResonanceStructures(mol, features=None):
     for mol0, aromaticBonds in molList:
         if not aromaticBonds:
             continue
+        # Save original bond orders in case this doesn't work out
+        originalBonds = []
+        for ring in aromaticBonds:
+            originalOrder = []
+            for bond in ring:
+                originalOrder.append(bond.order)
+            originalBonds.append(originalOrder)
+        # Change bond types to benzene bonds for all aromatic rings
         for ring in aromaticBonds:
             for bond in ring:
                 bond.order = 1.5
@@ -482,7 +492,37 @@ def generateAromaticResonanceStructures(mol, features=None):
         try:
             mol0.updateAtomTypes(logSpecies=False)
         except AtomTypeError:
-            continue
+            # If this didn't work the first time, then there might be a ring that is not actually aromatic
+            # Reset our changes
+            for ring, originalOrder in itertools.izip(aromaticBonds, originalBonds):
+                for bond, order in itertools.izip(ring, originalOrder):
+                    bond.order = order
+            # Try to make each ring aromatic, one by one
+            i = 0
+            counter = 0
+            while i < len(aromaticBonds) and counter < 2*len(aromaticBonds):
+                counter += 1
+                originalOrder = []
+                for bond in aromaticBonds[i]:
+                    originalOrder.append(bond.order)
+                    bond.order = 1.5
+                try:
+                    mol0.updateAtomTypes(logSpecies=False)
+                except AtomTypeError:
+                    # This ring could not be made aromatic, possibly because it depends on other rings
+                    # Undo changes
+                    for bond, order in itertools.izip(aromaticBonds[i], originalOrder):
+                        bond.order = order
+                    # Move it to the end of the list, and go on to the next ring
+                    aromaticBonds.append(aromaticBonds.pop(i))
+                    continue
+                else:
+                    # We're done with this ring, so go on to the next ring
+                    i += 1
+            # If we didn't end up making any of the rings aromatic, then this molecule is not actually aromatic
+            if i == 0:
+                # Move onto next molecule in the list
+                continue
 
         for mol1 in newMolList:
             if mol1.isIsomorphic(mol0):

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -25,7 +25,7 @@ class ResonanceTest(unittest.TestCase):
         """Test resonance structure generation for ethyl azide
 
         Simple case for N5dd <=> N5t resonance"""
-        molList = generateResonanceStructures(Molecule(SMILES="CCN=N=[N-]"))
+        molList = generateResonanceStructures(Molecule(SMILES="CCN=[N+]=[N-]"))
         self.assertEqual(len(molList), 3)
         self.assertTrue(all([any([atom.charge != 0 for atom in mol.vertices]) for mol in molList]))
 
@@ -70,6 +70,16 @@ class ResonanceTest(unittest.TestCase):
         Example radical polycyclic aromatic species where the radical can delocalize"""
         molList = generateResonanceStructures(Molecule(SMILES="[CH2]C1=CC=CC2C3=CC=CC=C3C=CC=21"))
         self.assertEqual(len(molList), 9)
+
+    def testAromaticWithLonePairResonance(self):
+        """Test resonance structure generation for aromatic species with lone pair <=> radical resonance"""
+        molList = generateResonanceStructures(Molecule(SMILES="c1ccccc1CC=N[O]"))
+        self.assertEqual(len(molList), 6)
+
+    def testAromaticWithNResonance(self):
+        """Test resonance structure generation for aromatic species with N5dd <=> N5t resonance"""
+        molList = generateResonanceStructures(Molecule(SMILES="c1ccccc1CCN=[N+]=[N-]"))
+        self.assertEqual(len(molList), 6)
 
     def testC13H11Rad(self):
         """Test resonance structure generation for p-methylbenzylbenzene radical

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -336,6 +336,311 @@ multiplicity 2
         self.assertTrue(result1[0].isIsomorphic(result2[0]))
         self.assertTrue(result1[0].isIsomorphic(result3[0]))
 
+    def testKekulizeBenzene(self):
+        """Test that we can kekulize benzene."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {6,B} {7,S}
+2  C u0 p0 c0 {1,B} {3,B} {8,S}
+3  C u0 p0 c0 {2,B} {4,B} {9,S}
+4  C u0 p0 c0 {3,B} {5,B} {10,S}
+5  C u0 p0 c0 {4,B} {6,B} {11,S}
+6  C u0 p0 c0 {1,B} {5,B} {12,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""")
+        keku = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,D} {6,S} {7,S}
+2  C u0 p0 c0 {1,D} {3,S} {8,S}
+3  C u0 p0 c0 {2,S} {4,D} {9,S}
+4  C u0 p0 c0 {3,D} {5,S} {10,S}
+5  C u0 p0 c0 {4,S} {6,D} {11,S}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].isIsomorphic(keku))
+
+    def testKekulizeNaphthalene(self):
+        """Test that we can kekulize naphthalene."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {3,B} {4,B}
+2  C u0 p0 c0 {1,B} {5,B} {6,B}
+3  C u0 p0 c0 {1,B} {8,B} {13,S}
+4  C u0 p0 c0 {1,B} {9,B} {14,S}
+5  C u0 p0 c0 {2,B} {10,B} {17,S}
+6  C u0 p0 c0 {2,B} {7,B} {18,S}
+7  C u0 p0 c0 {6,B} {8,B} {11,S}
+8  C u0 p0 c0 {3,B} {7,B} {12,S}
+9  C u0 p0 c0 {4,B} {10,B} {15,S}
+10 C u0 p0 c0 {5,B} {9,B} {16,S}
+11 H u0 p0 c0 {7,S}
+12 H u0 p0 c0 {8,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {4,S}
+15 H u0 p0 c0 {9,S}
+16 H u0 p0 c0 {10,S}
+17 H u0 p0 c0 {5,S}
+18 H u0 p0 c0 {6,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertFalse(out[0].isAromatic())
+
+        bonds = set()
+        for atom in out[0].atoms:
+            for bond in atom.bonds.itervalues():
+                bonds.add(bond)
+        dBonds = 0
+        for bond in bonds:
+            if bond.isDouble():
+                dBonds += 1
+
+        self.assertEqual(dBonds, 5)
+
+    def testKekulizePhenanthrene(self):
+        """Test that we can kekulize phenanthrene."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {3,B} {5,B}
+2  C u0 p0 c0 {1,B} {4,B} {9,B}
+3  C u0 p0 c0 {1,B} {6,B} {10,B}
+4  C u0 p0 c0 {2,B} {7,B} {8,B}
+5  C u0 p0 c0 {1,B} {12,B} {17,S}
+6  C u0 p0 c0 {3,B} {7,B} {18,S}
+7  C u0 p0 c0 {4,B} {6,B} {19,S}
+8  C u0 p0 c0 {4,B} {13,B} {20,S}
+9  C u0 p0 c0 {2,B} {14,B} {23,S}
+10 C u0 p0 c0 {3,B} {11,B} {24,S}
+11 C u0 p0 c0 {10,B} {12,B} {15,S}
+12 C u0 p0 c0 {5,B} {11,B} {16,S}
+13 C u0 p0 c0 {8,B} {14,B} {21,S}
+14 C u0 p0 c0 {9,B} {13,B} {22,S}
+15 H u0 p0 c0 {11,S}
+16 H u0 p0 c0 {12,S}
+17 H u0 p0 c0 {5,S}
+18 H u0 p0 c0 {6,S}
+19 H u0 p0 c0 {7,S}
+20 H u0 p0 c0 {8,S}
+21 H u0 p0 c0 {13,S}
+22 H u0 p0 c0 {14,S}
+23 H u0 p0 c0 {9,S}
+24 H u0 p0 c0 {10,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertFalse(out[0].isAromatic())
+
+        bonds = set()
+        for atom in out[0].atoms:
+            for bond in atom.bonds.itervalues():
+                bonds.add(bond)
+        dBonds = 0
+        for bond in bonds:
+            if bond.isDouble():
+                dBonds += 1
+
+        self.assertEqual(dBonds, 7)
+
+    def testKekulizePyrene(self):
+        """Test that we can kekulize pyrene."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {3,B} {6,B}
+2  C u0 p0 c0 {1,B} {4,B} {5,B}
+3  C u0 p0 c0 {1,B} {7,B} {8,B}
+4  C u0 p0 c0 {2,B} {9,B} {10,B}
+5  C u0 p0 c0 {2,B} {11,B} {12,B}
+6  C u0 p0 c0 {1,B} {13,B} {14,B}
+7  C u0 p0 c0 {3,B} {15,B} {18,S}
+8  C u0 p0 c0 {3,B} {9,B} {19,S}
+9  C u0 p0 c0 {4,B} {8,B} {20,S}
+10 C u0 p0 c0 {4,B} {16,B} {21,S}
+11 C u0 p0 c0 {5,B} {16,B} {23,S}
+12 C u0 p0 c0 {5,B} {13,B} {24,S}
+13 C u0 p0 c0 {6,B} {12,B} {25,S}
+14 C u0 p0 c0 {6,B} {15,B} {26,S}
+15 C u0 p0 c0 {7,B} {14,B} {17,S}
+16 C u0 p0 c0 {10,B} {11,B} {22,S}
+17 H u0 p0 c0 {15,S}
+18 H u0 p0 c0 {7,S}
+19 H u0 p0 c0 {8,S}
+20 H u0 p0 c0 {9,S}
+21 H u0 p0 c0 {10,S}
+22 H u0 p0 c0 {16,S}
+23 H u0 p0 c0 {11,S}
+24 H u0 p0 c0 {12,S}
+25 H u0 p0 c0 {13,S}
+26 H u0 p0 c0 {14,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertFalse(out[0].isAromatic())
+
+        bonds = set()
+        for atom in out[0].atoms:
+            for bond in atom.bonds.itervalues():
+                bonds.add(bond)
+        dBonds = 0
+        for bond in bonds:
+            if bond.isDouble():
+                dBonds += 1
+
+        self.assertEqual(dBonds, 8)
+
+    def testKekulizeCorannulene(self):
+        """Test that we can kekulize corannulene."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {5,B} {8,B}
+2  C u0 p0 c0 {1,B} {3,B} {10,B}
+3  C u0 p0 c0 {2,B} {4,B} {9,B}
+4  C u0 p0 c0 {3,B} {5,B} {6,B}
+5  C u0 p0 c0 {1,B} {4,B} {7,B}
+6  C u0 p0 c0 {4,B} {12,B} {13,B}
+7  C u0 p0 c0 {5,B} {14,B} {15,B}
+8  C u0 p0 c0 {1,B} {16,B} {20,B}
+9  C u0 p0 c0 {3,B} {11,B} {17,B}
+10 C u0 p0 c0 {2,B} {18,B} {19,B}
+11 C u0 p0 c0 {9,B} {12,B} {21,S}
+12 C u0 p0 c0 {6,B} {11,B} {22,S}
+13 C u0 p0 c0 {6,B} {14,B} {23,S}
+14 C u0 p0 c0 {7,B} {13,B} {24,S}
+15 C u0 p0 c0 {7,B} {16,B} {25,S}
+16 C u0 p0 c0 {8,B} {15,B} {26,S}
+17 C u0 p0 c0 {9,B} {18,B} {27,S}
+18 C u0 p0 c0 {10,B} {17,B} {28,S}
+19 C u0 p0 c0 {10,B} {20,B} {29,S}
+20 C u0 p0 c0 {8,B} {19,B} {30,S}
+21 H u0 p0 c0 {11,S}
+22 H u0 p0 c0 {12,S}
+23 H u0 p0 c0 {13,S}
+24 H u0 p0 c0 {14,S}
+25 H u0 p0 c0 {15,S}
+26 H u0 p0 c0 {16,S}
+27 H u0 p0 c0 {17,S}
+28 H u0 p0 c0 {18,S}
+29 H u0 p0 c0 {19,S}
+30 H u0 p0 c0 {20,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertFalse(out[0].isAromatic())
+
+        bonds = set()
+        for atom in out[0].atoms:
+            for bond in atom.bonds.itervalues():
+                bonds.add(bond)
+        dBonds = 0
+        for bond in bonds:
+            if bond.isDouble():
+                dBonds += 1
+
+        self.assertEqual(dBonds, 10)
+
+    def testKekulizeCoronene(self):
+        """Test that we can kekulize coronene."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {6,B} {12,B}
+2  C u0 p0 c0 {1,B} {3,B} {7,B}
+3  C u0 p0 c0 {2,B} {4,B} {8,B}
+4  C u0 p0 c0 {3,B} {5,B} {9,B}
+5  C u0 p0 c0 {4,B} {6,B} {10,B}
+6  C u0 p0 c0 {1,B} {5,B} {11,B}
+7  C u0 p0 c0 {2,B} {14,B} {15,B}
+8  C u0 p0 c0 {3,B} {16,B} {17,B}
+9  C u0 p0 c0 {4,B} {18,B} {19,B}
+10 C u0 p0 c0 {5,B} {20,B} {21,B}
+11 C u0 p0 c0 {6,B} {22,B} {23,B}
+12 C u0 p0 c0 {1,B} {13,B} {24,B}
+13 C u0 p0 c0 {12,B} {14,B} {25,S}
+14 C u0 p0 c0 {7,B} {13,B} {26,S}
+15 C u0 p0 c0 {7,B} {16,B} {27,S}
+16 C u0 p0 c0 {8,B} {15,B} {28,S}
+17 C u0 p0 c0 {8,B} {18,B} {29,S}
+18 C u0 p0 c0 {9,B} {17,B} {30,S}
+19 C u0 p0 c0 {9,B} {20,B} {31,S}
+20 C u0 p0 c0 {10,B} {19,B} {32,S}
+21 C u0 p0 c0 {10,B} {22,B} {33,S}
+22 C u0 p0 c0 {11,B} {21,B} {34,S}
+23 C u0 p0 c0 {11,B} {24,B} {35,S}
+24 C u0 p0 c0 {12,B} {23,B} {36,S}
+25 H u0 p0 c0 {13,S}
+26 H u0 p0 c0 {14,S}
+27 H u0 p0 c0 {15,S}
+28 H u0 p0 c0 {16,S}
+29 H u0 p0 c0 {17,S}
+30 H u0 p0 c0 {18,S}
+31 H u0 p0 c0 {19,S}
+32 H u0 p0 c0 {20,S}
+33 H u0 p0 c0 {21,S}
+34 H u0 p0 c0 {22,S}
+35 H u0 p0 c0 {23,S}
+36 H u0 p0 c0 {24,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertFalse(out[0].isAromatic())
+
+        bonds = set()
+        for atom in out[0].atoms:
+            for bond in atom.bonds.itervalues():
+                bonds.add(bond)
+        dBonds = 0
+        for bond in bonds:
+            if bond.isDouble():
+                dBonds += 1
+
+        self.assertEqual(dBonds, 12)
+
+    def testKekulizeBridgedAromatic(self):
+        """Test that we can kekulize a bridged polycyclic aromatic species."""
+        arom = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {3,S} {6,B}
+2  C u0 p0 c0 {1,B} {3,B} {11,S}
+3  C u0 p0 c0 {1,S} {2,B} {4,B}
+4  C u0 p0 c0 {3,B} {5,B} {12,S}
+5  C u0 p0 c0 {4,B} {6,B} {10,B}
+6  C u0 p0 c0 {1,B} {5,B} {7,B}
+7  C u0 p0 c0 {6,B} {8,B} {13,S}
+8  C u0 p0 c0 {7,B} {9,B} {14,S}
+9  C u0 p0 c0 {8,B} {10,B} {15,S}
+10 C u0 p0 c0 {5,B} {9,B} {16,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {7,S}
+14 H u0 p0 c0 {8,S}
+15 H u0 p0 c0 {9,S}
+16 H u0 p0 c0 {10,S}
+""")
+        out = generateKekuleStructure(arom)
+
+        self.assertEqual(len(out), 1)
+        self.assertFalse(out[0].isAromatic())
+
+        bonds = set()
+        for atom in out[0].atoms:
+            for bond in atom.bonds.itervalues():
+                bonds.add(bond)
+        dBonds = 0
+        for bond in bonds:
+            if bond.isDouble():
+                dBonds += 1
+
+        self.assertEqual(dBonds, 5)
+
     def testKekulizeResonanceIsomer(self):
         """
         Tests that an aromatic molecule returns at least one Kekulized resonance isomer.

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -81,6 +81,11 @@ class ResonanceTest(unittest.TestCase):
         molList = generateResonanceStructures(Molecule(SMILES="c1ccccc1CCN=[N+]=[N-]"))
         self.assertEqual(len(molList), 6)
 
+    def testNoClarStructures(self):
+        """Test that we can turn off Clar structure generation."""
+        molList = generateResonanceStructures(Molecule(SMILES='C1=CC=CC2C3=CC=CC=C3C=CC=21'), clarStructures=False)
+        self.assertEqual(len(molList), 2)
+
     def testC13H11Rad(self):
         """Test resonance structure generation for p-methylbenzylbenzene radical
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ def getMainExtensionModules():
         Extension('rmgpy.molecule.inchi', ['rmgpy/molecule/inchi.py'], include_dirs=['.']),
         Extension('rmgpy.molecule.resonance', ['rmgpy/molecule/resonance.py'], include_dirs=['.']),
         Extension('rmgpy.molecule.pathfinder', ['rmgpy/molecule/pathfinder.py'], include_dirs=['.']),
+        Extension('rmgpy.molecule.kekulize', ['rmgpy/molecule/kekulize.pyx'], include_dirs=['.']),
         # Pressure dependence
         Extension('rmgpy.pdep.collision', ['rmgpy/pdep/collision.pyx']),
         Extension('rmgpy.pdep.configuration', ['rmgpy/pdep/configuration.pyx']),


### PR DESCRIPTION
I'm reopening this pull request, since I still think these resonance fixes have higher priority than the react benzene changes, so they should be reviewed separately and merged first. I've included the new kekulizr module in this pull request because some of the fixes rely on it.

Changelog:
- Add kekulize module for generating Kekule structures.
- Add `getAllSimpleCyclesOfSize()` method to only retrieve monocyclic rings.
- Use `getAllSimplesCyclesOfSize()` instead of `getSSSR()` for ring retrieval to improve robustness of aromaticity detection.
    - For bridged polycyclics, the SSSR is not deterministic and can return different sets of rings. Using `getAllSimpleCyclesOfSize()` gives more consistent output.
- Improve generation of aromatic resonance structures when one ring in a polycyclic aromatic species is falsely identified as aromatic.
    - Previously, if one ring was falsely identified as aromatic, then the entire molecule would not be made aromatic. Now, the algorithm tries to check ring by ring.
- Also apply other resonance algorithms to aromatic species (lone pair/radical and N5dd/N5t).
    - Aromatics were not being checked for these other resonance types after special processing.
- Add OpenBabel as fallback option for aromaticity perception if RDKit fails.
    - Aromaticity detection would fail when encountering an aromatic species with nitrogen with valence>3 since RDKit cannot handle it.
- Add some more error handling for generating Clar structures, also add flag to more easily disable Clar structure generation.
    - Anticipated application for the flag is in reaction isomorphism checking, where Clar structures are not particularly helpful.