### PR TITLE
Revive Reaction Group Additivity

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1915,12 +1915,15 @@ class KineticsFamily(Database):
         """
         # Start with the generic kinetics of the top-level nodes
         kinetics = None
-        for entry in self.forwardTemplate.reactants:
-            if kinetics is None and entry.data is not None:
-                kinetics = entry.data
+        root = self.getRootTemplate()
+        kinetics = self.getKineticsForTemplate(root)
+        
         if kinetics is None:
             #raise UndeterminableKineticsError('Cannot determine group additivity kinetics estimate for template "{0}".'.format(','.join([e.label for e in template])))
             return None
+        else:
+            kinetics = kinetics[0]
+            
         # Now add in more specific corrections if possible
         return self.groups.estimateKineticsUsingGroupAdditivity(template, kinetics, degeneracy)        
         

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -196,12 +196,9 @@ class KineticsGroups(Database):
             kinetics.comment += comment_line + '\n'
 
         # Also include reaction-path degeneracy
-        if isinstance(kinetics, KineticsData):
-            kinetics.kdata.value_si *= degeneracy
-        elif isinstance(kinetics, Arrhenius):
-            kinetics.A.value_si *= degeneracy
-        elif kinetics is not None:
-            raise KineticsError('Unexpected kinetics type "{0}" encountered while generating kinetics from group values.'.format(kinetics.__class__))
+
+        kinetics.changeRate(degeneracy)
+
         kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
         
         return kinetics
@@ -210,7 +207,7 @@ class KineticsGroups(Database):
         """
         Multiply two kinetics objects `kinetics1` and `kinetics2` of the same
         class together, returning their product as a new kinetics object of 
-        that class. Currently this only works for :class:`KineticsData` or
+        that class. Currently this only works for :class:`KineticsData`, :class:`ArrheniusEP` or
         :class:`Arrhenius` objects.
         """
         if isinstance(kinetics1, KineticsData) and isinstance(kinetics2, KineticsData):
@@ -222,14 +219,41 @@ class KineticsGroups(Database):
             )
         elif isinstance(kinetics1, Arrhenius) and isinstance(kinetics2, Arrhenius):
             assert kinetics1.A.units == kinetics2.A.units
-            assert kinetics1.Ea.units == kinetics2.Ea.units
             assert kinetics1.T0.units == kinetics2.T0.units
             assert kinetics1.T0.value == kinetics2.T0.value
             kinetics = Arrhenius(
                 A = (kinetics1.A.value * kinetics2.A.value, kinetics1.A.units),
                 n = (kinetics1.n.value + kinetics2.n.value, kinetics1.n.units),
-                Ea = (kinetics1.Ea.value + kinetics2.Ea.value, kinetics1.Ea.units),
+                Ea = (kinetics1.Ea.value_si + kinetics2.Ea.value_si, 'J/mol'),
                 T0 = (kinetics1.T0.value, kinetics1.T0.units),
+            )
+        elif isinstance(kinetics1,ArrheniusEP) and isinstance(kinetics2,ArrheniusEP):
+            assert kinetics1.A.units == kinetics2.A.units
+            kinetics = ArrheniusEP(
+                A = (kinetics1.A.value * kinetics2.A.value, kinetics1.A.units),
+                n = (kinetics1.n.value + kinetics2.n.value, kinetics1.n.units),
+                alpha = kinetics1.alpha+kinetics2.alpha,
+                E0 = (kinetics1.E0.value_si + kinetics2.E0.value_si, 'J/mol'),
+            )
+        elif isinstance(kinetics1,Arrhenius) and isinstance(kinetics2,ArrheniusEP):
+            assert kinetics1.A.units == kinetics2.A.units
+            assert kinetics1.T0.units == 'K'
+            assert kinetics1.T0.value == 1.0
+            kinetics = ArrheniusEP(
+                A = (kinetics1.A.value * kinetics2.A.value, kinetics1.A.units),
+                n = (kinetics1.n.value + kinetics2.n.value, kinetics1.n.units),
+                alpha = kinetics2.alpha,
+                E0 = (kinetics1.Ea.value_si + kinetics2.E0.value_si, 'J/mol'),
+            )
+        elif isinstance(kinetics1,ArrheniusEP) and isinstance(kinetics2,Arrhenius):
+            assert kinetics1.A.units == kinetics2.A.units
+            assert 'K' == kinetics2.T0.units
+            assert 1.0 == kinetics2.T0.value
+            kinetics = ArrheniusEP(
+                A = (kinetics1.A.value * kinetics2.A.value, kinetics1.A.units),
+                n = (kinetics1.n.value + kinetics2.n.value, kinetics1.n.units),
+                alpha = kinetics1.alpha,
+                E0 = (kinetics1.E0.value_si + kinetics2.Ea.value_si, 'J/mol'),
             )
         else:
             raise KineticsError('Unable to multiply kinetics types "{0}" and "{1}".'.format(kinetics1.__class__, kinetics2.__class__))


### PR DESCRIPTION
This pull request enables reaction group additivity to be trained on the current training reactions and trees and estimateKineticsUsingGroupAdditivity to be called on a given template.  

Note this does not in anyway activate group additivity kinetics, it just makes it so that the functions needed to do so run.  