### PR TITLE
Symmetry corrections

### DIFF
--- a/documentation/source/users/rmg/thermo.rst
+++ b/documentation/source/users/rmg/thermo.rst
@@ -230,7 +230,10 @@ Symmetry
 --------
 
 The notion of symmetry is an essential part of molecules. 
-Molecular symmetry refers to the indistinguishable orientations of a molecule.
+Molecular symmetry refers to the indistinguishable orientations of a molecule and 
+can be represented by molecular groups or a symmetry number. RMG uses a symmetry number
+which is the number of superimposible configurations, which includes external symmetry and internal
+free rotors, which is described by detail by [Benson]_.
 This is macroscopically quantified as a decrease of the entropy S by a term  :math:`-R * ln(\sigma)`
 with R the universal gas constant and :math:`\sigma` the global symmetry number, 
 corresponding to the number of indistinguishable orientations of the molecule.
@@ -279,3 +282,5 @@ References
 .. [Yu] "Estimation method for the thermochemical properties of polycyclic aromatic molecules" (Ph.D), Joanna Yu, M.I.T (2005)
 
 .. [RDKit] Landrum, G. (2012). RDKit, http://rdkit.org.
+
+.. [Benson] Benson, S.W. (1965), https://en.wikipedia.org/wiki/Benson_group_increment_theory

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera >=2.2
   - coolprop
-  - cython ==0.21
+  - cython >=0.25.2
   - matplotlib >=1.5
   - rdkit >=2015.09.2
   - pydas >=1.0.1

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera >=2.2
   - coolprop
-  - cython ==0.21
+  - cython >=0.25.2
   - matplotlib >=1.5
   - rdkit >=2015.09.2
   - pydas >=1.0.1

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera >=2.2
   - coolprop
-  - cython ==0.21
+  - cython >=0.25.2
   - matplotlib >=1.5
   - rdkit >=2015.09.2
   - lpsolve55

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -167,18 +167,26 @@ def filterReactions(reactants, products, reactionList):
     not involve all the given `reactants` or whose products do not involve 
     all the given `products`. This method checks both forward and reverse
     directions, and only filters out reactions that don't match either.
+    
+    reactants and products can be either molecule or species objects
     """
     
     # Convert from molecules to species and generate resonance isomers.
     reactant_species = []
     for mol in reactants:
-        s = Species(molecule=[mol])
+        if isinstance(mol,Species):
+            s = mol
+        else:
+            s = Species(molecule=[mol])
         s.generateResonanceIsomers()
         reactant_species.append(s)
     reactants = reactant_species
     product_species = []
     for mol in products:
-        s = Species(molecule=[mol])
+        if isinstance(mol,Species):
+            s = mol
+        else:
+            s = Species(molecule=[mol])
         s.generateResonanceIsomers()
         product_species.append(s)
     products = product_species

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -754,6 +754,8 @@ class ThermoDatabase(object):
         """
         Load the thermo database from the given `path` on disk, where `path`
         points to the top-level folder of the thermo database.
+        
+        If no libraries are given, all are loaded.
         """
         self.libraries = {}; self.libraryOrder = []
         if libraries is None:
@@ -1019,6 +1021,10 @@ class ThermoDatabase(object):
         in order, returning the first match found, before falling back to
         estimation via group additivity.
         
+        The method corrects for symmetry when the molecule uses HBI or 
+        group additivity. Libraries and direct QM calculations are already
+        corrected.
+        
         Returns: ThermoData
         """
         from rmgpy.rmg.input import getInput
@@ -1026,18 +1032,20 @@ class ThermoDatabase(object):
         thermo0 = None
         
         thermo0 = self.getThermoDataFromLibraries(species)
+        
+        if thermo0 is not None:
+            logging.debug("Found thermo for {0} in {1}".format(species.label,thermo0[0].comment.lower()))
+            assert len(thermo0) == 3, "thermo0 should be a tuple at this point: (thermoData, library, entry)"
+            thermo0 = thermo0[0]
+            return thermo0
+
         try:
             quantumMechanics = getInput('quantumMechanics')
         except Exception, e:
             logging.debug('Quantum Mechanics DB could not be found.')
             quantumMechanics = None
-
-        if thermo0 is not None:
-            logging.debug("Found thermo for {0} in {1}".format(species.label,thermo0[0].comment.lower()))
-            assert len(thermo0) == 3, "thermo0 should be a tuple at this point: (thermoData, library, entry)"
-            thermo0 = thermo0[0]
             
-        elif quantumMechanics:
+        if quantumMechanics:
             original_molecule = species.molecule[0]
             if quantumMechanics.settings.onlyCyclics and not original_molecule.isCyclic():
                 pass
@@ -1077,6 +1085,9 @@ class ThermoDatabase(object):
                         species.molecule = [item[2] for item in thermo]
                         original_molecule = species.molecule[0]
                     thermo0 = thermo[0][3] 
+
+                    # update entropy by symmetry correction
+                    thermo0.S298.value_si -= constants.R * math.log(species.getSymmetryNumber())
                     
                 else: # Not too many radicals: do a direct calculation.
                     thermo0 = quantumMechanics.getThermoData(original_molecule) # returns None if it fails
@@ -1106,19 +1117,19 @@ class ThermoDatabase(object):
                         newMolList.extend([mol for mol in species.molecule if mol not in newMolList])
                     species.molecule = newMolList
                     thermo0 = thermo[0][2]
-                    
+
                 else:
                     # Did not find any saturated values in the thermo libraries, so try group additivity instead
                     thermo0 = self.getThermoDataFromGroups(species)
-                
-                
-                
-                
-                
+
             else:
                 # Saturated molecule, estimate it via groups since we've already checked libraries much earlier
                 thermo0 = self.getThermoDataFromGroups(species)
                 
+            # update entropy by symmetry correction
+            thermo0.S298.value_si -= constants.R * math.log(species.getSymmetryNumber())
+
+
         # Make sure to calculate Cp0 and CpInf if it wasn't done already
         findCp0andCpInf(species, thermo0)
 
@@ -1202,6 +1213,8 @@ class ThermoDatabase(object):
         # Last entry is always the estimate from group additivity
         # Make it a tuple
         data = (self.getThermoDataFromGroups(species), None, None)
+        # update group activity for symmetry
+        data[0].S298.value_si -= constants.R * math.log(species.getSymmetryNumber())
         thermoDataList.append(data)
 
         # Return all of the resulting thermo parameters
@@ -1265,6 +1278,8 @@ class ThermoDatabase(object):
         The resonance isomer (molecule) with the lowest H298 is used, and as a side-effect
         the resonance isomers (items in `species.molecule` list) are sorted in ascending order.
         
+        This does not account for symmetry. The method calling this sould correct for it.
+        
         Returns: ThermoData
         """       
         thermo = []
@@ -1320,6 +1335,8 @@ class ThermoDatabase(object):
         then applying hydrogen bond increment corrections for the radical
         site(s) and correcting for the symmetry.
         
+        No entropy is included in the returning term.
+        This should be done later by the calling function.
         """
         
         assert molecule.isRadical(), "Method only valid for radicals."
@@ -1353,9 +1370,6 @@ class ThermoDatabase(object):
             thermoData_sat.S298.value_si += constants.R * math.log(saturatedStruct.getSymmetryNumber())
         
         thermoData = thermoData_sat
-        
-        # Correct entropy for symmetry number of radical structure
-        thermoData.S298.value_si -= constants.R * math.log(molecule.getSymmetryNumber())
         
         # For each radical site, get radical correction
         # Only one radical site should be considered at a time; all others
@@ -1392,22 +1406,20 @@ class ThermoDatabase(object):
         :class:`Molecule` object `molecule` by estimation using the group
         additivity values. If no group additivity values are loaded, a
         :class:`DatabaseError` is raised.
+        
+        The entropy is not corrected for the symmetry of the molecule.
+        This should be done later by the calling function.
         """
         # For thermo estimation we need the atoms to already be sorted because we
         # iterate over them; if the order changes during the iteration then we
         # will probably not visit the right atoms, and so will get the thermo wrong
         molecule.sortAtoms()
 
-        if molecule.isRadical(): # radical species
+        if molecule.isRadical():
             thermoData = self.estimateRadicalThermoViaHBI(molecule, self.computeGroupAdditivityThermo)
-            return thermoData
-
-        else: # non-radical species
+        else:
             thermoData = self.computeGroupAdditivityThermo(molecule)
-            # Correct entropy for symmetry number
-            if not 'saturated' in molecule.props: 
-                thermoData.S298.value_si -= constants.R * math.log(molecule.getSymmetryNumber())
-            return thermoData
+        return thermoData
 
 
     def computeGroupAdditivityThermo(self, molecule):

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -110,13 +110,19 @@ class TestThermoDatabase(unittest.TestCase):
     def testSymmetryContributionRadicals(self):
         """
         Test that the symmetry contribution is correctly added for radicals
