### PR TITLE
Dynamics criterion (AcceleratorTools part 1)

### DIFF
--- a/examples/rmg/minimal_dynamics/input.py
+++ b/examples/rmg/minimal_dynamics/input.py
@@ -1,0 +1,51 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    toleranceMoveReactionToCore=5.0,
+    maximumEdgeSpecies=100000,
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=True,
+)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -31,6 +31,7 @@
 import logging
 import quantities
 import os
+import numpy
 
 from rmgpy import settings
 
@@ -235,17 +236,22 @@ def solvation(solvent):
         raise InputError("solvent should be a string like 'water'")
     rmg.solvent = solvent
 
-def model(toleranceMoveToCore=None, toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
+def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=numpy.inf, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
     """
-    How to generate the model. `toleranceMoveToCore` must be specified. Other parameters are optional and control the pruning.
+    How to generate the model. `toleranceMoveToCore` must be specified. 
+    toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
+    by default this criterion is turned off
+    Other parameters are optional and control the pruning.
     """
     if toleranceMoveToCore is None:
         raise InputError("You must provide a toleranceMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
     if toleranceMoveToCore > toleranceInterruptSimulation:
         raise InputError("toleranceMoveToCore must be less than or equal to toleranceInterruptSimulation, which is currently {0}".format(toleranceInterruptSimulation))
-
+    
     rmg.fluxToleranceKeepInEdge = toleranceKeepInEdge
     rmg.fluxToleranceMoveToCore = toleranceMoveToCore
+    rmg.reactionToleranceMoveToCore = toleranceMoveReactionToCore
+    rmg.reactionToleranceInterrupt = toleranceReactionInterruptSimulation
     rmg.fluxToleranceInterrupt = toleranceInterruptSimulation
     rmg.maximumEdgeSpecies = maximumEdgeSpecies
     rmg.minCoreSizeForPrune = minCoreSizeForPrune

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -236,12 +236,14 @@ def solvation(solvent):
         raise InputError("solvent should be a string like 'water'")
     rmg.solvent = solvent
 
-def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=numpy.inf, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False):
+def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,toleranceKeepInEdge=0.0, toleranceInterruptSimulation=1.0, toleranceReactionInterruptSimulation=numpy.inf, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
     by default this criterion is turned off
     Other parameters are optional and control the pruning.
+    ignoreOverallFluxCriterion=True will cause the toleranceMoveToCore to be only applied
+    to the pressure dependent network expansion and not movement of species from edge to core
     """
     if toleranceMoveToCore is None:
         raise InputError("You must provide a toleranceMoveToCore value. It should be less than or equal to toleranceInterruptSimulation which is currently {0}".format(toleranceInterruptSimulation))
@@ -257,6 +259,7 @@ def model(toleranceMoveToCore=None, toleranceMoveReactionToCore=numpy.inf,tolera
     rmg.minCoreSizeForPrune = minCoreSizeForPrune
     rmg.minSpeciesExistIterationsForPrune = minSpeciesExistIterationsForPrune
     rmg.filterReactions = filterReactions
+    rmg.ignoreOverallFluxCriterion=ignoreOverallFluxCriterion
 
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -167,6 +167,7 @@ class RMG(util.Subject):
         self.fluxToleranceInterrupt = 1.0
         self.reactionToleranceMoveToCore = numpy.inf
         self.reactionToleranceInterrupt = numpy.inf
+        self.ignoreOverallFluxCriterion=False
         
         self.absoluteTolerance = 1.0e-8
         self.relativeTolerance = 1.0e-4
@@ -591,6 +592,7 @@ class RMG(util.Subject):
                     toleranceInterruptSimulation = self.fluxToleranceInterrupt if prune else self.fluxToleranceMoveToCore,
                     toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt if prune else self.reactionToleranceMoveToCore,
                     pdepNetworks = self.reactionModel.networkList,
+                    ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
                     absoluteTolerance = self.absoluteTolerance,
                     relativeTolerance = self.relativeTolerance,
                     filterReactions=False,
@@ -620,8 +622,11 @@ class RMG(util.Subject):
                         assert len(objectsToEnlarge)>0
                     elif isinstance(obj,Reaction):
                         potentialSpcs = obj.reactants+obj.products
-                        filterFcn = lambda x: not (x in self.reactionModel.core.species)
+                        filterFcn = lambda x: not ((x in self.reactionModel.core.species)) #remove species already in core
                         neededSpcs = filter(filterFcn,potentialSpcs)
+                        for i in range(len(neededSpcs)): #remove duplicate species
+                            if neededSpcs.index(neededSpcs[i]) != i:
+                                del neededSpcs[i]
                         objectsToEnlarge.extend(neededSpcs)
                     self.done = False
     
@@ -666,6 +671,7 @@ class RMG(util.Subject):
                                 toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
                                 toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt,
                                 pdepNetworks = self.reactionModel.networkList,
+                                ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
                                 absoluteTolerance = self.absoluteTolerance,
                                 relativeTolerance = self.relativeTolerance,
                                 filterReactions=True,
@@ -719,8 +725,11 @@ class RMG(util.Subject):
                     edgeReactions = self.reactionModel.edge.reactions,
                     toleranceKeepInEdge = self.fluxToleranceKeepInEdge,
                     toleranceMoveToCore = self.fluxToleranceMoveToCore,
-                    toleranceInterruptSimulation = self.fluxToleranceInterrupt,
+                    toleranceReactionMoveToCore = self.reactionToleranceMoveToCore,
+                    toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
+                    toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt,
                     pdepNetworks = self.reactionModel.networkList,
+                    ignoreOverallFluxCriterion=self.ignoreOverallFluxCriterion,
                     absoluteTolerance = self.absoluteTolerance,
                     relativeTolerance = self.relativeTolerance,
                     sensitivity = True,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -55,6 +55,7 @@ from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.kinetics.diffusionLimited import diffusionLimiter
 
 from model import Species, CoreEdgeReactionModel
+from rmgpy.reaction import Reaction
 from pdep import PDepNetwork
 import rmgpy.util as util
 
@@ -616,7 +617,10 @@ class RMG(util.Subject):
                     elif isinstance(obj, Species):
                         objectsToEnlarge.append(obj)
                     elif isinstance(obj,Reaction):
-                        objectsToEnlarge.extend(filter(lambda x: not (x in coreSpecies), Reaction.reactants+Reaction.products))
+                        potentialSpcs = obj.reactants+obj.products
+                        filterFcn = lambda x: not (x in self.reactionModel.core.species)
+                        neededSpcs = filter(filterFcn,potentialSpcs)
+                        objectsToEnlarge.extend(neededSpcs)
                     self.done = False
     
     

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -614,8 +614,10 @@ class RMG(util.Subject):
                         # We do this here because we need a temperature and pressure
                         # Store the maximum leak species along with the associated network
                         obj = (obj, obj.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si))
+                        objectsToEnlarge.append(obj)
                     elif isinstance(obj, Species):
                         objectsToEnlarge.append(obj)
+                        assert len(objectsToEnlarge)>0
                     elif isinstance(obj,Reaction):
                         potentialSpcs = obj.reactants+obj.products
                         filterFcn = lambda x: not (x in self.reactionModel.core.species)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -164,6 +164,9 @@ class RMG(util.Subject):
         self.fluxToleranceKeepInEdge = 0.0
         self.fluxToleranceMoveToCore = 1.0
         self.fluxToleranceInterrupt = 1.0
+        self.reactionToleranceMoveToCore = numpy.inf
+        self.reactionToleranceInterrupt = numpy.inf
+        
         self.absoluteTolerance = 1.0e-8
         self.relativeTolerance = 1.0e-4
         self.sensitivityAbsoluteTolerance = 1.0e-6
@@ -583,7 +586,9 @@ class RMG(util.Subject):
                     edgeReactions = self.reactionModel.edge.reactions,
                     toleranceKeepInEdge = self.fluxToleranceKeepInEdge if prune else 0,
                     toleranceMoveToCore = self.fluxToleranceMoveToCore,
+                    toleranceReactionMoveToCore = self.reactionToleranceMoveToCore,
                     toleranceInterruptSimulation = self.fluxToleranceInterrupt if prune else self.fluxToleranceMoveToCore,
+                    toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt if prune else self.reactionToleranceMoveToCore,
                     pdepNetworks = self.reactionModel.networkList,
                     absoluteTolerance = self.absoluteTolerance,
                     relativeTolerance = self.relativeTolerance,
@@ -608,7 +613,10 @@ class RMG(util.Subject):
                         # We do this here because we need a temperature and pressure
                         # Store the maximum leak species along with the associated network
                         obj = (obj, obj.getMaximumLeakSpecies(reactionSystem.T.value_si, reactionSystem.P.value_si))
-                    objectsToEnlarge.append(obj)
+                    elif isinstance(obj, Species):
+                        objectsToEnlarge.append(obj)
+                    elif isinstance(obj,Reaction):
+                        objectsToEnlarge.extend(filter(lambda x: not (x in coreSpecies), Reaction.reactants+Reaction.products))
                     self.done = False
     
     
@@ -648,7 +656,9 @@ class RMG(util.Subject):
                                 edgeReactions = [],
                                 toleranceKeepInEdge = 0,
                                 toleranceMoveToCore = self.fluxToleranceMoveToCore,
+                                toleranceReactionMoveToCore = self.reactionToleranceMoveToCore,
                                 toleranceInterruptSimulation = self.fluxToleranceMoveToCore,
+                                toleranceReactionInterruptSimulation = self.reactionToleranceInterrupt,
                                 pdepNetworks = self.reactionModel.networkList,
                                 absoluteTolerance = self.absoluteTolerance,
                                 relativeTolerance = self.relativeTolerance,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -622,8 +622,8 @@ class RMG(util.Subject):
                         assert len(objectsToEnlarge)>0
                     elif isinstance(obj,Reaction):
                         potentialSpcs = obj.reactants+obj.products
-                        filterFcn = lambda x: not ((x in self.reactionModel.core.species)) #remove species already in core
-                        neededSpcs = filter(filterFcn,potentialSpcs)
+                        #remove species already in core
+                        neededSpcs = [x for x in potentialSpcs if x not in self.reactionModel.core.species]
                         for i in range(len(neededSpcs)): #remove duplicate species
                             if neededSpcs.index(neededSpcs[i]) != i:
                                 del neededSpcs[i]

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -69,7 +69,8 @@ cdef class ReactionSystem(DASx):
     # The reaction and species rates at the current time (in mol/m^3*s)
     cdef public numpy.ndarray coreSpeciesRates
     cdef public numpy.ndarray coreReactionRates
-
+    cdef public numpy.ndarray coreSpeciesProductionRates
+    cdef public numpy.ndarray coreSpeciesConsumptionRates
     cdef public numpy.ndarray edgeSpeciesRates
     cdef public numpy.ndarray edgeReactionRates
 
@@ -106,10 +107,11 @@ cdef class ReactionSystem(DASx):
         list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?, filterReactions=?)
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,
-        list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, sensitivityAbsoluteTolerance=?, 
-        sensitivityRelativeTolerance=?, sensWorksheet=?, filterReactions=?)
+        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
+        list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
+        sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
+        filterReactions=?)
 
-    cpdef logRates(self, double charRate, object species, double speciesRate, object network, double networkRate)
-
+    cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum, object network, double networkRate)
+     
     cpdef logConversions(self, speciesIndex, y0)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -108,7 +108,7 @@ cdef class ReactionSystem(DASx):
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
         double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,double toleranceReactionMoveToCore=?,double toleranceReactionInterruptSimulation=?,
-        list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
+        list pdepNetworks=?,ignoreOverallFluxCriterion=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
         sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
         filterReactions=?)
 

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -107,7 +107,7 @@ cdef class ReactionSystem(DASx):
         list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?, filterReactions=?)
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceReactionMoveToCore, double toleranceInterruptSimulation,double toleranceReactionInterruptSimulation,
+        double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,double toleranceReactionMoveToCore=?,double toleranceReactionInterruptSimulation=?,
         list pdepNetworks=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
         sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
         filterReactions=?)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -107,7 +107,8 @@ cdef class ReactionSystem(DASx):
         list pdepNetworks=?, atol=?, rtol=?, sensitivity=?, sens_atol=?, sens_rtol=?, filterReactions=?)
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,double toleranceReactionMoveToCore=?,double toleranceReactionInterruptSimulation=?,
+        double toleranceKeepInEdge, double toleranceMoveToCore,  double toleranceInterruptSimulation,
+        double toleranceReactionMoveToCore=?,double toleranceReactionInterruptSimulation=?,
         list pdepNetworks=?,ignoreOverallFluxCriterion=?, absoluteTolerance=?, relativeTolerance=?, sensitivity=?, 
         sensitivityAbsoluteTolerance=?, sensitivityRelativeTolerance=?, sensWorksheet=?,
         filterReactions=?)

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -350,7 +350,7 @@ cdef class ReactionSystem(DASx):
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
         double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,double toleranceReactionMoveToCore=numpy.inf, double toleranceReactionInterruptSimulation=numpy.inf,
-        list pdepNetworks=None, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
+        list pdepNetworks=None, ignoreOverallFluxCriterion=False, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
         sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
         filterReactions=False):
         """
@@ -602,12 +602,12 @@ cdef class ReactionSystem(DASx):
                                 bimolecularThreshold[i,j] = True
                                                     
             # Interrupt simulation if that flux exceeds the characteristic rate times a tolerance
-            if maxSpeciesRate > toleranceMoveToCore * charRate and not invalidObject:
+            if (not ignoreOverallFluxCriterion) and (maxSpeciesRate > toleranceMoveToCore * charRate and not invalidObject):
                 logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for moving to model core'.format(self.t, maxSpecies))
                 self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                 self.logConversions(speciesIndex, y0)
                 invalidObject = maxSpecies
-            if maxSpeciesRate > toleranceInterruptSimulation * charRate:
+            if (not ignoreOverallFluxCriterion) and (maxSpeciesRate > toleranceInterruptSimulation * charRate):
                 logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for simulation interruption'.format(self.t, maxSpecies))
                 self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
                 self.logConversions(speciesIndex, y0)

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -349,9 +349,10 @@ cdef class ReactionSystem(DASx):
 
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, list edgeReactions,
-        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,double toleranceReactionMoveToCore=numpy.inf, double toleranceReactionInterruptSimulation=numpy.inf,
-        list pdepNetworks=None, ignoreOverallFluxCriterion=False, absoluteTolerance=1e-16, relativeTolerance=1e-8, sensitivity=False, 
-        sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
+        double toleranceKeepInEdge, double toleranceMoveToCore, double toleranceInterruptSimulation,
+        double toleranceReactionMoveToCore=numpy.inf, double toleranceReactionInterruptSimulation=numpy.inf,
+        list pdepNetworks=None, ignoreOverallFluxCriterion=False, absoluteTolerance=1e-16, relativeTolerance=1e-8, 
+        sensitivity=False, sensitivityAbsoluteTolerance=1e-6, sensitivityRelativeTolerance=1e-4, sensWorksheet=None,
         filterReactions=False):
         """
         Simulate the reaction system with the provided reaction model,
@@ -373,7 +374,7 @@ cdef class ReactionSystem(DASx):
         cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesRates, edgeSpeciesRates, networkLeakRates, coreSpeciesProductionRates, coreSpeciesConsumptionRates, totalDivAccumNums
         cdef numpy.ndarray[numpy.float64_t, ndim=1] maxCoreSpeciesRates, maxEdgeSpeciesRates, maxNetworkLeakRates,maxEdgeSpeciesRateRatios, maxNetworkLeakRateRatios
         cdef bint terminated
-        cdef object maxSpecies, maxNetwork, 
+        cdef object maxSpecies, maxNetwork
         cdef int i, j, k
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
         cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
@@ -559,7 +560,7 @@ cdef class ReactionSystem(DASx):
                                 maxEdgeReactionAccum = reactionRate
                                 maxAccumReactionIndex = index
                     maxAccumReaction = edgeReactions[maxAccumReactionIndex]
-                elif len(totalDivAccumNums)>0:
+                else:
                     maxAccumReactionIndex = numpy.argmax(totalDivAccumNums)
                     maxAccumReaction = edgeReactions[maxAccumReactionIndex]
                     maxDifLnAccumNum = numpy.log(totalDivAccumNums[maxAccumReactionIndex])
@@ -701,7 +702,7 @@ cdef class ReactionSystem(DASx):
         Log information about the current maximum species and network rates.
         """
         logging.info('    Characteristic rate: {0:10.4e} mol/m^3*s'.format(charRate))
