### PR TITLE
Add Comment Stating that Annotated Chemkin File is Necessary

### DIFF
--- a/ipython/localUncertainty.ipynb
+++ b/ipython/localUncertainty.ipynb
@@ -34,6 +34,8 @@
    "outputs": [],
    "source": [
     "# Define the CHEMKIN and Dictionary file paths.  This is a reduced phenyldodecane (PDD) model.\n",
+    "\n",
+    "# Must use annotated chemkin file\n",
     "chemkinFile = 'uncertainty/chem_annotated.inp'\n",
     "dictFile = 'uncertainty/species_dictionary.txt'\n",
     "\n",


### PR DESCRIPTION
Instructs user that they must use the annotated chemkin file.