-        estimated via the HBI method. 
+        estimated via the HBI method.
+        
+        This is done by testing thermoData from a database and from group 
+        additivity and ensuring they give the correct value. 
         """
         spc = Species(molecule=[Molecule().fromSMILES('[CH3]')])
         
-        thermoData_lib = self.database.getThermoDataFromLibraries(spc)[0]
+        thermoData_lib = self.database.getThermoData(spc)
         
-        thermoData_ga = self.database.getThermoDataFromGroups(spc)
+        databaseWithoutLibraries = ThermoDatabase()
+        databaseWithoutLibraries.load(os.path.join(settings['database.directory'], 'thermo'),libraries = [])
+        
+        thermoData_ga = databaseWithoutLibraries.getThermoData(spc)
         
         self.assertAlmostEqual(thermoData_lib.getEntropy(298.), thermoData_ga.getEntropy(298.), 0)
 

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -850,12 +850,22 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
 
             # Bond type(s)
             if group:
+                code = '[{0}]'
                 if len(bond.order) == 1:
-                    adjlist += bond.getOrderStr()[0]
-                else:
-                    adjlist += '[{0}]'.format(','.join(bond.getOrderStr()))
+                    code = '{0}'
+                # preference is for string representation, backs down to number
+                # numbers if doesn't work
+                try:
+                    adjlist += code.format(','.join(bond.getOrderStr()))
+                except ValueError:
+                    adjlist += code.format(','.join(str(bond.getOrderNum())))
             else:
-                adjlist += bond.getOrderStr()
+                # preference is for string representation, backs down to number
+                # numbers if doesn't work
+                try:
+                    adjlist += bond.getOrderStr()
+                except ValueError:
+                    adjlist += str(bond.getOrderNum())
             adjlist += '}'
 
         # Each atom begins on a new line

--- a/rmgpy/molecule/adjlistTest.py
+++ b/rmgpy/molecule/adjlistTest.py
@@ -574,6 +574,45 @@ class TestMoleculeAdjLists(unittest.TestCase):
         newMolecule = Molecule().fromAdjacencyList(adjlist_1)
         self.assertTrue(molecule.isIsomorphic(newMolecule))
         
+    def testToAdjacencyListForNonIntegerBonds(self):
+        """
+        Test the adjacency list can be created for molecules with bond orders
+        that don't fit into single, double, triple, or benzene
+        """
+        from rmgpy.molecule.molecule import Atom, Bond, Molecule
+        atom1 = Atom(element='H',lonePairs=0)
+        atom2 = Atom(element='H',lonePairs=0)
+        bond = Bond(atom1, atom2, 0.5)
+        mol = Molecule(multiplicity=1)
+        mol.addAtom(atom1)
+        mol.addAtom(atom2)
+        mol.addBond(bond)
+        adjlist = mol.toAdjacencyList()
+        self.assertIn('H', adjlist)
+        self.assertIn('{1,0.5}',adjlist)
+
+    @work_in_progress
+    def testFromAdjacencyListForNonIntegerBonds(self):
+        """
+        Test molecule can be created from the adjacency list for molecules with bond orders
+        that don't fit into single, double, triple, or benzene.
+
+        This test is a work in progress since currently reading one of these
+        objects thows an `InvalidAdjacencyListError`. Since the number radical
+        electrons is an integer, having fractional bonds leads to this error.
+        Fixing it would require switching radical electrons to floats.
+        """
+        from rmgpy.molecule.molecule import Molecule
+        adjlist = """
+        1 H u1 p2 c0 {2,0.5}
+        2 H u1 p2 c0 {1,0.5}
+        """
+        mol = Molecule().fromAdjacencyList(adjlist)
+        atom0 = mol.atoms[0]
+        atoms, bonds = atom0.bonds.items()
+
+        self.assertAlmostEqual(bonds[0].getOrderNum(), 0.5)
+
     def testFromIntermediateAdjacencyList1(self):
         """
         Test we can read an intermediate style adjacency list with implicit hydrogens 1

--- a/rmgpy/molecule/draw.py
+++ b/rmgpy/molecule/draw.py
@@ -149,7 +149,7 @@ class MoleculeDrawer:
             try:
                 import cairo
             except ImportError:
-                print 'Cairo not found; molecule will not be drawn.'
+                logging.error('Cairo not found; molecule will not be drawn.')
                 return
         
         # Make a copy of the molecule so we don't modify the original
@@ -184,7 +184,12 @@ class MoleculeDrawer:
         else:
             # Generate the coordinates to use to draw the molecule
             try:
+                # before getting coordinates, make all bonds single and then
+                # replace the bonds after generating coordinates. This avoids
+                # bugs with RDKit
+                old_bond_dictionary = self.__make_single_bonds()
                 self.__generateCoordinates()
+                self.__replace_bonds(old_bond_dictionary)
                 
                 # Generate labels to use
                 self.__generateAtomLabels()
@@ -195,6 +200,12 @@ class MoleculeDrawer:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 traceback.print_exc()
                 return None, None, None
+            except KeyError:
+                logging.error('KeyError occured when drawing molecule, likely because' +\
+                            ' the molecule contained non-standard bond orders in the' +\
+                            ' getResonanceHybrid method. These cannot be drawn since' +\
+                            ' they cannot be sent to RDKit for coordinate placing.')
+                raise
 
         self.coordinates[:,1] *= -1
         self.coordinates *= self.options['bondLength']
@@ -963,7 +974,7 @@ class MoleculeDrawer:
         padding = self.options['padding']
         self.left -= padding; self.top -= padding; self.right += padding; self.bottom += padding
     
-    def __drawLine(self, cr, x1, y1, x2, y2):
+    def __drawLine(self, cr, x1, y1, x2, y2, dashed = False):
         """
         Draw a line on the given Cairo context `cr` from (`x1`, `y1`) to
         (`x2`,`y2`), and update the bounding rectangle if necessary.
@@ -975,9 +986,14 @@ class MoleculeDrawer:
         cairo
         cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
         cr.set_line_width(1.0)
+        if dashed:
+            cr.set_dash([3.5])
         cr.set_line_cap(cairo.LINE_CAP_ROUND)
         cr.move_to(x1, y1); cr.line_to(x2, y2)
         cr.stroke()
+        # remove dashes for next method call
+        if dashed:
+            cr.set_dash([])
         if x1 < self.left: self.left = x1
         if x1 > self.right: self.right = x1
         if y1 < self.top: self.top = y1
@@ -997,9 +1013,22 @@ class MoleculeDrawer:
             import cairocffi as cairo
         except ImportError:
             import cairo
-    
         bondLength = self.options['bondLength']
-    
+
+        # determine if aromatic
+        isAromatic = False
+        for cycle in self.cycles:
+            if self.molecule.atoms[atom1] in cycle and \
+                  self.molecule.atoms[atom2] in cycle:
+                allBenzenes = True
+                for index in range(len(cycle)):
+                    if not cycle[index -1].bonds[cycle[index]].isBenzene():
+                        allBenzenes = False
+                        break
+                if allBenzenes:
+                    isAromatic = True
+                    break
+
         x1, y1 = self.coordinates[atom1,:]
         x2, y2 = self.coordinates[atom2,:]
         angle = math.atan2(y2 - y1, x2 - x1)
@@ -1007,17 +1036,31 @@ class MoleculeDrawer:
         dx = x2 - x1; dy = y2 - y1
         du = math.cos(angle + math.pi / 2)
         dv = math.sin(angle + math.pi / 2)
-        if bond.isDouble() and (self.symbols[atom1] != '' or self.symbols[atom2] != ''):
-            # Draw double bond centered on bond axis
-            du *= 1.6; dv *= 1.6
-            self.__drawLine(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
-            self.__drawLine(cr, x1 + du, y1 + dv, x2 + du, y2 + dv)
-        elif bond.isTriple() and (self.symbols[atom1] != '' or self.symbols[atom2] != ''):
-            # Draw triple bond centered on bond axis
-            du *= 3; dv *= 3
-            self.__drawLine(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
-            self.__drawLine(cr, x1     , y1     , x2     , y2     )
-            self.__drawLine(cr, x1 + du, y1 + dv, x2 + du, y2 + dv)
+        if (self.symbols[atom1] != '' or \
+                         self.symbols[atom2] != ''):
+            if bond.isTriple():
+                # Draw triple bond centered on bond axis
+                du *= 3; dv *= 3
+                self.__drawLine(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
+                self.__drawLine(cr, x1     , y1     , x2     , y2     )
+                self.__drawLine(cr, x1 + du, y1 + dv, x2 + du, y2 + dv)
+            elif bond.getOrderNum() > 2 and bond.getOrderNum() < 3:
+                du *= 3; dv *= 3
+                self.__drawLine(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
+                self.__drawLine(cr, x1     , y1     , x2     , y2     )
+                self.__drawLine(cr, x1 + du, y1 + dv, x2 + du, y2 + dv, dashed = True)
+            elif bond.isDouble():
+                # Draw double bond centered on bond axis
+                du *= 1.6; dv *= 1.6
+                self.__drawLine(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
+                self.__drawLine(cr, x1 + du, y1 + dv, x2 + du, y2 + dv)
+            elif bond.getOrderNum() > 1 and bond.getOrderNum() < 2 and not isAromatic:
+                # Draw dashed double bond centered on bond axis
+                du *= 1.6; dv *= 1.6
+                self.__drawLine(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
+                self.__drawLine(cr, x1 + du, y1 + dv, x2 + du, y2 + dv, dashed=True)
+            else:
+                self.__drawLine(cr, x1, y1, x2, y2)
         else:
             # Draw bond on skeleton
             self.__drawLine(cr, x1, y1, x2, y2)
@@ -1029,7 +1072,14 @@ class MoleculeDrawer:
                 du *= 3; dv *= 3; dx = 2 * dx / bondLength; dy = 2 * dy / bondLength
                 self.__drawLine(cr, x1 - du + dx, y1 - dv + dy, x2 - du - dx, y2 - dv - dy)
                 self.__drawLine(cr, x1 + du + dx, y1 + dv + dy, x2 + du - dx, y2 + dv - dy)
-        
+            elif bond.getOrderNum() > 1 and bond.getOrderNum() < 2 and not isAromatic:
+                du *= 3.2; dv *= 3.2; dx = 2 * dx / bondLength; dy = 2 * dy / bondLength
+                self.__drawLine(cr, x1 + du + dx, y1 + dv + dy, x2 + du - dx, y2 + dv - dy, dashed=True)
+            elif bond.getOrderNum() > 2 and bond.getOrderNum() < 3:
+                du *= 3; dv *= 3; dx = 2 * dx / bondLength; dy = 2 * dy / bondLength
+                self.__drawLine(cr, x1 - du + dx, y1 - dv + dy, x2 - du - dx, y2 - dv - dy)
+                self.__drawLine(cr, x1 + du + dx, y1 + dv + dy, x2 + du - dx, y2 + dv - dy, dashed=True)
+
     def __renderAtom(self, symbol, atom, x0, y0, cr, heavyFirst=True, drawLonePairs=False):
         """
         Render the `label` for an atom centered around the coordinates (`x0`, `y0`)
@@ -1358,6 +1408,25 @@ class MoleculeDrawer:
         if boundingRect[3] > self.bottom:
             self.bottom = boundingRect[3]
 
