### PR TITLE
Accelerator Tools (AcceleratorTools part 3)

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -365,6 +365,24 @@ Because the ODE simulation is always interrupted, no pruning is performed.
 
 Please find more details about the theory behind pruning at :ref:`Pruning Theory <prune>`.
 
+Advanced Setting: Taking Multiple Species At A Time
+----------------------------------------------------
+Taking multiple objects (species, reactions or pdepNetworks) during a given simulation can often decrease your overall model generation time
+over only taking one.  For this purpose there is a maxNumObjsPerIter parameter that allows RMG to take
+that many species, reactions or pdepNetworks from a given simulation. This is done in the order they trigger their respective criteria.   
+
+For example ::
+
+	model(
+		toleranceKeepInEdge=0.0,
+		toleranceMoveToCore=0.1,
+		toleranceInterruptSimulation=0.1,
+		maxNumObjsPerIter=2,
+	)
+
+Note that this can also result in larger models, however, sometimes these larger models (from taking more than one
+object at a time) pick up chemistry that would otherwise have been missed.  
+
 .. _ontheflyquantumcalculations:
 
 On the fly Quantum Calculations
@@ -580,4 +598,23 @@ forbidden groups.
 
 By default, the ``allowSingletO2`` flag is set to ``False``.  See :ref:`representing_oxygen` for more information.  
 
+
+Staging
+========
+
+It is now possible to concatenate different model and simulator blocks into the same run in stages.  Any given stage will terminate when the RMG run terminates and then the current group of model and simulator parameters will be switched out with the next group and the run will continue until that stage terminates.  Once the last stage terminates the run ends normally.  This is currently enabled only for the model and simulator blocks.  
+
+There must be the same number of each of these blocks (although only having one simulator block and many model blocks is enabled as well) and RMG will enter each stage these define in the order they were put in the input file. 
+
+To enable easier manipulation of staging a new parameter in the model block was developed maxNumSpecies that is the number of core species at which that stage (or if it is the last stage the entire model generation process) will terminate.  
+
+For example ::
+
+	model(
+		toleranceKeepInEdge=0.0,
+		toleranceMoveToCore=0.1,
+		toleranceInterruptSimulation=0.1,
+		maximumEdgeSpecies=100000,
+		maxNumSpecies=100
+	)
 

