### PR TITLE
cythonization of markDuplicateReaction and markDuplicateReactions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ def getMainExtensionModules():
         Extension('rmgpy.quantity', ['rmgpy/quantity.py'], include_dirs=['.']),
         Extension('rmgpy.reaction', ['rmgpy/reaction.py'], include_dirs=['.']),
         Extension('rmgpy.species', ['rmgpy/species.py'], include_dirs=['.']),
+        Extension('rmgpy.chemkin', ['rmgpy/chemkin.pyx'], include_dirs=['.']),
     ]
     
 def getSolverExtensionModules():


### PR DESCRIPTION
This pull does a simple cythonization of the markDuplicateReaction and markDuplicateReactions functions.  In some profiling runs markDuplicateReaction had a significant contribution to runtime.  