### PR TITLE
Thermo Central Database Interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ env:
   global:
     - secure: "L2ja+ZnV83w4qG3E8FwTjm0D6IWNOnj5wuFOjYTwbzQP4OAgLAWBzCMtxzWy5sMxFLtRgkswBH1d5f5kg8Ab7GIyAMFgQwe8UFqMJ+N05QNszE1mJkAvJtv2XN7669XXQhTt5EXfHrCcGZaODVnI2CEA8GB5DxiHO2Lcqf/xvgE="
     - secure: "Fa/qcHKKkTzgNanhgz+XWXg5K+uae5Ukxd0hfzYaiOI4+ldFbyMrYbPpxxoYVXw1SSO0psSupLfPfXzHwyJpFOyc46P+fo+R3YgNTJwr2VfdvSC0bp9K01nlRJ/z62IpMwmDwR2UH5xnfTeB9nhtzviFNKZoDZ/GR7F1Wqd/nnU="
+    - secure: "dkhvrkbNEHv55q3NU+lNJ0SqaNG0/vPMsG3X2eQvYjFsq/e8EliILtEtjrugSgeFohxqms0F+sSyDpw46mtn+jukYejdywLVL7w8o9pxlkHv8uEqYhNiwCD8RjNyRPQAS9jL+sAJiqdqUWR6AzjwaLproCe6rFzzGe7Io5oDLMg="
+    - secure: "cfosGf5hvUhIlPoGJu0d/HFddrMwIFU7FfLwd8yRrMGkYv0ePOwAW9kmhFSxUYvuXkxzgD75cIICMFY2fSm6VXBXXzfPQD7vwzoApXf7a8vi0C64XhinXhdEyUYb5/v8fswa0zheUENYhUS1tOqDXT/h8EPNZT5wKizaA3O2Wa8="
+    - secure: "QXuqKYuwCocqsTMePBc5OugBbQC4/t+335TYLdkletiateP/rF/eDsVRG792/BVq5gKRZgz3NH9ipTNm5pZoCbAEPt9+eDpfts8WeAbxmjdcEjfBxxwZ69wUTPAVrezTGn2k7W2UBdFrWeUNKPAVCKIkoviXqOHFitqJEC+c6JY="
+    - secure: "jIyBEzR10l5SWvY5ouEYzA8YzPHIZNMXMBdcXwuwte8NCU8GBYUqhHA1L67nTaBdLhWbrZ2NireVKPQWJp3ctcI0IB6xZzaYlVpgN/udGPO+1MZd9Xhp9TWuJWrGZ9EoWGB9L5H+O7RYwcDMVH5CUrCIBdsSJuyE8aDpky1/IVE="
 addons:
   apt:
     packages:

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -39,3 +39,4 @@ dependencies:
   - networkx
   - mock
   - muq
+  - pymongo

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -38,3 +38,4 @@ dependencies:
   - networkx
   - mock
   # - muq
+  - pymongo

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -37,3 +37,4 @@ dependencies:
   - networkx
   - mock
   # - muq
+  - pymongo

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -736,6 +736,9 @@ class ThermoDatabase(object):
             self.depository = {}
         self.loadLibraries(os.path.join(path, 'libraries'), libraries)
         self.loadGroups(os.path.join(path, 'groups'))
+
+        self.recordRingGenericNodes()
+        self.recordPolycylicGenericNodes()
         
     def loadDepository(self, path):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -991,6 +991,14 @@ class ThermoDatabase(object):
             libstr = os.path.join(groupsPath, 'Other_Library.txt'),
         )
 
+    def recordPolycylicGenericNodes(self):
+
+        self.groups['polycyclic'].genericNodes = ['PolycyclicRing']
+        for label, entry in self.groups['polycyclic'].entries.iteritems():
+
+            if isinstance(entry.data, ThermoData): 
+                continue
+            self.groups['polycyclic'].genericNodes.append(label)
 
     def getThermoData(self, species, trainingSet=None):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1000,6 +1000,14 @@ class ThermoDatabase(object):
                 continue
             self.groups['polycyclic'].genericNodes.append(label)
 