--- a/examples/rmg/minimal_staged/input.py
+++ b/examples/rmg/minimal_staged/input.py
@@ -1,0 +1,67 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simulator( #first stage
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+simulator( #second stage
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(#first stage
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=1.0,
+    toleranceInterruptSimulation=1.0,
+    maximumEdgeSpecies=100000,
+    maxNumObjsPerIter=1,#number of objects (species, reactions, PDepNetworks) that can be taken from one simulation
+    maxNumSpecies = 10, #after this number of species is hit will move to next stage
+)
+
+model( #second stage
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    maximumEdgeSpecies=100000,
+    maxNumObjsPerIter=2,
+    maxNumSpecies = 100,
+)
+
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=True,
+)

--- a/examples/rmg/minimal_surface/input.py
+++ b/examples/rmg/minimal_surface/input.py
@@ -28,6 +28,20 @@ simpleReactor(
     terminationTime=(1e6,'s'),
 )
 
+simpleReactor(
+    temperature=(1000,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+
+
 simulator(
     atol=1e-16,
     rtol=1e-8,

--- a/rmgpy/reduction/reduction.py
+++ b/rmgpy/reduction/reduction.py
@@ -119,7 +119,7 @@ def simulateAll(rmg):
 
     data = []
 
-    atol, rtol = rmg.simulatorSettingsList[-1].absoluteTolerance, rmg.simulatorSettingsList[-1].relativeTolerance
+    atol, rtol = rmg.simulatorSettingsList[-1].atol, rmg.simulatorSettingsList[-1].rtol
     for reactionSystem in rmg.reactionSystems:
         data.append(simulateOne(reactionModel, atol, rtol, reactionSystem))
 
@@ -293,10 +293,12 @@ def computeObservables(targets, reactionModel, reactionSystem, atol, rtol):
     - resetting the reaction system, initialing with empty variables
     - running the simulation at the conditions stored in the reaction system
     """
+    simulatorSettings = SimulatorSettings(atol,rtol)
     reactionSystem.initializeModel(\
         reactionModel.core.species, reactionModel.core.reactions,\
         reactionModel.edge.species, reactionModel.edge.reactions, \
-        [],[],[], atol, rtol)
+        [],[],[],atol=simulatorSettings.atol,rtol=simulatorSettings.rtol,
+        sens_atol=simulatorSettings.sens_atol, sens_rtol=simulatorSettings.sens_rtol)
 
     #run the simulation:
     simulateOne(reactionModel, atol, rtol, reactionSystem)
@@ -344,11 +346,14 @@ def computeConversion(targetLabel, reactionModel, reactionSystem, atol, rtol):
 
     #reset reaction system variables:
     logging.info('No. of rxns in core reactions: {}'.format(len(reactionModel.core.reactions)))
-
+    
+    simulatorSettings = SimulatorSettings(atol,rtol)
+    
     reactionSystem.initializeModel(\
         reactionModel.core.species, reactionModel.core.reactions,\
         reactionModel.edge.species, reactionModel.edge.reactions, \
-        [],[],[], atol, rtol)
+        [],[],[],atol=simulatorSettings.atol,rtol=simulatorSettings.rtol,
+        sens_atol=simulatorSettings.sens_atol,sens_rtol=simulatorSettings.sens_rtol)
 
     #get the initial moles:
     y0 = reactionSystem.y.copy()
@@ -381,7 +386,7 @@ def reduceModel(tolerance, targets, reactionModel, rmg, reactionSystemIndex):
     #re-compute observables: 
     observables = computeObservables(targets, rmg.reactionModel,\
      rmg.reactionSystems[reactionSystemIndex],\
-     rmg.simulatorSettingsList[-1].absoluteTolerance, rmg.simulatorSettingsList[-1].relativeTolerance)
+     rmg.simulatorSettingsList[-1].atol, rmg.simulatorSettingsList[-1].rtol)
 
     #reset the reaction model to its original state:
     rmg.reactionModel.core.reactions = originalReactions

--- a/rmgpy/reduction/reduction.py
+++ b/rmgpy/reduction/reduction.py
@@ -39,6 +39,7 @@ from rmgpy.chemkin import getSpeciesIdentifier
 from rmgpy.scoop_framework.util import broadcast, get, map_
 from rmgpy.scoop_framework.util import logger as logging
 from rmgpy.rmg.main import RMG
+from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
 
 from model import ReductionReaction
 from rates import isImportant
@@ -84,6 +85,9 @@ def simulateOne(reactionModel, atol, rtol, reactionSystem):
     pdepNetworks = []
     for source, networks in reactionModel.networkDict.items():
         pdepNetworks.extend(networks)
+        
+    simulatorSettings = SimulatorSettings(atol,rtol)
+    modelSettings = ModelSettings(toleranceKeepInEdge=0,toleranceMoveToCore=1,toleranceInterruptSimulation=1)
     
     terminated, obj,sspcs,srxns = reactionSystem.simulate(
         coreSpecies = reactionModel.core.species,
@@ -92,12 +96,9 @@ def simulateOne(reactionModel, atol, rtol, reactionSystem):
         edgeReactions = reactionModel.edge.reactions,
         surfaceSpecies = [],
         surfaceReactions = [],
-        toleranceKeepInEdge = 0,
-        toleranceMoveToCore = 1,
-        toleranceInterruptSimulation = 1,
         pdepNetworks = pdepNetworks,
-        absoluteTolerance = atol,
-        relativeTolerance = rtol,
+        modelSettings = modelSettings,
+        simulatorSettings=simulatorSettings,
     ) 
 
     assert terminated
@@ -118,7 +119,7 @@ def simulateAll(rmg):
 
     data = []
 
-    atol, rtol = rmg.absoluteTolerance, rmg.relativeTolerance
+    atol, rtol = rmg.simulatorSettingsList[-1].absoluteTolerance, rmg.simulatorSettingsList[-1].relativeTolerance
     for reactionSystem in rmg.reactionSystems:
         data.append(simulateOne(reactionModel, atol, rtol, reactionSystem))
 
@@ -380,7 +381,7 @@ def reduceModel(tolerance, targets, reactionModel, rmg, reactionSystemIndex):
     #re-compute observables: 
     observables = computeObservables(targets, rmg.reactionModel,\
      rmg.reactionSystems[reactionSystemIndex],\
-     rmg.absoluteTolerance, rmg.relativeTolerance)
+     rmg.simulatorSettingsList[-1].absoluteTolerance, rmg.simulatorSettingsList[-1].relativeTolerance)
 
     #reset the reaction model to its original state:
     rmg.reactionModel.core.reactions = originalReactions

--- a/rmgpy/reduction/reductionTest.py
+++ b/rmgpy/reduction/reductionTest.py
@@ -68,13 +68,13 @@ class ReduceFunctionalTest(unittest.TestCase):
         reactionModel = rmg.reactionModel
 
         simulatorSettings = SimulatorSettings()
-        atol, rtol = simulatorSettings.absoluteTolerance, simulatorSettings.relativeTolerance
+        atol, rtol = simulatorSettings.atol, simulatorSettings.rtol
         
         index = 0
         reactionSystem = rmg.reactionSystems[index]
 
         conv = computeConversion(target, reactionModel, reactionSystem,\
-         rmg.simulatorSettingsList[-1].absoluteTolerance, rmg.simulatorSettingsList[-1].relativeTolerance)
+         rmg.simulatorSettingsList[-1].atol, rmg.simulatorSettingsList[-1].rtol)
         self.assertIsNotNone(conv)
 
 
@@ -84,12 +84,12 @@ class ReduceFunctionalTest(unittest.TestCase):
         reactionModel = rmg.reactionModel
 
         simulatorSettings = SimulatorSettings()
-        atol, rtol = simulatorSettings.absoluteTolerance, simulatorSettings.relativeTolerance
+        atol, rtol = simulatorSettings.atol, simulatorSettings.rtol
         index = 0
         reactionSystem = rmg.reactionSystems[index]
         
         observables = computeObservables(targets, reactionModel, reactionSystem, \
-            simulatorSettings.absoluteTolerance, simulatorSettings.relativeTolerance)
+            simulatorSettings.atol, simulatorSettings.rtol)
 
         tols = [0.7, 1e-3, 1e-6]
         for tol in tols:

--- a/rmgpy/reduction/reductionTest.py
+++ b/rmgpy/reduction/reductionTest.py
@@ -35,6 +35,7 @@ from .reduction import *
 
 from rmgpy.rmg.model import CoreEdgeReactionModel
 from rmgpy.species import Species
+from rmgpy.rmg.settings import SimulatorSettings
 
 class ReduceFunctionalTest(unittest.TestCase):
 
@@ -66,12 +67,14 @@ class ReduceFunctionalTest(unittest.TestCase):
         target = ReduceFunctionalTest.targets[0]
         reactionModel = rmg.reactionModel
 
-        atol, rtol = rmg.absoluteTolerance, rmg.relativeTolerance
+        simulatorSettings = SimulatorSettings()
+        atol, rtol = simulatorSettings.absoluteTolerance, simulatorSettings.relativeTolerance
+        
         index = 0
         reactionSystem = rmg.reactionSystems[index]
 
         conv = computeConversion(target, reactionModel, reactionSystem,\
-         rmg.absoluteTolerance, rmg.relativeTolerance)
+         rmg.simulatorSettingsList[-1].absoluteTolerance, rmg.simulatorSettingsList[-1].relativeTolerance)
         self.assertIsNotNone(conv)
 
 
@@ -80,13 +83,13 @@ class ReduceFunctionalTest(unittest.TestCase):
         targets = ReduceFunctionalTest.targets
         reactionModel = rmg.reactionModel
 
-
-        atol, rtol = rmg.absoluteTolerance, rmg.relativeTolerance
+        simulatorSettings = SimulatorSettings()
+        atol, rtol = simulatorSettings.absoluteTolerance, simulatorSettings.relativeTolerance
         index = 0
         reactionSystem = rmg.reactionSystems[index]
-
+        
         observables = computeObservables(targets, reactionModel, reactionSystem, \
-            rmg.absoluteTolerance, rmg.relativeTolerance)
+            simulatorSettings.absoluteTolerance, simulatorSettings.relativeTolerance)
 
         tols = [0.7, 1e-3, 1e-6]
         for tol in tols:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -233,7 +233,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
-          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False):
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,maxNumSpecies=None):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -250,7 +250,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion))
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies))
 
     
 def quantumMechanics(

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -233,7 +233,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
-          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,maxNumSpecies=None):
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,
+          maxNumSpecies=None,maxNumObjsPerIter=1):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -250,7 +251,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies))
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter))
 
     
 def quantumMechanics(

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -40,7 +40,7 @@ from rmgpy.quantity import Quantity
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 from rmgpy.solver.simple import SimpleReactor
 from rmgpy.solver.liquid import LiquidReactor
-
+from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
 from model import CoreEdgeReactionModel
 
 from rmgpy.scoop_framework.util import broadcast, get
@@ -221,10 +221,7 @@ def liquidReactor(temperature,
     rmg.reactionSystems.append(system)
     
 def simulator(atol, rtol, sens_atol=1e-6, sens_rtol=1e-4):
-    rmg.absoluteTolerance = atol
-    rmg.relativeTolerance = rtol
-    rmg.sensitivityAbsoluteTolerance = sens_atol
-    rmg.sensitivityRelativeTolerance = sens_rtol
+    rmg.simulatorSettingsList.append(SimulatorSettings(atol, rtol, sens_atol, sens_rtol))
     
 def solvation(solvent):
     # If solvation module in input file, set the RMG solvent variable
@@ -250,33 +247,11 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     if toleranceMoveToCore > toleranceInterruptSimulation:
         raise InputError("toleranceMoveToCore must be less than or equal to toleranceInterruptSimulation, which is currently {0}".format(toleranceInterruptSimulation))
     
-    rmg.fluxToleranceKeepInEdge = toleranceKeepInEdge
-    rmg.fluxToleranceMoveToCore = toleranceMoveToCore
-    rmg.toleranceMoveEdgeReactionToCore = toleranceMoveEdgeReactionToCore
-    rmg.fluxToleranceInterrupt = toleranceInterruptSimulation
-    rmg.maximumEdgeSpecies = maximumEdgeSpecies
-    rmg.minCoreSizeForPrune = minCoreSizeForPrune
-    rmg.minSpeciesExistIterationsForPrune = minSpeciesExistIterationsForPrune
-    rmg.filterReactions = filterReactions
-    rmg.ignoreOverallFluxCriterion=ignoreOverallFluxCriterion
-    rmg.toleranceMoveEdgeReactionToSurface = toleranceMoveEdgeReactionToSurface
-    rmg.toleranceMoveSurfaceSpeciesToCore = toleranceMoveSurfaceSpeciesToCore
-    rmg.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
-    
-    if toleranceInterruptSimulation:
-        rmg.fluxToleranceInterrupt = toleranceInterruptSimulation
-    else:
-        rmg.fluxToleranceInterrupt = toleranceMoveToCore
-        
-    if toleranceMoveEdgeReactionToSurfaceInterrupt:
-        rmg.toleranceMoveEdgeReactionToSurfaceInterrupt = toleranceMoveEdgeReactionToSurfaceInterrupt
-    else:
-        rmg.toleranceMoveEdgeReactionToSurfaceInterrupt = toleranceMoveEdgeReactionToSurface
-    
-    if toleranceMoveEdgeReactionToCoreInterrupt:
-        rmg.toleranceMoveEdgeReactionToCoreInterrupt = toleranceMoveEdgeReactionToCoreInterrupt
-    else:
-        rmg.toleranceMoveEdgeReactionToCoreInterrupt = toleranceMoveEdgeReactionToCore
+    rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
+          toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
+          toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion))
+
     
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -548,8 +548,8 @@ class RMG(util.Subject):
                     edgeSpecies = [],
                     edgeReactions = [],
                     pdepNetworks = self.reactionModel.networkList,
-                    atol = self.absoluteTolerance,
-                    rtol = self.relativeTolerance,
+                    atol = self.simulatorSettingsList[0].atol,
+                    rtol = self.simulatorSettingsList[0].rtol,
                     filterReactions=True,
                 )
                 self.updateReactionThresholdAndReactFlags(

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -42,6 +42,7 @@ import numpy
 import csv
 import gc
 import copy
+from copy import deepcopy
 
 from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.molecule import Molecule
@@ -73,7 +74,7 @@ from rmgpy.stats import ExecutionStatsWriter
 from rmgpy.thermo.thermoengine import submit
 from rmgpy.tools.sensitivity import plotSensitivity
 from cantera import ck2cti
-
+from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
 ################################################################################
 
 solvent = None
@@ -102,17 +103,8 @@ class RMG(util.Subject):
     `reactionSystems`                   A list of the reaction systems used in this job
     `database`                          The RMG database used in this job
     ----------------------------------- ------------------------------------------------
-    `absoluteTolerance`                 The absolute tolerance used in the ODE/DAE solver
-    `relativeTolerance`                 The relative tolerance used in the ODE/DAE solver
-    `sensitivityAbsoluteTolerance`      The absolute tolerance used in the ODE/DAE solver for the sensitivities
-    `sensitivityRelativeTolerance`      The relative tolerance used in the ODE/DAE solver for the sensitivities
-    `fluxToleranceKeepInEdge`           The relative species flux below which species are discarded from the edge
-    `fluxToleranceMoveToCore`           The relative species flux above which species are moved from the edge to the core
-    `fluxToleranceInterrupt`            The relative species flux above which the simulation will halt
-    `maximumEdgeSpecies`                The maximum number of edge species allowed at any time
-    `minCoreSizeForPrune`               Minimum number of core species before pruning is allowed
-    `minSpeciesExistIterationsForPrune` Minimum number of iterations a species must exist before it can be pruned
-    `filterReactions`                   Specify whether to filter reactions during model enlarging step
+    `modelSettingsList`                 List of ModelSettings objects containing information related to how to manage species/reaction movement
+    `simulatorSettingsList`             List of SimulatorSettings objects containing information on how to run simulations
     `unimolecularThreshold`             Array of flags indicating whether a species is above the unimolecular reaction threshold
     `bimolecularaThreshold`             Array of flags indicating whether two species are above the bimolecular reaction threshold
     `unimolecularReact`                 Array of flags indicating whether a species should react unimolecularly in the enlarge step
@@ -146,6 +138,8 @@ class RMG(util.Subject):
         self.inputFile = inputFile
         self.outputDirectory = outputDirectory
         self.clear()
+        self.modelSettingsList = []
+        self.simulatorSettingsList = []
     
     def clear(self):
         """
@@ -168,20 +162,9 @@ class RMG(util.Subject):
         self.database = None
         self.reactionSystem = None
         
-        self.fluxToleranceKeepInEdge = 0.0
-        self.fluxToleranceMoveToCore = 1.0
-        self.fluxToleranceInterrupt = 1.0
-        self.toleranceMoveEdgeReactionToCore = numpy.inf
-        self.toleranceReactionInterruptSimulation = numpy.inf
-        self.ignoreOverallFluxCriterion=False
+        self.modelSettingsList = []
+        self.simulatorSettingsList = []
         
-        self.absoluteTolerance = 1.0e-8
-        self.relativeTolerance = 1.0e-4
-        self.sensitivityAbsoluteTolerance = 1.0e-6
-        self.sensitivityRelativeTolerance = 1.0e-4
-        self.maximumEdgeSpecies = 1000000
-        self.minCoreSizeForPrune = 50
-        self.minSpeciesExistIterationsForPrune = 2
         self.filterReactions=False
         self.unimolecularReact = None
         self.bimolecularReact = None
@@ -556,7 +539,7 @@ class RMG(util.Subject):
         self.done = False
         
         # Initiate first reaction discovery step after adding all core species
-        if self.filterReactions:
+        if self.modelSettingsList[0].filterReactions:
             # Run the reaction system to update threshold and react flags
             for index, reactionSystem in enumerate(self.reactionSystems):
                 reactionSystem.initializeModel(
@@ -583,155 +566,141 @@ class RMG(util.Subject):
         
         self.makeSeedMech(firstTime=True)
         
-        # Main RMG loop
-        while not self.done:
-                
-            self.done = True
-            objectsToEnlarge = []
-            allTerminated = True
-            numCoreSpecies = len(self.reactionModel.core.species)
-            for index, reactionSystem in enumerate(self.reactionSystems):
-                
-                self.reactionSystem = reactionSystem
-                # Conduct simulation
-                logging.info('Conducting simulation of reaction system %s...' % (index+1))
-                prune = True
-                if numCoreSpecies < self.minCoreSizeForPrune:
-                    # Turn pruning off if we haven't reached minimum core size.
-                    prune = False
+        for q,modelSettings in enumerate(self.modelSettingsList):
+            if len(self.simulatorSettingsList) > 1: 
+                simulatorSettings = self.simulatorSettingsList[q]
+            else: #if they only provide one input for simulator use that everytime
+                simulatorSettings = self.simulatorSettingsList[0]
+            
+            self.filterReactions = modelSettings.filterReactions
+            
+            # Main RMG loop
+            while not self.done:
+
+                self.done = True
+                objectsToEnlarge = []
+                allTerminated = True
+                numCoreSpecies = len(self.reactionModel.core.species)
+                for index, reactionSystem in enumerate(self.reactionSystems):
+                    self.reactionSystem = reactionSystem
+                    # Conduct simulation
+                    logging.info('Conducting simulation of reaction system %s...' % (index+1))
+                    prune = True
+                    if numCoreSpecies < modelSettings.minCoreSizeForPrune:
+                        # Turn pruning off if we haven't reached minimum core size.
+                        prune = False
+    
+                    try: terminated, obj,surfaceSpecies,surfaceReactions = reactionSystem.simulate(
+                        coreSpecies = self.reactionModel.core.species,
+                        coreReactions = self.reactionModel.core.reactions,
+                        edgeSpecies = self.reactionModel.edge.species,
+                        edgeReactions = self.reactionModel.edge.reactions,
+                        surfaceSpecies = self.reactionModel.surfaceSpecies,
+                        surfaceReactions = self.reactionModel.surfaceReactions,
+                        pdepNetworks = self.reactionModel.networkList,
+                        prune = prune,
+                        modelSettings=modelSettings,
+                        simulatorSettings = simulatorSettings,
+                    )
                     
-
-                try: terminated, obj,surfaceSpecies,surfaceReactions = reactionSystem.simulate(
-                    coreSpecies = self.reactionModel.core.species,
-                    coreReactions = self.reactionModel.core.reactions,
-                    edgeSpecies = self.reactionModel.edge.species,
-                    edgeReactions = self.reactionModel.edge.reactions,
-                    surfaceSpecies = self.reactionModel.surfaceSpecies,
-                    surfaceReactions = self.reactionModel.surfaceReactions,
-                    toleranceKeepInEdge = self.fluxToleranceKeepInEdge if prune else 0,
-                    toleranceMoveToCore = self.fluxToleranceMoveToCore,
-                    toleranceMoveEdgeReactionToCore = self.toleranceMoveEdgeReactionToCore,
-                    toleranceInterruptSimulation = self.fluxToleranceInterrupt if prune else self.fluxToleranceMoveToCore,
-                    toleranceMoveEdgeReactionToCoreInterrupt= self.toleranceMoveEdgeReactionToCoreInterrupt if prune else self.toleranceMoveEdgeReactionToCore,
-                    toleranceMoveEdgeReactionToSurface = self.toleranceMoveEdgeReactionToSurface,
-                    toleranceMoveSurfaceSpeciesToCore = self.toleranceMoveSurfaceSpeciesToCore,
-                    toleranceMoveSurfaceReactionToCore = self.toleranceMoveSurfaceReactionToCore,
-                    toleranceMoveEdgeReactionToSurfaceInterrupt = self.toleranceMoveEdgeReactionToSurfaceInterrupt,
-                    pdepNetworks = self.reactionModel.networkList,
-                    ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
-                    absoluteTolerance = self.absoluteTolerance,
-                    relativeTolerance = self.relativeTolerance,
-                    filterReactions=False,
-                )
-                
-                except:
-                    logging.error("Model core reactions:")
-                    if len(self.reactionModel.core.reactions) > 5:
-                        logging.error("Too many to print in detail")
-                    else:
-                        from rmgpy.cantherm.output import prettify
-                        logging.error(prettify(repr(self.reactionModel.core.reactions)))
-                    self.makeSeedMech()
-                    raise
-
-                self.reactionModel.surfaceSpecies = surfaceSpecies
-                self.reactionModel.surfaceReactions = surfaceReactions
-
-                if self.generateSeedEachIteration:
-                    self.makeSeedMech()
-
-                allTerminated = allTerminated and terminated
-                logging.info('')
-                
-                # If simulation is invalid, note which species should be added to
-                # the core
-                if obj:
-                    objectsToEnlarge = self.processToSpeciesNetworks(obj)
-                    if isinstance(objectsToEnlarge[0],PDepNetwork):
-                        assert False
+                    except:
+                        logging.error("Model core reactions:")
+                        if len(self.reactionModel.core.reactions) > 5:
+                            logging.error("Too many to print in detail")
+                        else:
+                            from rmgpy.cantherm.output import prettify
+                            logging.error(prettify(repr(self.reactionModel.core.reactions)))
+                        self.makeSeedMech()
+                        raise
+    
+                    self.reactionModel.surfaceSpecies = surfaceSpecies
+                    self.reactionModel.surfaceReactions = surfaceReactions
+                    
+                    if self.generateSeedEachIteration:
+                        self.makeSeedMech()
                         
-                    self.done = False
-    
-            if not self.done: # There is something that needs exploring/enlarging
-                
-                # If we reached our termination conditions, then try to prune
-                # species from the edge
-                if allTerminated:
-                    self.reactionModel.prune(self.reactionSystems, self.fluxToleranceKeepInEdge, self.maximumEdgeSpecies, self.minSpeciesExistIterationsForPrune)
-                    # Perform garbage collection after pruning
-                    collected = gc.collect()
-                    logging.info('Garbage collector: collected %d objects.' % (collected))
-    
-                # Enlarge objects identified by the simulation for enlarging
-                # These should be Species or Network objects
-                logging.info('')
-                objectsToEnlarge = list(set(objectsToEnlarge))
-
-                if len(objectsToEnlarge) == 0:
-                    raise Exception("Expected a species or pdep object to enlarge, but there wasn't one found.")
-                
-                # Add objects to enlarge to the core first
-                for objectToEnlarge in objectsToEnlarge:
-                    self.reactionModel.enlarge(objectToEnlarge)
-                
-                if len(self.reactionModel.core.species) > numCoreSpecies:
-                    # If there were core species added, then react the edge
-                    # If there were no new core species, it means the pdep network needs be updated through another enlarge core step
-                    if self.filterReactions:
-                        # Run a raw simulation to get updated reaction system threshold values
-                        for index, reactionSystem in enumerate(self.reactionSystems):
-                            # Run with the same conditions as with pruning off
-                            reactionSystem.simulate(
-                                coreSpecies = self.reactionModel.core.species,
-                                coreReactions = self.reactionModel.core.reactions,
-                                edgeSpecies = [],
-                                edgeReactions = [],
-                                surfaceSpecies = self.reactionModel.surfaceSpecies,
-                                surfaceReactions = self.reactionModel.surfaceReactions,
-                                toleranceKeepInEdge = 0,
-                                toleranceMoveToCore = self.fluxToleranceMoveToCore,
-                                toleranceMoveEdgeReactionToCore = self.toleranceMoveEdgeReactionToCore,
-                                toleranceInterruptSimulation =  self.fluxToleranceMoveToCore,
-                                toleranceMoveEdgeReactionToCoreInterrupt=  self.toleranceMoveEdgeReactionToCore,
-                                toleranceMoveEdgeReactionToSurface = self.toleranceMoveEdgeReactionToSurface,
-                                toleranceMoveSurfaceSpeciesToCore = self.toleranceMoveSurfaceSpeciesToCore,
-                                toleranceMoveSurfaceReactionToCore = self.toleranceMoveSurfaceReactionToCore,
-                                toleranceMoveEdgeReactionToSurfaceInterrupt = self.toleranceMoveEdgeReactionToSurfaceInterrupt,
-                                pdepNetworks = self.reactionModel.networkList,
-                                ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
-                                absoluteTolerance = self.absoluteTolerance,
-                                relativeTolerance = self.relativeTolerance,
-                                filterReactions=True,
-                            )
-                            self.updateReactionThresholdAndReactFlags(
-                                rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
-                                rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold)
-    
-                        logging.info('')    
-                    else:
-                        self.updateReactionThresholdAndReactFlags()
+                    allTerminated = allTerminated and terminated
+                    logging.info('')
                     
-                    self.reactionModel.enlarge(reactEdge=True, 
-                            unimolecularReact=self.unimolecularReact, 
-                            bimolecularReact=self.bimolecularReact)
-
-            self.saveEverything()
-
-            # Consider stopping gracefully if the next iteration might take us
-            # past the wall time
-            if self.wallTime > 0 and len(self.execTime) > 1:
-                t = self.execTime[-1]
-                dt = self.execTime[-1] - self.execTime[-2]
-                if t + 3 * dt > self.wallTime:
-                    logging.info('MODEL GENERATION TERMINATED')
+                    # If simulation is invalid, note which species should be added to
+                    # the core
+                    if obj:
+                        objectsToEnlarge = self.processToSpeciesNetworks(obj)
+                        if isinstance(objectsToEnlarge[0],PDepNetwork):
+                            assert False
+                        self.done = False
+        
+                if not self.done: # There is something that needs exploring/enlarging
+                    
+                    # If we reached our termination conditions, then try to prune
+                    # species from the edge
+                    if allTerminated:
+                        self.reactionModel.prune(self.reactionSystems, modelSettings.fluxToleranceKeepInEdge, modelSettings.maximumEdgeSpecies, modelSettings.minSpeciesExistIterationsForPrune)
+                        # Perform garbage collection after pruning
+                        collected = gc.collect()
+                        logging.info('Garbage collector: collected %d objects.' % (collected))
+        
+                    # Enlarge objects identified by the simulation for enlarging
+                    # These should be Species or Network objects
                     logging.info('')
-                    logging.info('There is not enough time to complete the next iteration before the wall time is reached.')
-                    logging.info('The output model may be incomplete.')
-                    logging.info('')
-                    coreSpec, coreReac, edgeSpec, edgeReac = self.reactionModel.getModelSize()
-                    logging.info('The current model core has %s species and %s reactions' % (coreSpec, coreReac))
-                    logging.info('The current model edge has %s species and %s reactions' % (edgeSpec, edgeReac))
-                    return
+                    objectsToEnlarge = list(set(objectsToEnlarge))
+    
+                    if len(objectsToEnlarge) == 0:
+                        raise Exception("Expected a species or pdep object to enlarge, but there wasn't one found.")
+                    
+                    # Add objects to enlarge to the core first
+                    for objectToEnlarge in objectsToEnlarge:
+                        self.reactionModel.enlarge(objectToEnlarge)
+                    
+                    if len(self.reactionModel.core.species) > numCoreSpecies:
+                        tempModelSettings = deepcopy(modelSettings)
+                        tempModelSettings.toleranceKeepInEdge = 0
+                        # If there were core species added, then react the edge
+                        # If there were no new core species, it means the pdep network needs be updated through another enlarge core step
+                        if modelSettings.filterReactions:
+                            # Run a raw simulation to get updated reaction system threshold values
+                            for index, reactionSystem in enumerate(self.reactionSystems):
+                                # Run with the same conditions as with pruning off
+                                reactionSystem.simulate(
+                                    coreSpecies = self.reactionModel.core.species,
+                                    coreReactions = self.reactionModel.core.reactions,
+                                    edgeSpecies = [],
+                                    edgeReactions = [],
+                                    surfaceSpecies = self.reactionModel.surfaceSpecies,
+                                    surfaceReactions = self.reactionModel.surfaceReactions,
+                                    pdepNetworks = self.reactionModel.networkList,
+                                    modelSettings = tempModelSettings,
+                                    simulatorSettings = simulatorSettings,
+                                )
+                                self.updateReactionThresholdAndReactFlags(
+                                    rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
+                                    rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold)
+        
+                            logging.info('')    
+                        else:
+                            self.updateReactionThresholdAndReactFlags()
+                        
+                        self.reactionModel.enlarge(reactEdge=True, 
+                                unimolecularReact=self.unimolecularReact, 
+                                bimolecularReact=self.bimolecularReact)
+    
+                self.saveEverything()
+    
+                # Consider stopping gracefully if the next iteration might take us
+                # past the wall time
+                if self.wallTime > 0 and len(self.execTime) > 1:
+                    t = self.execTime[-1]
+                    dt = self.execTime[-1] - self.execTime[-2]
+                    if t + 3 * dt > self.wallTime:
+                        logging.info('MODEL GENERATION TERMINATED')
+                        logging.info('')
+                        logging.info('There is not enough time to complete the next iteration before the wall time is reached.')
+                        logging.info('The output model may be incomplete.')
+                        logging.info('')
+                        coreSpec, coreReac, edgeSpec, edgeReac = self.reactionModel.getModelSize()
+                        logging.info('The current model core has %s species and %s reactions' % (coreSpec, coreReac))
+                        logging.info('The current model edge has %s species and %s reactions' % (edgeSpec, edgeReac))
+                        return
         
         
         # Run sensitivity analysis post-model generation if sensitivity analysis is on
@@ -750,25 +719,13 @@ class RMG(util.Subject):
                     coreReactions = self.reactionModel.core.reactions,
                     edgeSpecies = self.reactionModel.edge.species,
                     edgeReactions = self.reactionModel.edge.reactions,
-                    surfaceSpecies = self.reactionModel.surfaceSpecies,
-                    surfaceReactions = self.reactionModel.surfaceReactions,
-                    toleranceKeepInEdge = self.fluxToleranceKeepInEdge,
-                    toleranceMoveToCore = self.fluxToleranceMoveToCore,
-                    toleranceMoveEdgeReactionToCore = self.toleranceMoveEdgeReactionToCore,
-                    toleranceInterruptSimulation =  self.fluxToleranceMoveToCore,
-                    toleranceMoveEdgeReactionToCoreInterrupt=  self.toleranceMoveEdgeReactionToCore,
-                    toleranceMoveEdgeReactionToSurface = self.toleranceMoveEdgeReactionToSurface,
-                    toleranceMoveSurfaceSpeciesToCore = self.toleranceMoveSurfaceSpeciesToCore,
-                    toleranceMoveSurfaceReactionToCore = self.toleranceMoveSurfaceReactionToCore,
-                    toleranceMoveEdgeReactionToSurfaceInterrupt = self.toleranceMoveEdgeReactionToSurfaceInterrupt,
+                    surfaceSpecies = [],
+                    surfaceReactions = [],
                     pdepNetworks = self.reactionModel.networkList,
-                    ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
-                    absoluteTolerance = self.absoluteTolerance,
-                    relativeTolerance = self.relativeTolerance,
                     sensitivity = True,
-                    sensitivityAbsoluteTolerance = self.sensitivityAbsoluteTolerance,
-                    sensitivityRelativeTolerance = self.sensitivityRelativeTolerance,
                     sensWorksheet = sensWorksheet,
+                    modelSettings = self.modelSettingsList[-1],
+                    simulatorSettings = self.simulatorSettingsList[-1],
                 )
                 
                 plotSensitivity(self.outputDirectory, index, reactionSystem.sensitiveSpecies)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -565,6 +565,8 @@ class RMG(util.Subject):
         self.saveEverything()
         
         self.makeSeedMech(firstTime=True)
+
+        maxNumSpcsHit = False #default
         
         for q,modelSettings in enumerate(self.modelSettingsList):
             if len(self.simulatorSettingsList) > 1: 
@@ -650,7 +652,13 @@ class RMG(util.Subject):
                     
                     # Add objects to enlarge to the core first
                     for objectToEnlarge in objectsToEnlarge:
+                        if len(self.reactionModel.core.species) >= modelSettings.maxNumSpecies:
+                            maxNumSpcsHit = True
+                            break
                         self.reactionModel.enlarge(objectToEnlarge)
+                        
+                    if maxNumSpcsHit: #breaks the while loop 
+                        break
                     
                     if len(self.reactionModel.core.species) > numCoreSpecies:
                         tempModelSettings = deepcopy(modelSettings)
@@ -701,7 +709,10 @@ class RMG(util.Subject):
                         logging.info('The current model core has %s species and %s reactions' % (coreSpec, coreReac))
                         logging.info('The current model edge has %s species and %s reactions' % (edgeSpec, edgeReac))
                         return
-        
+                    
+            if maxNumSpcsHit: #resets maxNumSpcsHit and continues the settings for loop
+                maxNumSpcsHit = False
+                continue
         
         # Run sensitivity analysis post-model generation if sensitivity analysis is on
         for index, reactionSystem in enumerate(self.reactionSystems):

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -628,8 +628,6 @@ class RMG(util.Subject):
                     # the core
                     if obj:
                         objectsToEnlarge = self.processToSpeciesNetworks(obj)
-                        if isinstance(objectsToEnlarge[0],PDepNetwork):
-                            assert False
                         self.done = False
         
                 if not self.done: # There is something that needs exploring/enlarging

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -585,6 +585,13 @@ class RMG(util.Subject):
 
                 self.done = True
                 objectsToEnlarge = []
+                newSurfaceSpcsAdd = set()
+                newSurfaceRxnsAdd = set()
+                newSurfaceSpcsLoss = set()
+                newSurfaceRxnsLoss = set()
+                surfSpcs = set(self.reactionModel.surfaceSpecies)
+                surfRxns = set(self.reactionModel.surfaceReactions)
+                
                 allTerminated = True
                 numCoreSpecies = len(self.reactionModel.core.species)
                 for index, reactionSystem in enumerate(self.reactionSystems):
@@ -595,20 +602,19 @@ class RMG(util.Subject):
                     if numCoreSpecies < modelSettings.minCoreSizeForPrune:
                         # Turn pruning off if we haven't reached minimum core size.
                         prune = False
-    
-                    try: terminated, obj,surfaceSpecies,surfaceReactions = reactionSystem.simulate(
+                        
+                    try: terminated, obj,newSurfaceSpecies,newSurfaceReactions = reactionSystem.simulate(
                         coreSpecies = self.reactionModel.core.species,
                         coreReactions = self.reactionModel.core.reactions,
                         edgeSpecies = self.reactionModel.edge.species,
                         edgeReactions = self.reactionModel.edge.reactions,
-                        surfaceSpecies = self.reactionModel.surfaceSpecies,
-                        surfaceReactions = self.reactionModel.surfaceReactions,
+                        surfaceSpecies = list(surfSpcs),
+                        surfaceReactions = list(surfRxns),
                         pdepNetworks = self.reactionModel.networkList,
                         prune = prune,
                         modelSettings=modelSettings,
                         simulatorSettings = simulatorSettings,
                     )
-                    
                     except:
                         logging.error("Model core reactions:")
                         if len(self.reactionModel.core.reactions) > 5:
@@ -618,24 +624,51 @@ class RMG(util.Subject):
                             logging.error(prettify(repr(self.reactionModel.core.reactions)))
                         self.makeSeedMech()
                         raise
-    
-                    self.reactionModel.surfaceSpecies = surfaceSpecies
-                    self.reactionModel.surfaceReactions = surfaceReactions
-                    
+
                     if self.generateSeedEachIteration:
                         self.makeSeedMech()
                         
+                    newSurfaceSpecies = set(newSurfaceSpecies)
+                    newSurfaceReactions = set(newSurfaceReactions)
+                    
+                    addedRxns = {k for k in obj if isinstance(k,Reaction)}
+                    addedSurfaceRxns = newSurfaceReactions - surfRxns
+                    
+                    addedBulkRxns = addedRxns-addedSurfaceRxns
+                    lostSurfaceRxns = (surfRxns - newSurfaceReactions) | addedBulkRxns
+                    
+                    addedSpcs = {k for k in obj if isinstance(k,Species)} | {k.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si) for k in obj if isinstance(k,PDepNetwork)}
+                    lostSurfaceSpcs = (surfSpcs-newSurfaceSpecies) | addedSpcs
+                    addedSurfaceSpcs = newSurfaceSpecies - surfSpcs
+                    
+                    newSurfaceSpcsAdd = newSurfaceSpcsAdd | addedSurfaceSpcs
+                    newSurfaceRxnsAdd = newSurfaceRxnsAdd | addedSurfaceRxns
+                    newSurfaceSpcsLoss = newSurfaceSpcsLoss | lostSurfaceSpcs
+                    newSurfaceRxnsLoss = newSurfaceRxnsLoss | lostSurfaceRxns
+                    
                     allTerminated = allTerminated and terminated
                     logging.info('')
-                    
+                        
                     # If simulation is invalid, note which species should be added to
                     # the core
-                    if obj:
-                        objectsToEnlarge = self.processToSpeciesNetworks(obj)
+                    if obj != [] and not (obj is None):
+                        objects = self.processToSpeciesNetworks(obj)
+                        for ob in objects:
+                            if not (ob in objectsToEnlarge):
+                                if isinstance(ob,Species): #keep Species before PDepNetworks
+                                    objectsToEnlarge.insert(0,ob)
+                                elif isinstance(ob[0],PDepNetwork):
+                                    objectsToEnlarge.append(ob)
+                                else:
+                                    raise TypeError('processed object not recognized')
+
                         self.done = False
-        
+                        
+                    if newSurfaceRxnsAdd != set() or newSurfaceRxnsLoss != set() or newSurfaceSpcsLoss != set() or newSurfaceSpcsAdd != set():
+                        self.done = False
+                        
                 if not self.done: # There is something that needs exploring/enlarging
-                    
+
                     # If we reached our termination conditions, then try to prune
                     # species from the edge
                     if allTerminated:
@@ -647,21 +680,13 @@ class RMG(util.Subject):
                     # Enlarge objects identified by the simulation for enlarging
                     # These should be Species or Network objects
                     logging.info('')
+
                     objectsToEnlarge = list(set(objectsToEnlarge))
-    
-                    if len(objectsToEnlarge) == 0:
-                        raise Exception("Expected a species or pdep object to enlarge, but there wasn't one found.")
-                    
+
                     # Add objects to enlarge to the core first
                     for objectToEnlarge in objectsToEnlarge:
-                        if len(self.reactionModel.core.species) >= modelSettings.maxNumSpecies:
-                            maxNumSpcsHit = True
-                            break
                         self.reactionModel.enlarge(objectToEnlarge)
                         
-                    if maxNumSpcsHit: #breaks the while loop 
-                        break
-                    
                     if len(self.reactionModel.core.species) > numCoreSpecies:
                         tempModelSettings = deepcopy(modelSettings)
                         tempModelSettings.toleranceKeepInEdge = 0
@@ -693,7 +718,19 @@ class RMG(util.Subject):
                         self.reactionModel.enlarge(reactEdge=True, 
                                 unimolecularReact=self.unimolecularReact, 
                                 bimolecularReact=self.bimolecularReact)
-    
+                    
+                    #Adjust Surface
+                    #we add added species and remove any species moved out of the core
+                    #for now we remove reactions that become part of a PDepNetwork by intersecting with the core
+                    #thus the surface algorithm currently (June 2017) is not implemented for pdep networks
+                    self.reactionModel.surfaceSpecies = list(((surfSpcs | newSurfaceSpcsAdd)-newSurfaceSpcsLoss) & set(self.reactionModel.core.species))
+                    self.reactionModel.surfaceReactions = list(((surfRxns | newSurfaceRxnsAdd)-newSurfaceRxnsLoss) & set(self.reactionModel.core.reactions))
+                        
+                    maxNumSpcsHit = len(self.reactionModel.core.species) >= modelSettings.maxNumSpecies
+
+                    if maxNumSpcsHit: #breaks the while loop 
+                        break
+                    
                 self.saveEverything()
     
                 # Consider stopping gracefully if the next iteration might take us

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -573,9 +573,13 @@ class RMG(util.Subject):
                 simulatorSettings = self.simulatorSettingsList[q]
             else: #if they only provide one input for simulator use that everytime
                 simulatorSettings = self.simulatorSettingsList[0]
-            
+
             self.filterReactions = modelSettings.filterReactions
+
+            logging.info('Beginning model generation stage {0}\n\n'.format(q+1))
             
+            self.done = False
+
             # Main RMG loop
             while not self.done:
 
@@ -709,6 +713,7 @@ class RMG(util.Subject):
                         return
                     
             if maxNumSpcsHit: #resets maxNumSpcsHit and continues the settings for loop
+                logging.info('The maximum number of species ({0}) has been hit, Exiting stage {1} ...'.format(modelSettings.maxNumSpecies,q+1))
                 maxNumSpcsHit = False
                 continue
         

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -887,12 +887,13 @@ class RMG(util.Subject):
             return list(self.processReactionsToSpecies(obj))
         elif isinstance(obj,list): #list of species
             rspcs = self.processReactionsToSpecies([k for k in obj if isinstance(k,Reaction)])
-            spcs = list({k for k in obj if isinstance(k,Species)} | rspcs)
-            nworks = list(set(self.processPdepNetworks([k for k in obj if isinstance(k,PDepNetwork)])))
+            spcs = {k for k in obj if isinstance(k,Species)} | rspcs
+            nworks,pspcs = self.processPdepNetworks([k for k in obj if isinstance(k,PDepNetwork)])
+            spcs = list(spcs-pspcs) #avoid duplicate species
             return spcs+nworks
         else:
             raise TypeError("improper call, obj input was incorrect")
-                
+
     def processPdepNetworks(self,obj):
         """
         properly processes PDepNetwork objects and lists of PDepNetwork objects returned from simulate
@@ -905,7 +906,9 @@ class RMG(util.Subject):
             ob = (obj, obj.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si))
             return ob
         elif isinstance(obj,list):
-            return [(ob, ob.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si)) for ob in obj]
+            spcs = [ob.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si) for ob in obj]
+            nworks = [(obj[i],spcs[i]) for i in xrange(len(obj))]
+            return nworks,set(spcs)
         else:
             raise TypeError("improper call, obj input was incorrect")
             

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -582,7 +582,8 @@ class RMG(util.Subject):
 
             # Main RMG loop
             while not self.done:
-
+                
+                self.reactionModel.iterationNum += 1
                 self.done = True
                 objectsToEnlarge = []
                 newSurfaceSpcsAdd = set()

--- a/rmgpy/rmg/mainTest.py
+++ b/rmgpy/rmg/mainTest.py
@@ -76,6 +76,10 @@ simpleReactor(
     },
     terminationTime=(1e6,'s'),
 )
+simulator(
+atol=1e-16,
+rtol=1e-8
+)
 model(
     toleranceKeepInEdge=0.0,
     toleranceMoveToCore=0.2,

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -71,15 +71,15 @@ class Species(rmgpy.species.Species):
 
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 
                  molecule=None, transportData=None, molecularWeight=None, 
-                 energyTransferModel=None, reactive=True, props=None, coreSizeAtCreation=0):
+                 energyTransferModel=None, reactive=True, props=None, creationIteration=0):
         rmgpy.species.Species.__init__(self, index, label, thermo, conformer, molecule, transportData, molecularWeight, energyTransferModel, reactive, props)
-        self.coreSizeAtCreation = coreSizeAtCreation
+        self.creationIteration = creationIteration
 
     def __reduce__(self):
         """
         A helper function used when pickling an object.
         """
-        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props, self.coreSizeAtCreation),)
+        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props,self.creationIteration),)
 
 ################################################################################
 
@@ -233,6 +233,7 @@ class CoreEdgeReactionModel:
         self.kineticsEstimator = 'group additivity'
         self.indexSpeciesDict = {}
         self.saveEdgeSpecies = False
+        self.iterationNum = 0
 
     def checkForExistingSpecies(self, molecule):
         """
@@ -318,7 +319,7 @@ class CoreEdgeReactionModel:
         except AttributeError, e:
             spec = Species(index=speciesIndex, label=label, molecule=[molecule], reactive=reactive)
         
-        spec.coreSizeAtCreation = len(self.core.species)
+        spec.creationIteration = self.iterationNum
         spec.generateResonanceIsomers()
         spec.molecularWeight = Quantity(spec.molecule[0].getMolecularWeight()*1000.,"amu")
         
@@ -1003,13 +1004,12 @@ class CoreEdgeReactionModel:
 
         ineligibleSpecies = []     # A list of the species which are not eligible for pruning, for any reason
 
-        numCoreSpecies = len(self.core.species)
         numEdgeSpecies = len(self.edge.species)
-
+        iteration = self.iterationNum
         # All edge species that have not existed for more than two enlarge
         # iterations are ineligible for pruning
         for spec in self.edge.species:
-            if numCoreSpecies - spec.coreSizeAtCreation <= minSpeciesExistIterationsForPrune:
+            if iteration - spec.creationIteration <= minSpeciesExistIterationsForPrune:
                 ineligibleSpecies.append(spec)
 
         # Get the maximum species rates (and network leak rates)

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -60,7 +60,7 @@ class ModelSettings(object):
     def __init__(self,toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, 
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
-          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False):
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -89,7 +89,12 @@ class ModelSettings(object):
             self.toleranceMoveEdgeReactionToCoreInterrupt = toleranceMoveEdgeReactionToCoreInterrupt
         else:
             self.toleranceMoveEdgeReactionToCoreInterrupt = toleranceMoveEdgeReactionToCore
-
+            
+        if maxNumSpecies:
+            self.maxNumSpecies = maxNumSpecies
+        else:
+            self.maxNumSpecies = numpy.inf
+            
 class SimulatorSettings(object):
     """
     class for holding the parameters affecting the behavior of the solver

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2017 Prof. William H. Green (whgreen@mit.edu), 
+#   Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This module contains settings classes for manipulation of RMG run parameters
+=========================================================================================================================
+    `atol`                                          The absolute tolerance used in the ODE/DAE solver
+    `rtol`                                          The relative tolerance used in the ODE/DAE solver
+    `sens_atol`                                     The absolute tolerance used in the ODE/DAE solver for the sensitivities
+    `sens_rtol`                                     The relative tolerance used in the ODE/DAE solver for the sensitivities
+    `toleranceKeepInEdge`                           The relative species flux below which species are discarded from the edge
+    `toleranceMoveToCore`                           The relative species flux above which species are moved from the edge to the core
+    `toleranceInterruptSimulation`                  The relative species flux above which the simulation will halt
+    `toleranceMoveEdgeReactionToCore`               The dynamics number above which reactions are moved from the edge to the core
+    `toleranceMoveEdgeReactionToCoreInterrupt`      The edge dynamics number above which the simulation will halt
+    `toleranceMoveEdgeReactionToSurface`            The dynamics number above which reactions are moved from the edge to the surface
+    `toleranceMoveEdgeReactionToSurfaceInterrupt`   The edge dynamics number above which simulation will halt
+    `toleranceMoveSurfaceReactionToCore`            The surface dynamics number above which reactions are moved from the surface to the bulk core
+    `toleranceMoveSurfaceSpeciesToCore`             The relative species flux above which species are moved from the surface to the bulk core
+    `maximumEdgeSpecies`                            The maximum number of edge species allowed at any time
+    `minCoreSizeForPrune`                           Minimum number of core species before pruning is allowed
+    `minSpeciesExistIterationsForPrune`             Minimum number of iterations a species must exist before it can be pruned
+    `filterReactions`                               Specify whether to filter reactions during model enlarging step
+    `ignoreOverallFluxCriterion`                    flag indicating that the ordinary flux criterion should be ignored except for pdep purposes
+=========================================================================================================================
+"""
+import numpy
+
+class ModelSettings(object):
+    """
+    class for holding the parameters affecting an RMG run
+    """
+    def __init__(self,toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, 
+          toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
+          toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False):
+        
+        self.fluxToleranceKeepInEdge = toleranceKeepInEdge
+        self.fluxToleranceMoveToCore = toleranceMoveToCore
+        self.toleranceMoveEdgeReactionToCore = toleranceMoveEdgeReactionToCore
+        self.fluxToleranceInterrupt = toleranceInterruptSimulation
+        self.maximumEdgeSpecies = maximumEdgeSpecies
+        self.minCoreSizeForPrune = minCoreSizeForPrune
+        self.minSpeciesExistIterationsForPrune = minSpeciesExistIterationsForPrune
+        self.filterReactions = filterReactions
+        self.ignoreOverallFluxCriterion=ignoreOverallFluxCriterion
+        self.toleranceMoveEdgeReactionToSurface = toleranceMoveEdgeReactionToSurface
+        self.toleranceMoveSurfaceSpeciesToCore = toleranceMoveSurfaceSpeciesToCore
+        self.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
+        
+        if toleranceInterruptSimulation:
+            self.fluxToleranceInterrupt = toleranceInterruptSimulation
+        else:
+            self.fluxToleranceInterrupt = toleranceMoveToCore
+            
+        if toleranceMoveEdgeReactionToSurfaceInterrupt:
+            self.toleranceMoveEdgeReactionToSurfaceInterrupt = toleranceMoveEdgeReactionToSurfaceInterrupt
+        else:
+            self.toleranceMoveEdgeReactionToSurfaceInterrupt = toleranceMoveEdgeReactionToSurface
+        
+        if toleranceMoveEdgeReactionToCoreInterrupt:
+            self.toleranceMoveEdgeReactionToCoreInterrupt = toleranceMoveEdgeReactionToCoreInterrupt
+        else:
+            self.toleranceMoveEdgeReactionToCoreInterrupt = toleranceMoveEdgeReactionToCore
+
+class SimulatorSettings(object):
+    """
+    class for holding the parameters affecting the behavior of the solver
+    """
+    def __init__(self,atol=1e-16, rtol=1e-8, sens_atol=1e-6, sens_rtol=1e-4):
+        self.absoluteTolerance = atol
+        self.relativeTolerance = rtol
+        self.sensitivityAbsoluteTolerance = sens_atol
+        self.sensitivityRelativeTolerance = sens_rtol

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -105,7 +105,7 @@ class SimulatorSettings(object):
     class for holding the parameters affecting the behavior of the solver
     """
     def __init__(self,atol=1e-16, rtol=1e-8, sens_atol=1e-6, sens_rtol=1e-4):
-        self.absoluteTolerance = atol
-        self.relativeTolerance = rtol
-        self.sensitivityAbsoluteTolerance = sens_atol
-        self.sensitivityRelativeTolerance = sens_rtol
+        self.atol = atol
+        self.rtol = rtol
+        self.sens_atol = sens_atol
+        self.sens_rtol = sens_rtol

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -30,7 +30,7 @@
 
 """
 This module contains settings classes for manipulation of RMG run parameters
-=========================================================================================================================
+==================================================================================================================================================
     `atol`                                          The absolute tolerance used in the ODE/DAE solver
     `rtol`                                          The relative tolerance used in the ODE/DAE solver
     `sens_atol`                                     The absolute tolerance used in the ODE/DAE solver for the sensitivities
@@ -49,7 +49,9 @@ This module contains settings classes for manipulation of RMG run parameters
     `minSpeciesExistIterationsForPrune`             Minimum number of iterations a species must exist before it can be pruned
     `filterReactions`                               Specify whether to filter reactions during model enlarging step
     `ignoreOverallFluxCriterion`                    flag indicating that the ordinary flux criterion should be ignored except for pdep purposes
-=========================================================================================================================
+    `maxNumSpecies`                                 Number of core species at which a stage/job will terminate
+    `maxNumObjPerIter`                              Maximum number of objects that can be sent for enlargement from a single simulation
+==================================================================================================================================================
 """
 import numpy
 

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -60,7 +60,7 @@ class ModelSettings(object):
     def __init__(self,toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, 
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
-          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None):
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -94,6 +94,11 @@ class ModelSettings(object):
             self.maxNumSpecies = maxNumSpecies
         else:
             self.maxNumSpecies = numpy.inf
+        
+        if maxNumObjsPerIter <= 0:
+            self.maxNumObjsPerIter = numpy.inf
+        else:
+            self.maxNumObjsPerIter = maxNumObjsPerIter
             
 class SimulatorSettings(object):
     """

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -26,13 +26,13 @@
 ################################################################################
 
 cimport numpy
-
+from cpython cimport bool
 include "settings.pxi"
 if DASPK == 1:
     from pydas.daspk cimport DASPK as DASx
 else:
     from pydas.dassl cimport DASSL as DASx
-    
+
 ################################################################################
 
 cdef class ReactionSystem(DASx):
@@ -110,16 +110,10 @@ cdef class ReactionSystem(DASx):
     cpdef initializeModel(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions, list surfaceSpecies=?,
         list surfaceReactions=?, list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?, filterReactions=?)
 
-    cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list surfaceSpecies, 
-        list edgeReactions,list surfaceReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,
-        double toleranceMoveEdgeReactionToCore=?,double toleranceMoveEdgeReactionToCoreInterrupt=?,
-        double toleranceMoveEdgeReactionToSurface=?, double toleranceMoveSurfaceSpeciesToCore=?, 
-        double toleranceMoveSurfaceReactionToCore=?,
-        double toleranceMoveEdgeReactionToSurfaceInterrupt=?, 
-        list pdepNetworks=?,ignoreOverallFluxCriterion=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
-        sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
-        filterReactions=?)
+    cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, 
+        list edgeReactions,list surfaceSpecies, list surfaceReactions,
+        list pdepNetworks=?, bool prune=?, bool sensitivity=?, list sensWorksheet=?, object modelSettings=?,
+        object simulatorSettings=?)
 
     cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum, object network, double networkRate)
      

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -545,7 +545,7 @@ cdef class ReactionSystem(DASx):
         toleranceKeepInEdge = modelSettings.fluxToleranceKeepInEdge if prune else 0
         toleranceMoveToCore = modelSettings.fluxToleranceMoveToCore
         toleranceMoveEdgeReactionToCore = modelSettings.toleranceMoveEdgeReactionToCore
-        toleranceInterruptSimulation =  modelSettings.toleranceInterruptSimulation if prune else modelSettings.fluxToleranceMoveToCore
+        toleranceInterruptSimulation =  modelSettings.fluxToleranceInterrupt if prune else modelSettings.fluxToleranceMoveToCore
         toleranceMoveEdgeReactionToCoreInterrupt=  modelSettings.toleranceMoveEdgeReactionToCore if prune else modelSettings.toleranceMoveEdgeReactionToCore
         toleranceMoveEdgeReactionToSurface = modelSettings.toleranceMoveEdgeReactionToSurface
         toleranceMoveSurfaceSpeciesToCore = modelSettings.toleranceMoveSurfaceSpeciesToCore

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -552,10 +552,10 @@ cdef class ReactionSystem(DASx):
         toleranceMoveSurfaceReactionToCore = modelSettings.toleranceMoveSurfaceReactionToCore
         toleranceMoveEdgeReactionToSurfaceInterrupt = modelSettings.toleranceMoveEdgeReactionToSurfaceInterrupt
         ignoreOverallFluxCriterion=modelSettings.ignoreOverallFluxCriterion
-        absoluteTolerance = simulatorSettings.absoluteTolerance
-        relativeTolerance = simulatorSettings.relativeTolerance
-        sensitivityAbsoluteTolerance = simulatorSettings.sensitivityAbsoluteTolerance
-        sensitivityRelativeTolerance = simulatorSettings.sensitivityRelativeTolerance
+        absoluteTolerance = simulatorSettings.atol
+        relativeTolerance = simulatorSettings.rtol
+        sensitivityAbsoluteTolerance = simulatorSettings.sens_atol
+        sensitivityRelativeTolerance = simulatorSettings.sens_rtol
         filterReactions = modelSettings.filterReactions
         maxNumObjsPerIter = modelSettings.maxNumObjsPerIter
         

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -248,6 +248,7 @@ cdef class ReactionSystem(DASx):
         cdef set possibleSpeciesIndices
         cdef int i,j
         cdef bool notInSurface
+        cdef object obj
         
         logging.info('initializing surface ...')
         
@@ -258,11 +259,12 @@ cdef class ReactionSystem(DASx):
         surfaceReactionIndices = []
         possibleSpeciesIndices = set()
         
-        for i in range(len(surfaceSpecies)):
-            surfaceSpeciesIndices.append(coreSpecies.index(surfaceSpecies[i]))
-        for i in range(len(surfaceReactions)):
-            surfaceReactionIndices.append(coreReactions.index(surfaceReactions[i]))
-        
+        for obj in surfaceSpecies:
+            surfaceSpeciesIndices.append(coreSpecies.index(obj))
+            
+        for obj in surfaceReactions:
+            surfaceReactionIndices.append(coreReactions.index(obj))
+       
         for i in surfaceReactionIndices: #remove surface reactions whose species have been moved to the bulk core
             notInSurface = True
             for j in productIndices[i]:

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -484,15 +484,8 @@ cdef class ReactionSystem(DASx):
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, 
         list edgeReactions,list surfaceSpecies, list surfaceReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,
-        double toleranceMoveEdgeReactionToCore=numpy.inf,double toleranceMoveEdgeReactionToCoreInterrupt=numpy.inf,
-        double toleranceMoveEdgeReactionToSurface=numpy.inf, double toleranceMoveSurfaceSpeciesToCore=numpy.inf,
-        double toleranceMoveSurfaceReactionToCore=numpy.inf,
-        double toleranceMoveEdgeReactionToSurfaceInterrupt=numpy.inf,
-        list pdepNetworks=None, ignoreOverallFluxCriterion=False, 
-        absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
-        sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
-        filterReactions=False):
+        list pdepNetworks=None, bool prune=False, bool sensitivity=False, list sensWorksheet=None, object modelSettings=None,
+        object simulatorSettings=None):
         """
         Simulate the reaction system with the provided reaction model,
         consisting of lists of core species, core reactions, edge species, and
@@ -503,7 +496,13 @@ cdef class ReactionSystem(DASx):
         the desired termination criteria and the model remains valid throughout,
         ``None`` is returned.
         """
