### PR TITLE
allow cantera objects to use RMG names

### DIFF
--- a/ipython/canteraSimulation.ipynb
+++ b/ipython/canteraSimulation.ipynb
@@ -128,7 +128,7 @@
     "\n",
     "# Now use the altered RMG objects to modify the kinetics and thermo\n",
     "job.modifyReactionKinetics(0, rmg_rxn)\n",
-    "job.modifySpeciesThermo(4, rmg_ethane)\n",
+    "job.modifySpeciesThermo(4, rmg_ethane, useChemkinIdentifier = True)\n",
     "\n",
     "# If we modify thermo, the cantera model must be refreshed.  If only kinetics are modified, this does not need to be done.\n",
     "job.refreshModel()\n",

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -192,7 +192,7 @@ class Reaction:
         else:
             return rmgpy.chemkin.writeReactionString(self)
     
-    def toCantera(self, speciesList=None, useChemkinIdentifier = True):
+    def toCantera(self, speciesList=None, useChemkinIdentifier = False):
         """
         Converts the RMG Reaction object to a Cantera Reaction object
         with the appropriate reaction class.

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -192,10 +192,13 @@ class Reaction:
         else:
             return rmgpy.chemkin.writeReactionString(self)
     
-    def toCantera(self, speciesList=None):
+    def toCantera(self, speciesList=None, useChemkinIdentifier = True):
         """
         Converts the RMG Reaction object to a Cantera Reaction object
         with the appropriate reaction class.
+
+        If useChemkinIdentifier is set to False, the species label is used
+        instead. Be sure that species' labels are unique when setting it False.
         """
         from rmgpy.kinetics import Arrhenius, ArrheniusEP, MultiArrhenius, PDepArrhenius, MultiPDepArrhenius, Chebyshev, ThirdBody, Lindemann, Troe
                     
@@ -208,14 +211,20 @@ class Reaction:
         # for initializing the cantera reaction object
         ctReactants = {}
         for reactant in self.reactants:
-            reactantName = reactant.toChemkin()  # Use the chemkin name for the species
+            if useChemkinIdentifier:
+                reactantName = reactant.toChemkin()
+            else:
+                reactantName = reactant.label
             if reactantName in ctReactants:
                 ctReactants[reactantName] += 1
             else:
                 ctReactants[reactantName] = 1
         ctProducts = {}
         for product in self.products:
-            productName = product.toChemkin()  # Use the chemkin name for the species
+            if useChemkinIdentifier:
+                productName = product.toChemkin()
+            else:
+                productName = product.label
             if productName in ctProducts:
                 ctProducts[productName] += 1
             else:

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -1190,7 +1190,7 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         rmgObjects = [self.arrheniusBi, self.arrheniusBi_irreversible, self.arrheniusMono, self.arrheniusTri]
         
         ctObjects = [self.ct_arrheniusBi, self.ct_arrheniusBi_irreversible, self.ct_arrheniusMono, self.ct_arrheniusTri]
-        converted_ctObjects = [obj.toCantera(self.speciesList) for obj in rmgObjects]
+        converted_ctObjects = [obj.toCantera(self.speciesList, useChemkinIdentifier = True) for obj in rmgObjects]
         
         for converted_obj, ct_obj in zip(converted_ctObjects, ctObjects):
             # Check that the reaction class is the same
@@ -1206,7 +1206,7 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         """
         rmgObjects = [self.multiArrhenius]
         ctObjects = [self.ct_multiArrhenius]
-        converted_ctObjects = [obj.toCantera(self.speciesList) for obj in rmgObjects]
+        converted_ctObjects = [obj.toCantera(self.speciesList, useChemkinIdentifier = True) for obj in rmgObjects]
                 
         for converted_obj, ct_obj in zip(converted_ctObjects, ctObjects):
             # Check that the same number of reactions are produced
