### PR TITLE
Model resurrection / Dynamics Time Scale (AcceleratorTools part 5)

### DIFF
--- a/examples/rmg/MR_test/input.py
+++ b/examples/rmg/MR_test/input.py
@@ -1,0 +1,314 @@
+#This syngas example is for testing Model Resurrection handling (recovery from solver errors)
+#The parameters chosen for this example were chosen to generate solver errors
+#(so this is not a good example to base an input file for a real job on)
+database(
+	#overrides RMG thermo calculation of RMG with these values.
+	#libraries found at http://rmg.mit.edu/database/thermo/libraries/
+	#if species exist in multiple libraries, the earlier libraries overwrite the 
+	#previous values
+    thermoLibraries = ['primaryThermoLibrary'],
+	#overrides RMG kinetics estimation if needed in the core of RMG. 
+	#list of libraries found at http://rmg.mit.edu/database/kinetics/libraries/
+	#libraries can be input as either a string or tuple of form ('library_name',True/False) 
+     #where a `True` indicates that all unused reactions will be automatically added 
+	#to the chemkin file at the end of the simulation. Placing just string values
+     #defaults the tuple to `False`. The string input is sufficient in almost
+     #all situations
+    reactionLibraries = [],
+	#seed mechanisms are reactionLibraries that are forced into the initial mechanism 
+	#in addition to species listed in this input file.  
+	#This is helpful for reducing run time for species you know will appear in 
+	#the mechanism.  
+    seedMechanisms = [],
+	#this is normally not changed in general RMG runs.  Usually used for testing with 
+	#outside kinetics databases
+    kineticsDepositories = 'default', 
+	#lists specific families used to generate the model. 'default' uses a list of 
+	#families from RMG-Database/input/families/recommended.py
+	#a visual list of families is available in PDF form at RMG-database/families
+    kineticsFamilies = 'default',
+	#specifies how RMG calculates rates.  currently, the only option is 'rate rules'
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+#list initial and expected species below to automatically put them into the core mechanism.  
+#'structure' can utilize method of SMILES("put_SMILES_here"), 
+#adjacencyList("""put_adj_list_here"""), or InChI("put_InChI_here")
+#for molecular oxygen, use the smiles string [O][O] so the triplet form is used
+species(
+   label='N2',
+   reactive=False,
+  structure=SMILES("N#N")
+)
+species(
+    label='CO',
+    reactive=True,
+    structure=SMILES("[C-]#[O+]")
+)
+    
+species(
+    label='H2',
+    reactive=True,
+    structure=SMILES("[H][H]"),
+)
+species(
+        label='O2',
+        reactive=True,
+        structure=SMILES("[O][O]")
+        )
+
+#Reaction systems
+#currently RMG models only constant temperature and pressure as homogeneous batch reactors.  
+#two options are: simpleReactor for gas phase or liquidReactor for liquid phase
+#use can use multiple reactors in an input file for each condition you want to test.  
+
+simpleReactor(
+	#specifies reaction temperature with units
+    temperature=(1000,'K'),
+	#specifies reaction pressure with units
+    pressure=(10.0,'bar'),
+	#list initial mole fractions of compounds using the label from the 'species' label.  
+	#RMG will normalize if sum/=1
+    initialMoleFractions={
+        "CO": .6,
+        "H2": .4,
+        "O2": .5,
+ 	"N2": 0,
+    },
+	#the following two values specify when to determine the final output model
+	#only one must be specified
+	#the first condition to be satisfied will terminate the process
+
+    terminationTime=(12,'s'),
+)
+
+
+
+simpleReactor(
+	#specifies reaction temperature with units
+    temperature=(1000,'K'),
+	#specifies reaction pressure with units
+    pressure=(100.0,'bar'),
+	#list initial mole fractions of compounds using the label from the 'species' label.  
+	#RMG will normalize if sum/=1
+    initialMoleFractions={
+        "CO": .6,
+        "H2": .4,
+        "O2": .5,
+	"N2": 0,
+    },
+	#the following two values specify when to determine the final output model
+	#only one must be specified
+	#the first condition to be satisfied will terminate the process
+
+    terminationTime=(12,'s'),
+)
+
+
+
+
+
+simpleReactor(
+              #specifies reaction temperature with units
+              temperature=(2000,'K'),
+              #specifies reaction pressure with units
+              pressure=(100.0,'bar'),
+              #list initial mole fractions of compounds using the label from the 'species' label.
+              #RMG will normalize if sum/=1
+              initialMoleFractions={
+              "CO": .6,
+              "H2": .4,
+              "O2": .5,
+	      "N2": 0,
+              },
+              #the following two values specify when to determine the final output model
+              #only one must be specified
+              #the first condition to be satisfied will terminate the process
+              
+              terminationTime=(12,'s'),
+              )
+simpleReactor(
+              #specifies reaction temperature with units
+              temperature=(2000,'K'),
+              #specifies reaction pressure with units
+              pressure=(10.0,'bar'),
+              #list initial mole fractions of compounds using the label from the 'species' label.
+              #RMG will normalize if sum/=1
+              initialMoleFractions={
+              "CO": .6,
+              "H2": .4,
+              "O2": .5,
+	      "N2": 0,
+              },
+              #the following two values specify when to determine the final output model
+              #only one must be specified
+              #the first condition to be satisfied will terminate the process
+              
+              terminationTime=(12,'s'),
+              )
+
+
+
+
+#1500
+simpleReactor(
+              #specifies reaction temperature with units
+              temperature=(1500,'K'),
+              #specifies reaction pressure with units
+              pressure=(100.0,'bar'),
+              #list initial mole fractions of compounds using the label from the 'species' label.
+              #RMG will normalize if sum/=1
+              initialMoleFractions={
+              "CO": .6,
+              "H2": .4,
+              "O2": .5,
+	      "N2": 0,
+              },
+              #the following two values specify when to determine the final output model
+              #only one must be specified
+              #the first condition to be satisfied will terminate the process
+              
+              terminationTime=(12,'s'),
+              )
+simpleReactor(
+              #specifies reaction temperature with units
+              temperature=(1500,'K'),
+              #specifies reaction pressure with units
+              pressure=(10.0,'bar'),
+              #list initial mole fractions of compounds using the label from the 'species' label.
+              #RMG will normalize if sum/=1
+              initialMoleFractions={
+              "CO": .6,
+              "H2": .4,
+              "O2": .5,
+              "N2": 0,
+              },
+              #the following two values specify when to determine the final output model
+              #only one must be specified
+              #the first condition to be satisfied will terminate the process
+              
+              terminationTime=(12,'s'),
+              )
+
+#determines absolute and relative tolerances for ODE solver and sensitivities.
+#normally this doesn't cause many issues and is modified after other issues are
+#ruled out
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+#    sens_atol=1e-6,
+#    sens_rtol=1e-4,
+)
+
+#used to add species to the model and to reduce memory usage by removing unimportant additional species.
+#all relative values are normalized by a characteristic flux at that time point
+model(
+	#determines the relative flux to put a species into the core.  
+	#A smaller value will result in a larger, more complex model
+	#when running a new model, it is recommended to start with higher values and then decrease to converge on the model
+    toleranceMoveToCore=0.01,
+    #comment out the next three terms to disable pruning
+	   #determines the relative flux needed to not remove species from the model.  
+	   #Lower values will keep more species and utilize more memory
+    toleranceKeepInEdge=0.0,
+	   #determines when to stop a ODE run to add a species.  
+	   #Lower values will improve speed. 
+	   #if it is too low, may never get to the end simulation to prune species.  
+    toleranceInterruptSimulation=0.01,
+	   #number of edge species needed to accumulate before pruning occurs
+	   #larger values require more memory and will prune less often
+    maximumEdgeSpecies=100000,
+        #minimum number of core species needed before pruning occurs.
+        #this prevents pruning when kinetic model is far away from completeness
+    minCoreSizeForPrune=50,
+        #make sure that the pruned edge species have existed for a set number of RMG iterations.  
+        #the user can specify to increase it from the default value of 2
+    minSpeciesExistIterationsForPrune=2,
+        #filter the reactions during the enlarge step to omit species from reacting if their
+        #concentration are deemed to be too low
+    filterReactions=True,
+    maxNumSpecies=24,
+)
+
+options(
+    	#provides a name for the seed mechanism produced at the end of an rmg run default is 'Seed'
+    name='Syngas',	
+	#if True every iteration it saves the current model as libraries/seeds
+	#(and deletes the old one)
+	#Unlike HTML this is inexpensive time-wise
+	#note a seed mechanism will be generated at the end of a completed run and some incomplete 
+	#runs even if this is set as False
+    generateSeedEachIteration=True,
+	#If True the mechanism will also be saved directly as kinetics and thermo libraries in the database
+    saveSeedToDatabase=False,
+	#only option is 'si'
+    units='si',
+	#how often you want to save restart files.  
+	#takes significant amount of time. comment out if you don't want to save 
+    saveRestartPeriod=None,
+	#Draws images of species and reactions and saves the model output to HTML.  
+	#May consume extra memory when running large models.
+    generateOutputHTML=True,
+	#generates plots of the RMG's performance statistics. Not helpful if you just want a model.
+    generatePlots=False,
+	#saves mole fraction of species in 'solver/' to help you create plots
+    saveSimulationProfiles=True,
+	#gets RMG to output comments on where kinetics were obtained in the chemkin file.  
+	#useful for debugging kinetics but increases memory usage of the chemkin output file
+    verboseComments=False,
+	#gets RMG to generate edge species chemkin files. Uses lots of memory in output.
+	#Helpful for seeing why some reaction are not appearing in core model.  
+    saveEdgeSpecies=False,
+    #Sets a time limit in the form DD:HH:MM:SS after which the RMG job will stop. Useful for profiling on jobs that
+    #do not converge.
+    #wallTime = '00:00:00', 
+    keepIrreversible=False,
+    #Forces RMG to import library reactions as reversible (default). Otherwise, if set to True, RMG will import library
+    #reactions while keeping the reversibility as as.
+)
+
+# optional module allows for correction to unimolecular reaction rates at low pressures and/or temperatures.
+pressureDependence(
+ 	#two methods available: 'modified strong collision' is faster and less accurate than 'reservoir state'
+ 	method='modified strong collision',
+ 	#these two categories determine how fine energy is descretized.
+ 	#more grains increases accuracy but takes longer
+ 	maximumGrainSize=(0.5,'kcal/mol'),
+ 	minimumNumberOfGrains=250,
+ 	#the conditions for the rate to be output over
+ 	#parameter order is: low_value, high_value, units, internal points
+ 	temperatures=(300,2200,'K',2),
+ 	pressures=(0.01,100.01,'bar',3),
+ 	#The two options for interpolation are 'PDepArrhenius' (no extra arguments) and 
+ 	#'Chebyshev' which is followed by the number of basis sets in 
+ 	#Temperature and Pressure. These values must be less than the number of 
+ 	#internal points specified above
+ 	interpolation=('Chebyshev', 6, 4),
+ 	#turns off pressure dependence for molecules with number of atoms greater than the number specified below
+ 	#this is due to faster internal rate of energy transfer for larger molecules
+ 	maximumAtoms=15,
+ )
+
+#optional block adds constraints on what RMG can output.  
+#This is helpful for improving the efficiency of RMG, but wrong inputs can lead to many errors.
+generatedSpeciesConstraints(
+	#allows exceptions to the following restrictions
+    allowed=['input species','seed mechanisms','reaction libraries'],
+	#maximum number of each atom in a molecule
+    maximumCarbonAtoms=4,
+    maximumOxygenAtoms=6,
+    maximumNitrogenAtoms=0,
+    maximumSiliconAtoms=0,
+    maximumSulfurAtoms=0,
+	#max number of non-hydrogen atoms
+    #maximumHeavyAtoms=20,
+	#maximum radicals on a molecule
+    maximumRadicalElectrons=2,
+    #If this is false or missing, RMG will throw an error if the more less-stable form of O2 is entered 
+    #which doesn't react in the RMG system. normally input O2 as triplet with SMILES [O][O]
+    #allowSingletO2=False,
+    # maximum allowed number of non-normal isotope atoms:
+    #maximumIsotopicAtoms=2,
+)
+