-        logging.info('    Max(Dif(Ln(accumulation number))):  {0:10.4e}'.format(maxDifLnAccumNum))
+        logging.info('    Dynamics number:  {0:10.4e}'.format(maxDifLnAccumNum))
         if charRate == 0.0:
             logging.info('    {0} rate: {1:10.4e} mol/m^3*s'.format(species, speciesRate))
             if network is not None:

--- a/rmgpy/solver/liquid.pyx
+++ b/rmgpy/solver/liquid.pyx
@@ -212,24 +212,26 @@ cdef class LiquidReactor(ReactionSystem):
         for j in xrange(ir.shape[0]):
             k = kf[j]
             if ir[j,0] >= numCoreSpecies or ir[j,1] >= numCoreSpecies or ir[j,2] >= numCoreSpecies:
-                reactionRate = 0.0
+                fReactionRate = 0.0
             elif ir[j,1] == -1: # only one reactant
-                reactionRate = k * C[ir[j,0]]
+                fReactionRate = k * C[ir[j,0]]
             elif ir[j,2] == -1: # only two reactants
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]]
             else: # three reactants!! (really?)
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
             k = kr[j]
             if ip[j,0] >= numCoreSpecies or ip[j,1] >= numCoreSpecies or ip[j,2] >= numCoreSpecies:
