### PR TITLE
Thermodynamics based pruning

### DIFF
--- a/examples/rmg/minimal_thermofilter/input.py
+++ b/examples/rmg/minimal_thermofilter/input.py
@@ -1,0 +1,52 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    minCoreSizeForPrune=2,
+    maximumEdgeSpecies=100,
+    toleranceThermoKeepSpeciesInEdge=1.0,
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=True,
+)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -234,7 +234,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1):
+          maxNumSpecies=None,maxNumObjsPerIter=1,toleranceThermoKeepSpeciesInEdge=numpy.inf):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -251,7 +251,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter))
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,toleranceThermoKeepSpeciesInEdge))
 
     
 def quantumMechanics(

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -557,8 +557,9 @@ class RMG(util.Subject):
                 self.updateReactionThresholdAndReactFlags(
                     rxnSysUnimolecularThreshold=reactionSystem.unimolecularThreshold, 
                     rxnSysBimolecularThreshold=reactionSystem.bimolecularThreshold)
-        
-        self.reactionModel.setThermodynamicFilteringParameters(self.Tmax,toleranceThermoKeepSpeciesInEdge=self.modelSettingsList[0].toleranceThermoKeepSpeciesInEdge,
+                
+        if not numpy.isinf(self.modelSettingsList[0].toleranceThermoKeepSpeciesInEdge):
+            self.reactionModel.setThermodynamicFilteringParameters(self.Tmax,toleranceThermoKeepSpeciesInEdge=self.modelSettingsList[0].toleranceThermoKeepSpeciesInEdge,
                                                               minCoreSizeForPrune=self.modelSettingsList[0].minCoreSizeForPrune, 
                                                               maximumEdgeSpecies =self.modelSettingsList[0].maximumEdgeSpecies,
                                                               reactionSystems=self.reactionSystems)
@@ -724,8 +725,9 @@ class RMG(util.Subject):
                             logging.info('')    
                         else:
                             self.updateReactionThresholdAndReactFlags()
-                        
-                        self.reactionModel.setThermodynamicFilteringParameters(self.Tmax, toleranceThermoKeepSpeciesInEdge=modelSettings.toleranceThermoKeepSpeciesInEdge,
+                            
+                        if not numpy.isinf(modelSettings.toleranceThermoKeepSpeciesInEdge):
+                            self.reactionModel.setThermodynamicFilteringParameters(self.Tmax, toleranceThermoKeepSpeciesInEdge=modelSettings.toleranceThermoKeepSpeciesInEdge,
                                                               minCoreSizeForPrune=modelSettings.minCoreSizeForPrune, 
                                                               maximumEdgeSpecies=modelSettings.maximumEdgeSpecies,
                                                               reactionSystems=self.reactionSystems)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -538,6 +538,8 @@ class RMG(util.Subject):
 
         self.done = False
         
+        self.Tmax = max([x.T for x in self.reactionSystems]).value_si
+        
         # Initiate first reaction discovery step after adding all core species
         if self.modelSettingsList[0].filterReactions:
             # Run the reaction system to update threshold and react flags
@@ -555,11 +557,18 @@ class RMG(util.Subject):
                 self.updateReactionThresholdAndReactFlags(
                     rxnSysUnimolecularThreshold=reactionSystem.unimolecularThreshold, 
                     rxnSysBimolecularThreshold=reactionSystem.bimolecularThreshold)
-
+        
+        self.reactionModel.setThermodynamicFilteringParameters(self.Tmax,toleranceThermoKeepSpeciesInEdge=self.modelSettingsList[0].toleranceThermoKeepSpeciesInEdge,
+                                                              minCoreSizeForPrune=self.modelSettingsList[0].minCoreSizeForPrune, 
+                                                              maximumEdgeSpecies =self.modelSettingsList[0].maximumEdgeSpecies,
+                                                              reactionSystems=self.reactionSystems)
+        
         self.reactionModel.enlarge(reactEdge=True, 
             unimolecularReact=self.unimolecularReact, 
             bimolecularReact=self.bimolecularReact)
-
+        
+        self.reactionModel.thermoFilterDown(maximumEdgeSpecies=self.modelSettingsList[0].maximumEdgeSpecies)
+        
         logging.info('Completed initial enlarge edge step...')
         
         self.saveEverything()
@@ -716,10 +725,16 @@ class RMG(util.Subject):
                         else:
                             self.updateReactionThresholdAndReactFlags()
                         
+                        self.reactionModel.setThermodynamicFilteringParameters(self.Tmax, toleranceThermoKeepSpeciesInEdge=modelSettings.toleranceThermoKeepSpeciesInEdge,
+                                                              minCoreSizeForPrune=modelSettings.minCoreSizeForPrune, 
+                                                              maximumEdgeSpecies=modelSettings.maximumEdgeSpecies,
+                                                              reactionSystems=self.reactionSystems)
+        
                         self.reactionModel.enlarge(reactEdge=True, 
                                 unimolecularReact=self.unimolecularReact, 
                                 bimolecularReact=self.bimolecularReact)
-                    
+                        
+                        self.reactionModel.thermoFilterDown(maximumEdgeSpecies=modelSettings.maximumEdgeSpecies)
                     #Adjust Surface
                     #we add added species and remove any species moved out of the core
                     #for now we remove reactions that become part of a PDepNetwork by intersecting with the core

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1219,7 +1219,10 @@ class CoreEdgeReactionModel:
 
         # clean up species references in reactionSystems
         for reactionSystem in reactionSystems:
-            reactionSystem.speciesIndex.pop(spec)
+            try:
+                reactionSystem.speciesIndex.pop(spec)
+            except KeyError:
+                pass
 
             # identify any reactions it's involved in
             rxnList = []

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -62,7 +62,8 @@ class ModelSettings(object):
     def __init__(self,toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, 
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
-          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1):
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
+          toleranceThermoKeepSpeciesInEdge=numpy.inf):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -76,6 +77,7 @@ class ModelSettings(object):
         self.toleranceMoveEdgeReactionToSurface = toleranceMoveEdgeReactionToSurface
         self.toleranceMoveSurfaceSpeciesToCore = toleranceMoveSurfaceSpeciesToCore
         self.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
+        self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
         
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation


### PR DESCRIPTION
This feature enables the user to prune based on the Gibbs energy of formation:  

The scaling used is Gn = (G_fi - G_max) / (G_max - G_min) where G_max and G_min are the minimum over all core species at the maximum reactor temperature.  

This is compared with a new parameter:  toleranceThermoKeepSpeciesInEdge.  For this parameter 0.0 denotes the maximum value of Gn within the core so 0.1 denotes 10% of the core Gibbs range beyond the maximum Gibbs value in the core.  