+    def recordRingGenericNodes(self):
+
+        self.groups['ring'].genericNodes = ['Ring']
+        for label, entry in self.groups['ring'].entries.iteritems():
+
+            if isinstance(entry.data, ThermoData): 
+                continue
+            self.groups['ring'].genericNodes.append(label)
     def getThermoData(self, species, trainingSet=None):
         """
         Return the thermodynamic parameters for a given :class:`Species`

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1800,7 +1800,22 @@ class ThermoCentralDatabaseInterface(object):
         self.client = self.connect()
 
     def connect(self):
-        return client
+        
+        import pymongo
+
+        remote_address = 'mongodb://{0}:{1}@{2}/thermoCentralDB'.format(self.username, 
+                                                            self.password,
+                                                            self.host)
+        client = pymongo.MongoClient(remote_address, 
+                                    self.port, 
+                                    serverSelectionTimeoutMS=2000)
+        try:
+            client.server_info()
+            return client
+        
+        except (pymongo.errors.ServerSelectionTimeoutError,
+                pymongo.errors.OperationFailure):
+            return None
 
     def registerInCentralThermoDB(self, species):
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1787,6 +1787,31 @@ class ThermoDatabase(object):
         
         return source
 
+class ThermoCentralDatabaseInterface(object):
+    """
+    A class for interfacing with RMG online thermo central database.
+    """
+
+    def __init__(self, host, port, username, password):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.client = self.connect()
+
+    def connect(self):
+        return client
+
+    def registerInCentralThermoDB(self, species):
+
+        # define host and credentials
+
+        # define insertion columns
+
+        # do the insertion
+        
+        self.client.insert
+
 def findCp0andCpInf(species, heatCap):
     """
     Calculate the Cp0 and CpInf values, and add them to the HeatCapacityModel object.

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -37,6 +37,7 @@ import re
 import math
 import logging
 import numpy
+import time
 from copy import deepcopy
 
 from base import Database, Entry, makeLogicNode, DatabaseError
@@ -1792,11 +1793,12 @@ class ThermoCentralDatabaseInterface(object):
     A class for interfacing with RMG online thermo central database.
     """
 
-    def __init__(self, host, port, username, password):
+    def __init__(self, host, port, username, password, application):
         self.host = host
         self.port = port
         self.username = username
         self.password = password
+        self.application = application
         self.client = self.connect()
 
     def connect(self):
@@ -1811,21 +1813,49 @@ class ThermoCentralDatabaseInterface(object):
                                     serverSelectionTimeoutMS=2000)
         try:
             client.server_info()
+            logging.info("\nConnection success to RMG Thermo Central Database!\n")
             return client
         
         except (pymongo.errors.ServerSelectionTimeoutError,
                 pymongo.errors.OperationFailure):
+            logging.info("\nConnection failure to RMG Thermo Central Database...")
+            logging.info("This RMG job still can run but cannot utilize data from central database.\n")
             return None
 
     def registerInCentralThermoDB(self, species):
 
-        # define host and credentials
-
-        # define insertion columns
-
-        # do the insertion
+        # choose registration table
+        db =  getattr(self.client, 'thermoCentralDB')
+        registration_table = getattr(db, 'registration_table')
+        results_table = getattr(db, 'results_table')
         
-        self.client.insert
+        # prepare registration entry
+        try:
+            aug_inchi = species.getAugmentedInChI()
+
+            # check if it's registered before or
+            # already have available data in results_table
+            registered_entries = list(registration_table.find({"aug_inchi": aug_inchi}))
+            finished_entries = list(results_table.find({"aug_inchi": aug_inchi}))
+            
+            if len(registered_entries) + len(finished_entries) > 0 :
+                return
+
+            SMILES_input = species.molecule[0].toSMILES()
+            status = 'pending'
+            species_registration_entry = {'aug_inchi': aug_inchi,
+                                        'SMILES_input': SMILES_input,
+                                        'radical_number': species.molecule[0].getRadicalCount(),
+                                        'status': status,
+                                        'user': self.username,
+                                        'application': self.application,
+                                        'timestamp': time.time()
+                                        }
+
+            registration_table.insert(species_registration_entry)
+
+        except ValueError:
+            logging.info('Fail to generate inchi/smiles for species below:\n{0}'.format(species.toAdjacencyList()))
 
 def findCp0andCpInf(species, heatCap):
     """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -874,16 +874,18 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
         port = 27017
         username = 'me'
         password = 'pswd'