-
+        cdef double toleranceKeepInEdge,toleranceMoveToCore,toleranceMoveEdgeReactionToCore,toleranceInterruptSimulation
+        cdef double toleranceMoveEdgeReactionToCoreInterrupt,toleranceMoveEdgeReactionToSurface
+        cdef double toleranceMoveSurfaceSpeciesToCore,toleranceMoveSurfaceReactionToCore
+        cdef double toleranceMoveEdgeReactionToSurfaceInterrupt
+        cdef bool ignoreOverallFluxCriterion, filterReactions
+        cdef double absoluteTolerance, relativeTolerance, sensitivityAbsoluteTolerance, sensitivityRelativeTolerance
+        
         cdef dict speciesIndex
         cdef list row
         cdef int index, spcIndex, maxSpeciesIndex, maxNetworkIndex, infAccumNumIndex
@@ -542,6 +541,22 @@ cdef class ReactionSystem(DASx):
 
         assert set(coreReactions) >= set(surfaceReactions), 'given surface reactions are not a subset of core reactions'
         assert set(coreSpecies) >= set(surfaceSpecies), 'given surface species are not a subset of core species' 
+
+        toleranceKeepInEdge = modelSettings.fluxToleranceKeepInEdge if prune else 0
+        toleranceMoveToCore = modelSettings.fluxToleranceMoveToCore
+        toleranceMoveEdgeReactionToCore = modelSettings.toleranceMoveEdgeReactionToCore
+        toleranceInterruptSimulation =  modelSettings.toleranceInterruptSimulation if prune else modelSettings.fluxToleranceMoveToCore
+        toleranceMoveEdgeReactionToCoreInterrupt=  modelSettings.toleranceMoveEdgeReactionToCore if prune else modelSettings.toleranceMoveEdgeReactionToCore
+        toleranceMoveEdgeReactionToSurface = modelSettings.toleranceMoveEdgeReactionToSurface
+        toleranceMoveSurfaceSpeciesToCore = modelSettings.toleranceMoveSurfaceSpeciesToCore
+        toleranceMoveSurfaceReactionToCore = modelSettings.toleranceMoveSurfaceReactionToCore
+        toleranceMoveEdgeReactionToSurfaceInterrupt = modelSettings.toleranceMoveEdgeReactionToSurfaceInterrupt
+        ignoreOverallFluxCriterion=modelSettings.ignoreOverallFluxCriterion
+        absoluteTolerance = simulatorSettings.absoluteTolerance
+        relativeTolerance = simulatorSettings.relativeTolerance
+        sensitivityAbsoluteTolerance = simulatorSettings.sensitivityAbsoluteTolerance
+        sensitivityRelativeTolerance = simulatorSettings.sensitivityRelativeTolerance
+        filterReactions = modelSettings.filterReactions
         
         speciesIndex = {}
         for index, spec in enumerate(coreSpecies):