--- a/examples/rmg/minimal_surface/input.py
+++ b/examples/rmg/minimal_surface/input.py
@@ -55,6 +55,7 @@ model(
     toleranceMoveEdgeReactionToSurface=1.0,
     toleranceMoveSurfaceReactionToCore=2.0,
     toleranceMoveSurfaceSpeciesToCore=.001,
+    dynamicsTimeScale=(1.0e-10,'sec'),
 )
 
 options(

--- a/rmgpy/reduction/reduction.py
+++ b/rmgpy/reduction/reduction.py
@@ -87,7 +87,7 @@ def simulateOne(reactionModel, atol, rtol, reactionSystem):
     simulatorSettings = SimulatorSettings(atol,rtol)
     modelSettings = ModelSettings(toleranceKeepInEdge=0,toleranceMoveToCore=1,toleranceInterruptSimulation=1)
     
-    terminated, obj,sspcs,srxns = reactionSystem.simulate(
+    terminated,resurrected,obj,sspcs,srxns = reactionSystem.simulate(
         coreSpecies = reactionModel.core.species,
         coreReactions = reactionModel.core.reactions,
         edgeSpecies = reactionModel.edge.species,

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -234,7 +234,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale=(0.0,'sec')):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -251,7 +251,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,terminateAtMaxObjects,toleranceThermoKeepSpeciesInEdge))
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,terminateAtMaxObjects,
+          toleranceThermoKeepSpeciesInEdge,Quantity(dynamicsTimeScale)))
     
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -54,6 +54,7 @@ This module contains settings classes for manipulation of RMG run parameters
 ==================================================================================================================================================
 """
 import numpy
+from rmgpy.quantity import Quantity
 
 class ModelSettings(object):
     """
