### PR TITLE
Reorder molecules when getting thermo data from library

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1239,13 +1239,21 @@ class ThermoDatabase(object):
         
         Returns a tuple: (ThermoData, library, entry)  or None.
         """
+        match = None
         for label, entry in library.entries.iteritems():
             for molecule in species.molecule:
                 if molecule.isIsomorphic(entry.item) and entry.data is not None:
                     thermoData = deepcopy(entry.data)
                     findCp0andCpInf(species, thermoData)
-                    return (thermoData, library, entry)
-        return None
+                    match = (thermoData, library, entry)
+                    break
+            if match is not None:
+                break
+        if match is not None:
+            # Move the matched molecule to the first position in the list
+            species.molecule.remove(molecule)
+            species.molecule.insert(0, molecule)
+        return match
 
     def getThermoDataFromGroups(self, species):
         """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -74,36 +74,6 @@ class TestThermoDatabase(unittest.TestCase):
         """A function that is run ONCE before all unit tests in this class."""
         global database
         self.database = database.thermo
-    
-    def setUp(self):
-        """
-        A function run before each unit test in this class.
-        """
-        self.Tlist = [300, 400, 500, 600, 800, 1000, 1500]
-        
-        self.testCases = [
-            # SMILES            symm  H298     S298     Cp300  Cp400  Cp500  Cp600  Cp800  Cp1000 Cp1500
-            
-            # 1,3-hexadiene decomposition products
-            ['C=CC=CCC',        3,    13.45, 86.37, 29.49, 37.67, 44.54, 50.12, 58.66, 64.95, 74.71],
-            ['[CH]=CC=CCC',     3,    72.55, 87.76, 29.30, 36.92, 43.18, 48.20, 55.84, 61.46, 70.18],
-            ['C=[C]C=CCC',      3,    61.15, 87.08, 29.68, 36.91, 43.03, 48.11, 55.96, 61.78, 71.54],
-            ['C=C[C]=CCC',      3,    61.15, 87.08, 29.68, 36.91, 43.03, 48.11, 55.96, 61.78, 71.54],
-            ['C=CC=[C]CC',      3,    70.35, 88.18, 29.15, 36.46, 42.6, 47.6, 55.32, 61.04, 69.95],
-            ['C=CC=C[CH]C',     6,    38.24, 84.41, 27.79, 35.46, 41.94, 47.43, 55.74, 61.92, 71.86],
-            ['C=CC=CC[CH2]',    2,    62.45, 89.78, 28.72, 36.31, 42.63, 47.72, 55.50, 61.21, 70.05],
-            ['[CH3]',           6,    34.81, 46.37, 9.14, 10.18, 10.81, 11.34, 12.57, 13.71, 15.2],
-            ['C=CC=C[CH2]',     2,    46.11, 75.82, 22.54, 28.95, 34.24, 38.64, 45.14, 49.97, 57.85],
-            ['[CH2]C',          6,    28.6, 59.87, 11.73, 14.47, 17.05, 19.34, 23.02, 25.91, 31.53],
-            ['C=CC=[CH]',       1,    85.18, 69.37, 18.93, 23.55, 27.16, 29.92, 34.02, 37.03, 41.81],
-            ['C=[CH]',          1,    71.62, 56.61, 10.01, 11.97, 13.66, 15.08, 17.32, 19.05, 21.85],
-            ['[CH]=CCC',        3,    58.99, 75.0, 20.38, 25.34, 29.68, 33.36, 39.14, 43.48, 50.22],
-            
-            # Cyclic Structures
-            ['C1CCCCC1',        12,   -29.45, 69.71, 27.20, 37.60, 46.60, 54.80, 67.50, 76.20, 88.50],
-            ['C1CCC1',          8,     6.51, 63.35, 17.39, 23.91, 29.86, 34.76, 42.40, 47.98, 56.33],
-            ['C1C=CC=C1',       2,    32.5, 65.5, 18.16, 24.71, 30.25, 34.7, 41.25, 45.83, 52.61],
-        ]
 
     def testPickle(self):
         """
@@ -114,13 +84,13 @@ class TestThermoDatabase(unittest.TestCase):
         thermodb0 = cPickle.loads(cPickle.dumps(self.database))
         
         self.assertEqual(thermodb0.libraryOrder, self.database.libraryOrder)
-        self.assertEqual(sorted(thermodb0.depository.keys()), \
-                        sorted(self.database.depository.keys()))
+        self.assertEqual(sorted(thermodb0.depository.keys()),
+                         sorted(self.database.depository.keys()))
 
-        self.assertEqual(sorted(thermodb0.libraries.keys()), \
-                        sorted(self.database.libraries.keys()))
-        self.assertEqual(sorted(thermodb0.groups.keys()), \
-                        sorted(self.database.groups.keys()))
+        self.assertEqual(sorted(thermodb0.libraries.keys()),
+                         sorted(self.database.libraries.keys()))
+        self.assertEqual(sorted(thermodb0.groups.keys()),
+                         sorted(self.database.groups.keys()))
 
         for key, depository0 in thermodb0.depository.iteritems():
             depository = self.database.depository[key]
@@ -137,36 +107,6 @@ class TestThermoDatabase(unittest.TestCase):
             self.assertTrue(type(group0), type(group))
             self.assertEqual(sorted(group0.entries.keys()), sorted(group.entries.keys()))
 
-
-
-    @work_in_progress
-    def testNewThermoGeneration(self):
-        """
-        Test that the new ThermoDatabase generates appropriate thermo data.
-        """
-        
-        for smiles, symm, H298, S298, Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500 in self.testCases:
-            Cplist = [Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500]
-            species = Species().fromSMILES(smiles)
-            species.generateResonanceIsomers()
-            thermoData = self.database.getThermoDataFromGroups(species)
-            molecule = species.molecule[0]
-            for mol in species.molecule[1:]:
-                thermoData0 = self.database.getAllThermoData(Species(molecule=[mol]))[0][0]
-                for data in self.database.getAllThermoData(Species(molecule=[mol]))[1:]:
-                    if data[0].getEnthalpy(298) < thermoData0.getEnthalpy(298):
-                        thermoData0 = data[0]
-                if thermoData0.getEnthalpy(298) < thermoData.getEnthalpy(298):
-                    thermoData = thermoData0
-                    molecule = mol
-            self.assertAlmostEqual(H298, thermoData.getEnthalpy(298) / 4184, places=1,
-                                   msg="H298 error for {0}. Expected {1}, but calculated {2}.".format(smiles, H298, thermoData.getEnthalpy(298) / 4184))
-            self.assertAlmostEqual(S298, thermoData.getEntropy(298) / 4.184, places=1,
-                                   msg="S298 error for {0}. Expected {1}, but calculated {2}.".format(smiles, S298, thermoData.getEntropy(298) / 4.184))
-            for T, Cp in zip(self.Tlist, Cplist):
-                self.assertAlmostEqual(Cp, thermoData.getHeatCapacity(T) / 4.184, places=1,
-                                       msg="Cp{3} error for {0}. Expected {1} but calculated {2}.".format(smiles, Cp, thermoData.getHeatCapacity(T) / 4.184, T))
-
     def testSymmetryContributionRadicals(self):
         """
         Test that the symmetry contribution is correctly added for radicals
