### PR TITLE
Update name of KlippensteinH2O2 in example files

### DIFF
--- a/examples/generateReactions/input.py
+++ b/examples/generateReactions/input.py
@@ -1,6 +1,6 @@
 # Data sources for kinetics
 database(
-    thermoLibraries = ['KlippensteinH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR'],
+    thermoLibraries = ['BurkeH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR'],
     reactionLibraries = [],  
     seedMechanisms = [],
     kineticsDepositories = 'default', 

--- a/examples/rmg/ch3no2/input.py
+++ b/examples/rmg/ch3no2/input.py
@@ -1,6 +1,6 @@
 # Data sources
 database(
-    thermoLibraries = ['KlippensteinH2O2', 'primaryThermoLibrary','DFT_QCI_thermo','CH','CHN','CHO','CHON','CN','NISTThermoLibrary','thermo_DFT_CCSDTF12_BAC','GRI-Mech3.0-N'],
+    thermoLibraries = ['BurkeH2O2', 'primaryThermoLibrary','DFT_QCI_thermo','CH','CHN','CHO','CHON','CN','NISTThermoLibrary','thermo_DFT_CCSDTF12_BAC','GRI-Mech3.0-N'],
     reactionLibraries = [('Nitrogen_Dean_and_Bozzelli',False)], 
     seedMechanisms = ['ERC-FoundationFuelv0.9'],
     kineticsDepositories = ['training'],

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -4,7 +4,7 @@ database(
 	#libraries found at http://rmg.mit.edu/database/thermo/libraries/
 	#if species exist in multiple libraries, the earlier libraries overwrite the 
 	#previous values
-    thermoLibraries = ['KlippensteinH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR'],
+    thermoLibraries = ['BurkeH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR'],
 	#overrides RMG kinetics estimation if needed in the core of RMG. 
 	#list of libraries found at http://rmg.mit.edu/database/kinetics/libraries/
 	#input each library as a ('library_name',True/False) where a True means that all 
@@ -14,7 +14,7 @@ database(
 	#in addition to species listed in this input file.  
 	#This is helpful for reducing run time for species you know will appear in 
 	#the mechanism.  
-    seedMechanisms = ['KlippensteinH2O2','ERC-FoundationFuelv0.9'],
+    seedMechanisms = ['BurkeH2O2inN2','ERC-FoundationFuelv0.9'],
 	#this is normally not changed in general RMG runs.  Usually used for testing with 
 	#outside kinetics databases
     kineticsDepositories = 'default', 

--- a/ipython/generateReactions.ipynb
+++ b/ipython/generateReactions.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "database = \"\"\"\n",
     "database(\t\t\n",
-    "    thermoLibraries = ['KlippensteinH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR','Narayanaswamy','Chernov'],\t\t\n",
+    "    thermoLibraries = ['BurkeH2O2','primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR','Narayanaswamy','Chernov'],\t\t\n",
     "    reactionLibraries = [],\t\t\n",
     "    seedMechanisms = [],\t\t\n",
     "    kineticsDepositories = ['training'],\t\t\n",


### PR DESCRIPTION
KlippensteinH2O2 was the name of a thermo and kinetics library that was recently updated and renamed to BurkeH2O2.py (thermo) and BurkeH2O2inArH2/BurkeH2O2inN2 in [this PR](https://github.com/ReactionMechanismGenerator/RMG-database/pull/168).

This PR reflects these changes to the example files in RMG-Py