@@ -63,7 +64,8 @@ class ModelSettings(object):
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
-          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale = Quantity((0.0,'sec'))):
+
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -79,7 +81,8 @@ class ModelSettings(object):
         self.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
         self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
         self.terminateAtMaxObjects = terminateAtMaxObjects
-
+        self.dynamicsTimeScale = dynamicsTimeScale.value_si
+        
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation
         else:

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -534,7 +534,7 @@ cdef class ReactionSystem(DASx):
         cdef numpy.ndarray[numpy.float64_t,ndim=1] surfaceTotalDivAccumNums, surfaceSpeciesRateRatios
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
         cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
-        cdef bool firstTime, useDynamics, terminateAtMaxObjects, schanged
+        cdef bool useDynamicsTemp, firstTime, useDynamics, terminateAtMaxObjects, schanged
         cdef numpy.ndarray[numpy.float64_t, ndim=1] edgeReactionRates
         cdef double reactionRate, production, consumption
         cdef numpy.ndarray[numpy.int_t,ndim=1] surfaceSpeciesIndices, surfaceReactionIndices
@@ -589,7 +589,7 @@ cdef class ReactionSystem(DASx):
         surfaceSpeciesIndices = self.surfaceSpeciesIndices
         surfaceReactionIndices = self.surfaceReactionIndices
         