--- a/rmgpy/solver/baseTest.py
+++ b/rmgpy/solver/baseTest.py
@@ -31,7 +31,7 @@ import os.path
 import numpy
 from rmgpy.tools.loader import loadRMGPyJob
 import rmgpy
-
+from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
 from rmgpy.solver.base import *
 
 class ConcentrationPrinter:
@@ -159,7 +159,10 @@ class ReactionSystemTest(unittest.TestCase):
         reactionModel = self.rmg.reactionModel
 
         self.assertEqual(self.listener.data, [])
-
+        
+        modelSettings = ModelSettings(toleranceMoveToCore=1,toleranceKeepInEdge=0,toleranceInterruptSimulation=1)
+        simulatorSettings = SimulatorSettings()
+        
         # run simulation:
         terminated, obj,sspcs,srxns = reactionSystem.simulate(
             coreSpecies = reactionModel.core.species,
@@ -168,9 +171,8 @@ class ReactionSystemTest(unittest.TestCase):
             edgeReactions = reactionModel.edge.reactions,
             surfaceSpecies = [],
             surfaceReactions = [],
-            toleranceKeepInEdge = 0,
-            toleranceMoveToCore = 1,
-            toleranceInterruptSimulation = 1,
+            modelSettings = modelSettings,
+            simulatorSettings = simulatorSettings,
         ) 
 
         self.assertNotEqual(self.listener.data, [])

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -45,7 +45,7 @@ from rmgpy.solver.base import TerminationTime, TerminationConversion
 import rmgpy.constants as constants
 from rmgpy.chemkin import loadChemkinFile
 from rmgpy.rmg.main import RMG
