### PR TITLE
Degeneracy & Multiple TS

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -95,7 +95,7 @@ def saveEntry(f, entry):
                                                     "but reaction {0!s} has label {1!r}".format(
                                                      entry.item, entry.label))
             # Add degeneracy if the reaction is coming from a depository or kinetics library
-            f.write('    degeneracy = {0:d},\n'.format(entry.item.degeneracy))
+            f.write('    degeneracy = {0:.1f},\n'.format(entry.item.degeneracy))
             if entry.item.duplicate:
                 f.write('    duplicate = {0!r},\n'.format(entry.item.duplicate))
             if not entry.item.reversible:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -134,6 +134,36 @@ class TemplateReaction(Reaction):
         TemplateReaction this should be a KineticsGroups object.
         """
         return self.family
+        
+    def copy(self):
+        """
+        creates a new instance of TemplateReaction
+        """
+        other = TemplateReaction.__new__(TemplateReaction)
+        
+        # this was copied from Reaction.copy class
+        other.index = self.index
+        other.label = self.label
+        other.reactants = []
+        for reactant in self.reactants:
+            other.reactants.append(reactant.copy(deep=True))
+        other.products = []
+        for product in self.products:
+            other.products.append(product.copy(deep=True))
+        other.degeneracy = self.degeneracy
+        other.kinetics = deepcopy(self.kinetics)
+        other.reversible = self.reversible
+        other.transitionState = deepcopy(self.transitionState)
+        other.duplicate = self.duplicate
+        other.pairs = deepcopy(self.pairs)
+        
+        # added for TemplateReaction information
+        other.family = self.family
+        other.template = self.template
+        other.estimator = self.estimator
+        other.reverse = self.reverse
+        
+        return other
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1040,10 +1040,13 @@ class KineticsFamily(Database):
             item.kinetics = data
             data = item.generateReverseRateCoefficient()
             
-            item = Reaction(reactants=[m.molecule[0].copy(deep=True) for m in entry.item.products], products=[m.molecule[0].copy(deep=True) for m in entry.item.reactants])
+            item = TemplateReaction(reactants=[m.molecule[0].copy(deep=True) for m in entry.item.products], 
+                                               products=[m.molecule[0].copy(deep=True) for m in entry.item.reactants])
             template = self.getReactionTemplate(item)
-            item.degeneracy = self.calculateDegeneracy(item)
-            
+
+            item.template = self.getReactionTemplateLabels(item)
+            new_degeneracy = self.calculateDegeneracy(item)
+
             new_entry = Entry(
                 index = index,
                 label = ';'.join([g.label for g in template]),
@@ -1063,7 +1066,7 @@ class KineticsFamily(Database):
                 shortDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.shortDesc,
                 longDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.longDesc,
             )
-            new_entry.data.A.value_si /= item.degeneracy
+            new_entry.data.A.value_si /= new_degeneracy
             try:
                 self.rules.entries[new_entry.label].append(new_entry)
             except KeyError:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1549,8 +1549,12 @@ class KineticsFamily(Database):
         # If products is given, remove reactions from the reaction list that
         # don't generate the given products
         if products is not None:
-            
-            products = [product.generateResonanceIsomers() for product in products]
+            if isinstance(products[0],Molecule):
+                products = [product.generateResonanceIsomers() for product in products]
+            elif isinstance(products[0],Species):
+                products = [product.molecule for product in products]
+            else:
+                raise TypeError('products input to __generateReactions must be Species or Molecule Objects')
             
             rxnList0 = rxnList[:]
             rxnList = []

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -667,6 +667,41 @@ class TestReactionDegeneracy(unittest.TestCase):
         self.assertNotEqual(pp_kinetics_list[0][0].getRateCoefficient(300), pb_kinetics_list[0][0].getRateCoefficient(300))
         self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300) / 2, pb_kinetics_list[0][0].getRateCoefficient(300))
         
+    def test_reaction_degeneracy_independent_of_generatereactions_direction(self):
+        """
+        test_reaction_degeneracy_independent_of_generatereactions_direction
+        
+        Ensure the returned kinetics have the same degeneracy irrespective of
+        whether __generateReactions has forward = True or False
+        """
+        from rmgpy.rmg.react import correctDegeneracyOfReverseReactions
+
+        family = database.kinetics.families['Disproportionation']
+
+        molA = Molecule().fromSMILES('C[CH2]')
+        molB = Molecule().fromSMILES('C[CH2]')
+        molC = Molecule().fromSMILES('C=C')
+        molD = Molecule().fromSMILES('CC')
+        
+        molA.assignAtomIDs()
+        molB.assignAtomIDs()
+        molC.assignAtomIDs()
+        molD.assignAtomIDs()
+
+        # generate reactions in both directions
+        forward_reactions = family._KineticsFamily__generateReactions([molA, molB], products=[molC, molD], forward=True)
+        reverse_reactions = family._KineticsFamily__generateReactions([molC, molD], products=[molA, molB], forward=False)
+
+        forward_reactions = findDegeneracies(forward_reactions)
+        reverse_reactions = findDegeneracies(reverse_reactions)
+
+        # correct reverse reaction degeneracy
+        correctDegeneracyOfReverseReactions(forward_reactions, reactants = [molA, molB])
+        correctDegeneracyOfReverseReactions(reverse_reactions, reactants = [molC, molD])
+
+        self.assertEqual(forward_reactions[0].degeneracy, reverse_reactions[0].degeneracy,
+                         'the kinetics from forward and reverse directions had different degeneracies, {} and {} respectively'.format(forward_reactions[0].degeneracy, reverse_reactions[0].degeneracy))
+
 class TestKineticsCommentsParsing(unittest.TestCase):
 
     @classmethod

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -28,12 +28,17 @@
 import os
 import unittest 
 from external.wip import work_in_progress
+import itertools
+
 from rmgpy import settings
 from rmgpy.data.kinetics.database import KineticsDatabase
 from rmgpy.data.base import DatabaseError
 import numpy
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.data.rmg import RMGDatabase
+from rmgpy.rmg.react import findDegeneracies, reduceSameReactantDegeneracy, react, reactSpecies, _labelListOfSpecies
+from rmgpy.data.base import ForbiddenStructures
+from rmgpy.species import Species
 ###################################################
 
 def setUpModule():
@@ -48,12 +53,17 @@ def setUpModule():
             'R_Recombination',
             'Disproportionation',
             'R_Addition_MultipleBond',
+            'H_Abstraction'
         ],
         testing=True,
         depository=False,
         solvation=False,
     )
-    database.loadForbiddenStructures()
+    #load empty forbidden structures to avoid any dependence on forbidden structures
+    #for these tests
+    for family in database.kinetics.families.values():
+        family.forbidden = ForbiddenStructures()
+    database.forbiddenStructures = ForbiddenStructures()
 
     # Prepare the database by loading training reactions and averaging the rate rules
     for family in database.kinetics.families.values():
@@ -94,6 +104,104 @@ class TestReactionDegeneracy(unittest.TestCase):
         """A function that is run ONCE before all unit tests in this class."""
         global database
         self.database = database
+
+    def testR_Addition_MultipleBondBenzene(self):
+        """Test that the proper degeneracy is calculated for H addition to benzene"""
+        family = 'R_Addition_MultipleBond'
+        reactants = [
+            Molecule().fromSMILES('c1ccccc1'),
+            Molecule().fromSMILES('[H]'),
+        ]
+        # assign atom IDs
+        for reactant in reactants: reactant.assignAtomIDs()
+
+        reactants = [mol.generateResonanceIsomers() for mol in reactants]
+
+        combinations = itertools.product(reactants[0], reactants[1])
+
+        reactionList = []
+        for combi in combinations:
+            reactionList.extend(self.database.kinetics.families[family].generateReactions(combi))
+
+        reactionList = findDegeneracies(reactionList)
+
+        self.assertEqual(len(reactionList), 1)
+        for rxn in reactionList:
+            self.assertEqual(rxn.degeneracy, 6)
+
+    def testR_Addition_MultipleBondMethylNaphthalene(self):
+        """Test that the proper degeneracy is calculated for H addition to methylnaphthalene"""
+        family = 'R_Addition_MultipleBond'
+        reactants = [
+            Molecule().fromSMILES('C1=CC=C2C=CC=CC2=C1C'),
+            Molecule().fromSMILES('[H]'),
+        ]
+        # assign atom IDs
+        for reactant in reactants: reactant.assignAtomIDs()
+        
+        reactants = [mol.generateResonanceIsomers() for mol in reactants]
+
+        combinations = itertools.product(reactants[0], reactants[1])
+
+        reactionList = []
+        for combi in combinations:
+            reactionList.extend(self.database.kinetics.families[family].generateReactions(combi))
+
+        product = Species().fromSMILES('C[C]1CC=CC2=CC=CC=C12')
+        product.generateResonanceIsomers()
+
+        targetReactions = []
+        for rxn in reactionList:
+            for spc in rxn.products:
+                if product.isIsomorphic(spc):
+                    targetReactions.append(rxn)
+
+        targetReactions = findDegeneracies(targetReactions)
+
+        self.assertEqual(len(targetReactions), 1)
+        for rxn in targetReactions:
+            self.assertEqual(rxn.degeneracy, 1)
+
+    def testR_RecombinationPhenyl(self):
+        """Test that the proper degeneracy is calculated for phenyl + H recombination"""
+        family = 'R_Recombination'
+        reactants = [
+            Molecule().fromSMILES('[c]1ccccc1'),
+            Molecule().fromSMILES('[H]'),
+        ]
+
+        # assign atom IDs
+        for reactant in reactants: reactant.assignAtomIDs()
+
+        reactants = [mol.generateResonanceIsomers() for mol in reactants]
+
+        combinations = itertools.product(reactants[0], reactants[1])
+
+        reactionList = []
+        for combi in combinations:
+            reactionList.extend(self.database.kinetics.families[family].generateReactions(combi))
+
+        reactionList = findDegeneracies(reactionList)
+
+        self.assertEqual(len(reactionList), 1)
+        for rxn in reactionList:
+            self.assertEqual(rxn.degeneracy, 1)
+
+    def testR_RecombinationH(self):
+        """Test that the proper degeneracy is calculated for H + H recombination"""
+        family = 'R_Recombination'
+        reactants = [
+            Molecule().fromSMILES('[H]'),
+            Molecule().fromSMILES('[H]'),
+        ]
+        for reactant in reactants: reactant.assignAtomIDs()
+
+        reactionList = self.database.kinetics.families[family].generateReactions(reactants)
+
+        reactionList = findDegeneracies(reactionList)
+
+        self.assertEqual(len(reactionList), 1)
+        self.assertEqual(reactionList[0].degeneracy, 1)
 
     def test_degeneracy_for_methyl_methyl_recombination(self):
         """Test that the proper degeneracy is calculated for methyl + methyl recombination"""
@@ -242,13 +350,129 @@ class TestReactionDegeneracy(unittest.TestCase):
         family = self.database.kinetics.families[rxn_family_str]
         reactants = [Molecule().fromAdjacencyList(reactants_adj_list[0]),
                      Molecule().fromAdjacencyList(reactants_adj_list[1])]
-
+        for reactant in reactants: reactant.assignAtomIDs()
         reactions = family.generateReactions(reactants)
+        reactions = findDegeneracies(reactions)
+        reduceSameReactantDegeneracy(reactions)
         self.assertEqual(len(reactions), num_independent_reactions,'only {1} reaction(s) should be produced. Produced reactions {0}'.format(reactions,num_independent_reactions))
 
         return sum([reaction.degeneracy for reaction in reactions]), reactions
 
-    def test_propyl_propyl_reaction_is_the_same_as_propyl_butyl(self):
+    def test_degeneracy_does_not_include_identical_atom_labels(self):
+        """
+        ensure rxns with identical atom_ids are not counted twice for degeneracy
+        
+        this test uses [H] + CC=C[CH]C -> H2 + [CH2]C=C[CH]C as an example. Since
+        the reactant is symmetric with the middle carbon, the degeneracy should be
+        6.
+        """
+        spcA = Species().fromSMILES('[H]')
+        spcB = Species().fromSMILES('CC=C[CH]C')
+        spcB.generateResonanceIsomers(keepIsomorphic=True)
+        spcTuples = [(spcA,spcB)]
+        
+        reactionList = list(react(*spcTuples))
+        
+        # find reaction with a specific product
+        specific_product = Species().fromSMILES('[CH2]C=C[CH]C')
+        
+        specific_product.generateResonanceIsomers()
+        
+        specific_reaction = None
+        for rxn in reactionList:
+            if any([specific_product.isIsomorphic(product) for product in rxn.products]):
+                specific_reaction = rxn
+                break
+        self.assertIsNotNone(specific_reaction,'no reaction found with the specified product')
+        
+        self.assertEqual(specific_reaction.degeneracy, 6,'The reaction output the wrong degeneracy of {}.'.format(specific_reaction.degeneracy))
+    def test_degeneracy_keeps_separate_transition_states_separated(self):
+        """
+        ensure rxns with multiple transition states are kept as separate reactions
+        
+        this test uses C[C]=C + C=C[CH2] -> C=C=C + C=CC as an example. 
+        This reaction should have two transition states, which should occur regardless
+        of the order .
+        """
+        spcA = Species().fromSMILES('C[C]=C')
+        spcB = Species().fromSMILES('C=C[CH2]')
+        spcTuples = [(spcA,spcB)]
+        reactionList = list(react(*spcTuples))
+        # find reaction with a specific product
+        specific_products = [Species().fromSMILES('C=C=C'),
+                             Species().fromSMILES('CC=C'),]
+        
+        # eliminate rxns that do not match products
+        isomorphic_rxns = 0
+        for rxn in reactionList:
+            #  rxn contains all products
+            if all([any([specific_product.isIsomorphic(product) for product in rxn.products]) for specific_product in specific_products]):
+                isomorphic_rxns += 1
+
+        self.assertEqual(isomorphic_rxns, 2,'The reaction output did not output all the transition states in either order of reactants')
+     
+    def test_separate_transition_states_generated_regardless_of_reactant_order(self):
+        """
+        ensure rxns with multiple transition states are kept as separate reactions
+        
+        this test uses C[C]=C + C=C[CH2] -> C=C=C + C=CC as an example. 
+        This reaction should have two transition states, which should occur regardless
+        of the order .
+        """
+        molA = Molecule().fromSMILES('C=[C]C')
+        molB = Molecule().fromSMILES('C=C[CH2]')
+        molC = Molecule().fromSMILES('C=C=C')
+        molD = Molecule().fromSMILES('C=CC')
+        reactionList = database.kinetics.families['Disproportionation']._KineticsFamily__generateReactions([molA, molB], products=[molC,molD])
+        
+        swapped_reactionList = database.kinetics.families['Disproportionation']._KineticsFamily__generateReactions([molB, molA], products=[molC,molD])
+        
+        
+        # eliminate rxns that do not match products
+        templates = {}
+        for rxn in reactionList:
+            try:
+                templates[rxn.template[0]] += 1
+            except KeyError:
+                templates[rxn.template[0]] = 1
+        reverseTemplates = {}
+        for rxn in swapped_reactionList:  
+            try:
+                reverseTemplates[rxn.template[0]] += 1
+            except KeyError:
+                reverseTemplates[rxn.template[0]] = 1
+
+        self.assertEqual(reverseTemplates, templates,'The reaction output did not output all the transition states in either order of reactants')
+
+    def test_degeneracy_keeps_track_of_both_rate_rules_from_resonance_isomers(self):
+        """
+        rxns that have multiple resonance structures hitting different rate rules should 
+        be kept separate when findDegeneracy is used.
+
+        this test uses [H] + CC=C[CH]C -> H2 + [CH2]C=C[CH]C as an example. 
+        This reaction should have two transition states.
+        """
+        spcA = Species().fromSMILES('[H]')
+        spcB = Species().fromSMILES('CC=C[CH]C')
+        spcB.generateResonanceIsomers(keepIsomorphic=True)
+        spcTuples = [(spcA,spcB)]
+        
+        reactionList = list(react(*spcTuples))
+        
+        # find reaction with a specific product
+        specific_product = Species().fromSMILES('CC=C[CH][CH2]')
+        specific_product.generateResonanceIsomers()
+        
+        specific_reactions_found = 0
+        templates_found = []
+        for rxn in reactionList:
+            if any([specific_product.isIsomorphic(product) for product in rxn.products]):
+                specific_reactions_found += 1
+                templates_found.append(rxn.template)
+        
+        self.assertEqual(specific_reactions_found, 2,'The reaction output did not contain 2 transition states.')
+        self.assertNotEqual(templates_found[0],templates_found[1],'The reactions should have different templates')
+    def test_propyl_propyl_reaction_is_the_half_propyl_butyl(self):
         """
         test that propyl propyl r-recombination is the same rate as propyl butyl
 