@@ -1226,7 +1226,7 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         """
         rmgObjects = [self.pdepArrhenius]
         ctObjects = [self.ct_pdepArrhenius]
-        converted_ctObjects = [obj.toCantera(self.speciesList) for obj in rmgObjects]
+        converted_ctObjects = [obj.toCantera(self.speciesList, useChemkinIdentifier = True) for obj in rmgObjects]
         
         for converted_obj, ct_obj in zip(converted_ctObjects, ctObjects):
             # Check that the reaction class is the same
@@ -1243,7 +1243,7 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         
         rmgObjects = [self.multiPdepArrhenius]
         ctObjects = [self.ct_multiPdepArrhenius]
-        converted_ctObjects = [obj.toCantera(self.speciesList) for obj in rmgObjects]
+        converted_ctObjects = [obj.toCantera(self.speciesList, useChemkinIdentifier = True) for obj in rmgObjects]
                 
         for converted_obj, ct_obj in zip(converted_ctObjects, ctObjects):
             # Check that the same number of reactions are produced
@@ -1262,7 +1262,7 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         """
         Tests formation of cantera reactions with Chebyshev kinetics.
         """
-        ct_chebyshev = self.chebyshev.toCantera(self.speciesList)
+        ct_chebyshev = self.chebyshev.toCantera(self.speciesList, useChemkinIdentifier = True)
         self.assertEqual(type(ct_chebyshev),type(self.ct_chebyshev))
         self.assertEqual(repr(ct_chebyshev),repr(self.ct_chebyshev))
         
@@ -1277,13 +1277,13 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         """
         Tests formation of cantera reactions with Falloff kinetics.
         """
-        ct_thirdBody = self.thirdBody.toCantera(self.speciesList)
+        ct_thirdBody = self.thirdBody.toCantera(self.speciesList, useChemkinIdentifier = True)
         self.assertEqual(type(ct_thirdBody),type(self.ct_thirdBody))
         self.assertEqual(repr(ct_thirdBody),repr(self.ct_thirdBody))
         self.assertEqual(str(ct_thirdBody.rate), str(self.ct_thirdBody.rate))
         self.assertEqual(ct_thirdBody.efficiencies, self.ct_thirdBody.efficiencies)
         
-        ct_lindemann = self.lindemann.toCantera(self.speciesList)
+        ct_lindemann = self.lindemann.toCantera(self.speciesList, useChemkinIdentifier = True)
         self.assertEqual(type(ct_lindemann),type(self.ct_lindemann))
         self.assertEqual(repr(ct_lindemann), repr(self.ct_lindemann))
         self.assertEqual(ct_lindemann.efficiencies, self.ct_lindemann.efficiencies)
@@ -1292,7 +1292,7 @@ Thermo group additivity estimation: group(Os-OsH) + gauche(Os(RR)) + other(R) + 
         self.assertEqual(str(ct_lindemann.falloff), str(self.ct_lindemann.falloff))
         
         
-        ct_troe = self.troe.toCantera(self.speciesList)
+        ct_troe = self.troe.toCantera(self.speciesList, useChemkinIdentifier = True)
         self.assertEqual(type(ct_troe),type(self.ct_troe))
         self.assertEqual(repr(ct_troe), repr(self.ct_troe))
         self.assertEqual(ct_troe.efficiencies, self.ct_troe.efficiencies)

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -257,7 +257,7 @@ class Species(object):
         from rmgpy.chemkin import getSpeciesIdentifier
         return getSpeciesIdentifier(self)
         
-    def toCantera(self, useChemkinIdentifier = True):
+    def toCantera(self, useChemkinIdentifier = False):
         """
         Converts the RMG Species object to a Cantera Species object
         with the appropriate thermo data.

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -257,10 +257,13 @@ class Species(object):
         from rmgpy.chemkin import getSpeciesIdentifier
         return getSpeciesIdentifier(self)
         
-    def toCantera(self):
+    def toCantera(self, useChemkinIdentifier = True):
         """
         Converts the RMG Species object to a Cantera Species object
         with the appropriate thermo data.
+
+        If useChemkinIdentifier is set to False, the species label is used
+        instead. Be sure that species' labels are unique when setting it False.
         """
         import cantera as ct
         
@@ -273,8 +276,10 @@ class Species(object):
                 elementDict[symbol] = 1
             else:
                 elementDict[symbol] += 1
-        
-        ctSpecies = ct.Species(self.toChemkin(), elementDict)
+        if useChemkinIdentifier:
+            ctSpecies = ct.Species(self.toChemkin(), elementDict)
+        else:
+            ctSpecies = ct.Species(self.label, elementDict)
         if self.thermo:
             try:
                 ctSpecies.thermo = self.thermo.toCantera()