-
+from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
 
 ################################################################################
 
@@ -229,8 +229,13 @@ class LiquidReactorCheck(unittest.TestCase):
         #print solver_dfdk
         
         integrationTime = 1e-8
+        
+        modelSettings = ModelSettings(toleranceKeepInEdge = 0,toleranceMoveToCore=1,toleranceInterruptSimulation=0)
+        simulatorSettings = SimulatorSettings()
+        
         rxnSystem0.termination.append(TerminationTime((integrationTime,'s')))
-        rxnSystem0.simulate(coreSpecies, coreReactions, [], [], [],[], 0, 1, 0)
+        
+        rxnSystem0.simulate(coreSpecies, coreReactions, [], [], [],[], modelSettings=modelSettings,simulatorSettings=simulatorSettings)
 
         y0 = rxnSystem0.y
         
@@ -251,7 +256,9 @@ class LiquidReactorCheck(unittest.TestCase):
             
             
             rxnSystem.termination.append(TerminationTime((integrationTime,'s')))
-            rxnSystem.simulate(coreSpecies, coreReactions, [], [],[],[], 0, 1, 0)
+            modelSettings = ModelSettings(toleranceKeepInEdge = 0,toleranceMoveToCore=1,toleranceInterruptSimulation=0)
+            simulatorSettings = SimulatorSettings()
+            rxnSystem.simulate(coreSpecies, coreReactions,[],[],[],[], modelSettings=modelSettings,simulatorSettings=simulatorSettings)
             
             rxnList[i].kinetics.A.value_si = rxnList[i].kinetics.A.value_si/(1+1e-3)  # reset A factor
             