-       
+        totalDivAccumNums = None #the product of the ratios between accumulation numbers with and without a given reaction for products and reactants
 
         invalidObjects = []
         newSurfaceReactions = []
@@ -628,19 +628,51 @@ cdef class ReactionSystem(DASx):
         
         stepTime = 1e-12
         prevTime = self.t
+
+        firstTime = True
+        
         while not terminated:
             # Integrate forward in time by one time step
-            try:
-                self.step(stepTime)
-            except DASxError as e:
-                logging.error("Trying to step from time {} to {}".format(prevTime, stepTime))
-                logging.error("Core species names: {!r}".format([getSpeciesIdentifier(s) for s in coreSpecies]))
-                logging.error("Core species moles: {!r}".format(self.y[:numCoreSpecies]))
-                logging.error("Volume: {!r}".format(self.V))
-                logging.error("Core species net rates: {!r}".format(self.coreSpeciesRates))
-                logging.error("Edge species net rates: {!r}".format(self.edgeSpeciesRates))
-                logging.error("Network leak rates: {!r}".format(self.networkLeakRates))
-                raise e
+            
+            if not firstTime:
+                try:
+                    self.step(stepTime)
+                except DASxError as e:
+                    logging.error("Trying to step from time {} to {} resulted in a solver (DASPK) error".format(prevTime, stepTime))
+                    
+                    logging.info('Resurrecting Model...')
+                    
+                    if invalidObjects == []:
+                        #species flux criterion
+                        if len(edgeSpeciesRateRatios) > 0:
+                            ind = numpy.argmax(edgeSpeciesRateRatios)
+                            obj = edgeSpecies[ind]
+                            logging.info('At time {0:10.4e} s, species {1} at rate ratio {2} was added to model core in model resurrection process'.format(self.t, obj,maxEdgeSpeciesRates[ind]))
+                            invalidObjects.append(obj)
+                        
+                        if totalDivAccumNums and len(totalDivAccumNums) > 0: #if dynamics data available
+                            ind = numpy.argmax(totalDivAccumNums)
+                            obj = edgeReactions[ind]
+                            logging.info('At time {0:10.4e} s, Reaction {1} at dynamics number {2} was added to model core in model resurrection process'.format(self.t, obj,totalDivAccumNums[ind]))
+                            invalidObjects.append(obj)
+                        
+                        if pdepNetworks != [] and networkLeakRateRatios != []:
+                            ind = numpy.argmax(networkLeakRateRatios)
+                            obj = pdepNetworks[ind]
+                            logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} at network leak rate {2} was sent for exploring during model resurrection process'.format(self.t, obj.index, networkLeakRateRatios[ind]))
+                            invalidObjects.append(obj)
+                    
+                    if invalidObjects != []:
+                        return False,invalidObjects,surfaceSpecies,surfaceReactions
+                    else:
+                        logging.error('Model Resurrection has failed')
+                        logging.error("Core species names: {!r}".format([getSpeciesIdentifier(s) for s in coreSpecies]))
+                        logging.error("Core species moles: {!r}".format(self.y[:numCoreSpecies]))
+                        logging.error("Volume: {!r}".format(self.V))
+                        logging.error("Core species net rates: {!r}".format(self.coreSpeciesRates))
+                        logging.error("Edge species net rates: {!r}".format(self.edgeSpeciesRates))
+                        logging.error("Network leak rates: {!r}".format(self.networkLeakRates))
+                        raise DASxError
             
             y_coreSpecies = self.y[:numCoreSpecies]
             totalMoles = numpy.sum(y_coreSpecies)