-                pass
+                revReactionRate = 0.0
             elif ip[j,1] == -1: # only one reactant
-                reactionRate -= k * C[ip[j,0]]
+                revReactionRate = k * C[ip[j,0]]
             elif ip[j,2] == -1: # only two reactants
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]]
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]]
             else: # three reactants!! (really?)
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
-
-           # Set the reaction and species rates
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
+                
+            reactionRate = fReactionRate-revReactionRate
+            
+            # Set the reaction and species rates
             if j < numCoreReactions:
                 # The reaction is a core reaction
                 coreReactionRates[j] = reactionRate
@@ -239,26 +241,32 @@ cdef class LiquidReactor(ReactionSystem):
                 # and products are core species
                 first = ir[j,0]
                 coreSpeciesRates[first] -= reactionRate
-                coreSpeciesConsumptionRates[first] += reactionRate
+                coreSpeciesConsumptionRates[first] += fReactionRate
+                coreSpeciesProductionRates[first] += revReactionRate
                 second = ir[j,1]
                 if second != -1:
                     coreSpeciesRates[second] -= reactionRate
-                    coreSpeciesConsumptionRates[second] += reactionRate
+                    coreSpeciesConsumptionRates[second] += fReactionRate
+                    coreSpeciesProductionRates[second] += revReactionRate
                     third = ir[j,2]
                     if third != -1:
                         coreSpeciesRates[third] -= reactionRate
