### PR TITLE
Add bugfix for alignment of species when displaying reactions

### DIFF
--- a/rmgpy/molecule/draw.py
+++ b/rmgpy/molecule/draw.py
@@ -1423,19 +1423,14 @@ class ReactionDrawer:
             
         # Next determine size required for surface
         rxn_width = 0; rxn_height = 0; rxn_top = 0
-        for surface, cr, rect in reactants:
+        for surface, cr, rect in reactants + products:
             left, top, width, height = rect
             rxn_width += width
             if height > rxn_height: rxn_height = height
             if height + top > rxn_top: rxn_top = height + top
-        for surface, cr, rect in products:
-            left, top, width, height = rect
-            rxn_width += width
-            if height > rxn_height: rxn_height = height
-            if height + top > rxn_top: rxn_top = height + top
-        
+
         rxn_top = 0.5 * rxn_height - rxn_top
-        
+
         # Also include '+' and reaction arrow in width
         cr.set_font_size(fontSizeNormal)
         plus_extents = cr.text_extents(' + ')
@@ -1467,6 +1462,7 @@ class ReactionDrawer:
                 rxn_x += plus_extents[4]
             # Draw the reactant
             rxn_y = top + rxn_top + 0.5 * rxn_height
+            if rxn_y < 0 : rxn_y = 0
             rxn_cr.save()
             rxn_cr.set_source_surface(surface, rxn_x, rxn_y)
             rxn_cr.paint()
@@ -1504,6 +1500,7 @@ class ReactionDrawer:
                 rxn_x += plus_extents[4]
             # Draw the product
             rxn_y = top + rxn_top + 0.5 * rxn_height
+            if rxn_y < 0 : rxn_y = 0
             rxn_cr.save()
             rxn_cr.set_source_surface(surface, rxn_x, rxn_y)
             rxn_cr.paint()


### PR DESCRIPTION
There has clearly been some thought put into how to align the reactions as seen [here](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/bb3904eb4e7961c2a0935234441df2038a37bd66) and [here](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/d29d620a0bf20253b59bca9a80cffae16e42aaff), although I can't follow the implementation's logic. The end result does look better than just centering every object. 

However, sometimes the algorithm for aligning species would draw a molecule above the `rxn_y =0.0` line, making part of the species above the limits of the image. This PR adds an `if` statement that will catch these cases and set `rxn_y = 0`. 