--- a/rmgpy/solver/simpleTest.py
+++ b/rmgpy/solver/simpleTest.py
@@ -43,6 +43,7 @@ from rmgpy.solver.simple import SimpleReactor
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 import rmgpy.constants as constants
 from rmgpy.chemkin import loadChemkinFile
+from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
 
 ################################################################################
 
@@ -193,7 +194,9 @@ class SimpleReactorCheck(unittest.TestCase):
         
         integrationTime = 1e-8
         rxnSystem0.termination.append(TerminationTime((integrationTime,'s')))
-        rxnSystem0.simulate(coreSpecies, coreReactions, [], [], [],[], 0, 1, 0)
+        modelSettings = ModelSettings(toleranceKeepInEdge = 0,toleranceMoveToCore=1,toleranceInterruptSimulation=0)
+        simulatorSettings = SimulatorSettings()
+        rxnSystem0.simulate(coreSpecies, coreReactions, [], [], [],[], modelSettings = modelSettings, simulatorSettings=simulatorSettings)
 
         y0 = rxnSystem0.y
         
@@ -212,7 +215,10 @@ class SimpleReactorCheck(unittest.TestCase):
             
             
             rxnSystem.termination.append(TerminationTime((integrationTime,'s')))
-            rxnSystem.simulate(coreSpecies, coreReactions, [], [], [], [], 0, 1, 0)
+            modelSettings = ModelSettings(toleranceKeepInEdge=0,toleranceMoveToCore=1,toleranceInterruptSimulation=0)
+            simulatorSettings = SimulatorSettings()
+            
+            rxnSystem.simulate(coreSpecies, coreReactions, [], [], [], [], modelSettings=modelSettings, simulatorSettings=simulatorSettings)
             
             rxnList[i].kinetics.A.value_si = rxnList[i].kinetics.A.value_si/(1+1e-3)  # reset A factor
             

