### PR TITLE
Cantherm Free Rotors, Reduced Moment of Inertia Calculations and bug fix

### DIFF
--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -40,7 +40,7 @@ from rmgpy.species import Species, TransitionState
 from rmgpy.statmech.translation import Translation, IdealGasTranslation
 from rmgpy.statmech.rotation import Rotation, LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor
 from rmgpy.statmech.vibration import Vibration, HarmonicOscillator
-from rmgpy.statmech.torsion import Torsion, HinderedRotor
+from rmgpy.statmech.torsion import Torsion, HinderedRotor, FreeRotor
 from rmgpy.statmech.conformer import Conformer
 
 from rmgpy.thermo.thermodata import ThermoData
@@ -355,6 +355,7 @@ def loadInputFile(path):
         'SphericalTopRotor': SphericalTopRotor,
         'HarmonicOscillator': HarmonicOscillator,
         'HinderedRotor': HinderedRotor,
+        'FreeRotor':FreeRotor,
         # Thermo
         'ThermoData': ThermoData,
         'Wilhoit': Wilhoit,

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -295,11 +295,11 @@ class StatMechJob:
             rotors = local_context['rotors']
         except KeyError:
             rotors = []
-        
+
         # But don't consider hindered rotors if flag is not set
         if not self.includeHinderedRotors:
             rotors = []
-        
+
         logging.debug('    Reading molecular degrees of freedom...')
         conformer = statmechLog.loadConformer(symmetry=externalSymmetry, spinMultiplicity=spinMultiplicity, opticalIsomers=opticalIsomers)
         
@@ -334,7 +334,9 @@ class StatMechJob:
         # Read and fit the 1D hindered rotors if applicable
         # If rotors are found, the vibrational frequencies are also
         # recomputed with the torsional modes removed
+
         F = statmechLog.loadForceConstantMatrix()
+
         if F is not None and len(mass) > 1 and len(rotors) > 0:
             
             logging.debug('    Fitting {0} hindered rotors...'.format(len(rotors)))
@@ -409,17 +411,22 @@ class StatMechJob:
             frequencies = numpy.array(projectRotors(conformer, F, rotors, linear, TS))
 
         elif len(conformer.modes) > 2:
+            if len(rotors) > 0:
+                logging.warn('Force Constant Matrix Missing Ignoring rotors, if running Gaussian if not already present you need to add the keyword iop(7/33=1) in your Gaussian frequency job for Gaussian to generate the force constant matrix')
             frequencies = conformer.modes[2].frequencies.value_si
             rotors = numpy.array([])
         else:
+            if len(rotors) > 0:
+                logging.warn('Force Constant Matrix Missing Ignoring rotors, if running Gaussian if not already present you need to add the keyword iop(7/33=1) in your Gaussian frequency job for Gaussian to generate the force constant matrix')
             frequencies = numpy.array([])
             rotors = numpy.array([])
-    
+
         for mode in conformer.modes:
             if isinstance(mode, HarmonicOscillator):
                 mode.frequencies = (frequencies * self.frequencyScaleFactor,"cm^-1")
         
         self.species.conformer = conformer
+
         
     def getZPEfromfrequencies(self, frequencies):
                 

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -393,13 +393,6 @@ class StatMechJob:
                        
             logging.debug('    Determining frequencies from reduced force constant matrix...')
             frequencies = numpy.array(projectRotors(conformer, F, rotors, linear, TS))
-            
-            # The frequencies have changed after projection, hence we need to recompute the ZPE
-            # We might need to multiply the scaling factor to the frequencies 
-            ZPE = self.getZPEfromfrequencies(frequencies)
-            E0_withZPE = E0 + ZPE
-            # Reset the E0 of the conformer
-            conformer.E0 = (E0_withZPE*0.001,"kJ/mol")
 
         elif len(conformer.modes) > 2:
             frequencies = conformer.modes[2].frequencies.value_si

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -380,8 +380,12 @@ class StatMechJob:
                     
                     if fit=='cosine':
                         rotor=cosineRotor
+                        rotorCount += 1
+                        conformer.modes.append(rotor)
                     elif fit =='fourier':
                         rotor=fourierRotor
+                        rotorCount += 1
+                        conformer.modes.append(rotor)
                     elif fit =='best':
                     
                         rms_cosine = numpy.sqrt(numpy.sum((Vlist_cosine - Vlist) * (Vlist_cosine - Vlist)) / (len(Vlist) - 1)) / 4184.

--- a/rmgpy/statmech/conformer.pxd
+++ b/rmgpy/statmech/conformer.pxd
@@ -63,7 +63,7 @@ cdef class Conformer:
 
     cpdef getPrincipalMomentsOfInertia(self)
 
-    cpdef double getInternalReducedMomentOfInertia(self, pivots, top1) except -1
+    cpdef double getInternalReducedMomentOfInertia(self, pivots, top1, option=?) except -1
 
     cpdef getSymmetricTopRotors(self)
 

--- a/rmgpy/statmech/torsion.pxd
+++ b/rmgpy/statmech/torsion.pxd
@@ -76,3 +76,18 @@ cdef class HinderedRotor(Torsion):
     cpdef fitFourierPotentialToData(self, numpy.ndarray angle, numpy.ndarray V)
     
     cpdef fitCosinePotentialToData(self, numpy.ndarray angle, numpy.ndarray V)