@@ -707,15 +739,15 @@ cdef class ReactionSystem(DASx):
                 maxSpecies = edgeSpecies[maxSpeciesIndex]
                 maxSpeciesRate = edgeSpeciesRates[maxSpeciesIndex]
                 logging.info('At time {0:10.4e} s, species {1} was added to model core to avoid singularity'.format(self.t, maxSpecies))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, numpy.inf, maxNetwork, maxNetworkRate)
-                self.logConversions(speciesIndex, y0)
                 invalidObjects.append(maxSpecies)
                 break
             
-            if useDynamics:
+            if useDynamics and not firstTime:
+                
                 #######################################################
                 # Calculation of dynamics criterion for edge reactions#
                 #######################################################
+                
                 totalDivAccumNums = numpy.ones(numEdgeReactions)
                 for index in xrange(numEdgeReactions):
                     reactionRate = edgeReactionRates[index]
@@ -873,10 +905,8 @@ cdef class ReactionSystem(DASx):
                 tempNewObjectInds = []
                 tempNewObjectVals = []
             
-            if useDynamics:     
-                
-                #movement of reactions to core/surface based on dynamics number
-            
+            if useDynamics and not firstTime:     
+                #movement of reactions to core/surface based on dynamics number 
                 validLayeringIndices = self.validLayeringIndices
                 tempSurfaceObjects = []
                 
@@ -971,6 +1001,9 @@ cdef class ReactionSystem(DASx):
             if schanged: #reinitialize surface
                 surfaceSpecies,surfaceReactions = self.initialize_surface(coreSpecies,coreReactions,surfaceSpecies,surfaceReactions)
                 schanged = False
+
+            if firstTime: #turn off firstTime
+                firstTime = False
                 
             if interrupt: #breaks while loop terminating iterations
                 logging.info('terminating simulation due to interrupt...')

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -663,7 +663,7 @@ cdef class ReactionSystem(DASx):
                             invalidObjects.append(obj)
                     
                     if invalidObjects != []:
-                        return False,invalidObjects,surfaceSpecies,surfaceReactions
+                        return False,True,invalidObjects,surfaceSpecies,surfaceReactions
                     else:
                         logging.error('Model Resurrection has failed')
                         logging.error("Core species names: {!r}".format([getSpeciesIdentifier(s) for s in coreSpecies]))