--- a/rmgpy/speciesTest.py
+++ b/rmgpy/speciesTest.py
@@ -228,7 +228,7 @@ class TestSpecies(unittest.TestCase):
 Thermo library: primaryThermoLibrary
 """), molecule=[Molecule(SMILES="[Ar]")], transportData=TransportData(shapeIndex=0, epsilon=(1134.93,'J/mol'), sigma=(3.33,'angstrom'), dipoleMoment=(2,'De'), polarizability=(1,'angstrom^3'), rotrelaxcollnum=15.0, comment="""GRI-Mech"""))
         
-        rmg_ctSpecies = rmgSpecies.toCantera()
+        rmg_ctSpecies = rmgSpecies.toCantera(useChemkinIdentifier = True)
         
         ctSpecies = ct.Species.fromCti("""species(name=u'Ar',
         atoms='Ar:1',

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -246,14 +246,14 @@ class Cantera:
         Load a cantera Solution model from the job's own speciesList and reactionList attributes
         """
 
-        ctSpecies =[spec.toCantera() for spec in self.speciesList]
+        ctSpecies =[spec.toCantera(useChemkinIdentifier = True) for spec in self.speciesList]
 
         self.reactionMap = {}
         ctReactions = []
         for rxn in self.reactionList:
             index = len(ctReactions)
 
-            convertedReactions = rxn.toCantera(self.speciesList)
+            convertedReactions = rxn.toCantera(self.speciesList, useChemkinIdentifier = True)
 
             if isinstance(convertedReactions, list):
                 indices = range(index, index+len(convertedReactions))
@@ -306,20 +306,20 @@ class Cantera:
         is generated directly from rmg objects and not from a chemkin file)
         """
         indices = self.reactionMap[rmgReactionIndex]
-        modified_ctReactions = rmgReaction.toCantera(self.speciesList)
+        modified_ctReactions = rmgReaction.toCantera(self.speciesList, useChemkinIdentifier = True)
         if not isinstance(modified_ctReactions, list):
             modified_ctReactions = [modified_ctReactions]
 
         for i in range(len(indices)):
             self.model.modify_reaction(indices[i], modified_ctReactions[i])
 
-    def modifySpeciesThermo(self, rmgSpeciesIndex, rmgSpecies):
+    def modifySpeciesThermo(self, rmgSpeciesIndex, rmgSpecies, useChemkinIdentifier = False):
         """
         Modify the corresponding cantera species thermo to match that of a
         `rmgSpecies` object, given the `rmgSpeciesIndex` which indicates the
         index at which this species appears in the `speciesList`
         """
-        modified_ctSpecies = rmgSpecies.toCantera()
+        modified_ctSpecies = rmgSpecies.toCantera(useChemkinIdentifier = useChemkinIdentifier)
         ctSpecies = self.model.species(rmgSpeciesIndex)
         ctSpecies.thermo = modified_ctSpecies.thermo
 

--- a/rmgpy/tools/canteraTest.py
+++ b/rmgpy/tools/canteraTest.py
@@ -92,10 +92,10 @@ class RMGToCanteraTest(unittest.TestCase):
         
         species, reactions = loadChemkinFile(chemkinPath, dictionaryPath,transportPath) 
         
-        self.rmg_ctSpecies = [spec.toCantera() for spec in species]
+        self.rmg_ctSpecies = [spec.toCantera(useChemkinIdentifier = True) for spec in species]
         self.rmg_ctReactions = []
         for rxn in reactions:
-            convertedReactions = rxn.toCantera(species)
+            convertedReactions = rxn.toCantera(species, useChemkinIdentifier = True)
             if isinstance(convertedReactions,list):
                 self.rmg_ctReactions.extend(convertedReactions)
             else:

--- a/rmgpy/tools/muq.py
+++ b/rmgpy/tools/muq.py
@@ -286,7 +286,7 @@ class ReactorModPiece(ModPiece):
         deltaH = randomInput*uncertaintyFactor*4184.0   # Convert kcal/mol to J/mol
         
         species.thermo.changeBaseEnthalpy(deltaH)
-        self.cantera.modifySpeciesThermo(speciesIndex, species)
+        self.cantera.modifySpeciesThermo(speciesIndex, species, useChemkinIdentifier = True)
         
         
 class ReactorPCEFactory:


### PR DESCRIPTION
Added an option to 'toCantera' methods in Species and Reaction
to allow for the name of the species/reaction to be the RMG name
instead of the chemkin name. The default behavior is still the same.

We can still not create cantera input files with RMG names. This PR is just one step in addressing issue #1065.