+
+cdef class FreeRotor(Torsion):
+    
+    cdef public ScalarQuantity _inertia
+    cdef public int symmetry
+    
+    cdef double getRotationalConstantEnergy(self)
+    
+    cpdef double getPartitionFunction(self, double T) except -1
+        
+    cpdef double getHeatCapacity(self, double T) except -100000000
+
+    cpdef double getEnthalpy(self, double T) except 100000000
+
+    cpdef double getEntropy(self, double T) except -100000000

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -564,3 +564,108 @@ cdef class HinderedRotor(Torsion):
         self.symmetry = symmetry
         
         return self
+
+cdef class FreeRotor(Torsion):
+    """
+    A statistical mechanical model of a one-dimensional hindered rotor.  
+    Based on Pfaendtner et al. 2007.  
+    The attributes are:
+    
+    ======================== ===================================================
+    Attribute                Description
+    ======================== ===================================================
+    `inertia`                The moment of inertia of the rotor
+    `rotationalConstant`     The rotational constant of the rotor
+    ======================== ===================================================
+
+    Note that the moment of inertia and the rotational constant are simply two
+    ways of representing the same quantity; only one of these can be specified
+    independently.
+    """
+    def __init__(self,inertia=None,symmetry=1,rotationalConstant=None):
+        Torsion.__init__(self, symmetry, False)
+        if inertia is not None and rotationalConstant is not None:
+            raise ValueError('Only one of moment of inertia and rotational constant can be specified.')
+        elif rotationalConstant is not None:
+            self.rotationalConstant = rotationalConstant
+        else:
+            self.inertia = inertia
+        
+    def __repr__(self):
+        """
+        Return a string representation that can be used to reconstruct the
+        FreeRotor object.
+        """
+        result = 'FreeRotor(inertia={0!r}, symmetry={1:d}'.format(self.inertia, self.symmetry)
+        result += ')'
+        return result
+            
+    def __reduce__(self):
+        """
+        A helper function used when pickling a FreeRotor object.
+        """
+        return (FreeRotor, (self.inertia, self.symmetry))
+    
+    property inertia:
+        """The moment of inertia of the rotor."""
+        def __get__(self):
+            return self._inertia
+        def __set__(self, value):
+            self._inertia = quantity.Inertia(value)
+    
+    property rotationalConstant:
+        """The rotational constant of the rotor."""
+        def __get__(self):
+            cdef double I = self._inertia.value_si
+            cdef double B = constants.h / (8 * constants.pi * constants.pi * I) / (constants.c * 100.)
+            return quantity.Quantity(B,"cm^-1")
+        def __set__(self, B):
+            cdef double I
+            B = quantity.Frequency(B)
+            I = constants.h / (8 * constants.pi * constants.pi * (B.value_si * constants.c * 100.))
+            self._inertia = quantity.ScalarQuantity(I / (constants.amu * 1e-20), "amu*angstrom^2")
+    
+    cdef double getRotationalConstantEnergy(self):
+        """
+        Return the value of the rotational constant in J/mol.
+        """
+        return constants.hbar * constants.hbar / (2 * self._inertia.value_si) * constants.Na
+    
+    cpdef double getPartitionFunction(self, double T) except -1:
+        """
+        Return the value of the partition function :math:`Q(T)` at the
+        specified temperature `T` in K.
+        """
+        return numpy.sqrt(8*numpy.pi**3*constants.kb*T*self._inertia.value_si)/(self.symmetry*constants.h)
+        
+  
+    cpdef double getHeatCapacity(self, double T) except -100000000:
+        """
+        Return the heat capacity in J/mol*K for the degree of freedom at the
+        specified temperature `T` in K.
+        """
+        return constants.R/2.0
+       
+    
+    cpdef double getEnthalpy(self, double T) except 100000000:
+        """
+        Return the enthalpy in J/mol for the degree of freedom at the
+        specified temperature `T` in K.
+        """
+        return constants.R*T/2.0
+        
+
+    cpdef double getEntropy(self, double T) except -100000000:
+        """
+        Return the entropy in J/mol*K for the degree of freedom at the
+        specified temperature `T` in K.
+        """
+        cdef double Q
+        Q = self.getPartitionFunction(T)
+        return constants.R*(numpy.log(Q)+.5)
+        
+        
+
+
+    
+

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -636,7 +636,7 @@ cdef class FreeRotor(Torsion):
         Return the value of the partition function :math:`Q(T)` at the
         specified temperature `T` in K.
         """
-        return numpy.sqrt(8*numpy.pi**3*constants.kb*T*self._inertia.value_si)/(self.symmetry*constants.h)
+        return numpy.sqrt(8*numpy.pi**3*constants.kB*T*self._inertia.value_si)/(self.symmetry*constants.h)
         
   
     cpdef double getHeatCapacity(self, double T) except -100000000:


### PR DESCRIPTION
This pull request adds Free Rotors to Cantherm, adds two additional methods of calculating the reduced moment of inertia.  It also fixes a bug where if the HinderedRotor fit is not specified as 'best' the rotor is ignored.  

Based from pull #942.  