@@ -630,3 +854,73 @@ class TestKinetics(unittest.TestCase):
         out = lib.convertDuplicatesToMulti()
         self.assertIsNone(out)
 
+    def testaddReverseAttribute(self):
+        """
+        tests that the addReverseAttribute method gets the reverse degeneracy correct
+        """
+        from rmgpy.data.rmg import getDB
+        from rmgpy.data.kinetics.family import TemplateReaction
+        adjlist = ['''
+        multiplicity 2
+        1 H u0 p0 c0 {7,S}
+        2 H u0 p0 c0 {4,S}
+        3 C u1 p0 c0 {5,S} {7,S} {8,S}
+        4 C u0 p0 c0 {2,S} {6,S} {7,D}
+        5 H u0 p0 c0 {3,S}
+        6 H u0 p0 c0 {4,S}
+        7 C u0 p0 c0 {1,S} {3,S} {4,D}
+        8 H u0 p0 c0 {3,S}
+        ''',
+          '''
+        1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+        2 C u0 p0 c0 i13 {1,S} {3,D} {7,S}
+        3 C u0 p0 c0 {2,D} {8,S} {9,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {1,S}
+        7 H u0 p0 c0 {2,S}
+        8 H u0 p0 c0 {3,S}
+        9 H u0 p0 c0 {3,S}
+        ''',
+                '''
+        multiplicity 2
+        1 H u0 p0 c0 {7,S}
+        2 H u0 p0 c0 {4,S}
+        3 C u1 p0 c0 {5,S} {7,S} {8,S}
+        4 C u0 p0 c0 {2,S} {6,S} {7,D}
+        5 H u0 p0 c0 {3,S}
+        6 H u0 p0 c0 {4,S}
+        7 C u0 p0 c0 i13 {1,S} {3,S} {4,D}
+        8 H u0 p0 c0 {3,S}
+        ''',
+          '''
+        1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+        2 C u0 p0 c0 {1,S} {3,D} {7,S}
+        3 C u0 p0 c0 {2,D} {8,S} {9,S}
+        4 H u0 p0 c0 {1,S}
+        5 H u0 p0 c0 {1,S}
+        6 H u0 p0 c0 {1,S}
+        7 H u0 p0 c0 {2,S}
+        8 H u0 p0 c0 {3,S}
+        9 H u0 p0 c0 {3,S}
+        '''
+          ]
+        family = getDB('kinetics').families['H_Abstraction']
+        r1 = Species(molecule=[Molecule().fromAdjacencyList(adjlist[0])])
+        r2 = Species(molecule=[Molecule().fromAdjacencyList(adjlist[1])])
+        p1 = Species(molecule=[Molecule().fromAdjacencyList(adjlist[2])])
+        p2 = Species(molecule=[Molecule().fromAdjacencyList(adjlist[3])])
+        r1.generateResonanceIsomers(keepIsomorphic=True)
+        p1.generateResonanceIsomers(keepIsomorphic=True)
+        
+        
+        rxn = TemplateReaction(reactants = [r1, r2], 
+                               products = [p1, p2]
+)
+        
+        rxn.degeneracy = family.calculateDegeneracy(rxn)
+        self.assertEqual(rxn.degeneracy, 6)
+        
+        family.addReverseAttribute(rxn)
+        
+        self.assertEqual(rxn.reverse.degeneracy, 6)

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -206,7 +206,7 @@ class TestReactionDegeneracy(unittest.TestCase):
     def test_degeneracy_for_methyl_methyl_recombination(self):
         """Test that the proper degeneracy is calculated for methyl + methyl recombination"""
 