-                        coreSpeciesConsumptionRates[third] += reactionRate
+                        coreSpeciesConsumptionRates[third] += fReactionRate
+                        coreSpeciesProductionRates[third] += revReactionRate
                 first = ip[j,0]
                 coreSpeciesRates[first] += reactionRate
-                coreSpeciesProductionRates[first] += reactionRate
+                coreSpeciesProductionRates[first] += fReactionRate
+                coreSpeciesConsumptionRates[first] += revReactionRate
                 second = ip[j,1]
                 if second != -1:
                     coreSpeciesRates[second] += reactionRate
-                    coreSpeciesProductionRates[second] += reactionRate
+                    coreSpeciesProductionRates[second] += fReactionRate
+                    coreSpeciesConsumptionRates[second] += revReactionRate
                     third = ip[j,2]
                     if third != -1:
                         coreSpeciesRates[third] += reactionRate
-                        coreSpeciesProductionRates[third] += reactionRate
+                        coreSpeciesProductionRates[third] += fReactionRate
+                        coreSpeciesConsumptionRates[third] += revReactionRate
 
             else:
                 # The reaction is an edge reaction

--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -241,7 +241,7 @@ cdef class SimpleReactor(ReactionSystem):
         cdef numpy.ndarray[numpy.float64_t, ndim=1] res, kf, kr, knet, delta, equilibriumConstants
         cdef int numCoreSpecies, numCoreReactions, numEdgeSpecies, numEdgeReactions, numPdepNetworks
         cdef int i, j, z, first, second, third