+        application = 'test'
 
-        tcdi = ThermoCentralDatabaseInterface(host, port, username, password)
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
 
         self.assertTrue(tcdi.client is None)
 
     def testConnectSuccess(self):
 
         host, port, username, password = getTCDAuthenticationInfo()
+        application = 'test'
 
-        tcdi = ThermoCentralDatabaseInterface(host, port, username, password)
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
 
         self.assertTrue(tcdi.client is not None)
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -882,14 +882,125 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
 
     def testConnectSuccess(self):
 
-        host, port, username, password = getTCDAuthenticationInfo()
+        host, port, username, password = getTestingTCDAuthenticationInfo()
         application = 'test'
 
         tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
 
         self.assertTrue(tcdi.client is not None)
 
-def getTCDAuthenticationInfo():
+    def testRegisterInCentralThermoDB1(self):
+        """
+        Test situation where both registration_table and results_table have no
+        species as the one going to be registered
+        """
+        # connect to thermo central database
+        host, port, username, password = getTestingTCDAuthenticationInfo()
+        application = 'test'
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
+
+        # prepare species to register
+        species = Species().fromSMILES('C1=C=C2CC23C=CC=1C=C3')
+        expected_aug_inchi = "InChI=1S/C10H6/c1-2-9-7-10(9)5-3-8(1)4-6-10/h3-6H,7H2"
+
+        # select registration table
+        # and clean previous data
+        db =  getattr(tcdi.client, 'thermoCentralDB')
+        registration_table = getattr(db, 'registration_table')
+        results_table = getattr(db, 'results_table')
+        registration_table.delete_many({"aug_inchi": expected_aug_inchi})
+        results_table.delete_many({"aug_inchi": expected_aug_inchi})
+
+        tcdi.registerInCentralThermoDB(species)
+        registered_species_entries = list(registration_table.find({"aug_inchi": expected_aug_inchi}))
+
+        # should expect only one registered such species
+        self.assertEqual(len(registered_species_entries), 1)
+        registered_species_entry = registered_species_entries[0]
+
+        # check all the columns are expected
+        registered_species = Species().fromSMILES(str(registered_species_entry['SMILES_input']))
+        self.assertEqual(registered_species_entry['aug_inchi'], expected_aug_inchi)
+        self.assertTrue(registered_species.isIsomorphic(species))
+        self.assertIn(registered_species_entry['status'], ['pending', 'submitted'])
+
+        # clean up the table
+        registration_table.delete_many({"aug_inchi": expected_aug_inchi})
+
+    def testRegisterInCentralThermoDB2(self):
+        """
+        Test situation where registration_table has species as the one going 
+        to be registered
+        """
+
+        # connect to thermo central database
+        host, port, username, password = getTestingTCDAuthenticationInfo()
+        application = 'test'
+
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
+
+        # prepare species to register
+        species = Species().fromSMILES('C1=C=C2CC23C=CC=1C=C3')
+        expected_aug_inchi = "InChI=1S/C10H6/c1-2-9-7-10(9)5-3-8(1)4-6-10/h3-6H,7H2"
+
+        # select registration table
+        # and clean previous data
+        db =  getattr(tcdi.client, 'thermoCentralDB')
+        registration_table = getattr(db, 'registration_table')
+        results_table = getattr(db, 'results_table')
+        registration_table.delete_many({"aug_inchi": expected_aug_inchi})
+        registration_table.insert_one({"aug_inchi": expected_aug_inchi})
+        results_table.delete_many({"aug_inchi": expected_aug_inchi})
+
+        tcdi.registerInCentralThermoDB(species)
+        registered_species_entries = list(registration_table.find({"aug_inchi": expected_aug_inchi}))
+
+        # should expect only one registered such species
+        self.assertEqual(len(registered_species_entries), 1)
+        registered_species_entry = registered_species_entries[0]
+
+        # check all the columns are expected
+        self.assertEqual(registered_species_entry['aug_inchi'], expected_aug_inchi)
+        self.assertTrue(len(registered_species_entry), 2)
+
+        # clean up the table
+        registration_table.delete_many({"aug_inchi": expected_aug_inchi})
+
+    def testRegisterInCentralThermoDB3(self):
+        """
+        Test situation where results_table has species as the one going 
+        to be registered
+        """
+
+        # connect to thermo central database
+        host, port, username, password = getTestingTCDAuthenticationInfo()
+        application = 'test'
+        
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
+
+        # prepare species to register
+        species = Species().fromSMILES('C1=C=C2CC23C=CC=1C=C3')
+        expected_aug_inchi = "InChI=1S/C10H6/c1-2-9-7-10(9)5-3-8(1)4-6-10/h3-6H,7H2"
+
+        # select registration table
+        # and clean previous data
+        db =  getattr(tcdi.client, 'thermoCentralDB')
+        registration_table = getattr(db, 'registration_table')
+        results_table = getattr(db, 'results_table')
+        registration_table.delete_many({"aug_inchi": expected_aug_inchi})
+        results_table.delete_many({"aug_inchi": expected_aug_inchi})
+        results_table.insert_one({"aug_inchi": expected_aug_inchi})
+
+        tcdi.registerInCentralThermoDB(species)
+        registered_species_entries = list(registration_table.find({"aug_inchi": expected_aug_inchi}))
+
+        # should expect only one registered such species
+        self.assertEqual(len(registered_species_entries), 0)
+
+        # clean up the table
+        results_table.delete_many({"aug_inchi": expected_aug_inchi})
+
+def getTestingTCDAuthenticationInfo():
 
     try:
         host = os.environ['TCD_HOST']

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -863,6 +863,42 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         joinedCycle=combineCycles(testCycle1,testCycle2)
         self.assertTrue(sorted(mainCycle)==sorted(joinedCycle))
 
