### PR TITLE
Numba-ing of markDuplicateReaction and addSpeciesToCore

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -16,6 +16,7 @@ dependencies:
   - lpsolve55
   - quantities
   - scipy
+  - numba
   - xlwt
   - markupsafe
   - jinja2

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -16,6 +16,7 @@ dependencies:
   - lpsolve55
   - quantities
   - scipy
+  - numba
   - xlwt
   - markupsafe
   - jinja2

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -14,6 +14,7 @@ dependencies:
   - lpsolve55
   - quantities
   - scipy
+  - numba
   - xlwt
   - markupsafe
   - jinja2

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -37,6 +37,7 @@ import logging
 import textwrap
 import os.path
 import numpy
+from numba import jit
 
 import rmgpy.kinetics as _kinetics
 from rmgpy.molecule.element import getElement
@@ -1660,7 +1661,7 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
     return string
 
 ################################################################################
-
+@jit
 def markDuplicateReaction(test_reaction, reaction_list):
     """
     If the test_reaction is a duplicate (in Chemkin terms) of one in reaction_list, then set `duplicate=True` on both instances.
@@ -1688,7 +1689,7 @@ def markDuplicateReaction(test_reaction, reaction_list):
                     logging.warning('Marked reaction {0} as duplicate of {1} for saving to Chemkin file.'.format(reaction1, reaction2))
                     reaction1.duplicate = True
                     reaction2.duplicate = True
-
+@jit
 def markDuplicateReactions(reactions):
     """
     For a given list of `reactions`, mark all of the duplicate reactions as

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -36,6 +36,7 @@ import logging
 import math
 import numpy
 import itertools
+from numba import jit
 
 from rmgpy.display import display
 #import rmgpy.chemkin
@@ -179,7 +180,7 @@ class ReactionModel:
 
 ################################################################################
 
-class CoreEdgeReactionModel:
+class CoreEdgeReactionModel(object):
     """
     Represent a reaction model constructed using a rate-based screening
     algorithm. The species and reactions in the model itself are called the
@@ -925,7 +926,8 @@ class CoreEdgeReactionModel:
         logging.info('    The model core has {0:d} species and {1:d} reactions'.format(coreSpeciesCount, coreReactionCount))
         logging.info('    The model edge has {0:d} species and {1:d} reactions'.format(edgeSpeciesCount, edgeReactionCount))
         logging.info('')
-
+    
+    @jit
     def addSpeciesToCore(self, spec):
         """
         Add a species `spec` to the reaction model core (and remove from edge if
@@ -934,7 +936,9 @@ class CoreEdgeReactionModel:
         If this are any such reactions, they are returned in a list.
         """
 
-        assert spec not in self.core.species, "Tried to add species {0} to core, but it's already there".format(spec.label)
+        if spec not in self.core.species:
+            logging.info("Tried to add species {0} to core, but it's already there".format(spec.label))
+            assert False
 
         # Add the species to the core
         self.core.species.append(spec)


### PR DESCRIPTION
This pull request adds Numba as a dependency to RMG and uses the numba jit compiler to compile the functions markDuplicateReaction and addSpeciesToCore on the fly.  

See issue #1001 