@@ -672,7 +672,7 @@ cdef class ReactionSystem(DASx):
                         logging.error("Core species net rates: {!r}".format(self.coreSpeciesRates))
                         logging.error("Edge species net rates: {!r}".format(self.edgeSpeciesRates))
                         logging.error("Network leak rates: {!r}".format(self.networkLeakRates))
-                        raise DASxError
+                        raise ValueError('invalidObjects could not be filled during resurrection process')
             
             y_coreSpecies = self.y[:numCoreSpecies]
             totalMoles = numpy.sum(y_coreSpecies)
@@ -1067,7 +1067,7 @@ cdef class ReactionSystem(DASx):
 
         # Return the invalid object (if the simulation was invalid) or None
         # (if the simulation was valid)
-        return terminated, invalidObjects, surfaceSpecies, surfaceReactions
+        return terminated, False, invalidObjects, surfaceSpecies, surfaceReactions
 
     cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum, object network, double networkRate):
         """

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -573,8 +573,11 @@ cdef class ReactionSystem(DASx):
         sensitivityRelativeTolerance = simulatorSettings.sens_rtol
         filterReactions = modelSettings.filterReactions
         maxNumObjsPerIter = modelSettings.maxNumObjsPerIter
+
         #if not pruning always terminate at max objects, otherwise only do so if terminateAtMaxObjects=True
         terminateAtMaxObjects = True if not prune else modelSettings.terminateAtMaxObjects 
+
+        dynamicsTimeScale = modelSettings.dynamicsTimeScale
         
         useDynamics = not (toleranceMoveEdgeReactionToCore == numpy.inf and toleranceMoveEdgeReactionToSurface == numpy.inf)
         
@@ -742,12 +745,11 @@ cdef class ReactionSystem(DASx):
                 invalidObjects.append(maxSpecies)
                 break
             
-            if useDynamics and not firstTime:
-                
+            if useDynamics and not firstTime and self.t >= dynamicsTimeScale:
                 #######################################################
                 # Calculation of dynamics criterion for edge reactions#
                 #######################################################
-                
+
                 totalDivAccumNums = numpy.ones(numEdgeReactions)
                 for index in xrange(numEdgeReactions):
                     reactionRate = edgeReactionRates[index]
@@ -904,9 +906,9 @@ cdef class ReactionSystem(DASx):
                 tempNewObjects = []
                 tempNewObjectInds = []
                 tempNewObjectVals = []
-            
-            if useDynamics and not firstTime:     
-                #movement of reactions to core/surface based on dynamics number 
+                              
+            if useDynamics and not firstTime and self.t >= dynamicsTimeScale:     
+                #movement of reactions to core/surface based on dynamics number  
                 validLayeringIndices = self.validLayeringIndices
                 tempSurfaceObjects = []
                 

--- a/rmgpy/solver/baseTest.py
+++ b/rmgpy/solver/baseTest.py
@@ -164,7 +164,7 @@ class ReactionSystemTest(unittest.TestCase):
         simulatorSettings = SimulatorSettings()
         
         # run simulation:
-        terminated, obj,sspcs,srxns = reactionSystem.simulate(
+        terminated,resurrected,obj,sspcs,srxns = reactionSystem.simulate(
             coreSpecies = reactionModel.core.species,
             coreReactions = reactionModel.core.reactions,
             edgeSpecies = reactionModel.edge.species,


### PR DESCRIPTION
This feature attempts to kick the model dynamics by adding a few species/reactions if a DASPK error occurs, in order to make sure the rates information is present when any DASPK error occurs I've set it to skip the stepping function the first time through the while loop in base.pyx, in theory this could cause slight changes in the regression test since it enables objects to be picked up at t=0 rather than forcing it to wait until after the first time step as is currently done.  

This is based from #1082 . 

I have appended the small dynamics time scale feature to this pull request since it is programmatically related:  
This pull request implements a DynamicsTimeScale which is a time before which the dynamics criterion within the surface algorithm will not be able to pull reactions into the model. This is useful because as t->0 the assumptions made in the math behind the dynamics criterion fail making it sometimes more robust to restrict its use until further in the simulation.