@@ -179,31 +119,6 @@ class TestThermoDatabase(unittest.TestCase):
         thermoData_ga = self.database.getThermoDataFromGroups(spc)
         
         self.assertAlmostEqual(thermoData_lib.getEntropy(298.), thermoData_ga.getEntropy(298.), 0)
-        
-    @work_in_progress
-    def testSymmetryNumberGeneration(self):
-        """
-        Test we generate symmetry numbers correctly.
-        
-        This uses the new thermo database to generate the H298, used 
-        to select the stablest resonance isomer.
-        """
-        for smiles, symm, H298, S298, Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500 in self.testCases:
-            species = Species().fromSMILES(smiles)
-            species.generateResonanceIsomers()
-            thermoData = self.database.getThermoDataFromGroups(species)
-            # pick the molecule with lowest H298
-            molecule = species.molecule[0]
-            for mol in species.molecule[1:]:
-                thermoData0 = self.database.getAllThermoData(Species(molecule=[mol]))[0][0]
-                for data in self.database.getAllThermoData(Species(molecule=[mol]))[1:]:
-                    if data[0].getEnthalpy(298) < thermoData0.getEnthalpy(298):
-                        thermoData0 = data[0]
-                if thermoData0.getEnthalpy(298) < thermoData.getEnthalpy(298):
-                    thermoData = thermoData0
-                    molecule = mol
-            self.assertEqual(symm, molecule.calculateSymmetryNumber(),
-                             msg="Symmetry number error for {0}. Expected {1} but calculated {2}.".format(smiles, symm, molecule.calculateSymmetryNumber()))
 
     def testParseThermoComments(self):
         """
@@ -281,7 +196,7 @@ class TestThermoDatabase(unittest.TestCase):
         self.assertEqual(source['GAV']['group'][0][1],2)  # weight of the group(Cs-CsCsHH) conbtribution should be 2
         
     def testSpeciesThermoGenerationHBILibrary(self):
-        """Test thermo generation for species objects.
+        """Test thermo generation for species objects for HBI correction on library value.
 
         Ensure that molecule list is only reordered, and not changed after matching library value"""
         spec = Species().fromSMILES('C[CH]c1ccccc1')