+    def __make_single_bonds(self):
+        """This method converts all bonds to single bonds and then returns
+        a dictionary of Bond object keys with the old bond order as a value"""
+        dictionary = {}
+        for atom1 in self.molecule.atoms:
+            for atom2, bond in atom1.bonds.items():
+                if not bond.isSingle():
+                    dictionary[bond] = bond.getOrderNum()
+                    bond.setOrderNum(1)
+        return dictionary
+
+    def __replace_bonds(self,bond_order_dictionary):
+        """
+        Sets the bond order in self.molecule equal to the orders in bond_order_dictionary
+        which is obtained from __make_single_bonds().
+        """
+        for bond, order in bond_order_dictionary.items():
+            bond.setOrderNum(order)
+
 ################################################################################
 
 class ReactionDrawer:
@@ -1398,7 +1467,7 @@ class ReactionDrawer:
             try:
                 import cairo
             except ImportError:
-                print 'Cairo not found; molecule will not be drawn.'
+                logging.error('Cairo not found; molecule will not be drawn.')
                 return
 
         from .molecule import Molecule

--- a/rmgpy/molecule/drawTest.py
+++ b/rmgpy/molecule/drawTest.py
@@ -38,7 +38,7 @@ import os.path
 
 from rmgpy.molecule import  Molecule
 from rmgpy.molecule.draw import MoleculeDrawer
-
+from rmgpy.species import Species
 ################################################################################
 
 class TestMoleculeDrawer(unittest.TestCase):
@@ -113,6 +113,17 @@ class TestMoleculeDrawer(unittest.TestCase):
         surface, cr, (xoff, yoff, width, height) = self.drawer.draw(self.molecule, format='pdf')
         self.assertIsInstance(surface, PDFSurface)
         self.assertGreater(width, height)
+
+    def testDrawNonStandardBonds(self):
+        
+        spec = Species().fromSMILES('[CH2]C=C[CH2]')
+        hybrid = spec.getResonanceHybrid()
+        try:
+            from cairocffi import PDFSurface
+        except ImportError:
+            from cairo import PDFSurface
+        surface, cr, (xoff, yoff, width, height) = self.drawer.draw(hybrid, format='pdf')
+        self.assertIsInstance(surface, PDFSurface)
 
 ################################################################################
 

--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -376,14 +376,15 @@ def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
             rdAtomIndices[atom] = index
     
     rdBonds = Chem.rdchem.BondType
-    orders = {1: rdBonds.SINGLE, 2: rdBonds.DOUBLE, 3: rdBonds.TRIPLE, 1.5: rdBonds.AROMATIC}
+    orders = {'S': rdBonds.SINGLE, 'D': rdBonds.DOUBLE, 'T': rdBonds.TRIPLE, 'B': rdBonds.AROMATIC}
     # Add the bonds
     for atom1 in mol.vertices:
         for atom2, bond in atom1.edges.iteritems():
             index1 = atoms.index(atom1)
             index2 = atoms.index(atom2)
             if index1 < index2:
-                order = orders[bond.order]
+                order_string = bond.getOrderStr()
+                order = orders[order_string]
                 rdkitmol.AddBond(index1, index2, order)
     
     # Make editable mol into a mol and rectify the molecule

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -135,4 +135,6 @@ cdef class Graph:
 
     cpdef list getSmallestSetOfSmallestRings(self)
     
+    cpdef list getLargestRing(self, Vertex vertex)
+    
     cpdef bint isMappingValid(self, Graph other, dict mapping) except -2

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -985,6 +985,21 @@ cdef class Graph:
 
         return cycleList
 
+    cpdef list getLargestRing(self, Vertex vertex):
+        """
+        returns the largest ring containing vertex. This is typically
+        useful for finding the longest path in a polycyclic ring, since
+        the polycyclic rings returned from getPolycyclicRings are not necessarily
+        in order in the ring structure.
+        """
+        all_cycles = self.getAllCycles(vertex)
+        longest_cycle = []
+        for cycle in all_cycles:
+            if len(cycle) > len(longest_cycle):
+                longest_cycle = cycle
+        return longest_cycle
+        
+        
     cpdef bint isMappingValid(self, Graph other, dict mapping) except -2:
         """
         Check that a proposed `mapping` of vertices from `self` to `other`

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -239,7 +239,7 @@ cdef class Graph:
 
     cpdef dict getEdges(self, Vertex vertex):
         """
-        Return a list of the edges involving the specified `vertex`.
+        Return a dictionary of the edges involving the specified `vertex`.
         """
         return vertex.edges
 

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -667,6 +667,64 @@ class TestGraph(unittest.TestCase):
         for ring in expectedContinuousRings:
             self.assertTrue(ring in continuousRings)
 
+
+    def test_getLargestRing(self):
+        """
+        Test that the Graph.getPolycyclicRings() method returns only polycyclic rings.
+        """
+        vertices = [Vertex() for i in range(27)]
+        bonds = [
+                 (0,1),
+                 (1,2),
+                 (2,3),
+                 (3,4),
+                 (4,5),
+                 (5,6),
+                 (6,7),
+                 (9,10),
+                 (10,11),
+                 (11,12),
+                 (12,13),
+                 (13,14),
+                 (14,15),
+                 (12,16),
+                 (10,17),
+                 (17,18),
+                 (18,19),
+                 (9,20),
+                 (20,21),
+                 (6,22),
+                 (22,23),
+                 (22,8),
+                 (8,4),
+                 (23,3),
+                 (23,24),
+                 (24,25),
+                 (25,1)
+                 ]
+        edges = []
+        for bond in bonds:
+            edges.append(Edge(vertices[bond[0]], vertices[bond[1]]))
+
+        graph = Graph()
+        for vertex in vertices: graph.addVertex(vertex)
+        for edge in edges: graph.addEdge(edge)
+        graph.updateConnectivityValues()
+        
+        rings = graph.getPolycyclicRings()
+        self.assertEqual(len(rings), 1)
+        
+        #ensure the last ring doesn't include vertex 8, since it isn't in the
+        #longest ring. Try two different items since one might contain the vertex 8
+        long_ring = graph.getLargestRing(rings[0][0])
+        long_ring2 = graph.getLargestRing(rings[0][1])
+        
+        if len(long_ring) > len(long_ring2):
+            longest_ring = long_ring
+        else:
+            longest_ring = long_ring2
+        
+        self.assertEqual(len(longest_ring), len(rings[0]) - 1)
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -671,7 +671,11 @@ class GroupBond(Edge):
             elif value == 'B':
                 values.append(1.5)
             else:
-                raise TypeError('Bond order {} is not hardcoded into this method'.format(value))
+                # try to see if an float disguised as a string was input by mistake
+                try:
+                    values.append(float(value))
+                except ValueError:
+                    raise TypeError('Bond order {} is not hardcoded into this method'.format(value))
         self.order = values      
 
         

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -207,7 +207,7 @@ cdef class Molecule(Graph):
 
     cpdef double calculateCpInf(self) except -1
     
-    cpdef updateAtomTypes(self, logSpecies=?)
+    cpdef updateAtomTypes(self, bint logSpecies=?, bint raiseException=?)
     
     cpdef bint isRadical(self) except -2
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -514,8 +514,7 @@ class Bond(Edge):
         elif self.isTriple():
             return 'T'
         else:
-            raise ValueError("Bond order {} does not have string representation." +  \
-            "".format(self.order))
+            raise ValueError("Bond order {} does not have string representation.".format(self.order))
         
     def setOrderStr(self, newOrder):
         """
@@ -980,11 +979,15 @@ class Molecule(Graph):
                     self.addBond(bond)
         self.updateAtomTypes()
         
-    def updateAtomTypes(self, logSpecies=True):
+    def updateAtomTypes(self, logSpecies=True, raiseException=True):
         """
         Iterate through the atoms in the structure, checking their atom types
         to ensure they are correct (i.e. accurately describe their local bond
         environment) and complete (i.e. are as detailed as possible).
+        
+        If `raiseException` is `False`, then the generic atomType 'R' will
+        be prescribed to any atom when getAtomType fails. Currently used for
+        resonance hybrid atom types.
         """
         for atom in self.vertices:
             try:
@@ -992,7 +995,9 @@ class Molecule(Graph):
             except AtomTypeError:
                 if logSpecies:
                     logging.error("Could not update atomtypes for {0}.\n{1}".format(self, self.toAdjacencyList()))