--- a/rmgpy/tools/fluxdiagram.py
+++ b/rmgpy/tools/fluxdiagram.py
@@ -43,7 +43,7 @@ import pydot
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 from rmgpy.solver.simple import SimpleReactor
 import rmgpy.util as util
-
+from rmgpy.rmg.settings import SimulatorSettings
 from .loader import loadRMGJob
 
 ################################################################################
@@ -312,7 +312,11 @@ def simulate(reactionModel, reactionSystem, settings = None):
     for index, spec in enumerate(coreSpecies):
         speciesIndex[spec] = index
     
-    reactionSystem.initializeModel(coreSpecies, coreReactions, edgeSpecies, edgeReactions, [], [], [], absoluteTolerance, relativeTolerance)
+    simulatorSettings = SimulatorSettings(atol=absoluteTolerance,rtol=relativeTolerance)
+
+    reactionSystem.initializeModel(coreSpecies, coreReactions, edgeSpecies, edgeReactions, [], [], [], 
+                                   atol=simulatorSettings.atol,rtol=simulatorSettings.rtol,
+                                   sens_atol=simulatorSettings.sens_atol,sens_rtol=simulatorSettings.sens_rtol)
 
     # Copy the initial conditions to use in evaluating conversions
     y0 = reactionSystem.y.copy()