@@ -294,7 +209,7 @@ class TestThermoDatabase(unittest.TestCase):
         self.assertTrue('library' in thermo.comment, 'Thermo not found from library, test purpose not fulfilled.')
 
     def testSpeciesThermoGenerationHBIGAV(self):
-        """Test thermo generation for species objects.
+        """Test thermo generation for species objects for HBI correction on group additivity value.
 
         Ensure that molecule list is only reordered, and not changed after group additivity"""
         spec = Species().fromSMILES('CCC[CH]c1ccccc1')
@@ -348,12 +263,11 @@ multiplicity 2
         self.assertTrue('library' in thermo.comment, 'Thermo not found from library, test purpose not fulfilled.')
 
 
-class TestThermoDatabaseAromatics(TestThermoDatabase):
+class TestThermoAccuracy(unittest.TestCase):
     """
-    Test only Aromatic species.
-    
-    A copy of the above class, but with different test compounds
+    Contains tests for accuracy of thermo estimates and symmetry calculations.
     """
+
     @classmethod
     def setUpClass(self):
         """A function that is run ONCE before all unit tests in this class."""
@@ -361,14 +275,104 @@ class TestThermoDatabaseAromatics(TestThermoDatabase):
         self.database = database.thermo
 
     def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        self.Tlist = [300, 400, 500, 600, 800, 1000, 1500]
+
+        self.testCases = [
+            # SMILES         symm    H298   S298  Cp300  Cp400  Cp500  Cp600  Cp800 Cp1000 Cp1500
+
+            # 1,3-hexadiene decomposition products
+            ['C=CC=CCC',        3,  13.45, 86.37, 29.49, 37.67, 44.54, 50.12, 58.66, 64.95, 74.71],
+            ['[CH]=CC=CCC',     3,  72.55, 87.76, 29.30, 36.92, 43.18, 48.20, 55.84, 61.46, 70.18],
+            ['C=[C]C=CCC',      3,  61.15, 87.08, 29.68, 36.91, 43.03, 48.11, 55.96, 61.78, 71.54],
+            ['C=C[C]=CCC',      3,  61.15, 87.08, 29.68, 36.91, 43.03, 48.11, 55.96, 61.78, 71.54],
+            ['C=CC=[C]CC',      3,  70.35, 88.18, 29.15, 36.46, 42.6,  47.6,  55.32, 61.04, 69.95],
+            ['C=CC=C[CH]C',     6,  38.24, 84.41, 27.79, 35.46, 41.94, 47.43, 55.74, 61.92, 71.86],
+            ['C=CC=CC[CH2]',    2,  62.45, 89.78, 28.72, 36.31, 42.63, 47.72, 55.50, 61.21, 70.05],
+            ['[CH3]',           6,  34.81, 46.37,  9.14, 10.18, 10.81, 11.34, 12.57, 13.71, 15.2],
+            ['C=CC=C[CH2]',     2,  46.11, 75.82, 22.54, 28.95, 34.24, 38.64, 45.14, 49.97, 57.85],
+            ['[CH2]C',          6,  28.6,  59.87, 11.73, 14.47, 17.05, 19.34, 23.02, 25.91, 31.53],
+            ['C=CC=[CH]',       1,  85.18, 69.37, 18.93, 23.55, 27.16, 29.92, 34.02, 37.03, 41.81],
+            ['C=[CH]',          1,  71.62, 56.61, 10.01, 11.97, 13.66, 15.08, 17.32, 19.05, 21.85],
+            ['[CH]=CCC',        3,  58.99, 75.0,  20.38, 25.34, 29.68, 33.36, 39.14, 43.48, 50.22],
+
+            # Cyclic Structures
+            ['C1CCCCC1',       12, -29.45, 69.71, 27.20, 37.60, 46.60, 54.80, 67.50, 76.20, 88.50],
+            ['C1CCC1',          8,   6.51, 63.35, 17.39, 23.91, 29.86, 34.76, 42.40, 47.98, 56.33],
+            ['C1C=CC=C1',       2,  32.5,  65.5,  18.16, 24.71, 30.25, 34.7,  41.25, 45.83, 52.61],
+        ]
+
+    @work_in_progress
+    def testNewThermoGeneration(self):
+        """
+        Test that the new ThermoDatabase generates appropriate thermo data.
+        """
+        for smiles, symm, H298, S298, Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500 in self.testCases:
+            Cplist = [Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500]
+            species = Species().fromSMILES(smiles)
+            species.generateResonanceIsomers()
+            thermoData = self.database.getThermoDataFromGroups(species)
+            molecule = species.molecule[0]
+            for mol in species.molecule[1:]:
+                thermoData0 = self.database.getAllThermoData(Species(molecule=[mol]))[0][0]
+                for data in self.database.getAllThermoData(Species(molecule=[mol]))[1:]:
+                    if data[0].getEnthalpy(298) < thermoData0.getEnthalpy(298):
+                        thermoData0 = data[0]
+                if thermoData0.getEnthalpy(298) < thermoData.getEnthalpy(298):
+                    thermoData = thermoData0
+                    molecule = mol
+            self.assertAlmostEqual(H298, thermoData.getEnthalpy(298) / 4184, places=1,
+                                   msg="H298 error for {0}. Expected {1}, but calculated {2}.".format(smiles, H298, thermoData.getEnthalpy(298) / 4184))
+            self.assertAlmostEqual(S298, thermoData.getEntropy(298) / 4.184, places=1,
+                                   msg="S298 error for {0}. Expected {1}, but calculated {2}.".format(smiles, S298, thermoData.getEntropy(298) / 4.184))
+            for T, Cp in zip(self.Tlist, Cplist):
+                self.assertAlmostEqual(Cp, thermoData.getHeatCapacity(T) / 4.184, places=1,
+                                       msg="Cp{3} error for {0}. Expected {1} but calculated {2}.".format(smiles, Cp, thermoData.getHeatCapacity(T) / 4.184, T))
+
+    @work_in_progress
+    def testSymmetryNumberGeneration(self):
+        """
+        Test we generate symmetry numbers correctly.
+
+        This uses the new thermo database to generate the H298, used
+        to select the stablest resonance isomer.
+        """
+        for smiles, symm, H298, S298, Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500 in self.testCases:
+            species = Species().fromSMILES(smiles)
+            species.generateResonanceIsomers()
+            thermoData = self.database.getThermoDataFromGroups(species)
+            # pick the molecule with lowest H298
+            molecule = species.molecule[0]
+            for mol in species.molecule[1:]:
+                thermoData0 = self.database.getAllThermoData(Species(molecule=[mol]))[0][0]
+                for data in self.database.getAllThermoData(Species(molecule=[mol]))[1:]:
+                    if data[0].getEnthalpy(298) < thermoData0.getEnthalpy(298):
+                        thermoData0 = data[0]
+                if thermoData0.getEnthalpy(298) < thermoData.getEnthalpy(298):
+                    thermoData = thermoData0
+                    molecule = mol
+            self.assertEqual(symm, molecule.calculateSymmetryNumber(),
+                             msg="Symmetry number error for {0}. Expected {1} but calculated {2}.".format(smiles, symm, molecule.calculateSymmetryNumber()))
+
+
+class TestThermoAccuracyAromatics(TestThermoAccuracy):
+    """
+    Contains tests for accuracy of thermo estimates and symmetry calculations for aromatics only.
+    
+    A copy of the above class, but with different test compounds.
+    """
+    def setUp(self):
         self.Tlist = [300, 400, 500, 600, 800, 1000, 1500]
         self.testCases = [
-            # SMILES            symm  H298     S298     Cp300  Cp400  Cp500  Cp600  Cp800  Cp1000 Cp1500
-            ['c1ccccc1', 12, 19.80, 64.24, 19.44, 26.64, 32.76, 37.80, 45.24, 50.46, 58.38],
-            ['c1ccc2ccccc2c1', 4, 36.0, 79.49, 31.94, 42.88, 52.08, 59.62, 70.72, 78.68, 90.24],
+            # SMILES         symm    H298   S298  Cp300  Cp400  Cp500  Cp600  Cp800 Cp1000 Cp1500
+            ['c1ccccc1',       12,  19.80, 64.24, 19.44, 26.64, 32.76, 37.80, 45.24, 50.46, 58.38],
+            ['c1ccc2ccccc2c1',  4,   36.0, 79.49, 31.94, 42.88, 52.08, 59.62, 70.72, 78.68, 90.24],
         ]
+
     def __init__(self, *args, **kwargs):
-        super(TestThermoDatabaseAromatics, self).__init__(*args, **kwargs)
+        super(TestThermoAccuracyAromatics, self).__init__(*args, **kwargs)
         self._testMethodDoc = self._testMethodDoc.strip().split('\n')[0] + " for Aromatics.\n"
 
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -306,6 +306,47 @@ class TestThermoDatabase(unittest.TestCase):
         self.assertEqual(set(initial), set(spec.molecule))
         self.assertTrue('group additivity' in thermo.comment, 'Thermo not found from GAV, test purpose not fulfilled.')
 
+    def testSpeciesThermoGenerationLibrary(self):
+        """Test thermo generation for species objects for library value.
+
+        Ensure that the matched molecule is placed at the beginning of the list."""
+        spec = Species().fromSMILES('c12ccccc1c(C=[CH])ccc2')
+        arom = Molecule().fromAdjacencyList("""
+multiplicity 2
+1  C u0 p0 c0 {2,B} {3,B} {5,B}
+2  C u0 p0 c0 {1,B} {4,B} {7,B}
+3  C u0 p0 c0 {1,B} {6,B} {11,S}
+4  C u0 p0 c0 {2,B} {8,B} {13,S}
+5  C u0 p0 c0 {1,B} {9,B} {16,S}
+6  C u0 p0 c0 {3,B} {10,B} {17,S}
+7  C u0 p0 c0 {2,B} {10,B} {19,S}
+8  C u0 p0 c0 {4,B} {9,B} {14,S}
+9  C u0 p0 c0 {5,B} {8,B} {15,S}
+10 C u0 p0 c0 {6,B} {7,B} {18,S}
+11 C u0 p0 c0 {3,S} {12,D} {20,S}
+12 C u1 p0 c0 {11,D} {21,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {8,S}
+15 H u0 p0 c0 {9,S}
+16 H u0 p0 c0 {5,S}
+17 H u0 p0 c0 {6,S}
+18 H u0 p0 c0 {10,S}
+19 H u0 p0 c0 {7,S}
+20 H u0 p0 c0 {11,S}
+21 H u0 p0 c0 {12,S}
+""")
+        spec.generateResonanceIsomers()
+
+        self.assertTrue(arom.isIsomorphic(spec.molecule[1]))  # The aromatic structure should be the second one
+
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.getThermoData(spec)
+
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue(arom.isIsomorphic(spec.molecule[0]))  # The aromatic structure should now be the first one
+        self.assertTrue('library' in thermo.comment, 'Thermo not found from library, test purpose not fulfilled.')
+
 
 class TestThermoDatabaseAromatics(TestThermoDatabase):
     """


### PR DESCRIPTION
We currently reorder the molecules in a `Species()` object when we generate thermo from GAV or HBI to match the order of the thermo estimates based on H298. However, we don't do any reordering when getting thermo from a library. This PR changes `getThermoDataFromLibrary()` to move the matched molecule to the first position in the molecule list.

Reordering molecules affects kinetics estimation in the current algorithm, as explained in #494. While that issue is still yet to be solved, this change should at least make behavior more consistent regardless of the thermo source. 