-                raise
+                if raiseException:
+                    raise
+                atom.atomType = atomTypes['R']
             
     def updateMultiplicity(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -744,7 +744,7 @@ class Molecule(Graph):
 
     def getBonds(self, atom):
         """
-        Return a list of the bonds involving the specified `atom`.
+        Return a dictionary of the bonds involving the specified `atom`.
         """
         return self.getEdges(atom)
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -487,10 +487,10 @@ class Bond(Edge):
         cython.declare(bond=Bond, bp=gr.GroupBond)
         if isinstance(other, Bond):
             bond = other
-            return (self.getOrderNum() == bond.getOrderNum())
+            return self.isOrder(bond.getOrderNum())
         elif isinstance(other, gr.GroupBond):
             bp = other
-            return (self.getOrderNum() in bp.getOrderNum())
+            return any([self.isOrder(otherOrder) for otherOrder in bp.getOrderNum()])
 
     def isSpecificCaseOf(self, other):
         """
@@ -567,7 +567,7 @@ class Bond(Edge):
         NOTE: we can replace the absolute value relation with math.isclose when
         we swtich to python 3.5+
         """
-        return abs(self.order - otherOrder) <= 1e-9
+        return abs(self.order - otherOrder) <= 1e-6
 
         
     def isSingle(self):
@@ -575,28 +575,28 @@ class Bond(Edge):
         Return ``True`` if the bond represents a single bond or ``False`` if
         not.
         """
-        return abs(self.order-1) <= 1e-9
+        return abs(self.order-1) <= 1e-6
 
     def isDouble(self):
         """
         Return ``True`` if the bond represents a double bond or ``False`` if
         not.
         """
-        return abs(self.order-2) <= 1e-9
+        return abs(self.order-2) <= 1e-6
 
     def isTriple(self):
         """
         Return ``True`` if the bond represents a triple bond or ``False`` if
         not.
         """
-        return abs(self.order-3) <= 1e-9
+        return abs(self.order-3) <= 1e-6
 
     def isBenzene(self):
         """
         Return ``True`` if the bond represents a benzene bond or ``False`` if
         not.
         """
-        return abs(self.order-1.5) <= 1e-9
+        return abs(self.order-1.5) <= 1e-6
 
     def incrementOrder(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -529,7 +529,11 @@ class Bond(Edge):
         elif newOrder == 'B':
             self.order = 1.5
         else:
-            raise TypeError('Bond order {} is not hardcoded into this method'.format(newOrder))
+            # try to see if an float disguised as a string was input by mistake
+            try:
+                self.order = float(newOrder)
+            except ValueError:
+                raise TypeError('Bond order {} is not hardcoded into this method'.format(newOrder))
             
             
     def getOrderNum(self):
@@ -712,9 +716,15 @@ class Molecule(Graph):
         """
         cython.declare(multiplicity=cython.int)
         multiplicity = self.multiplicity
-        if multiplicity != self.getRadicalCount() + 1:
-            return 'Molecule(SMILES="{0}", multiplicity={1:d})'.format(self.toSMILES(), multiplicity)
-        return 'Molecule(SMILES="{0}")'.format(self.toSMILES())
+        try:
+            if multiplicity != self.getRadicalCount() + 1:
+                return 'Molecule(SMILES="{0}", multiplicity={1:d})'.format(self.toSMILES(), multiplicity)
+            return 'Molecule(SMILES="{0}")'.format(self.toSMILES())
+        except KeyError:
+            logging.warning('Could not generate SMILES for this molecule object.'+\
+                        ' Likely due to a keyerror when converting to RDKit'+\
+                        ' Here is molecules AdjList: {}'.format(self.toAdjacencyList()))
+            return 'Molecule().fromAdjacencyList"""{}"""'.format(self.toAdjacencyList())
 
     def __reduce__(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1562,6 +1562,7 @@ class Molecule(Graph):
         includes both external and internal modes.
         """
         from rmgpy.molecule.symmetry import calculateSymmetryNumber
+        self.updateConnectivityValues() # for consistent results
         self.symmetryNumber = calculateSymmetryNumber(self)
         return self.symmetryNumber
     

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -163,7 +163,7 @@ class Atom(Vertex):
         """
         Return ``True`` if `other` is indistinguishable from this atom, or
         ``False`` otherwise. If `other` is an :class:`Atom` object, then all
-        attributes except `label` must match exactly. If `other` is an
+        attributes except `label` and 'ID' must match exactly. If `other` is an
         :class:`GroupAtom` object, then the atom must match any of the
         combinations in the atom pattern.
         """
@@ -174,7 +174,8 @@ class Atom(Vertex):
                 self.element                is atom.element and
                 self.radicalElectrons       == atom.radicalElectrons   and
                 self.lonePairs              == atom.lonePairs           and
-                self.charge                 == atom.charge
+                self.charge                 == atom.charge and
+                self.atomType              is atom.atomType
                 )
         elif isinstance(other, gr.GroupAtom):
             cython.declare(a=AtomType, radical=cython.short, lp=cython.short, charge=cython.short)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -527,6 +527,7 @@ def generateAromaticResonanceStructures(mol, features=None):
                         bond.order = order
                     # Move it to the end of the list, and go on to the next ring
                     aromaticBonds.append(aromaticBonds.pop(i))
+                    mol0.updateAtomTypes(logSpecies=False)
                     continue
                 else:
                     # We're done with this ring, so go on to the next ring

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -90,10 +90,12 @@ def calculateAtomSymmetryNumber(molecule, atom):
             if count == [3]: symmetryNumber *= 3
             elif count == [2, 1]: symmetryNumber *= 1
             elif count == [1, 1, 1]: symmetryNumber *= 1
-
         elif single == 2:
             # Two single bonds
             if count == [2]: symmetryNumber *= 2
+        # for resonance hybrids
+        elif single == 1:
+            if count == [2, 1]: symmetryNumber *= 2
         elif double == 2:
             # Two double bonds
             if count == [2]: symmetryNumber *= 2

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -126,49 +126,48 @@ def calculateBondSymmetryNumber(molecule, atom1, atom2):
     """
     bond = atom1.edges[atom2]
     symmetryNumber = 1
-    if bond.isSingle() or bond.isDouble() or bond.isTriple():
-        if atom1.equivalent(atom2):
-            # An O-O bond is considered to be an "optical isomer" and so no
-            # symmetry correction will be applied
-            if atom1.atomType.label == 'Os' and atom2.atomType.label == 'Os' and atom1.radicalElectrons == atom2.radicalElectrons == 0:
-                return symmetryNumber
-            # If the molecule is diatomic, then we don't have to check the
-            # ligands on the two atoms in this bond (since we know there
-            # aren't any)
-            elif len(molecule.vertices) == 2:
-                symmetryNumber = 2
-            else:
-                molecule.removeBond(bond)
-                structure = molecule.copy(True)
-                molecule.addBond(bond)
+    if atom1.equivalent(atom2):
+        # An O-O bond is considered to be an "optical isomer" and so no
+        # symmetry correction will be applied
+        if atom1.atomType.label == 'Os' and atom2.atomType.label == 'Os' and atom1.radicalElectrons == atom2.radicalElectrons == 0:
+            return symmetryNumber
+        # If the molecule is diatomic, then we don't have to check the
+        # ligands on the two atoms in this bond (since we know there
+        # aren't any)
+        elif len(molecule.vertices) == 2:
+            symmetryNumber = 2
+        else:
+            molecule.removeBond(bond)
+            structure = molecule.copy(True)
+            molecule.addBond(bond)
 
-                atom1 = structure.atoms[molecule.atoms.index(atom1)]
-                atom2 = structure.atoms[molecule.atoms.index(atom2)]
-                fragments = structure.split()
-                
-                if len(fragments) != 2: return symmetryNumber
+            atom1 = structure.atoms[molecule.atoms.index(atom1)]
+            atom2 = structure.atoms[molecule.atoms.index(atom2)]
+            fragments = structure.split()
 
-                fragment1, fragment2 = fragments
-                if atom1 in fragment1.atoms: fragment1.removeAtom(atom1)
-                if atom2 in fragment1.atoms: fragment1.removeAtom(atom2)
-                if atom1 in fragment2.atoms: fragment2.removeAtom(atom1)
-                if atom2 in fragment2.atoms: fragment2.removeAtom(atom2)
-                groups1 = fragment1.split()
-                groups2 = fragment2.split()
+            if len(fragments) != 2: return symmetryNumber
 
-                # Test functional groups for symmetry
-                if len(groups1) == len(groups2) == 1:
-                    if groups1[0].isIsomorphic(groups2[0]): symmetryNumber *= 2
-                elif len(groups1) == len(groups2) == 2:
-                    if groups1[0].isIsomorphic(groups2[0]) and groups1[1].isIsomorphic(groups2[1]): symmetryNumber *= 2
-                    elif groups1[1].isIsomorphic(groups2[0]) and groups1[0].isIsomorphic(groups2[1]): symmetryNumber *= 2
-                elif len(groups1) == len(groups2) == 3:
-                    if groups1[0].isIsomorphic(groups2[0]) and groups1[1].isIsomorphic(groups2[1]) and groups1[2].isIsomorphic(groups2[2]): symmetryNumber *= 2
-                    elif groups1[0].isIsomorphic(groups2[0]) and groups1[1].isIsomorphic(groups2[2]) and groups1[2].isIsomorphic(groups2[1]): symmetryNumber *= 2
-                    elif groups1[0].isIsomorphic(groups2[1]) and groups1[1].isIsomorphic(groups2[2]) and groups1[2].isIsomorphic(groups2[0]): symmetryNumber *= 2
-                    elif groups1[0].isIsomorphic(groups2[1]) and groups1[1].isIsomorphic(groups2[0]) and groups1[2].isIsomorphic(groups2[2]): symmetryNumber *= 2
-                    elif groups1[0].isIsomorphic(groups2[2]) and groups1[1].isIsomorphic(groups2[0]) and groups1[2].isIsomorphic(groups2[1]): symmetryNumber *= 2
-                    elif groups1[0].isIsomorphic(groups2[2]) and groups1[1].isIsomorphic(groups2[1]) and groups1[2].isIsomorphic(groups2[0]): symmetryNumber *= 2
+            fragment1, fragment2 = fragments
+            if atom1 in fragment1.atoms: fragment1.removeAtom(atom1)
+            if atom2 in fragment1.atoms: fragment1.removeAtom(atom2)
+            if atom1 in fragment2.atoms: fragment2.removeAtom(atom1)
+            if atom2 in fragment2.atoms: fragment2.removeAtom(atom2)
+            groups1 = fragment1.split()
+            groups2 = fragment2.split()
+
+            # Test functional groups for symmetry
+            if len(groups1) == len(groups2) == 1:
+                if groups1[0].isIsomorphic(groups2[0]): symmetryNumber *= 2
+            elif len(groups1) == len(groups2) == 2:
+                if groups1[0].isIsomorphic(groups2[0]) and groups1[1].isIsomorphic(groups2[1]): symmetryNumber *= 2
+                elif groups1[1].isIsomorphic(groups2[0]) and groups1[0].isIsomorphic(groups2[1]): symmetryNumber *= 2
+            elif len(groups1) == len(groups2) == 3:
+                if groups1[0].isIsomorphic(groups2[0]) and groups1[1].isIsomorphic(groups2[1]) and groups1[2].isIsomorphic(groups2[2]): symmetryNumber *= 2
+                elif groups1[0].isIsomorphic(groups2[0]) and groups1[1].isIsomorphic(groups2[2]) and groups1[2].isIsomorphic(groups2[1]): symmetryNumber *= 2
+                elif groups1[0].isIsomorphic(groups2[1]) and groups1[1].isIsomorphic(groups2[2]) and groups1[2].isIsomorphic(groups2[0]): symmetryNumber *= 2
+                elif groups1[0].isIsomorphic(groups2[1]) and groups1[1].isIsomorphic(groups2[0]) and groups1[2].isIsomorphic(groups2[2]): symmetryNumber *= 2
+                elif groups1[0].isIsomorphic(groups2[2]) and groups1[1].isIsomorphic(groups2[0]) and groups1[2].isIsomorphic(groups2[1]): symmetryNumber *= 2
+                elif groups1[0].isIsomorphic(groups2[2]) and groups1[1].isIsomorphic(groups2[1]) and groups1[2].isIsomorphic(groups2[0]): symmetryNumber *= 2
                 
                 
     return symmetryNumber
@@ -212,7 +211,8 @@ def calculateAxisSymmetryNumber(molecule):
     doubleBonds = []
     for atom1 in molecule.vertices:
         for atom2 in atom1.edges:
-            if atom1.edges[atom2].isDouble() and molecule.vertices.index(atom1) < molecule.vertices.index(atom2):
+            if (atom1.edges[atom2].isDouble() or atom1.edges[atom2].order > 2) \
+                and molecule.vertices.index(atom1) < molecule.vertices.index(atom2):
                 doubleBonds.append((atom1, atom2))
 
     # Search for adjacent double bonds

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -345,89 +345,78 @@ def calculateCyclicSymmetryNumber(molecule):
     Get the symmetry number correction for cyclic regions of a molecule.
     For complicated fused rings the smallest set of smallest rings is used.
     """
-    from rdkit.Chem.rdmolops import SanitizeMol
-    from rdkit.Chem.rdchem import Mol 
-
+    from rmgpy.molecule.vf2 import VF2
+    # setup isomorphism checker
+    vf2 = VF2(molecule, molecule)
+    
     symmetryNumber = 1
     
-    rings = molecule.getSmallestSetOfSmallestRings()
-
-    # Get symmetry number for each ring in structure
-    for ring0 in rings:
-
-        # Make another copy structure
-        structure = molecule.copy(True)
-        ring = [structure.atoms[molecule.atoms.index(atom)] for atom in ring0]
+    # for polycyclics, We should be getting the largest ring, not the smallest
+    singleRings, polycyclicRings = molecule.getDisparateRings()
+    for ring in polycyclicRings: singleRings.append(molecule.getLargestRing(ring[0]))
+    # Get symmetry number for each ring in structure & multiply
+    for ring in singleRings:
+        size = len(ring)
         
-        # Remove bonds of ring from structure
-        for i, atom1 in enumerate(ring):
-            for atom2 in ring[i+1:]:
-                if structure.hasBond(atom1, atom2):
-                    structure.removeBond(atom1.edges[atom2])
-
-        structures = structure.split()
-        groups = []
-        for struct in structures:
-            for atom in ring:
-                if struct.hasAtom(atom): struct.removeAtom(atom)
-            groups.append(struct.split())
-        # Find equivalent functional groups on ring
-        equivalentGroups = []; equivalentGroupCount = []
-        for group in groups:
-            found = False
-            for i, eqGroup in enumerate(equivalentGroups):
-                if not found and len(group) == len(eqGroup):
-                    for g, eg in zip(group, eqGroup):
-                        if not g.isIsomorphic(eg):
-                            # The groups do not match
+        # look for twisting rotation
+        # go through each possible number of symmetrical sets
+        for num_sections in range(size,0,-1):
+            # only go through if it can give symmetry (only factors of size)
+            if size % num_sections == 0:
+                # only check the minimum number of sections necessary
+                num_rotations = size / num_sections
+                # check rotation around the ring
+                all_the_same = True
+                starting_index = 0
+                while all_the_same and starting_index < size / 2: 
+                    for atom_index in range(num_rotations,size,num_rotations):
+                        if not vf2.feasible(ring[starting_index],ring[(starting_index + atom_index) % size]):
+                            all_the_same = False
                             break
-                    else:
-                        # The groups match
-                        found = True
-                if found:
-                    # We've found a matching group, so increment its count
-                    equivalentGroupCount[i] += 1        
+                    starting_index += 1
+                if all_the_same:
+                    symmetryNumber *= num_sections
                     break
-            else:
-                # No matching group found, so add it as a new group
-                equivalentGroups.append(group)
-                equivalentGroupCount.append(1)
 
-        # Find equivalent bonds on ring
-        equivalentBonds = []
-        for i, atom1 in enumerate(ring0):
-            for atom2 in ring0[i+1:]:
-                if molecule.hasBond(atom1, atom2):
-                    bond = molecule.getBond(atom1, atom2)
-                    found = False
-                    for eqBond in equivalentBonds:
-                        if not found:
-                            if bond.equivalent(eqBond[0]):
-                                eqBond.append(group)
-                                found = True
-                    if not found:
-                        equivalentBonds.append([bond])
-
-        # Find maximum number of equivalent groups and bonds
-        minEquivalentGroups = min(equivalentGroupCount)
-        maxEquivalentGroups = max(equivalentGroupCount)
-        minEquivalentBonds = None
-        maxEquivalentBonds = 0
-        for bonds in equivalentBonds:
-            N = len(bonds)
-            if minEquivalentBonds is None or N < minEquivalentBonds:
-                minEquivalentBonds = N
-            if N > maxEquivalentBonds:
-                maxEquivalentBonds = N
-
-        if maxEquivalentGroups == maxEquivalentBonds == len(ring):
-            symmetryNumber *= len(ring) * 2
+        # look for flipping rotation. 
+        if size % 2 == 0: # even length only has to go through half
+            flipping_atom_indexes = range(int(size/2))
         else:
-            symmetryNumber *= min(minEquivalentGroups, minEquivalentBonds)
+            flipping_atom_indexes = range(size)
 
+        for flipping_atom_index in flipping_atom_indexes:
+            
+            # check for flipping with across an axis containing atoms
+            all_the_same = True
+            min_index = flipping_atom_index + 1
+            max_index = flipping_atom_index + size - 1
+            while min_index <= max_index:
+                # ensure the two atoms are different. use mod size to loop to the start
+                # of the list when index out of bounds
+                if not vf2.feasible(ring[min_index % size], ring[max_index % size]):
+                    all_the_same = False
+                    break
+                min_index += 1
+                max_index += -1
 
+            # for even rings, check for flipping accross bonds too
+            if not all_the_same and size % 2 == 0:
+                all_the_same = True
+                min_index = flipping_atom_index 
+                max_index = flipping_atom_index + size - 1
+                while min_index < max_index:
+                    # ensure the two atoms are different. use mod size to loop to the start
+                    # of the list when index out of bounds
+                    if not vf2.feasible(ring[min_index % size], ring[max_index % size]):
+                        all_the_same = False
+                        break
+                    min_index += 1
+                    max_index += -1
+
+            if all_the_same:
+                symmetryNumber *= 2
+                break
     return symmetryNumber
-
 ################################################################################
 
 def calculateSymmetryNumber(molecule):

--- a/rmgpy/molecule/symmetryTest.py
+++ b/rmgpy/molecule/symmetryTest.py
@@ -272,7 +272,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
         symmetryNumber = calculateCyclicSymmetryNumber(molecule)
         self.assertEqual(symmetryNumber, 12)
 
-    @work_in_progress
     def testCyclicSymmetryNumberCyclohexanone(self):
         """
         Test the Molecule.calculateCyclicSymmetryNumber() on C1CCCCC1=O
@@ -281,7 +280,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
         symmetryNumber = calculateCyclicSymmetryNumber(molecule)
         self.assertEqual(symmetryNumber, 2)
         
-    @work_in_progress
     def testCyclicSymmetryNumberCyclohexan_tri_one(self):
         """
         Test the Molecule.calculateCyclicSymmetryNumber() on C1CCC(=O)C(=O)C1=O
@@ -417,7 +415,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
                     symmetryNumber *= calculateBondSymmetryNumber(molecule, atom1, atom2)
         self.assertEqual(symmetryNumber, 1)
 
-    @work_in_progress
     def testTotalSymmetryNumberToluene(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1C
@@ -447,7 +444,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 2)
 
-    @work_in_progress
     def testTotalSymmetryNumberPhenoxyKecle(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1[O]
@@ -478,7 +474,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 18)
 
-    @work_in_progress
     def testTotalSymmetryNumber14Dimethylbenzene(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on Cc1ccc(C)cc1

--- a/rmgpy/molecule/symmetryTest.py
+++ b/rmgpy/molecule/symmetryTest.py
@@ -34,7 +34,7 @@ from external.wip import work_in_progress
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.molecule.symmetry import calculateAtomSymmetryNumber, calculateAxisSymmetryNumber, calculateBondSymmetryNumber, calculateCyclicSymmetryNumber
 from rmgpy.species import Species
-
+from rmgpy.molecule.resonance import generateAromaticResonanceStructures
 ################################################################################
 
 class TestMoleculeSymmetry(unittest.TestCase):
@@ -136,7 +136,7 @@ class TestMoleculeSymmetry(unittest.TestCase):
     
     def testBondSymmetryNumberEthylene(self):
         """
-        Test the Molecule.calculateBondSymmetryNumber() on C=C.
+        Test the Molecule.calculateBondSymmetryNumber() on C=C
         """
         molecule = Molecule().fromSMILES('C=C')
         symmetryNumber = 1
@@ -272,25 +272,194 @@ class TestMoleculeSymmetry(unittest.TestCase):
         symmetryNumber = calculateCyclicSymmetryNumber(molecule)
         self.assertEqual(symmetryNumber, 12)
 
+    @work_in_progress
+    def testCyclicSymmetryNumberCyclohexanone(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on C1CCCCC1=O
+        """
+        molecule = Molecule().fromSMILES('C1CCCCC1=O')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 2)
+        
+    @work_in_progress
+    def testCyclicSymmetryNumberCyclohexan_tri_one(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on C1CCC(=O)C(=O)C1=O
+        """
+        molecule = Molecule().fromSMILES('C1CCC(=O)C(=O)C1=O')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 2)
+
     def testTotalSymmetryNumberBenzene(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1
         """
         molecule = Molecule().fromSMILES('c1ccccc1')
         species = Species(molecule=[molecule])
-        species.generateResonanceIsomers()
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 12)
 
+    def testTotalSymmetryNumberAllyl(self):
+        """
+        Test the Species.getSymmetryNumber() (total symmetry) on Allyl, [CH2]C=C
+        """
+        molecule = Molecule().fromSMILES('[CH2]C=C')
+        species = Species(molecule=[molecule])
+        symmetryNumber = species.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 2)
+
+    def testTotalSymmetryNumberPentenyl(self):
+        """
+        Test the Species.getSymmetryNumer() for C[CH]C=CC
+        and ensures that it is differet than the molecule object
+        """
+        spc = Species(molecule=[Molecule().fromSMILES('C[CH]C=CC')])
+        symmetryNumber = spc.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 18, 'the symmetry number for C[CH]C=CC is 18, but RMG returned {}'.format(symmetryNumber))
+
+    def testSpeciesSymmetryNumberIsNotMoleculeSymmetryNumber(self):
+        """
+        Tests that the species symmetry number can be different from the molecule symmetry number
+
+        This molecule's resonance isomer hybrid should return more symmetry
+        than the base molecule object.
+        """
+        molecule = Molecule().fromSMILES('C[CH]C=CC')
+        species = Species(molecule=[molecule])
+        self.assertEqual(molecule.getSymmetryNumber() * 2, species.getSymmetryNumber())
+
+    def testAxisSymmetryNumberAllyl(self):
+        """
+        Test the Molecule.calculateAxisSymmetryNumber() on [CH2]C=C
+        """
+        spc = Species(molecule=[Molecule().fromSMILES('[CH2]C=C')])
+        molecule = spc.getResonanceHybrid()
+        self.assertEqual(calculateAxisSymmetryNumber(molecule), 1)
+
+    def testMiddleCarbonAtomSymmetryNumberAllylUsingResonanceHybrid(self):
+        """
+        Test the Molecule.calculateAtomSymmetryNumber() for the middle carbon
+        on [CH2]C=C using the resonance hybrid structure
+        """
+        molecule = Molecule().fromSMILES('[CH2]C=C')
+        species = Species(molecule=[molecule])
+        resonanceHybrid = species.getResonanceHybrid()
+        for atom in resonanceHybrid.atoms:
+            if atom.symbol == 'C':
+                number_carbon_bonds = sum([1 for bond in atom.bonds if bond.symbol=='C'])
+                if number_carbon_bonds == 2:
+                    atom.label = 'center'
+                    symmetryNumber = calculateAtomSymmetryNumber(resonanceHybrid, atom)
+                    self.assertEqual(symmetryNumber, 2)
+                    pass
+
+    def testEdgeCarbonAtomSymmetryNumberAllyl(self):
+        """
+        Test the Molecule.calculateAtomSymmetryNumber() for the edge carbons
+        on [CH2]C=C
+        """
+        spc = Species(molecule=[Molecule().fromSMILES('[CH2]C=C')])
+        molecule = spc.getResonanceHybrid()
+        for atom in molecule.atoms:
+            if atom.symbol =='C':
+                number_carbon_bonds = sum([1 for bond in atom.bonds if bond.symbol=='C'])
+                if number_carbon_bonds == 1:
+                    atom.label = 'edge'
+                    symmetryNumber = calculateAtomSymmetryNumber(molecule, atom)
+                    self.assertEqual(symmetryNumber, 1)
+        
+    def testEdgeCarbonAtomSymmetryNumberAllylUsingResonanceHybrid(self):
+        """
+        Test the Molecule.calculateAtomSymmetryNumber() for the edge carbons
+        on [CH2]C=C
+        """
+        molecule = Molecule().fromSMILES('[CH2]C=C')
+        species = Species(molecule=[molecule])
+        resonanceHybrid = species.getResonanceHybrid()
+        for atom in resonanceHybrid.atoms:
+            if atom.symbol =='C':
+                number_carbon_bonds = sum([1 for bond in atom.bonds if bond.symbol=='C'])
+                if number_carbon_bonds == 1:
+                    atom.label = 'edge'
+                    symmetryNumber = calculateAtomSymmetryNumber(resonanceHybrid, atom)
+                    self.assertEqual(symmetryNumber, 1)
+
+    def testAtomSymmetryNumberAllyl(self):
+        """
+        Test the Molecule.calculateAtomSymmetryNumber() on [CH2]C=C
+        """
+        spc = Species(molecule=[Molecule().fromSMILES('[CH2]C=C')])
+        molecule = spc.getResonanceHybrid()
+        symmetryNumber = 1
+        for atom in molecule.atoms:
+            if not molecule.isAtomInCycle(atom):
+                symmetryNumber *= calculateAtomSymmetryNumber(molecule, atom)
+        self.assertEqual(symmetryNumber, 2)
+
+    def testBondSymmetryNumberAllyl(self):
+        """
+        Test the Molecule.calculateBondSymmetryNumber() on [CH2]C=C
+        """
+        spc = Species(molecule=[Molecule().fromSMILES('[CH2]C=C')])
+        molecule = spc.getResonanceHybrid()
+        symmetryNumber = 1
+        for atom1 in molecule.atoms:
+            for atom2 in atom1.bonds:
+                if molecule.atoms.index(atom1) < molecule.atoms.index(atom2):
+                    symmetryNumber *= calculateBondSymmetryNumber(molecule, atom1, atom2)
+        self.assertEqual(symmetryNumber, 1)
+
+    @work_in_progress
     def testTotalSymmetryNumberToluene(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1C
         """
         molecule = Molecule().fromSMILES('c1ccccc1C')
         species = Species(molecule=[molecule])
-        species.generateResonanceIsomers()
         symmetryNumber = species.getSymmetryNumber()
-        self.assertEqual(symmetryNumber, 3)
+        self.assertEqual(symmetryNumber, 6)
+
+    @work_in_progress
+    def testTotalSymmetryNumberSpecialCyclic(self):
+        """
+        Test the Species.getSymmetryNumber() (total symmetry) from issue # 332
+        """
+        molecule = Molecule().fromSMILES('C1(C(C(C(C(C1C2CCC2)C3CCC3)C4CCC4)C5CCC5)C6CCC6)C7CCC7')
+        species = Species(molecule=[molecule])
+        symmetryNumber = species.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 12)
+
+    @work_in_progress
+    def testTotalSymmetryNumberChlorobenzene(self):
+        """
+        Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1Cl
+        """
+        molecule = Molecule().fromSMILES('c1ccccc1Cl')
+        species = Species(molecule=[molecule])
+        symmetryNumber = species.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 2)
+
+    @work_in_progress
+    def testTotalSymmetryNumberPhenoxyKecle(self):
+        """
+        Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1[O]
+        using kecle structure
+        """
+        molecule = Molecule().fromSMILES('c1ccccc1[O]')
+        species = Species(molecule=[molecule])
+        symmetryNumber = species.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 2)
+
+    @work_in_progress
+    def testTotalSymmetryNumberPhenoxyBenzene(self):
+        """
+        Test symmetry on c1ccccc1[O] using phenoxy benzene structure
+        """
+        molecule = Molecule().fromSMILES('c1ccccc1[O]')
+        species = Species(molecule=[molecule])
+        aromatic_molecule = generateAromaticResonanceStructures(molecule)[0]
+        symmetryNumber = aromatic_molecule.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 2)
 
     def testTotalSymmetryNumber12Dimethylbenzene(self):
         """
@@ -298,7 +467,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
         """
         molecule = Molecule().fromSMILES('Cc1ccccc1C')
         species = Species(molecule=[molecule])
-        species.generateResonanceIsomers()
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 18)
 
@@ -309,7 +477,6 @@ class TestMoleculeSymmetry(unittest.TestCase):
         """
         molecule = Molecule().fromSMILES('Cc1ccc(C)cc1')
         species = Species(molecule=[molecule])
-        species.generateResonanceIsomers()
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 36)
         
