### PR TITLE
categorize tests with authentication requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - make
 
 script: 
-  - make test
+  - make test-all
   - make test-database
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ decython:
 	find . -name *.so ! \( -name _statmech.so -o -name quantity.so -o -regex '.*rmgpy/solver/.*' \) -exec rm -f '{}' \;
 	find . -name *.pyc -exec rm -f '{}' \;
 
-test:
+test-all:
 ifeq ($(OS),Windows_NT)
 	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 else
@@ -82,6 +82,16 @@ else
 	rm -rf testing/coverage/*
 	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 endif
+
+test:
+ifeq ($(OS),Windows_NT)
+	nosetests --nocapture --nologcapture --all-modules --attr '!auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+else
+	mkdir -p testing/coverage
+	rm -rf testing/coverage/*
+	nosetests --nocapture --nologcapture --all-modules --attr '!auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+endif
+
 test-database:
 	nosetests -v -d testing/databaseTest.py	
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -4,6 +4,7 @@
 import os
 import unittest
 from external.wip import work_in_progress
+from nose.plugins.attrib import attr
 
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase, database
@@ -863,6 +864,7 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         joinedCycle=combineCycles(testCycle1,testCycle2)
         self.assertTrue(sorted(mainCycle)==sorted(joinedCycle))
 
+@attr('auth')
 class TestThermoCentralDatabaseInterface(unittest.TestCase):
     """
     Contains unit tests for methods of ThermoCentralDatabaseInterface


### PR DESCRIPTION
This PR provides a solution for #1035, which categories tests into tests requiring authentication and internet and tests that don't require. It's done using `nose attribute` decorator.

It also reorganizes the test modes in makefile:
- `make test` only runs tests that don't require authentication, designed for general users and develoers with no internet.
- `make test-all` runs all the tests, designed for developers and travis