### PR TITLE
windows environment file to include cairo and cairocffi 

### DIFF
--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -24,8 +24,8 @@ dependencies:
   - nose
   - coverage
   - gprof2dot
-  #- cairo
-  #- cairocffi
+  - cairo
+  - cairocffi
   - openbabel
   - psutil
   - symmetry


### PR DESCRIPTION
Now these two binaries are available in RMG channel, this PR allows users to install these two directly when creating `rmg_env` environment, solving the issue #960 