+class TestThermoCentralDatabaseInterface(unittest.TestCase):
+    """
+    Contains unit tests for methods of ThermoCentralDatabaseInterface
+    """
+
+    def testConnectFailure(self):
+
+        host = 'somehost'
+        port = 27017
+        username = 'me'
+        password = 'pswd'
+
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password)
+
+        self.assertTrue(tcdi.client is None)
+
+    def testConnectSuccess(self):
+
+        host, port, username, password = getTCDAuthenticationInfo()
+
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password)
+
+        self.assertTrue(tcdi.client is not None)
+
+def getTCDAuthenticationInfo():
+
+    try:
+        host = os.environ['TCD_HOST']
+        port = int(os.environ['TCD_PORT'])
+        username = os.environ['TCD_USER']
+        password = os.environ['TCD_PW']
+    except KeyError:
+        print('Thermo Central Database Authentication Environment Variables Not Completely Set!')
+        return 'None', 0, 'None', 'None'
+
+    return host, port, username, password
 
 ################################################################################
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -867,6 +867,12 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
     """
     Contains unit tests for methods of ThermoCentralDatabaseInterface
     """
+    @classmethod
+    def setUpClass(self):
+        """A function that is run ONCE before all unit tests in this class."""
+        global database
+        self.database = database.thermo
+
     def connectToTestCentralDatabase(self):
 
         host, port, username, password = getTestingTCDAuthenticationInfo()
@@ -892,6 +898,91 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
         tcdi = self.connectToTestCentralDatabase()
 
         self.assertTrue(tcdi.client is not None)