-        correct_degeneracy = 1
+        correct_degeneracy = 0.5
         rxn_family_str = 'R_Recombination'
         adj_lists = [
             """
@@ -254,7 +254,7 @@ class TestReactionDegeneracy(unittest.TestCase):
     def test_degeneracy_for_ethyl_ethyl_disproportionation(self):
         """Test that the proper degeneracy is calculated for ethyl + ethyl disproportionation"""
 
-        correct_degeneracy = 6
+        correct_degeneracy = 3
         rxn_family_str = 'Disproportionation'
         adj_lists = [
             """
@@ -350,6 +350,7 @@ class TestReactionDegeneracy(unittest.TestCase):
         family = self.database.kinetics.families[rxn_family_str]
         reactants = [Molecule().fromAdjacencyList(reactants_adj_list[0]),
                      Molecule().fromAdjacencyList(reactants_adj_list[1])]
+
         for reactant in reactants: reactant.assignAtomIDs()
         reactions = family.generateReactions(reactants)
         reactions = findDegeneracies(reactions)
@@ -472,13 +473,14 @@ class TestReactionDegeneracy(unittest.TestCase):
         
         self.assertEqual(specific_reactions_found, 2,'The reaction output did not contain 2 transition states.')
         self.assertNotEqual(templates_found[0],templates_found[1],'The reactions should have different templates')
+
     def test_propyl_propyl_reaction_is_the_half_propyl_butyl(self):
         """
         test that propyl propyl r-recombination is the same rate as propyl butyl
 
         this test assures that r-recombination reactions from the same rate rule
-        have the same reaction rate since they have both symmetrical transition
-        states and reactants, which should cancel out in TST
+        with identical reactants have half the reaction rate since there is a 
+        symmetrical transition state.
         """
         rxn_family_str = 'R_Recombination'
         propyl_adj_list = """
@@ -534,21 +536,22 @@ class TestReactionDegeneracy(unittest.TestCase):
         self.assertEqual(len(pb_kinetics_list), 1, 'The propyl and butyl recombination should only return one reaction. It returned {0}. Here is the full kinetics: {1}'.format(len(pb_kinetics_list),pb_kinetics_list))
 
         # the same reaction group must be found or this test will not work
-        self.assertIn(pp_kinetics_list[0][0].comment,pb_kinetics_list[0][0].comment,
+        self.assertIn(pb_kinetics_list[0][0].comment,pp_kinetics_list[0][0].comment,
                          'this test found different kinetics for the two groups, so it will not function as expected\n' +
                          str(pp_kinetics_list)+str(pb_kinetics_list))
 
         # test that the kinetics are correct
-        self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300), pb_kinetics_list[0][0].getRateCoefficient(300))
+        self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300) * 2, pb_kinetics_list[0][0].getRateCoefficient(300))
 
-    def test_identical_reactants_have_faster_kinetics(self):
+    def test_identical_reactants_have_similar_kinetics(self):
         """
-        tests identical reactants have faster kinetics that different reactants.
-
-        this test assures that r addition multiple bond reactions from the same
-        rate rule have the faster reaction rate if the reactants are identicaal
-        since they have symmetrical reactants, with little change in the
-        transition state symmetry. This should be more robust than just checking
+        tests identical reactants have the same kinetics than different reactants.
+        
+        this test assures that r addition multiple bond reactions from the same 
+        rate rule have the same reaction rate if the reactants are identicaal 
+        since little changes in the reactant or transition state symmetry. 
+        
+        This method should be more robust than just checking
         the degeneracy of reactions.
         """
         rxn_family_str = 'R_Addition_MultipleBond'
@@ -664,8 +667,7 @@ class TestReactionDegeneracy(unittest.TestCase):
                          str(pp_kinetics_list)+str(pb_kinetics_list))
 
         # test that the kinetics are correct
-        self.assertNotEqual(pp_kinetics_list[0][0].getRateCoefficient(300), pb_kinetics_list[0][0].getRateCoefficient(300))
-        self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300) / 2, pb_kinetics_list[0][0].getRateCoefficient(300))
+        self.assertAlmostEqual(pp_kinetics_list[0][0].getRateCoefficient(300), pb_kinetics_list[0][0].getRateCoefficient(300))
         
     def test_reaction_degeneracy_independent_of_generatereactions_direction(self):
         """

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -45,7 +45,20 @@ class TestSoluteDatabase(TestCase):
     def setUp(self):
         self.database = SolvationDatabase()
         self.database.load(os.path.join(settings['database.directory'], 'solvation'))
-    
+
+    def tearDown(self):
+        """
+        Reset the database & liquid parameters for solution
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+        
+        from rmgpy.rmg.model import Species as DifferentSpecies
+        DifferentSpecies.solventData = None
+        DifferentSpecies.solventName = None
+        DifferentSpecies.solventStructure = None
+        DifferentSpecies.solventViscosity = None
+        
     def runTest(self):
         pass
     

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -225,4 +225,8 @@ cdef class Molecule(Graph):
 
     cpdef assignAtomIDs(self)
 
+    cpdef bint atomIDValid(self)
+
     cpdef bint isIdentical(self, Molecule other) except -2
+
+cdef atom_id_counter

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2049,11 +2049,11 @@ multiplicity 2
         molCopy = mol.copy(deep=True)
         # Remove a hydrogen from mol
         a = mol.atoms[-1]
-        self.assertEquals(a.id, 13)
+
         mol.removeAtom(a)
         # Remove a different hydrogen from molCopy
         b = molCopy.atoms[-2]
-        self.assertEquals(b.id, 12)
+
         molCopy.removeAtom(b)
 
         self.assertTrue(mol.isIsomorphic(molCopy))
@@ -2087,6 +2087,32 @@ multiplicity 2
 
         self.assertTrue(mol.isIsomorphic(molCopy))
         self.assertFalse(mol.isIdentical(molCopy))
+
+    def testatomidvalid(self):
+        """see if the atomIDVvalid method properly returns True"""
+        mol = Molecule(SMILES='CCCC')
+        for index, atom in enumerate(mol.atoms):
+            atom.id =index
+        self.assertTrue(mol.atomIDValid())
+
+    def testatomidvalid2(self):
+        """see if the atomIDVvalid method properly returns False"""
+        mol = Molecule(SMILES='CCCC')
+        for index, atom in enumerate(mol.atoms):
+            atom.index =index
+        mol.atoms[3].index = 4
+        self.assertFalse(mol.atomIDValid())
+
+    def testatomidvalid2(self):
+        """see if the atomIDVvalid method properly returns False"""
+        mol = Molecule(SMILES='CCCC')
+        self.assertFalse(mol.atomIDValid())
+
+    def testassignatomid(self):
+        """see if the assignAtomID method properly labels molecule"""
+        mol = Molecule(SMILES='CCCC')
+        mol.assignAtomIDs()
+        self.assertTrue(mol.atomIDValid())
 
 ################################################################################
 

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -45,7 +45,7 @@ cdef class Reaction:
     cdef public TransitionState transitionState
     cdef public KineticsModel kinetics
     cdef public bint duplicate
-    cdef public int _degeneracy
+    cdef public float _degeneracy
     cdef public list pairs
     cdef public dict k_effective_cache
     

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -61,7 +61,7 @@ cdef class Reaction:
     
     cpdef bint matchesMolecules(self, list reactants)
 
-    cpdef bint isIsomorphic(self, Reaction other, bint eitherDirection=?)
+    cpdef bint isIsomorphic(self, Reaction other, bint eitherDirection=?, bint checkIdentical=?)
 
     cpdef double getEnthalpyOfReaction(self, double T)
 
@@ -102,4 +102,5 @@ cdef class Reaction:
     cpdef generatePairs(self)
     
     cpdef copy(self)
-    
+
+cpdef bint _isomorphicSpeciesList(list list1, list list2, bint checkIdentical=?)

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -132,7 +132,7 @@ class Reaction:
         if not self.reversible: string += 'reversible={0}, '.format(self.reversible)
         if self.transitionState is not None: string += 'transitionState={0!r}, '.format(self.transitionState)
         if self.duplicate: string += 'duplicate={0}, '.format(self.duplicate)
-        if self.degeneracy != 1: string += 'degeneracy={0:d}, '.format(self.degeneracy)
+        if self.degeneracy != 1: string += 'degeneracy={0:.1f}, '.format(self.degeneracy)
         if self.pairs is not None: string += 'pairs={0}, '.format(self.pairs)
         string = string[:-2] + ')'
         return string
@@ -164,15 +164,16 @@ class Reaction:
     def __getDegneneracy(self):
         return self._degeneracy
     def __setDegeneracy(self, new):
-        # find how much to modify the rate
-        if self._degeneracy < 2:
-            degeneracyRatio = new
-        else:
-            degeneracyRatio = (new*1.0) / self._degeneracy
         # modify rate if kinetics exists
         if self.kinetics is not None:
+            if self._degeneracy < 2:
+                degeneracyRatio = new
+            else:
+                degeneracyRatio = (new*1.0) / self._degeneracy
             self.kinetics.changeRate(degeneracyRatio)
-            logging.debug('did not modify A factor when modifying degeneracy since the reaction rate was not set')
+        else:
+            logging.debug('did not modify A factor when modifying degeneracy since' \
+                          'the reaction rate was not set')
         # set new degeneracy
         self._degeneracy = new
     degeneracy = property(__getDegneneracy, __setDegeneracy)
@@ -1116,11 +1117,11 @@ class Reaction:
         other.products = []
         for product in self.products:
             other.products.append(product.copy(deep=True))
+        other.degeneracy = self.degeneracy
         other.kinetics = deepcopy(self.kinetics)
         other.reversible = self.reversible
         other.transitionState = deepcopy(self.transitionState)
         other.duplicate = self.duplicate
-        other.degeneracy = self.degeneracy
         other.pairs = deepcopy(self.pairs)
         
         return other

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -357,90 +357,25 @@ class Reaction:
             raise NotImplementedError("Can't check isomorphism of reactions with {0} reactants".format(len(reactants)))
         # If we're here then neither direction matched, so return false
         return False
-        
-    def isIsomorphic(self, other, eitherDirection=True):
+
+    def isIsomorphic(self, other, eitherDirection=True, checkIdentical = False):
         """
         Return ``True`` if this reaction is the same as the `other` reaction,
-        or ``False`` if they are different. 
+        or ``False`` if they are different. The comparison involves comparing
+        isomorphism of reactants and products, and doesn't use any kinetic
+        information.
+
         If `eitherDirection=False` then the directions must match.
         """
-        
+
         # Compare reactants to reactants
-        forwardReactantsMatch = False
-        if len(self.reactants) == len(other.reactants) == 1:
-            if self.reactants[0].isIsomorphic(other.reactants[0]):
-                forwardReactantsMatch = True
-        elif len(self.reactants) == len(other.reactants) == 2:
-            if self.reactants[0].isIsomorphic(other.reactants[0]) and self.reactants[1].isIsomorphic(other.reactants[1]):
-                forwardReactantsMatch = True
-            elif self.reactants[0].isIsomorphic(other.reactants[1]) and self.reactants[1].isIsomorphic(other.reactants[0]):
-                forwardReactantsMatch = True
-        elif len(self.reactants) == len(other.reactants) == 3:
-            if (    self.reactants[0].isIsomorphic(other.reactants[0]) and
-                    self.reactants[1].isIsomorphic(other.reactants[1]) and
-                    self.reactants[2].isIsomorphic(other.reactants[2]) ):
-                forwardReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.reactants[0]) and
-                    self.reactants[1].isIsomorphic(other.reactants[2]) and
-                    self.reactants[2].isIsomorphic(other.reactants[1]) ):
-                forwardReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.reactants[1]) and
-                    self.reactants[1].isIsomorphic(other.reactants[0]) and
-                    self.reactants[2].isIsomorphic(other.reactants[2]) ):
-                forwardReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.reactants[2]) and
-                    self.reactants[1].isIsomorphic(other.reactants[0]) and
-                    self.reactants[2].isIsomorphic(other.reactants[1]) ):
-                forwardReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.reactants[1]) and
-                    self.reactants[1].isIsomorphic(other.reactants[2]) and
-                    self.reactants[2].isIsomorphic(other.reactants[0]) ):
-                forwardReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.reactants[2]) and
-                    self.reactants[1].isIsomorphic(other.reactants[1]) and
-                    self.reactants[2].isIsomorphic(other.reactants[0]) ):
-                forwardReactantsMatch = True
-        elif len(self.reactants) == len(other.reactants):
-            raise NotImplementedError("Can't check isomorphism of reactions with {0} reactants".format(len(self.reactants)))
+        forwardReactantsMatch = _isomorphicSpeciesList(self.reactants, 
+                                    other.reactants,checkIdentical = checkIdentical)
         
         # Compare products to products
-        forwardProductsMatch = False
-        if len(self.products) == len(other.products) == 1:
-            if self.products[0].isIsomorphic(other.products[0]):
-                forwardProductsMatch = True
-        elif len(self.products) == len(other.products) == 2:
-            if self.products[0].isIsomorphic(other.products[0]) and self.products[1].isIsomorphic(other.products[1]):
-                forwardProductsMatch = True
-            elif self.products[0].isIsomorphic(other.products[1]) and self.products[1].isIsomorphic(other.products[0]):
-                forwardProductsMatch = True
-        elif len(self.products) == len(other.products) == 3:
-            if (    self.products[0].isIsomorphic(other.products[0]) and
-                    self.products[1].isIsomorphic(other.products[1]) and
-                    self.products[2].isIsomorphic(other.products[2]) ):
-                forwardProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.products[0]) and
-                    self.products[1].isIsomorphic(other.products[2]) and
-                    self.products[2].isIsomorphic(other.products[1]) ):
-                forwardProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.products[1]) and
-                    self.products[1].isIsomorphic(other.products[0]) and
-                    self.products[2].isIsomorphic(other.products[2]) ):
-                forwardProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.products[2]) and
-                    self.products[1].isIsomorphic(other.products[0]) and
-                    self.products[2].isIsomorphic(other.products[1]) ):
-                forwardProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.products[1]) and
-                    self.products[1].isIsomorphic(other.products[2]) and
-                    self.products[2].isIsomorphic(other.products[0]) ):
-                forwardProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.products[2]) and
-                    self.products[1].isIsomorphic(other.products[1]) and
-                    self.products[2].isIsomorphic(other.products[0]) ):
-                forwardProductsMatch = True
-        elif len(self.products) == len(other.products):
-            raise NotImplementedError("Can't check isomorphism of reactions with {0} products".format(len(self.products)))
-        
+        forwardProductsMatch = _isomorphicSpeciesList(self.products, 
+                                    other.products,checkIdentical = checkIdentical)
+
         # Return now, if we can
         if (forwardReactantsMatch and forwardProductsMatch):
             return True
@@ -448,84 +383,16 @@ class Reaction:
             return False
         
         # Compare reactants to products
-        reverseReactantsMatch = False
-        if len(self.reactants) == len(other.products) == 1:
-            if self.reactants[0].isIsomorphic(other.products[0]):
-                reverseReactantsMatch = True
-        elif len(self.reactants) == len(other.products) == 2:
-            if self.reactants[0].isIsomorphic(other.products[0]) and self.reactants[1].isIsomorphic(other.products[1]):
-                reverseReactantsMatch = True
-            elif self.reactants[0].isIsomorphic(other.products[1]) and self.reactants[1].isIsomorphic(other.products[0]):
-                reverseReactantsMatch = True
-        elif len(self.reactants) == len(other.products) == 3:
-            if (    self.reactants[0].isIsomorphic(other.products[0]) and
-                    self.reactants[1].isIsomorphic(other.products[1]) and
-                    self.reactants[2].isIsomorphic(other.products[2]) ):
-                reverseReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.products[0]) and
-                    self.reactants[1].isIsomorphic(other.products[2]) and
-                    self.reactants[2].isIsomorphic(other.products[1]) ):
-                reverseReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.products[1]) and
-                    self.reactants[1].isIsomorphic(other.products[0]) and
-                    self.reactants[2].isIsomorphic(other.products[2]) ):
-                reverseReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.products[2]) and
-                    self.reactants[1].isIsomorphic(other.products[0]) and
-                    self.reactants[2].isIsomorphic(other.products[1]) ):
-                reverseReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.products[1]) and
-                    self.reactants[1].isIsomorphic(other.products[2]) and
-                    self.reactants[2].isIsomorphic(other.products[0]) ):
-                reverseReactantsMatch = True
-            elif (  self.reactants[0].isIsomorphic(other.products[2]) and
-                    self.reactants[1].isIsomorphic(other.products[1]) and
-                    self.reactants[2].isIsomorphic(other.products[0]) ):
-                reverseReactantsMatch = True
-        elif len(self.reactants) == len(other.products):
-            raise NotImplementedError("Can't check isomorphism of reactions with {0} reactants".format(len(self.reactants)))
+        reverseReactantsMatch = _isomorphicSpeciesList(self.reactants, 
+                                    other.products,checkIdentical = checkIdentical)
 
         # Compare products to reactants
-        reverseProductsMatch = False
-        if len(self.products) == len(other.reactants) == 1:
-            if self.products[0].isIsomorphic(other.reactants[0]):
-                reverseProductsMatch = True
-        elif len(self.products) == len(other.reactants) == 2:
-            if self.products[0].isIsomorphic(other.reactants[0]) and self.products[1].isIsomorphic(other.reactants[1]):
-                reverseProductsMatch = True
-            elif self.products[0].isIsomorphic(other.reactants[1]) and self.products[1].isIsomorphic(other.reactants[0]):
-                reverseProductsMatch = True
-        elif len(self.products) == len(other.reactants) == 3:
-            if (    self.products[0].isIsomorphic(other.reactants[0]) and
-                    self.products[1].isIsomorphic(other.reactants[1]) and
-                    self.products[2].isIsomorphic(other.reactants[2]) ):
-                reverseProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.reactants[0]) and
-                    self.products[1].isIsomorphic(other.reactants[2]) and
-                    self.products[2].isIsomorphic(other.reactants[1]) ):
-                reverseProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.reactants[1]) and
-                    self.products[1].isIsomorphic(other.reactants[0]) and
-                    self.products[2].isIsomorphic(other.reactants[2]) ):
-                reverseProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.reactants[2]) and
-                    self.products[1].isIsomorphic(other.reactants[0]) and
-                    self.products[2].isIsomorphic(other.reactants[1]) ):
-                reverseProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.reactants[1]) and
-                    self.products[1].isIsomorphic(other.reactants[2]) and
-                    self.products[2].isIsomorphic(other.reactants[0]) ):
-                reverseProductsMatch = True
-            elif (  self.products[0].isIsomorphic(other.reactants[2]) and
-                    self.products[1].isIsomorphic(other.reactants[1]) and
-                    self.products[2].isIsomorphic(other.reactants[0]) ):
-                reverseProductsMatch = True
-        elif len(self.products) == len(other.reactants):
-            raise NotImplementedError("Can't check isomorphism of reactions with {0} products".format(len(self.products)))
-        
+        reverseProductsMatch = _isomorphicSpeciesList(self.products, 
+                                    other.reactants,checkIdentical = checkIdentical)
+
         # should have already returned if it matches forwards, or we're not allowed to match backwards
         return  (reverseReactantsMatch and reverseProductsMatch)
-    
+
     def getEnthalpyOfReaction(self, T):
         """
         Return the enthalpy of reaction in J/mol evaluated at temperature
@@ -1126,3 +993,62 @@ class Reaction:
         
         return other
 
+def _isomorphicSpeciesList(list1, list2, checkIdentical=False):
+    """
+    This method compares whether lists of species or molecules are isomorphic
+    or identical. It is used for the 'isIsomorphic' method of Reaction class.
+    It likely can be useful elswehere as well:
+        
+        list1 - list of species/molecule objects of reaction1
+        list2 - list of species/molecule objects of reaction2
+        checkIdentical - if true, uses the 'isIdentical' comparison
+                         if false, uses the 'isIsomorphic' comparison
+                         
+    Returns True if the lists are isomorphic/identical & false otherwise
+    """
+
+    def comparison_method(other1, other2, checkIdentical=checkIdentical):
+        if checkIdentical:
+            return other1.isIdentical(other2)
+        else:
+            return other1.isIsomorphic(other2)
+
+    if len(list1) == len(list2) == 1:
+        if comparison_method(list1[0], list2[0]):
+            return True
+    elif len(list1) == len(list2) == 2:
+        if comparison_method(list1[0], list2[0]) \
+                    and comparison_method(list1[1], list2[1]):
+            return True
+        elif comparison_method(list1[0], list2[1]) \
+                    and comparison_method(list1[1], list2[0]):
+            return True
+    elif len(list1) == len(list2) == 3:
+        if (    comparison_method(list1[0], list2[0]) and
+                comparison_method(list1[1], list2[1]) and
+                comparison_method(list1[2], list2[2]) ):
+            return True
+        elif (  comparison_method(list1[0], list2[0]) and
+                comparison_method(list1[1], list2[2]) and
+                comparison_method(list1[2], list2[1]) ):
+            return True
+        elif (  comparison_method(list1[0], list2[1]) and
+                comparison_method(list1[1], list2[0]) and
+                comparison_method(list1[2], list2[2]) ):
+            return True
+        elif (  comparison_method(list1[0], list2[2]) and
+                comparison_method(list1[1], list2[0]) and
+                comparison_method(list1[2], list2[1]) ):
+            return True
+        elif (  comparison_method(list1[0], list2[1]) and
+                comparison_method(list1[1], list2[2]) and
+                comparison_method(list1[2], list2[0]) ):
+            return True
+        elif (  comparison_method(list1[0], list2[2]) and
+                comparison_method(list1[1], list2[1]) and
+                comparison_method(list1[2], list2[0]) ):
+            return True
+    elif len(list1) == len(list2):
+        raise NotImplementedError("Can't check isomorphism of lists with {0} species/molecules".format(len(list1)))
+    # nothing found
+    return False

--- a/rmgpy/rmg/mainTest.py
+++ b/rmgpy/rmg/mainTest.py
@@ -99,7 +99,10 @@ options(
         shutil.rmtree(self.dir_name)
         # go back to the main RMG-Py directory
         os.chdir('..')
-        
+        # remove modular level database
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+
     def testRMGExecute(self):
         """
         This example is to test if RMG.execute increases the core reactions

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -635,24 +635,10 @@ class CoreEdgeReactionModel:
         # Generate kinetics of new reactions
         logging.info('Generating kinetics for new reactions...')
         for reaction in self.newReactionList:
-            family = getFamilyLibraryObject(reaction.family)
-
             # If the reaction already has kinetics (e.g. from a library),
             # assume the kinetics are satisfactory
             if reaction.kinetics is None:
-                # Set the reaction kinetics
-                kinetics, source, entry, isForward = self.generateKinetics(reaction)
-                reaction.kinetics = kinetics
-                # Flip the reaction direction if the kinetics are defined in the reverse direction
-                if not isForward:
-                    reaction.reactants, reaction.products = reaction.products, reaction.reactants
-                    reaction.pairs = [(p,r) for r,p in reaction.pairs]
-                    if family.ownReverse and hasattr(reaction,'reverse'):
-                        if reaction.reverse:
-                            reaction.template = reaction.reverse.template
-                            reaction.degeneracy = reaction.reverse.degeneracy
-                        # We're done with the "reverse" attribute, so delete it to save a bit of memory
-                        reaction.reverse = None
+                self.applyKineticsToReaction(reaction)
                     
         # For new reactions, convert ArrheniusEP to Arrhenius, and fix barrier heights.
         # self.newReactionList only contains *actually* new reactions, all in the forward direction.
@@ -778,6 +764,28 @@ class CoreEdgeReactionModel:
                         self.core.reactions.remove(rxn)
                     if rxn in self.edge.reactions:
                         self.edge.reactions.remove(rxn)
+
+    def applyKineticsToReaction(self, reaction):
+        """
+        retrieve the best kinetics for the reaction and apply it towards the forward 
+        or reverse direction (if reverse, flip the direaction).
+        """
+        from rmgpy.data.rmg import getDB
+        # Find the reaction kinetics
+        kinetics, source, entry, isForward = self.generateKinetics(reaction)
+        # Flip the reaction direction if the kinetics are defined in the reverse direction
+        if not isForward:
+            family = getDB('kinetics').families[reaction.family]
+            reaction.reactants, reaction.products = reaction.products, reaction.reactants
+            reaction.pairs = [(p,r) for r,p in reaction.pairs]
+            if family.ownReverse and hasattr(reaction,'reverse'):
+                if reaction.reverse:
+                    reaction.template = reaction.reverse.template
+                    # replace degeneracy
+                    reaction.degeneracy = reaction.reverse.degeneracy
+                # We're done with the "reverse" attribute, so delete it to save a bit of memory
+                reaction.reverse = None
+        reaction.kinetics = kinetics
 
     def generateKinetics(self, reaction):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -386,20 +386,35 @@ class CoreEdgeReactionModel:
         for rxn0 in shortlist:
             rxn_id0 = generateReactionId(rxn0)
 
-            if (rxn_id == rxn_id0):
-                if isinstance(familyObj, KineticsLibrary):
-                    # If the reaction comes from a kinetics library, then we can retain duplicates if they are marked
-                    if areIdenticalSpeciesReferences(rxn, rxn0):
-                        if not rxn.duplicate:
+            if (rxn_id == rxn_id0) and isinstance(familyObj, KineticsLibrary):
+                # If the reaction comes from a kinetics library, then we can 
+                # retain duplicates if they are marked
+                if areIdenticalSpeciesReferences(rxn, rxn0) and not rxn.duplicate:
+                    return True, rxn0
+            elif ((rxn_id == rxn_id0) or (rxn_id == rxn_id0[::-1])) and \
+                        isinstance(familyObj, KineticsFamily):
+                # ensure TemplateReactions have the same templates and families in order
+                # to classify this as existing reaction. Also checks for reverse
+                # direction matching. Marks duplicate if identical species and different
+                # templates or families
+                if areIdenticalSpeciesReferences(rxn, rxn0):
+                    if rxn.family == rxn0.family:
+                        equal_templates = frozenset(rxn.template) == frozenset(rxn0.template)
+                        # check reverse template
+                        if not equal_templates and familyObj.ownReverse and \
+                                    rxn.reverse is not None:
+                            equal_templates = frozenset(rxn.reverse.template) == frozenset(rxn0.template)
+                        if equal_templates:
                             return True, rxn0
-                else:
-                    if areIdenticalSpeciesReferences(rxn, rxn0):
-                        return True, rxn0
-            if isinstance(familyObj, KineticsFamily):
-                
-                if (rxn_id == rxn_id0[::-1]):
-                    if areIdenticalSpeciesReferences(rxn, rxn0):
-                        return True, rxn0
+                        else:
+                            rxn.duplicate = True
+                            rxn0.duplicate = True
+                    else:
+                        rxn.duplicate = True
+                        rxn0.duplicate = True
+            elif (rxn_id == rxn_id0):
+                if areIdenticalSpeciesReferences(rxn, rxn0):
+                    return True, rxn0
 
         # Now check seed mechanisms
         # We want to check for duplicates in *other* seed mechanisms, but allow

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -210,6 +210,228 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         for rxn in rxns:
             self.assertTrue(rxn.isBalanced())
 
+    def test_checkForExistingReaction_elminates_duplicate(self):
+        """
+        Test that checkForExistingReaction catches duplicate reactions
+        """
+        from rmgpy.data.kinetics.family import TemplateReaction
+        cerm = CoreEdgeReactionModel()
+
+        # make species' objects
+        spcA = Species().fromSMILES('[H]')
+        spcB = Species().fromSMILES('C=C[CH2]C')
+        spcC = Species().fromSMILES('C=C=CC')
+        spcD = Species().fromSMILES('[H][H]')
+        spcA.label = '[H]'
+        spcB.label = 'C=C[CH2]C'
+        spcC.label = 'C=C=CC'
+        spcD.label = '[H][H]'
+        spcB.generateResonanceIsomers()
+
+        cerm.addSpeciesToCore(spcA)
+        cerm.addSpeciesToCore(spcB)
+        cerm.addSpeciesToCore(spcC)
+        cerm.addSpeciesToCore(spcD)
+
+        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Csd','H'])
+        reaction_in_model.reactants.sort()
+        reaction_in_model.products.sort()
+
+        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Csd','H'])
+        cerm.addReactionToCore(reaction_in_model)
+        cerm.registerReaction(reaction_in_model)
+
+        found, rxn = cerm.checkForExistingReaction(reaction_to_add)
+
+        self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction')
+
+    def test_checkForExistingReaction_keeps_different_template_reactions(self):
+        """
+        Test that checkForExistingReaction keeps reactions with different templates
+        """
+        from rmgpy.data.kinetics.family import TemplateReaction
+        cerm = CoreEdgeReactionModel()
+
+        # make species' objects
+        spcA = Species().fromSMILES('[H]')
+        spcB = Species().fromSMILES('C=C[CH2]C')
+        spcC = Species().fromSMILES('C=C=CC')
+        spcD = Species().fromSMILES('[H][H]')
+        spcA.label = '[H]'
+        spcB.label = 'C=C[CH2]C'
+        spcC.label = 'C=C=CC'
+        spcD.label = '[H][H]'
+        spcB.generateResonanceIsomers()
+
+        cerm.addSpeciesToCore(spcA)
+        cerm.addSpeciesToCore(spcB)
+        cerm.addSpeciesToCore(spcC)
+        cerm.addSpeciesToCore(spcD)
+        
+        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Csd','H'])
+        reaction_in_model.reactants.sort()
+        reaction_in_model.products.sort()
+
+        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Cs12345','H'])
+        cerm.addReactionToCore(reaction_in_model)
+        cerm.registerReaction(reaction_in_model)
+
+        found, rxn = cerm.checkForExistingReaction(reaction_to_add)
+
+        self.assertFalse(found, 'checkForExistingReaction failed to identify reactions with different templates')
+
+    def test_checkForExistingReaction_removes_duplicates_in_opposite_directions(self):
+        """
+        Test that checkForExistingReaction will remove duplicates if reaction.reverse
+        would be a duplicate
+        """
+        from rmgpy.data.kinetics.family import TemplateReaction
+        cerm = CoreEdgeReactionModel()
+
+        # make species' objects
+        spcA = Species().fromSMILES('[H]')
+        spcB = Species().fromSMILES('C=C[CH2]C')
+        spcC = Species().fromSMILES('C=C=CC')
+        spcD = Species().fromSMILES('[H][H]')
+        spcA.label = '[H]'
+        spcB.label = 'C=C[CH2]C'
+        spcC.label = 'C=C=CC'
+        spcD.label = '[H][H]'
+        spcB.generateResonanceIsomers()
+
+        cerm.addSpeciesToCore(spcA)
+        cerm.addSpeciesToCore(spcB)
+        cerm.addSpeciesToCore(spcC)
+        cerm.addSpeciesToCore(spcD)
+
+        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Csd','H'])
+        reaction_in_model.reactants.sort()
+        reaction_in_model.products.sort()
+
+        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Csd','H'])
+        cerm.addReactionToCore(reaction_in_model)
+        cerm.registerReaction(reaction_in_model)
+
+        found, rxn = cerm.checkForExistingReaction(reaction_to_add)
+
+        self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction')
+
+    def test_checkForExistingReaction_keeps_different_template_reactions(self):
+        """
+        Test that checkForExistingReaction keeps reactions with different templates
+        """
+        from rmgpy.data.kinetics.family import TemplateReaction
+        cerm = CoreEdgeReactionModel()
+
+        # make species' objects
+        spcA = Species().fromSMILES('[H]')
+        spcB = Species().fromSMILES('C=C[CH2]C')
+        spcC = Species().fromSMILES('C=C=CC')
+        spcD = Species().fromSMILES('[H][H]')
+        spcA.label = '[H]'
+        spcB.label = 'C=C[CH2]C'
+        spcC.label = 'C=C=CC'
+        spcD.label = '[H][H]'
+        spcB.generateResonanceIsomers()
+
+        cerm.addSpeciesToCore(spcA)
+        cerm.addSpeciesToCore(spcB)
+        cerm.addSpeciesToCore(spcC)
+        cerm.addSpeciesToCore(spcD)
+        
+        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Csd','H'])
+        reaction_in_model.reactants.sort()
+        reaction_in_model.products.sort()
+
+        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
+                                             products = [spcC, spcD],
+                                                family = 'H_Abstraction',
+                                                template = ['Cs12345','H'])
+        cerm.addReactionToCore(reaction_in_model)
+        cerm.registerReaction(reaction_in_model)
+
+        found, rxn = cerm.checkForExistingReaction(reaction_to_add)
+
+        self.assertFalse(found, 'checkForExistingReaction failed to identify reactions with different templates')
+
+    def test_checkForExistingReaction_removes_duplicates_in_opposite_directions(self):
+        """
+        Test that checkForExistingReaction will remove duplicates if reaction.reverse
+        would be a duplicate
+        """
+        from rmgpy.data.kinetics.family import TemplateReaction
+        cerm = CoreEdgeReactionModel()
+
+        # make species' objects
+        s1 = Species().fromSMILES("[H]")
+        s2 = Species().fromSMILES("CC")
+        s3 = Species().fromSMILES("[H][H]")
+        s4 = Species().fromSMILES("C[CH2]")
+        s1.label = 'H'
+        s2.label = 'CC'
+        s3.label = 'HH'
+        s4.label = 'C[CH2]'
+
+        rxn_f = TemplateReaction(reactants = [s1, s2],
+                                    products = [s3, s4],
+                                    template = ['C/H3/Cs\H3','H_rad'],
+                                    degeneracy = 6,
+                                    family = 'H_Abstraction',
+                                    reverse = TemplateReaction(reactants = [s3, s4],
+                                                            products = [s1, s2],
+                                                            template = ['H2', 'C_rad/H2/Cs\\H3'],
+                                                            degeneracy = 2,
+                                                            family = 'H_Abstraction',
+                                                            )
+                                    )
+
+        rxn_r = TemplateReaction(reactants = [s3, s4],
+                                    products = [s1, s2],
+                                    template = ['H2', 'C_rad/H2/Cs\\H3'],
+                                    degeneracy = 2,
+                                    family = 'H_Abstraction',
+                                    reverse = TemplateReaction(reactants = [s1, s2],
+                                                            products = [s3, s4],
+                                                            template = ['C/H3/Cs\H3','H_rad'],
+                                                            degeneracy = 6,
+                                                            family = 'H_Abstraction',
+                                                            )
+                                    )
+
+        rxn_f.reactants.sort()
+        rxn_f.products.sort()
+
+        cerm.addReactionToCore(rxn_f)
+        cerm.registerReaction(rxn_f)
+
+        reactions = cerm.searchRetrieveReactions(rxn_r)
+        self.assertEqual(1, len(reactions),'cerm.searchRetrieveReactions could not identify reverse reaction')
+
+        found, rxn = cerm.checkForExistingReaction(rxn_r)
+
+        self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction when it is in the reverse direction')
+        self.assertEqual(rxn, rxn_f)
 
     @classmethod
     def tearDownClass(cls):

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -37,6 +37,7 @@ from rmgpy.rmg.main import RMG
 from rmgpy.reaction import Reaction
 from rmgpy.rmg.react import react
 from rmgpy.rmg.model import *
+from rmgpy.data.base import ForbiddenStructures
 
 ###################################################
 
@@ -45,20 +46,20 @@ class TestSpecies(unittest.TestCase):
     """
     Contains unit tests of the Species class.
     """
-
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """
         A method that is run before each unit test in this class.
         """
         # set-up RMG object
-        self.rmg = RMG()
+        cls.rmg = RMG()
 
         # load kinetic database and forbidden structures
-        self.rmg.database = RMGDatabase()
+        cls.rmg.database = RMGDatabase()
         path = os.path.join(settings['database.directory'])
 
         # forbidden structure loading
-        self.rmg.database.loadThermo(os.path.join(path, 'thermo'))
+        cls.rmg.database.loadThermo(os.path.join(path, 'thermo'))
         
 
     def testGetThermoData(self):
@@ -79,7 +80,8 @@ class TestSpecies(unittest.TestCase):
         spc.getThermoData()
         self.assertNotEquals(id(thermo), id(spc.thermo))
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """
         Reset the loaded database
         """
@@ -91,26 +93,31 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
     Contains unit tests of the CoreEdgeReactionModel class.
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """
         A method that is run before each unit test in this class.
         """
         TESTFAMILY = 'H_Abstraction'
 
         # set-up RMG object
-        self.rmg = RMG()
+        rmg = RMG()
 
         # load kinetic database and forbidden structures
-        self.rmg.database = RMGDatabase()
-        path = os.path.join(settings['database.directory'])
+        rmg.database = RMGDatabase()
+        path=os.path.join(settings['test_data.directory'], 'testing_database')
 
-        # forbidden structure loading
-        self.rmg.database.loadForbiddenStructures(os.path.join(path, 'forbiddenStructures.py'))
+
         # kinetics family loading
-        self.rmg.database.loadKinetics(os.path.join(path, 'kinetics'),
+        rmg.database.loadKinetics(os.path.join(path, 'kinetics'),
                                        kineticsFamilies=[TESTFAMILY],
                                        reactionLibraries=[]
                                        )
+        #load empty forbidden structures to avoid any dependence on forbidden structures
+        #for these tests
+        for family in rmg.database.kinetics.families.values():
+            family.forbidden = ForbiddenStructures()
+        rmg.database.forbiddenStructures = ForbiddenStructures()
 
     def testMakeNewSpecies(self):
         """
@@ -204,7 +211,8 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
             self.assertTrue(rxn.isBalanced())
 
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """
         Reset the loaded database
         """

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -257,6 +257,22 @@ def convertToSpeciesObjects(reaction):
     except AttributeError:
         pass
 
+def reduceSameReactantDegeneracy(rxnList):
+    """
+    This method reduces the degeneracy of reactions with identical reactants,
+    since translational component of the transition states are already taken
+    into account (so swapping the same reactant is not valid)
+    
+    This comes from work by Bishop and Laidler in 1965
+    """
+    for reaction in rxnList:
+        if len(reaction.reactants) == 2 and reaction.reactants[0].isIsomorphic(reaction.reactants[1]):
+            reaction.degeneracy *= 0.5
+            print('Degeneracy of reaction {} was decreased by 50% to {} since the reactants are identical'.format(reaction,reaction.degeneracy))
+        if reaction.reverse and len(reaction.reverse.reactants) == 2 and \
+                                   reaction.reverse.reactants[0].isIsomorphic(reaction.reverse.reactants[1]):
+            reaction.reverse.degeneracy *= 0.5
+            print('Degeneracy of reaction {} was decreased by 50% to {} since the reactants are identical'.format(reaction.reverse,reaction.reverse.degeneracy))
 
 def correctDegeneracyOfReverseReactions(reactionList, reactants):
     """

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -79,6 +79,21 @@ class TestReact(unittest.TestCase):
         self.assertIsNotNone(reactionList)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reactionList]))
 
+    def test_labelListofSpecies(self):
+        """
+        Ensure labelListofSpecies modifies atomlabels
+        """
+        from rmgpy.rmg.react import _labelListOfSpecies
+        s1 = Species().fromSMILES('CCC')
+        s2 = Species().fromSMILES('C=C[CH]C')
+        self.assertEqual(s2.molecule[0].atoms[0].id, -1)
+        
+        _labelListOfSpecies([s1, s2])
+        # checks atom id
+        self.assertNotEqual(s2.molecule[0].atoms[0].id, -1)
+        # checks second resonance structure id
+        self.assertNotEqual(s2.molecule[1].atoms[0].id, -1)
+
     def testReact(self):
         """
         Test that reaction generation from the available families works.

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -110,9 +110,9 @@ class TestReact(unittest.TestCase):
         """
         Test that reaction deflate function works.
         """
-        molA = Molecule().fromSMILES('[OH]')
-        molB = Molecule().fromSMILES('CC')
-        molC = Molecule().fromSMILES('[CH3]')
+        molA = Species().fromSMILES('[OH]')
+        molB = Species().fromSMILES('CC')
+        molC = Species().fromSMILES('[CH3]')
 
         reactants = [molA, molB]
 
@@ -189,15 +189,15 @@ class TestReact(unittest.TestCase):
         Test if the deflateReaction function works.
         """
 
-        molA = Molecule().fromSMILES('[OH]')
-        molB = Molecule().fromSMILES('CC')
-        molC = Molecule().fromSMILES('[CH3]')
+        molA = Species().fromSMILES('[OH]')
+        molB = Species().fromSMILES('CC')
+        molC = Species().fromSMILES('[CH3]')
 
         reactants = [molA, molB]
 
         # both reactants were already part of the core:
         reactantIndices = [1, 2]
-        molDict = {molA: 1, molB: 2}
+        molDict = {molA.molecule[0]: 1, molB.molecule[0]: 2}
 
         rxn = Reaction(reactants=[molA, molB], products=[molC],
         pairs=[(molA, molC), (molB, molC)])
@@ -212,7 +212,7 @@ class TestReact(unittest.TestCase):
 
         # one of the reactants was not yet part of the core:
         reactantIndices = [-1, 2]
-        molDict = {molA: Species(molecule=[molA]), molB: 2}
+        molDict = {molA.molecule[0]: molA, molB.molecule[0]: 2}
 
         rxn = Reaction(reactants=[molA, molB], products=[molC],
                 pairs=[(molA, molC), (molB, molC)])
@@ -220,7 +220,7 @@ class TestReact(unittest.TestCase):
         deflateReaction(rxn, molDict)
 
         for spc, t in zip(rxn.reactants, [Species, int]):
-            self.assertTrue(isinstance(spc, t))
+            self.assertTrue(isinstance(spc, t), 'Species {} is not of type {}'.format(spc,t))
         for spc in rxn.products:
             self.assertTrue(isinstance(spc, Species))
 

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -38,32 +38,35 @@ from rmgpy.molecule import Molecule
 from rmgpy.rmg.react import react
 from rmgpy.restart import saveRestartFile
 import rmgpy
+from rmgpy.data.base import ForbiddenStructures
 ###################################################
 
 class TestRMGWorkFlow(unittest.TestCase):
-
-    def setUp(self):
+    
+    @classmethod
+    def setUpClass(self):
         """
-        A method that is run before each unit test in this class.
+        A method that is run before all unit tests in this class.
         """
         # set-up RMG object
         self.rmg = RMG()
         self.rmg.reactionModel = CoreEdgeReactionModel()
 
-        self.rmg_dummy = RMG()
-        self.rmg_dummy.reactionModel = CoreEdgeReactionModel()
-
         # load kinetic database and forbidden structures
         self.rmg.database = RMGDatabase()
-        path = os.path.join(settings['database.directory'])
+        path = os.path.join(settings['test_data.directory'], 'testing_database')
 
-        # forbidden structure loading
-        self.rmg.database.loadForbiddenStructures(os.path.join(path, 'forbiddenStructures.py'))
         # kinetics family Disproportionation loading
         self.rmg.database.loadKinetics(os.path.join(path, 'kinetics'), \
-                                       kineticsFamilies=['R_Addition_MultipleBond'],reactionLibraries=[])
+                                       kineticsFamilies=['H_Abstraction','R_Addition_MultipleBond'],reactionLibraries=[])
 
-    def tearDown(self):
+        #load empty forbidden structures 
+        for family in self.rmg.database.kinetics.families.values():
+            family.forbidden = ForbiddenStructures()
+        self.rmg.database.forbiddenStructures = ForbiddenStructures()
+
+    @classmethod
+    def tearDownClass(self):
         """
         Reset the loaded database
         """
@@ -172,10 +175,6 @@ class TestRMGWorkFlow(unittest.TestCase):
 
     def testRestartFileGenerationAndParsing(self):
         
-        # load ownReverse family
-        db_path = os.path.join(settings['database.directory'])
-        self.rmg.database.loadKinetics(os.path.join(db_path, 'kinetics'), \
-                                       kineticsFamilies=['H_Abstraction'],reactionLibraries=[])
         # react
         spc1 = Species().fromSMILES("[H]")
         spc2 = Species().fromSMILES("C=C=C=O")

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -73,7 +73,6 @@ class TestRMGWorkFlow(unittest.TestCase):
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
         
-    @work_in_progress
     def testDeterministicReactionTemplateMatching(self):
         """
         Test RMG work flow can match reaction template for kinetics estimation 
@@ -81,6 +80,8 @@ class TestRMGWorkFlow(unittest.TestCase):
 
         In this test, a change of molecules order in a reacting species should 
         not change the reaction template matched.
+        
+        H + C=C=C=O -> O=C[C]=C
         """
 
         # react
@@ -89,16 +90,12 @@ class TestRMGWorkFlow(unittest.TestCase):
         newReactions = []		
         newReactions.extend(react((spc,)))
 
-        # process newly generated reactions to make sure no duplicated reactions
-        self.rmg.reactionModel.processNewReactions(newReactions, spc, None)
-
         # try to pick out the target reaction 
         mol_H = Molecule().fromSMILES("[H]")
         mol_C3H2O = Molecule().fromSMILES("C=C=C=O")
 
-        target_rxns = findTargetRxnsContaining(mol_H, mol_C3H2O, \
-                                               self.rmg.reactionModel.edge.reactions)
-        self.assertEqual(len(target_rxns), 1)
+        target_rxns = findTargetRxnsContaining(mol_H, mol_C3H2O, newReactions)
+        self.assertEqual(len(target_rxns), 2)
 
         # reverse the order of molecules in spc
         spc.molecule = list(reversed(spc.molecule))
@@ -107,16 +104,12 @@ class TestRMGWorkFlow(unittest.TestCase):
         newReactions_reverse = []
         newReactions_reverse.extend(react((spc,)))
 
-        # process newly generated reactions again to make sure no duplicated reactions
-        self.rmg_dummy.reactionModel.processNewReactions(newReactions_reverse, spc, None)
-
         # try to pick out the target reaction 
-        target_rxns_reverse = findTargetRxnsContaining(mol_H, mol_C3H2O, \
-                                                       self.rmg_dummy.reactionModel.edge.reactions)
-        self.assertEqual(len(target_rxns_reverse), 1)
+        target_rxns_reverse = findTargetRxnsContaining(mol_H, mol_C3H2O, newReactions_reverse)
+        self.assertEqual(len(target_rxns_reverse), 2)
 
         # whatever order of molecules in spc, the reaction template matched should be same
-        self.assertEqual(target_rxns[0].template, target_rxns_reverse[0].template)
+        self.assertEqual(target_rxns[0].template, target_rxns_reverse[-1].template)
 
     def testCheckForExistingSpeciesForBiAromatics(self):
         """

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -335,7 +335,7 @@ class LiquidReactorCheck(unittest.TestCase):
         
     def tearDown(self):
         """
-        Reset the database
+        Reset the database & liquid parameters for solution
         """
         global diffusionLimiter        
         from rmgpy.kinetics.diffusionLimited import diffusionLimiter
@@ -344,4 +344,8 @@ class LiquidReactorCheck(unittest.TestCase):
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
 
-        
+        from rmgpy.rmg.model import Species as DifferentSpecies
+        DifferentSpecies.solventData = None
+        DifferentSpecies.solventName = None
+        DifferentSpecies.solventStructure = None
+        DifferentSpecies.solventViscosity = None

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -52,7 +52,9 @@ cdef class Species:
     
     cpdef generateResonanceIsomers(self,bint keepIsomorphic=?)
     
-    cpdef bint isIsomorphic(self, other)
+    cpdef bint isIsomorphic(self, other) except -2
+
+    cpdef bint isIdentical(self, other) except -2
     
     cpdef fromAdjacencyList(self, adjlist)
     cpdef fromSMILES(self, smiles)

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -147,6 +147,8 @@ class Species(object):
         """
         Return a string representation of the species, in the form 'label(id)'.
         """
+        if not self.label:
+            self.label = self.molecule[0].toSMILES()
         if self.index == -1: return self.label
         else: return '{0}({1:d})'.format(self.label, self.index)
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -191,6 +191,25 @@ class Species(object):
         else:
             raise ValueError('Unexpected value "{0!r}" for other parameter; should be a Molecule or Species object.'.format(other))
         return False
+
+    def isIdentical(self, other):
+        """
+        Return ``True`` if at least one molecule of the species is identical to `other`,
+        which can be either a :class:`Molecule` object or a :class:`Species` object.
+        """
+        if isinstance(other, Molecule):
+            for molecule in self.molecule:
+                if molecule.isIdentical(other):
+                    return True
+        elif isinstance(other, Species):
+                for molecule1 in self.molecule:
+                    for molecule2 in other.molecule:
+                        if molecule1.isIdentical(molecule2):
+                            return True
+        else:
+            raise ValueError('Unexpected value "{0!r}" for other parameter; should be a Molecule or Species object.'.format(other))
+        return False
+
     
     def fromAdjacencyList(self, adjlist):
         """

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -170,7 +170,8 @@ class Species(object):
         resonance isomers have already been generated.
         """
         if len(self.molecule) == 1:
-            self.molecule[0].assignAtomIDs()
+            if not self.molecule[0].atomIDValid():
+                self.molecule[0].assignAtomIDs()
             self.molecule = self.molecule[0].generateResonanceIsomers(keepIsomorphic)
     
     def isIsomorphic(self, other):

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -164,7 +164,7 @@ class Species(object):
         self._molecularWeight = quantity.Mass(value)
     molecularWeight = property(getMolecularWeight, setMolecularWeight, """The molecular weight of the species. (Note: value_si is in kg/molecule not kg/mole)""")
 
-    def generateResonanceIsomers(self, keepIsomorphic=False):
+    def generateResonanceIsomers(self, keepIsomorphic=True):
         """
         Generate all of the resonance isomers of this species. The isomers are
         stored as a list in the `molecule` attribute. If the length of

--- a/rmgpy/test_data/testing_database/kinetics/families/H_Abstraction/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/H_Abstraction/groups.py
@@ -230,6 +230,49 @@ entry(
     kinetics = None,
 )
 
+entry(
+    index = 63,
+    label = "C/H3/Cs",
+    group = 
+"""
+1 *1 C  u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 H  u0 {1,S}
+3    H  u0 {1,S}
+4    H  u0 {1,S}
+5    Cs u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 78,
+    label = "C/H3/Cd",
+    group = 
+"""
+1 *1 C  u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 H  u0 {1,S}
+3    H  u0 {1,S}
+4    H  u0 {1,S}
+5    Cd u0 {1,S} {6,D}
+6    C  u0 {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 65,
+    label = "C/H3/Cdot",
+    group = 
+"""
+1 *1 C  u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 H  u0 {1,S}
+3    H  u0 {1,S}
+4    H  u0 {1,S}
+5    C  u1 {1,S}
+""",
+    kinetics = None,
+)
+
 tree(
 """
 L1: X_H_or_Xrad_H_Xbirad_H_Xtrirad_H
@@ -243,6 +286,9 @@ L1: X_H_or_Xrad_H_Xbirad_H_Xtrirad_H
         L3: NH_singlet_H
     L2: Xrad_H
     L2: X_H
+        L3: C/H3/Cs
+        L3: C/H3/Cdot
+        L3: C/H3/Cd
 L1: Y_rad_birad_trirad_quadrad
     L2: Y_1centerquadrad
         L3: C_quintet

--- a/rmgpy/test_data/testing_database/kinetics/families/R_Addition_MultipleBond/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/R_Addition_MultipleBond/groups.py
@@ -45,6 +45,31 @@ entry(
 
 entry(
     index = 3,
+    label = "Ck_O",
+    group = 
+"""
+1 *1 Cdd u0 {2,D} {3,D}
+2 *2 Od  u0 {1,D}
+3    C   u0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 127,
+    label = "Ck_Ca",
+    group = 
+"""
+1 *1 Cdd u0 {2,D} {3,D}
+2 *2 Cdd u0 {1,D} {4,D}
+3    Od  u0 {1,D}
+4    C   u0 {2,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 838,
     label = "Ct_R",
     group = 
 """
@@ -410,6 +435,8 @@ tree(
 """
 L1: R_R
     L2: Cd_R
+        L3: Ck_O
+        L3: Ck_Ca
     L2: Ct_R
     L2: Od_R
     L2: Nd_R

--- a/rmgpy/thermo/nasaTest.py
+++ b/rmgpy/thermo/nasaTest.py
@@ -68,7 +68,19 @@ class TestNASA(unittest.TestCase):
             E0 = (self.E0, "J/mol"),
             comment = self.comment,
         )
-    
+    def tearDown(self):
+        """
+        Reset the database & liquid parameters for solution
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+        
+        from rmgpy.rmg.model import Species as DifferentSpecies
+        DifferentSpecies.solventData = None
+        DifferentSpecies.solventName = None
+        DifferentSpecies.solventStructure = None
+        DifferentSpecies.solventViscosity = None
+        
     def test_polyLow(self):
         """
         Test that the NASA low-temperature polynomial was properly set.

--- a/rmgpy/thermo/thermoengineTest.py
+++ b/rmgpy/thermo/thermoengineTest.py
@@ -67,6 +67,12 @@ def tearDown():
     """
     import rmgpy.data.rmg
     rmgpy.data.rmg.database = None
+    
+    from rmgpy.rmg.model import Species as DifferentSpecies
+    DifferentSpecies.solventData = None
+    DifferentSpecies.solventName = None
+    DifferentSpecies.solventStructure = None
+    DifferentSpecies.solventViscosity = None
 
 def funcSubmit():
     """

--- a/rmgpy/thermo/wilhoitTest.py
+++ b/rmgpy/thermo/wilhoitTest.py
@@ -77,7 +77,20 @@ class TestWilhoit(unittest.TestCase):
             Tmax = (self.Tmax,"K"),
             comment = self.comment,
         )
+
+    def tearDown(self):
+        """
+        Reset the database & liquid parameters for solution
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
         
+        from rmgpy.rmg.model import Species as DifferentSpecies
+        DifferentSpecies.solventData = None
+        DifferentSpecies.solventName = None
+        DifferentSpecies.solventStructure = None
+        DifferentSpecies.solventViscosity = None
+
     def test_Cp0(self):
         """
         Test that the Wilhoit Cp0 property was properly set.

--- a/rmgpy/tools/fluxtest.py
+++ b/rmgpy/tools/fluxtest.py
@@ -50,3 +50,7 @@ class FluxDiagramTest(unittest.TestCase):
         
         shutil.rmtree(outputdir)
         shutil.rmtree(speciesdir)
+
+    def tearDown(self):
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None

--- a/rmgpy/tools/regressionTest.py
+++ b/rmgpy/tools/regressionTest.py
@@ -45,3 +45,7 @@ class regressionTest(unittest.TestCase):
 
         args = readInputFile(inputFile)
         run(benchmark, tested, *args)
+        
+    def tearDown(self):
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None

--- a/rmgpy/tools/testSensitivity.py
+++ b/rmgpy/tools/testSensitivity.py
@@ -52,3 +52,7 @@ class SensitivityTest(unittest.TestCase):
         
         os.remove(simfile)
         os.remove(sensfile)
+        
+    def tearDown(self):
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None


### PR DESCRIPTION

This PR solves two related problems in RMG: reaction degeneracy values that take into account resonance structures and allows multiple transition states to be stored in RMG's output file. This PR will solve underterminable kinetics problems (#494) , muptiple TS (#323, #142), and proper degeneracy values (#876, #833, #619, #552) . These two problems both involve updates to the degeneracy-finding algorithm, which is why they are in one PR. The major modification for this pull request is the order in which the generate reactions steps take place. The reactions of all resonance structures are now generated before algorithms like degeneracy or finding reverse kinetics are run. In addition, the degeneracy algorithm was redone to take into account which atoms have actually been switched (this correct the excessive degneracy from certain classes # ) and the templates that are matched (to allow multiple transition states). In addition, the adding of new reactions to CoreEdgeReactionModel also checks the family and template, and marks duplicate reactions when they exist (allowing for multiple TS and removing underterminatee kinetics problems)

1. redefines the degeneracy variable as a private float. When degeneracy is updated, the kinetic rate (if set) is too.
2. modularizes parts of generateReactions - finding rxn.reverse and degeneracy are separate methods
3. runs reactions betwween all resonance structures of species before finding degeneracy
1. utilizes reaction templates to find and keep multiple transition states (as separate reactions)
1. uses atomIDs to identify when a reaction path has already been added to degeneracy
1. adding proper cleanup to many test methods (including solvation database cleanup)
1. some code cleanup and other modularization of methods.

This PR is ready for code review. Testing this could involve merging it and running a job of interest, though I think RMG-Tests is already doing that. If it is merged, PR #323 can be removed. 