--- a/rmgpy/tools/sensitivity.py
+++ b/rmgpy/tools/sensitivity.py
@@ -38,6 +38,7 @@ import csv
 from .loader import loadRMGJob
 import rmgpy.util as util 
 from rmgpy.tools.plot import ReactionSensitivityPlot, ThermoSensitivityPlot
+from rmgpy.rmg.settings import ModelSettings
 
 def plotSensitivity(outputDirectory, reactionSystemIndex, sensitiveSpeciesList, number=10, fileformat='.png'):
     """
@@ -107,7 +108,10 @@ def simulate(rmg):
         pdepNetworks = []
         for source, networks in rmg.reactionModel.networkDict.items():
             pdepNetworks.extend(networks)
-            
+        
+        modelSettings = ModelSettings(toleranceKeepInEdge = 0, toleranceMoveToCore = 1, toleranceInterruptSimulation = 1)
+        simulatorSettings = rmg.simulatorSettingsList[-1]
+        
         terminated, obj,sspcs,srxns = reactionSystem.simulate(
             coreSpecies = rmg.reactionModel.core.species,
             coreReactions = rmg.reactionModel.core.reactions,
@@ -115,16 +119,11 @@ def simulate(rmg):
             edgeReactions = rmg.reactionModel.edge.reactions,
             surfaceSpecies = [],
             surfaceReactions = [],
-            toleranceKeepInEdge = 0,
-            toleranceMoveToCore = 1,
-            toleranceInterruptSimulation = 1,
             pdepNetworks = pdepNetworks,
-            absoluteTolerance = rmg.absoluteTolerance,
-            relativeTolerance = rmg.relativeTolerance,
             sensitivity = True if reactionSystem.sensitiveSpecies else False,
-            sensitivityAbsoluteTolerance = rmg.sensitivityAbsoluteTolerance,
-            sensitivityRelativeTolerance = rmg.sensitivityRelativeTolerance,
             sensWorksheet = sensWorksheet,
+            modelSettings = modelSettings,
+            simulatorSettings = simulatorSettings,
         )
         
         if reactionSystem.sensitiveSpecies:


### PR DESCRIPTION
This represents part 3 of the AcceleratorTools branch.  

This pull request contains a number of tools for manipulating the RMG algorithm:

1) Model Concatenation:  model() and simulator() inputs from the input file are now appended to a list and iterated through in main.  This allows model runs to be done one after another (i.e. run it at certain parameters at first and then after the first run terminates start the next run with the model produced by the first run.  

2) Max Number of Species Termination Criterion:  this setting causes a run to terminate when the number of species reaches a set number 

3) Number of Objects Returned from Simulate Setting:  this setting causes simulate runs to continue until they have a set number of objects contained with invalidObject rather than terminating when invalidObject has one object in it, this allows for collection of more objects per simulation speeding up the rmg run.  

4) Additionally settings from model() and simulator() are now held in objects ModelSettings and SimulatorSettings, which makes the syntax for simulator calls much simpler

This was built on surfaceAlgorithm #1054  for convenience since surfaceAlgorithm involves lots of new settings.  