+
+    def testSatisfyRegistrationRequirements1(self):
+        """
+        the species is non-cyclic, currently regarded no need to 
+        register in thermo central database
+        """
+        tcdi = self.connectToTestCentralDatabase()
+
+        species = Species().fromSMILES('C[CH2]')
+
+        thermoData = self.database.getThermoDataFromGroups(species)
+
+        self.assertFalse(tcdi.satisfyRegistrationRequirements(species, thermoData, self.database))
+
+    def testSatisfyRegistrationRequirements2(self):
+        """
+        the species is for non-cyclic, so no need to register in 
+        thermo central database
+        """
+        tcdi = self.connectToTestCentralDatabase()
+
+        species = Species().fromSMILES('CC')
+
+        thermoData = self.database.getThermoDataFromGroups(species)
+
+        self.assertFalse(tcdi.satisfyRegistrationRequirements(species, thermoData, self.database))
+
+
+    def testSatisfyRegistrationRequirements3(self):
+        """
+        the thermo is exact match, so no need to register in 
+        thermo central database
+        """
+        tcdi = self.connectToTestCentralDatabase()
+
+        species = Species().fromSMILES('C1CC1')
+
+        thermoData = self.database.getThermoDataFromGroups(species)
+
+        self.assertFalse(tcdi.satisfyRegistrationRequirements(species, thermoData, self.database))
+
+    def testSatisfyRegistrationRequirements4(self):
+        """
+        the thermo is from library, so no need to register in 
+        thermo central database
+        """
+        tcdi = self.connectToTestCentralDatabase()
+
+        species = Species().fromSMILES('[H][H]')
+
+        thermoData = self.database.getThermoDataFromLibraries(species)
+
+        self.assertFalse(tcdi.satisfyRegistrationRequirements(species, thermoData, self.database))
+
+    def testSatisfyRegistrationRequirements5(self):
+        """
+        the thermo is matching generic node, so it needs to register in 
+        thermo central database
+
+        In the future, if RMG-database includes corresponding exact match
+        this test should be modified.
+        """
+        tcdi = self.connectToTestCentralDatabase()
+
+        species = Species().fromSMILES('C1C=CC2C=CC2=C1')
+
+        thermoData = self.database.getThermoDataFromGroups(species)
+
+        self.assertTrue(tcdi.satisfyRegistrationRequirements(species, thermoData, self.database))
+
+    def testSatisfyRegistrationRequirements6(self):
+        """
+        the thermo is matching generic node, so it needs to register in 
+        thermo central database
+
+        In the future, if RMG-database includes corresponding exact match
+        this test should be modified.
+        """
+        tcdi = self.connectToTestCentralDatabase()
+
+        species = Species().fromSMILES('C1=C=C2CC23C=CC=1C=C3')
+
+        thermoData = self.database.getThermoDataFromGroups(species)
+
+        self.assertTrue(tcdi.satisfyRegistrationRequirements(species, thermoData, self.database))
 
     def testRegisterInCentralThermoDB1(self):
         """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -867,6 +867,13 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
     """
     Contains unit tests for methods of ThermoCentralDatabaseInterface
     """
+    def connectToTestCentralDatabase(self):
+
+        host, port, username, password = getTestingTCDAuthenticationInfo()
+        application = 'test'
+
+        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
+        return tcdi
 
     def testConnectFailure(self):
 
@@ -882,10 +889,7 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
 
     def testConnectSuccess(self):
 
-        host, port, username, password = getTestingTCDAuthenticationInfo()
-        application = 'test'
-
-        tcdi = ThermoCentralDatabaseInterface(host, port, username, password, application)
+        tcdi = self.connectToTestCentralDatabase()
 
         self.assertTrue(tcdi.client is not None)
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -359,13 +359,15 @@ def generatedSpeciesConstraints(**kwargs):
 def thermoCentralDatabase(host,
                         port,
                         username,
-                        password):
+                        password,
+                        application):
     
     from rmgpy.data.thermo import ThermoCentralDatabaseInterface
     rmg.thermoCentralDatabase = ThermoCentralDatabaseInterface(host,
                                                             port,
                                                             username,
-                                                            password)
+                                                            password,
+                                                            application)
                     
 
 ################################################################################
@@ -423,6 +425,7 @@ def readInputFile(path, rmg0):
         'pressureDependence': pressureDependence,
         'options': options,
         'generatedSpeciesConstraints': generatedSpeciesConstraints,
+        'thermoCentralDatabase': thermoCentralDatabase
     }
 
     try:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -356,6 +356,18 @@ def generatedSpeciesConstraints(**kwargs):
         
         rmg.speciesConstraints[key] = value
 
+def thermoCentralDatabase(host,
+                        port,
+                        username,
+                        password):
+    
+    from rmgpy.data.thermo import ThermoCentralDatabaseInterface
+    rmg.thermoCentralDatabase = ThermoCentralDatabaseInterface(host,
+                                                            port,
+                                                            username,
+                                                            password)
+                    
+
 ################################################################################
 
 def setGlobalRMG(rmg0):
@@ -669,6 +681,8 @@ def getInput(name):
             return rmg.speciesConstraints
         elif name == 'quantumMechanics':
             return rmg.quantumMechanics
+        elif name == 'thermoCentralDatabase':
+            return rmg.thermoCentralDatabase
         else:
             raise Exception('Unrecognized keyword: {}'.format(name))
     else:

--- a/rmgpy/rmg/inputTest.py
+++ b/rmgpy/rmg/inputTest.py
@@ -89,7 +89,37 @@ class TestInputDatabase(unittest.TestCase):
         inp.database(reactionLibraries=[('test',True)])
         self.assertIsInstance(rmg.reactionLibraries[0], tuple)
         self.assertTrue(rmg.reactionLibraries[0][1])
+
+
+class TestInputThemoCentralDatabase(unittest.TestCase):
+    """
+    Contains unit tests rmgpy.rmg.input.thermoCentralDatabase
+    """
+    def tearDown(self):
+        # remove the reactionLibraries value
+        global rmg
+        rmg.thermoCentralDatabase = None
         
+    def testThemoCentralDatabase(self):
+        """
+        Test that we can input.
+        """
+        global rmg
+        # add database properties to RMG
+        inp.thermoCentralDatabase(
+                host='some_host',
+                port=0,
+                username='some_usr',
+                password='some_pw',
+                application='some_app'
+        )
+        self.assertEqual(rmg.thermoCentralDatabase.host, 'some_host')
+        self.assertEqual(rmg.thermoCentralDatabase.port, 0)
+        self.assertEqual(rmg.thermoCentralDatabase.username, 'some_usr')
+        self.assertEqual(rmg.thermoCentralDatabase.password, 'some_pw')
+        self.assertEqual(rmg.thermoCentralDatabase.application, 'some_app')
+        self.assertEqual(rmg.thermoCentralDatabase.client, None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -196,6 +196,8 @@ class RMG(util.Subject):
         self.initializationTime = 0
         self.kineticsdatastore = None
 
+        self.thermoCentralDatabase = None
+
         self.execTime = []
     
     def loadInput(self, path=None):

--- a/rmgpy/thermo/thermoengine.py
+++ b/rmgpy/thermo/thermoengine.py
@@ -101,6 +101,23 @@ def generateThermoData(spc, thermoClass=NASA):
         return None
     
     thermo0 = thermodb.getThermoData(spc) 
+
+    # 1. maybe only submit cyclic core
+    # 2. to help radical prediction, HBI should also
+    #    look up centrailThermoDB for its saturated version
+    #    currently it only looks up libraries or estimates via GAV 
+    from rmgpy.rmg.input import getInput
+    
+    try:
+        thermoCentralDatabase = getInput('thermoCentralDatabase')
+    except Exception, e:
+        logging.debug('thermoCentralDatabase could not be found.')
+        thermoCentralDatabase = None
+    
+    if thermoCentralDatabase and thermoCentralDatabase.client \
+        and thermoCentralDatabase.satisfyRegistrationRequirements(spc, thermo0, thermodb):
+        
+        thermoCentralDatabase.registerInCentralThermoDB(spc)
         
     return processThermoData(spc, thermo0, thermoClass)    
 


### PR DESCRIPTION
This PR introduces an interface to thermo central database, which is designed as a first step to solve inaccurate themo estimation problems for crazy-structured species (potentially can also be expanded to other species spaces where RMG is not familiar with, e.g., sulfur nitrogen compounds).

The whole workflow would include:

- identify target species (e.g., crazy-structured, no exactly matched groups)

- connect to thermo central database

- check if it exists (can fetch thermo if there's results) or not (insert this species to database registration table)

- automatically launch quantum mechanics calculations for registered species (this step is not included in this PR)

The **only requirement** from user who is willing to use the functionality is add an authentication block in RMG `input.py` e.g., 

```
thermoCentralDatabase(
    host='xxxx',
    port=1234,
    username='my_username',
    password='my_pwd',
    application='my_RMG_application'
)
```

The first stage (currently) will be for internal usage; we only allow people from Green group and West group to connect to the central database (others can get referred by people from these two groups).

Some details about central database. It currently is constructed using [MongoDB](https://www.mongodb.com/). Will be hosted by two servers, one for developer testing, one for production. A simple [web dashboard](http://kehangsblog.com/thermo_central_db/) is available.

For developers, testing authentication info is now stored as environment variables, which can be easily encrypted for Travis test.