-        cdef double k, V, reactionRate, T, P, Peff
+        cdef double k, V, reactionRate, revReactionRate, T, P, Peff
         cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesConcentrations, coreSpeciesRates, coreReactionRates, edgeSpeciesRates, edgeReactionRates, networkLeakRates, coreSpeciesConsumptionRates, coreSpeciesProductionRates
         cdef numpy.ndarray[numpy.float64_t, ndim=1] C, y_coreSpecies
         cdef numpy.ndarray[numpy.float64_t, ndim=2] jacobian, dgdk, colliderEfficiencies
@@ -304,23 +304,25 @@ cdef class SimpleReactor(ReactionSystem):
         for j in xrange(ir.shape[0]):
             k = kf[j]
             if ir[j,0] >= numCoreSpecies or ir[j,1] >= numCoreSpecies or ir[j,2] >= numCoreSpecies:
-                reactionRate = 0.0
+                fReactionRate = 0.0
             elif ir[j,1] == -1: # only one reactant
-                reactionRate = k * C[ir[j,0]]
+                fReactionRate = k * C[ir[j,0]]
             elif ir[j,2] == -1: # only two reactants
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]]
             else: # three reactants!! (really?)
-                reactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
             k = kr[j]
             if ip[j,0] >= numCoreSpecies or ip[j,1] >= numCoreSpecies or ip[j,2] >= numCoreSpecies:
-                pass
+                revReactionRate = 0.0
             elif ip[j,1] == -1: # only one reactant
-                reactionRate -= k * C[ip[j,0]]
+                revReactionRate = k * C[ip[j,0]]
             elif ip[j,2] == -1: # only two reactants
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]]
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]]
             else: # three reactants!! (really?)
-                reactionRate -= k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
-
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
+                
+            reactionRate = fReactionRate-revReactionRate
+            
             # Set the reaction and species rates
             if j < numCoreReactions:
                 # The reaction is a core reaction
@@ -331,26 +333,32 @@ cdef class SimpleReactor(ReactionSystem):
                 # and products are core species
                 first = ir[j,0]
                 coreSpeciesRates[first] -= reactionRate
-                coreSpeciesConsumptionRates[first] += reactionRate
+                coreSpeciesConsumptionRates[first] += fReactionRate
+                coreSpeciesProductionRates[first] += revReactionRate
                 second = ir[j,1]
                 if second != -1:
                     coreSpeciesRates[second] -= reactionRate
-                    coreSpeciesConsumptionRates[second] += reactionRate
+                    coreSpeciesConsumptionRates[second] += fReactionRate
+                    coreSpeciesProductionRates[second] += revReactionRate
                     third = ir[j,2]
                     if third != -1:
                         coreSpeciesRates[third] -= reactionRate
-                        coreSpeciesConsumptionRates[third] += reactionRate
+                        coreSpeciesConsumptionRates[third] += fReactionRate
+                        coreSpeciesProductionRates[third] += revReactionRate
                 first = ip[j,0]
                 coreSpeciesRates[first] += reactionRate
-                coreSpeciesProductionRates[first] += reactionRate
+                coreSpeciesProductionRates[first] += fReactionRate
+                coreSpeciesConsumptionRates[first] += revReactionRate
                 second = ip[j,1]
                 if second != -1:
                     coreSpeciesRates[second] += reactionRate
-                    coreSpeciesProductionRates[second] += reactionRate
+                    coreSpeciesProductionRates[second] += fReactionRate
+                    coreSpeciesConsumptionRates[second] += revReactionRate
                     third = ip[j,2]
                     if third != -1:
                         coreSpeciesRates[third] += reactionRate
-                        coreSpeciesProductionRates[third] += reactionRate
+                        coreSpeciesProductionRates[third] += fReactionRate
+                        coreSpeciesConsumptionRates[third] += revReactionRate
 
             else:
                 # The reaction is an edge reaction


### PR DESCRIPTION
This pull request implements the dynamics criterion.  The dynamic criterion is designed to work alongside the flux criterion, but instead considers how edge reactions affect core concentrations rather than the formation rates of edge species.  The dynamics criterion moves edge reactions (all species in a given edge reaction) rather than a single edge species to the core.  