@@ -317,98 +484,98 @@ class TestMoleculeSymmetry(unittest.TestCase):
         """
         Test the Molecule.calculateSymmetryNumber() on CC
         """
-        self.assertEqual(Molecule().fromSMILES('CC').calculateSymmetryNumber(), 18)
+        self.assertEqual(Species().fromSMILES('CC').getSymmetryNumber(), 18)
     
     def testTotalSymmetryNumber1(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C=C=[C]C(C)(C)[C]=C=C
         """
-        self.assertEqual(Molecule().fromSMILES('C=C=[C]C(C)(C)[C]=C=C').calculateSymmetryNumber(), 18)
+        self.assertEqual(Species().fromSMILES('C=C=[C]C(C)(C)[C]=C=C').getSymmetryNumber(), 18)
     
     @work_in_progress
     def testTotalSymmetryNumber2(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C(=CC(c1ccccc1)C([CH]CCCCCC)C=Cc1ccccc1)[CH]CCCCCC
         """
-        self.assertEqual(Molecule().fromSMILES('C(=CC(c1ccccc1)C([CH]CCCCCC)C=Cc1ccccc1)[CH]CCCCCC').calculateSymmetryNumber(), '36?')
+        self.assertEqual(Species().fromSMILES('C(=CC(c1ccccc1)C([CH]CCCCCC)C=Cc1ccccc1)[CH]CCCCCC').getSymmetryNumber(), '36?')
     
     def testSymmetryNumberHydroxyl(self):
         """
         Test the Molecule.calculateSymmetryNumber() on [OH]
         """
-        self.assertEqual(Molecule().fromSMILES('[OH]').calculateSymmetryNumber(), 1)
+        self.assertEqual(Species().fromSMILES('[OH]').getSymmetryNumber(), 1)
        
     def testSymmetryNumberOxygen(self):
         """
         Test the Molecule.calculateSymmetryNumber() on O=O
         """
-        self.assertEqual(Molecule().fromSMILES('O=O').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('O=O').getSymmetryNumber(), 2)
         
     def testSymmetryNumberDicarbon(self):
         """
         Test the Molecule.calculateSymmetryNumber() on [C]#[C]
         """
-        self.assertEqual(Molecule().fromSMILES('[C]#[C]').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('[C]#[C]').getSymmetryNumber(), 2)
     
     def testSymmetryNumberHydrogen(self):
         """
         Test the Molecule.calculateSymmetryNumber() on [H][H]
         """
-        self.assertEqual(Molecule().fromSMILES('[H][H]').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('[H][H]').getSymmetryNumber(), 2)
     
     def testSymmetryNumberAcetylene(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C#C
         """
-        self.assertEqual(Molecule().fromSMILES('C#C').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('C#C').getSymmetryNumber(), 2)
     
     def testSymmetryNumberButadiyne(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C#CC#C
         """
-        self.assertEqual(Molecule().fromSMILES('C#CC#C').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('C#CC#C').getSymmetryNumber(), 2)
     
     def testSymmetryNumberMethane(self):
         """
         Test the Molecule.calculateSymmetryNumber() on CH4
         """
-        self.assertEqual(Molecule().fromSMILES('C').calculateSymmetryNumber(), 12)
+        self.assertEqual(Species().fromSMILES('C').getSymmetryNumber(), 12)
     
     def testSymmetryNumberFormaldehyde(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C=O
         """
-        self.assertEqual(Molecule().fromSMILES('C=O').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('C=O').getSymmetryNumber(), 2)
     
     def testSymmetryNumberMethyl(self):
         """
         Test the Molecule.calculateSymmetryNumber() on [CH3]
         """
-        self.assertEqual(Molecule().fromSMILES('[CH3]').calculateSymmetryNumber(), 6)
+        self.assertEqual(Species().fromSMILES('[CH3]').getSymmetryNumber(), 6)
     
     def testSymmetryNumberWater(self):
         """
         Test the Molecule.calculateSymmetryNumber() on H2O
         """
-        self.assertEqual(Molecule().fromSMILES('O').calculateSymmetryNumber(), 2)
+        self.assertEqual(Species().fromSMILES('O').getSymmetryNumber(), 2)
     
     def testSymmetryNumberEthylene(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C=C
         """
-        self.assertEqual(Molecule().fromSMILES('C=C').calculateSymmetryNumber(), 4)
+        self.assertEqual(Species().fromSMILES('C=C').getSymmetryNumber(), 4)
     
     def testSymmetryNumberEthenyl(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C=[CH].
         """
-        self.assertEqual(Molecule().fromSMILES('C=[CH]').calculateSymmetryNumber(), 1)
+        self.assertEqual(Species().fromSMILES('C=[CH]').getSymmetryNumber(), 1)
     
     def testSymmetryNumberCyclic(self):
         """
         Test the Molecule.calculateSymmetryNumber() on C1=C=C=1
         """
-        self.assertEqual(Molecule().fromSMILES('C1=C=C=1').calculateSymmetryNumber(), 6)
+        self.assertEqual(Species().fromSMILES('C1=C=C=1').getSymmetryNumber(), 6)
     
 ################################################################################
 

--- a/rmgpy/molecule/symmetryTest.py
+++ b/rmgpy/molecule/symmetryTest.py
@@ -299,6 +299,14 @@ class TestMoleculeSymmetry(unittest.TestCase):
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 12)
 
+    def testTotalSymmetryNumberbute_di_yl(self):
+        """
+        Test the Species.getSymmetryNumber() (total symmetry) on [CH2][CH]C=C
+        """
+        species = Species().fromSMILES('[CH2][CH]C=C')
+        symmetryNumber = species.getSymmetryNumber()
+        self.assertEqual(symmetryNumber, 2)
+
     def testTotalSymmetryNumberAllyl(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on Allyl, [CH2]C=C

--- a/rmgpy/molecule/vf2.pxd
+++ b/rmgpy/molecule/vf2.pxd
@@ -29,6 +29,8 @@ from graph cimport Vertex, Edge, Graph
 cdef class VF2:
 
     cdef Graph graph1, graph2
+
+    cpdef Graph graphA, graphB
     
     cdef dict initialMapping
     cdef bint subgraph
@@ -49,7 +51,7 @@ cdef class VF2:
 
     cdef bint match(self, int callDepth) except -2
         
-    cdef bint feasible(self, Vertex vertex1, Vertex vertex2) except -2
+    cpdef bint feasible(self, Vertex vertex1, Vertex vertex2) except -2
     
     cdef addToMapping(self, Vertex vertex1, Vertex vertex2)
         

--- a/rmgpy/molecule/vf2.pyx
+++ b/rmgpy/molecule/vf2.pyx
@@ -31,7 +31,7 @@ algorithm of Vento and Foggia.
 """
 
 cimport cython
-
+from rmgpy.molecule.graph import Graph
 ################################################################################
 
 class VF2Error(Exception):
@@ -46,10 +46,27 @@ cdef class VF2:
     An implementation of the second version of the Vento-Foggia (VF2) algorithm
     for graph and subgraph isomorphism.
     """
-    
-    def __init__(self):
-        self.graph1 = None
-        self.graph2 = None
+    def __init__(self, graphA = None, graphB = None):
+        self.graph1 = graphA
+        self.graph2 = graphB
+
+    @property
+    def graphA(self):
+        return self.graph1
+
+    @graphA.setter
+    def graphA(self, value):
+        self.graph1 = value
+        self.graph1.sortVertices()
+
+    @property
+    def graphB(self):
+        return self.graph2
+
+    @graphB.setter
+    def graphB(self, value):
+        self.graph2 = value
+        self.graph2.sortVertices()
 
     cpdef bint isIsomorphic(self, Graph graph1, Graph graph2, dict initialMapping) except -2:
         """
@@ -210,7 +227,7 @@ cdef class VF2:
         # None of the proposed matches led to a complete isomorphism, so return False
         return False     
         
-    cdef bint feasible(self, Vertex vertex1, Vertex vertex2) except -2:
+    cpdef bint feasible(self, Vertex vertex1, Vertex vertex2) except -2:
         """
         Return ``True`` if vertex `vertex1` from the first graph is a feasible
         match for vertex `vertex2` from the second graph, or ``False`` if not.

--- a/rmgpy/molecule/vf2Test.py
+++ b/rmgpy/molecule/vf2Test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+from external.wip import work_in_progress
+from nose.tools import assert_raises
+from numpy import testing
+
+from rmgpy.molecule.molecule import Molecule
+from rmgpy.molecule.symmetry import calculateAtomSymmetryNumber, calculateAxisSymmetryNumber, calculateBondSymmetryNumber, calculateCyclicSymmetryNumber
+from rmgpy.species import Species
+from rmgpy.molecule.resonance import generateAromaticResonanceStructures
+from rmgpy.molecule.vf2 import VF2
+from rmgpy.molecule.graph import getVertexConnectivityValue
+################################################################################
+
+class TestVF2(unittest.TestCase):
+    """
+    Contains unit tests of the methods for computing symmetry numbers for a
+    given Molecule object.
+    """
+
+    def setUp(self):
+        self.vf2 = VF2()
+        self.mol = Molecule().fromSMILES("CC(=O)C[CH2]")
+        self.mol2 = self.mol.copy(deep=True)
+
+    def test_import_graph(self):
+        """Test that we can add graphs to the object and that they are sorted"""
+
+        self.mol.sortVertices()
+        
+        ordered_original_connectivity_order = [getVertexConnectivityValue(atom) for atom in self.mol.atoms]
+
+        self.vf2.graphA = self.mol
+        self.vf2.graphB = self.mol2
+        
+        final_connectivity_order = [getVertexConnectivityValue(atom) for atom in self.vf2.graphA.atoms]
+        final_connectivity_order2 = [getVertexConnectivityValue(atom) for atom in self.vf2.graphB.atoms]
+
+        testing.assert_array_equal(final_connectivity_order,final_connectivity_order2)
+        testing.assert_array_equal(final_connectivity_order,ordered_original_connectivity_order)
+
+    def test_feasible(self):
+        """
+        Test that feasibility returns correct values on highly functional molecule
+        
+        `feasible` method isn't perfect in assigning values but it should do a good
+        job on highly functional values
+        """
+        
+        self.vf2.graphA = self.mol
+        self.vf2.graphB = self.mol2
+
+        for atom1 in self.vf2.graphA.atoms:
+            for atom2 in self.vf2.graphB.atoms:
+                # same connectivity values should result in `feasible` being true
+                if getVertexConnectivityValue(atom1) == getVertexConnectivityValue(atom2):
+                    self.assertTrue(self.vf2.feasible(atom1, atom2))
+                else: # different connectivity values should return false
+                    self.assertFalse(self.vf2.feasible(atom1, atom2))
+################################################################################
+
+if __name__ == '__main__':
+    unittest.main( testRunner = unittest.TextTestRunner(verbosity=2) )

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -45,7 +45,7 @@ cdef class Reaction:
     cdef public TransitionState transitionState
     cdef public KineticsModel kinetics
     cdef public bint duplicate
-    cdef public int degeneracy
+    cdef public int _degeneracy
     cdef public list pairs
     cdef public dict k_effective_cache
     

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -108,11 +108,11 @@ class Reaction:
         self.label = label
         self.reactants = reactants
         self.products = products
+        self.degeneracy = degeneracy
         self.kinetics = kinetics
         self.reversible = reversible
         self.transitionState = transitionState
         self.duplicate = duplicate
-        self.degeneracy = degeneracy
         self.pairs = pairs
         
         if diffusionLimiter.enabled:
@@ -160,6 +160,22 @@ class Reaction:
                            self.degeneracy,
                            self.pairs
                            ))
+
+    def __getDegneneracy(self):
+        return self._degeneracy
+    def __setDegeneracy(self, new):
+        # find how much to modify the rate
+        if self._degeneracy < 2:
+            degeneracyRatio = new
+        else:
+            degeneracyRatio = (new*1.0) / self._degeneracy
+        # modify rate if kinetics exists
+        if self.kinetics is not None:
+            self.kinetics.changeRate(degeneracyRatio)
+            logging.debug('did not modify A factor when modifying degeneracy since the reaction rate was not set')
+        # set new degeneracy
+        self._degeneracy = new
+    degeneracy = property(__getDegneneracy, __setDegeneracy)
 
     def toChemkin(self, speciesList=None, kinetics=True):
         """

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -976,6 +976,16 @@ class TestReaction(unittest.TestCase):
 
         diffusionLimiter.enabled = False
 
+    def testDegeneracyUpdatesRate(self):
+        """
+        This method tests that a change in degeneracy will result in a modified rate constant
+        """
+
+        prefactor = self.reaction.kinetics.A.value_si
+        degeneracyFactor = 2
+        self.reaction.degeneracy *= degeneracyFactor
+        self.assertAlmostEqual(self.reaction.kinetics.A.value_si, degeneracyFactor * prefactor)
+
 class TestReactionToCantera(unittest.TestCase):
     """
     Contains unit tests of the Reaction class associated with forming Cantera objects.

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -31,6 +31,7 @@ from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 from rmgpy.thermo.model cimport HeatCapacityModel
 from rmgpy.statmech.conformer cimport Conformer
 from rmgpy.kinetics.model cimport TunnelingModel
+from rmgpy.molecule.molecule cimport Atom, Bond, Molecule
 
 ################################################################################
 
@@ -47,6 +48,7 @@ cdef class Species:
     cdef public object energyTransferModel
     cdef public dict props
     cdef public str aug_inchi
+    cdef public short symmetryNumber
     
     cpdef generateResonanceIsomers(self)
     

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -50,7 +50,7 @@ cdef class Species:
     cdef public str aug_inchi
     cdef public short symmetryNumber
     
-    cpdef generateResonanceIsomers(self)
+    cpdef generateResonanceIsomers(self,bint keepIsomorphic=?)
     
     cpdef bint isIsomorphic(self, other)
     

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -48,12 +48,10 @@ import cython
 import logging
 
 import rmgpy.quantity as quantity
-from rmgpy.molecule import Molecule
 
 from rmgpy.pdep import SingleExponentialDown
 from rmgpy.statmech.conformer import Conformer
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
-
 #: This dictionary is used to add multiplicity to species label
 _multiplicity_labels = {1:'S',2:'D',3:'T',4:'Q',5:'V',}
                            
@@ -97,7 +95,8 @@ class Species(object):
 
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 
                  molecule=None, transportData=None, molecularWeight=None, 
-                 energyTransferModel=None, reactive=True, props=None, aug_inchi=None):
+                 energyTransferModel=None, reactive=True, props=None, aug_inchi=None,
+                 symmetryNumber = -1):
         self.index = index
         self.label = label
         self.thermo = thermo
@@ -109,7 +108,7 @@ class Species(object):
         self.energyTransferModel = energyTransferModel        
         self.props = props or {}
         self.aug_inchi = aug_inchi
-        
+        self.symmetryNumber = symmetryNumber
         # Check multiplicity of each molecule is the same
         if molecule is not None and len(molecule)>1:
             mult = molecule[0].multiplicity
@@ -171,7 +170,8 @@ class Species(object):
         resonance isomers have already been generated.
         """
         if len(self.molecule) == 1:
-            self.molecule = self.molecule[0].generateResonanceIsomers()
+            self.molecule[0].assignAtomIDs()
+            self.molecule = self.molecule[0].generateResonanceIsomers(keepIsomorphic)
     
     def isIsomorphic(self, other):
         """
@@ -374,13 +374,79 @@ class Species(object):
     def getSymmetryNumber(self):
         """
         Get the symmetry number for the species, which is the highest symmetry number amongst
-        its resonance isomers.  This function is currently used for website purposes and testing only as it
+        its resonance isomers and the resonance hybrid.  
+        This function is currently used for website purposes and testing only as it
         requires additional calculateSymmetryNumber calls.
         """
-        cython.declare(symmetryNumber=cython.int)
-        symmetryNumber = numpy.max([mol.getSymmetryNumber() for mol in self.molecule])
-        return symmetryNumber
+        if self.symmetryNumber < 1:
+            cython.declare(resonanceHybrid = Molecule, maxSymmetryNum = cython.short)
+            resonanceHybrid = self.getResonanceHybrid()
+            self.symmetryNumber = resonanceHybrid.getSymmetryNumber()
+            maxSymmetryNum = max([mol.getSymmetryNumber() for mol in self.molecule])
+            if maxSymmetryNum > self.symmetryNumber:
+                self.symmetryNumber = maxSymmetryNum
+        return self.symmetryNumber
         
+    def getResonanceHybrid(self):
+        """
+        Returns a molecule object with bond orders that are the average 
+        of all the resonance structures.
+        """
+        # get labeled resonance isomers
+        self.generateResonanceIsomers()
+
+        # return if no resonance
+        if len(self.molecule) == 1:
+            return self.molecule[0]
+
+        # create a sorted list of atom objects for each resonance structure
+        cython.declare(atomsFromStructures = list, oldAtoms = list, newAtoms = list,
+                       numResonanceStructures=cython.short, structureNum = cython.short,
+                       oldBondOrder = cython.float,
+                       index1 = cython.short, index2 = cython.short,
+                      newMol=Molecule, oldMol = Molecule,
+                      atom1=Atom, atom2=Atom, 
+                      bond=Bond,  
+                      atoms=list,)
+
+        atomsFromStructures = []
+        for newMol in self.molecule:
+            newMol.atoms.sort(key=lambda atom: atom.id)
+            atomsFromStructures.append(newMol.atoms)
+
+        numResonanceStructures = len(self.molecule)
+
+        # make original structure with no bonds
+        newMol = Molecule()
+        originalAtoms = atomsFromStructures[0]
+        for atom1 in originalAtoms:
+            atom = newMol.addAtom(Atom(atom1.element))
+            atom.id = atom1.id
+
+        newAtoms = newMol.atoms
+
+        # initialize bonds to zero order
+        for index1, atom1 in enumerate(originalAtoms):
+            for atom2 in atom1.bonds:
+                index2 = originalAtoms.index(atom2)
+                bond = Bond(newAtoms[index1],newAtoms[index2], 0)
+                newMol.addBond(bond)
+
+        # set bonds to the proper value
+        for structureNum, oldMol in enumerate(self.molecule):
+            oldAtoms = atomsFromStructures[structureNum]
+
+            for index1, atom1 in enumerate(oldAtoms):
+                for atom2 in atom1.bonds:
+                    index2 = oldAtoms.index(atom2)
+
+                    newBond = newMol.getBond(newAtoms[index1], newAtoms[index2])
+                    oldBondOrder = oldMol.getBond(oldAtoms[index1], oldAtoms[index2]).getOrderNum()
+                    newBond.applyAction(('CHANGE_BOND',None,oldBondOrder / numResonanceStructures / 2))
+
+        newMol.updateAtomTypes(logSpecies = False, raiseException=False)
+        return newMol
+
     def calculateCp0(self):
         """
         Return the value of the heat capacity at zero temperature in J/mol*K.

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -162,7 +162,7 @@ class Species(object):
         self._molecularWeight = quantity.Mass(value)
     molecularWeight = property(getMolecularWeight, setMolecularWeight, """The molecular weight of the species. (Note: value_si is in kg/molecule not kg/mole)""")
 
-    def generateResonanceIsomers(self):
+    def generateResonanceIsomers(self, keepIsomorphic=False):
         """
         Generate all of the resonance isomers of this species. The isomers are
         stored as a list in the `molecule` attribute. If the length of
@@ -382,9 +382,6 @@ class Species(object):
             cython.declare(resonanceHybrid = Molecule, maxSymmetryNum = cython.short)
             resonanceHybrid = self.getResonanceHybrid()
             self.symmetryNumber = resonanceHybrid.getSymmetryNumber()
-            maxSymmetryNum = max([mol.getSymmetryNumber() for mol in self.molecule])
-            if maxSymmetryNum > self.symmetryNumber:
-                self.symmetryNumber = maxSymmetryNum
         return self.symmetryNumber
         
     def getResonanceHybrid(self):
@@ -393,7 +390,7 @@ class Species(object):
         of all the resonance structures.
         """
         # get labeled resonance isomers
-        self.generateResonanceIsomers()
+        self.generateResonanceIsomers(keepIsomorphic=True)
 
         # return if no resonance
         if len(self.molecule) == 1:

--- a/rmgpy/speciesTest.py
+++ b/rmgpy/speciesTest.py
@@ -176,6 +176,35 @@ class TestSpecies(unittest.TestCase):
         for i, j in zip(spec.molecule, spec2.molecule):
             self.assertTrue(i.isIsomorphic(j))
 
+    def testGetResonanceHybrid(self):
+        """
+        Tests that getResonanceHybrid returns an isomorphic structure
+        which has intermediate bond orders.
+        
+        This check is for C=C[CH]CC which has another resonance structure,
+        [CH2]C=CC. When these structures are merged, the bond structure should be,
+        C~C~CC, where '~' is a hybrid bond of order 1.5. 
+        """
+        spec = Species().fromSMILES('C=C[CH]CC')
+        hybridMol = spec.getResonanceHybrid()
+        
+        self.assertTrue(hybridMol.toSingleBonds().isIsomorphic(spec.molecule[0].toSingleBonds()))
+        
+        # a rough check for intermediate bond orders
+        expected_orders = [1,1.5]
+        bonds = []
+        # ensure all bond orders are expected
+        for atom in hybridMol.atoms:
+            for atom2 in atom.bonds:
+                bond = hybridMol.getBond(atom,atom2)
+                self.assertTrue(any([bond.isOrder(otherOrder) for otherOrder in expected_orders]), 'Unexpected bond order {}'.format(bond.getOrderNum()))
+                bonds.append(bond)
+                
+        # ensure all expected orders are present
+        for expected_order in expected_orders:
+            self.assertTrue(any([bond.isOrder(expected_order) for bond in bonds]),'No bond of order {} found'.format(expected_order))
+            
+            
     def testCopy(self):
         """Test that we can make a copy of a Species object."""
 

--- a/rmgpy/speciesTest.py
+++ b/rmgpy/speciesTest.py
@@ -174,7 +174,7 @@ class TestSpecies(unittest.TestCase):
         exec('spec2 = {0!r}'.format(spec))
         self.assertEqual(len(spec.molecule), len(spec2.molecule))
         for i, j in zip(spec.molecule, spec2.molecule):
-            self.assertTrue(i.isIsomorphic(j))
+            self.assertTrue(j.isIsomorphic(i), msg='i is not isomorphic with j, where i is {} and j is {}'.format(i.toSMILES(), j.toSMILES()))
 
     def testGetResonanceHybrid(self):
         """


### PR DESCRIPTION
This PR expands RMG's ability to estimate symmetry numbers for resonance structures and cyclic compounds.

1. Symmetry numbers used in thermo come from Species objects, not molecule objects
1. When estimating the symmetry number of a Species, a hybrid resonance structure is created that is the average of all the bond orders of various resonance structures.
1. Redid how RMG calculates cyclic symmetry numbers, fixing #858, #119 (and reducing computational time by 50%).
1. Allow for float inputs to Adjacency Lists for the bond order (in addition to the strings). 
1. Updated to a newer cython version for increased functionality
1. Allowed for partial bonds to be represented with dots in ipython notebooks
1. Some doc-string fixes and other functionality improvements.