### PR TITLE
Add try/except for resetting signal after calling lpsolve

### DIFF
--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -819,7 +819,11 @@ def _clarOptimization(mol, constraints=None, maxNum=None):
     lpsolve('delete_lp', lp)  # Delete the LP problem to clear up memory
 
     # Reset signal handling since lpsolve changed it
-    signal.signal(signal.SIGINT, sig)
+    try:
+        signal.signal(signal.SIGINT, sig)
+    except ValueError:
+        # This is not being run in the main thread, so we cannot reset signal
+        pass
 
     # Check that optimization was successful
     if status != 0:


### PR DESCRIPTION
When RMG is not run on the main thread (eg. for RMG-website), signal cannot be set and will raise an exception.