### PR TITLE
allow cantherm to create valid chemkin files

### DIFF
--- a/documentation/source/users/cantherm/output.rst
+++ b/documentation/source/users/cantherm/output.rst
@@ -19,15 +19,12 @@ The output file contains the entire contents of the input file. In
 addition, the output file contains a block of ``pdepreaction()`` calls. The 
 parameters of each ``pdepreaction()`` block match those of the ``reaction()`` 
 block from the input file, except that no transition state data is given and 
-the ``kinetics`` are by definition pressure-dependent. 
+the ``kinetics`` are by definition pressure-dependent.
 
-A ``pdepreaction()`` item is printed for the forward and reverse direction of 
-every reaction involving isomers and reactant channels only. For reactions 
-involving a product channel, there is only a ``pdepreaction()`` item for the 
-direction in which the product channel is the product of the reaction. To use
-this output, you must either keep all of the reactions and treat them as
-irreversible, or discard the duplicate reverse directions and treat the
-remaining reactions as reversible. This decision is left to the end user.
+A ``pdepreaction()`` item is printed for each reaction pathway possible in the
+network. Each reaction is reversible. Reactions in the opposite direction are
+provided as commented out, so a user can choose to use them if she/he desires.
+
 
 Chemkin Output File
 ===================

--- a/documentation/source/users/cantherm/output.rst
+++ b/documentation/source/users/cantherm/output.rst
@@ -29,6 +29,25 @@ this output, you must either keep all of the reactions and treat them as
 irreversible, or discard the duplicate reverse directions and treat the
 remaining reactions as reversible. This decision is left to the end user.
 
+Chemkin Output File
+===================
+
+In addition to the ``output.py`` which contains the thermodynamic,
+kinetic, and pressure dependent results from a cantherm run, a Chemkin 
+input file, ``chem.inp`` is also returned. This file contains species and their 
+thermodynamic parameters for each species that has the ``thermo()`` in the 
+input file. The file also contains kinetics, both pressure dependent and high 
+pressure limit, which have the ``kinetics()`` or ``pressureDependence()`` module 
+called.
+
+For the output file to function, all the names of species should be in valid
+chemkin format. The butanol and ethyl examples both show how to obtain a valid 
+chemkin file.
+
+The ``chem.inp`` file can be used in Chemkin software package or converted to 
+a Cantera input file for use in Cantera software.
+
+
 Log File
 ========
 

--- a/examples/cantherm/networks/n-butanol/input.py
+++ b/examples/cantherm/networks/n-butanol/input.py
@@ -69,6 +69,10 @@ species(
     energyTransferModel = None,
 )
 
+thermo('H2O','NASA')
+thermo('C4H8','NASA')
+thermo('n-C4H10','NASA')
+
 ################################################################################
 
 transitionState(

--- a/examples/cantherm/reactions/H+C2H4=C2H5/input.py
+++ b/examples/cantherm/reactions/H+C2H4=C2H5/input.py
@@ -11,6 +11,10 @@ species('C2H4', '../../species/C2H4/ethene.py')
 species('C2H5', '../../species/C2H5/ethyl.py')
 transitionState('TS', 'TS.py')
 
+thermo('H','NASA')
+thermo('C2H4','NASA')
+thermo('C2H5','NASA')
+
 reaction(
     label = 'H + C2H4 <=> C2H5',
     reactants = ['H', 'C2H4'],

--- a/rmgpy/cantherm/main.py
+++ b/rmgpy/cantherm/main.py
@@ -45,7 +45,14 @@ try:
 except ImportError:
     pass
 
+from rmgpy.chemkin import writeElementsSection, writeThermoEntry, writeKineticsEntry
+
 from rmgpy.cantherm.input import loadInputFile
+
+from rmgpy.cantherm.kinetics import KineticsJob
+from rmgpy.cantherm.statmech import StatMechJob
+from rmgpy.cantherm.thermo import ThermoJob
+from rmgpy.cantherm.pdep import PressureDependenceJob
 
 ################################################################################
 
@@ -229,12 +236,40 @@ class CanTherm:
         with open(outputFile, 'w') as f:
             pass
         chemkinFile = os.path.join(self.outputDirectory, 'chem.inp')
+
+        # write the chemkin files and run the thermo and then kinetics jobs
         with open(chemkinFile, 'w') as f:
-            pass
-        
-        # Run the jobs
+            writeElementsSection(f)
+            
+            f.write('SPECIES\n\n')
+
+            # write each species in species block
+            for job in self.jobList:
+                if isinstance(job,ThermoJob):
+                    f.write(job.species.toChemkin())
+                    f.write('\n')
+
+            f.write('\nEND\n\n\n\n')
+            f.write('THERM ALL\n')
+            f.write('    300.000  1000.000  5000.000\n\n')
+
+        # run thermo jobs (printing out thermo stuff)
         for job in self.jobList:
-            job.execute(outputFile=outputFile, plot=self.plot)
-        
+            if isinstance(job,ThermoJob) or isinstance(job, StatMechJob):
+                job.execute(outputFile=outputFile, plot=self.plot)
+
+        with open(chemkinFile, 'a') as f:
+            f.write('\n')
+            f.write('END\n\n\n\n')
+            f.write('REACTIONS    KCAL/MOLE   MOLES\n\n')
+
+        # run kinetics and pdep jobs (and outputing chemkin stuff)
+        for job in self.jobList:
+            if isinstance(job,KineticsJob) or isinstance(job, PressureDependenceJob):
+                job.execute(outputFile=outputFile, plot=self.plot)
+
+        with open(chemkinFile, 'a') as f:
+            f.write('END\n\n')
+
         # Print some information to the end of the log
         self.logFooter()

--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -391,6 +391,7 @@ class PressureDependenceJob(object):
         
         logging.info('Saving pressure dependence results for {0} network...'.format(self.network.label))
         f = open(outputFile, 'a')
+        f_chemkin = open(os.path.join(os.path.dirname(outputFile), 'chem.inp'), 'a')
     
         Nreac = self.network.Nisom + self.network.Nreac
         Nprod = Nreac + self.network.Nprod
@@ -400,12 +401,27 @@ class PressureDependenceJob(object):
         Pcount = Plist.shape[0]
         
         count = 0
+        printed_reactions = [] # list of rxns already printed
         for prod in range(Nprod):
             for reac in range(Nreac):
                 if reac == prod: continue
                 reaction = self.network.netReactions[count]
                 count += 1
-                
+                # make sure we aren't double counting any reactions
+                if not any([reaction.isIsomorphic(other_rxn,checkOnlyLabel=True) \
+                            for other_rxn in printed_reactions]):
+                    duplicate = False
+                    # add reaction to printed reaction
+                    printed_reactions.append(reaction)
+                else:
+                    # comment out the extra reverse reaction
+                    duplicate = True
+
+                # write chemkin output.
+                string = writeKineticsEntry(reaction, speciesList=None, verbose=False, commented = duplicate)
+                f_chemkin.write('{0}\n'.format(string))
+
+                # write to 'output.py'
                 kdata = self.K[:,:,prod,reac].copy()
                 order = len(reaction.reactants)
                 kdata *= 1e6 ** (order-1)
@@ -436,22 +452,14 @@ class PressureDependenceJob(object):
                     [product.label for product in reaction.products],
                     reaction.kinetics,
                 )
-                f.write('{0}\n\n'.format(prettify(string)))
-        
+                pdep_function = '{0}\n\n'.format(prettify(string))
+                if duplicate:
+                    # add comments to the start of the string
+                    pdep_function = '#   ' + pdep_function.replace('\n','\n#   ')
+                f.write(pdep_function)
+
         f.close()
-        
-        f = open(os.path.join(os.path.dirname(outputFile), 'chem.inp'), 'a')
-        
-        count = 0
-        for prod in range(Nprod):
-            for reac in range(Nreac):
-                if reac == prod: continue
-                reaction = self.network.netReactions[count]
-                count += 1
-                string = writeKineticsEntry(reaction, speciesList=None, verbose=False)
-                f.write('{0}\n'.format(string))
-            
-        f.close()
+        f_chemkin.close()
 
     def plot(self, outputDirectory):
 

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1495,7 +1495,7 @@ def writeReactionString(reaction, javaLibrary = False):
     
 ################################################################################
 
-def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = False):
+def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = False, commented=False):
     """
     Return a string representation of the reaction as used in a Chemkin
     file. Use verbose = True to turn on comments.  Use javaLibrary = True in order to 
@@ -1526,8 +1526,12 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
                          specificCollider=reaction.specificCollider,
                          reversible=reaction.reversible,
                          kinetics=kinetics)
-            string += writeKineticsEntry(new_reaction, speciesList, verbose, javaLibrary)
+            string += writeKineticsEntry(new_reaction, speciesList, verbose, javaLibrary, commented)
             string += "DUPLICATE\n"
+
+        if commented:
+            # add comments to the start of each line
+            string = '! ' + string.replace('\n','\n! ')
         return string + "\n"
     
     # Add to global chemkin reaction count if the kinetics is not a duplicate
@@ -1686,6 +1690,9 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
     if reaction.duplicate:
         string += 'DUPLICATE\n'
 
+    if commented:
+        # add comments to the start of each line
+        string = '! ' + string.replace('\n','\n! ')
     return string
 
 ################################################################################

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -63,7 +63,7 @@ cdef class Reaction:
     
     cpdef bint matchesMolecules(self, list reactants)
 
-    cpdef bint isIsomorphic(self, Reaction other, bint eitherDirection=?, bint checkIdentical=?)
+    cpdef bint isIsomorphic(self, Reaction other, bint eitherDirection=?, bint checkIdentical=?, bint checkOnlyLabel=?)
 
     cpdef double getEnthalpyOfReaction(self, double T)
 
@@ -105,4 +105,4 @@ cdef class Reaction:
     
     cpdef copy(self)
 
-cpdef bint _isomorphicSpeciesList(list list1, list list2, bint checkIdentical=?)
+cpdef bint _isomorphicSpeciesList(list list1, list list2, bint checkIdentical=?, bint checkOnlyLabel=?)

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -387,7 +387,8 @@ class Reaction:
         # If we're here then neither direction matched, so return false
         return False
 
-    def isIsomorphic(self, other, eitherDirection=True, checkIdentical = False):
+    def isIsomorphic(self, other, eitherDirection=True, checkIdentical = False,
+                     checkOnlyLabel = False):
         """
         Return ``True`` if this reaction is the same as the `other` reaction,
         or ``False`` if they are different. The comparison involves comparing
@@ -395,16 +396,23 @@ class Reaction:
         information.
 
         If `eitherDirection=False` then the directions must match.
+
+        `checkIdentical` indicates that atom ID's must match and is used in
+                        checking degeneracy
+        `checkOnlyLabel` indicates that the string representation will be 
+                        checked, ignoring the molecular structure comparisons
         """
 
         # Compare reactants to reactants
         forwardReactantsMatch = _isomorphicSpeciesList(self.reactants, 
-                                    other.reactants,checkIdentical = checkIdentical)
+                                    other.reactants,checkIdentical = checkIdentical,
+                                    checkOnlyLabel = checkOnlyLabel)
         
         # Compare products to products
         forwardProductsMatch = _isomorphicSpeciesList(self.products, 
-                                    other.products,checkIdentical = checkIdentical)
-        
+                                    other.products,checkIdentical = checkIdentical,
+                                    checkOnlyLabel = checkOnlyLabel)
+
         # Compare specificCollider to specificCollider
         ColliderMatch = (self.specificCollider == other.specificCollider)
 
@@ -416,11 +424,13 @@ class Reaction:
         
         # Compare reactants to products
         reverseReactantsMatch = _isomorphicSpeciesList(self.reactants, 
-                                    other.products,checkIdentical = checkIdentical)
+                                    other.products,checkIdentical = checkIdentical,
+                                    checkOnlyLabel = checkOnlyLabel)
 
         # Compare products to reactants
         reverseProductsMatch = _isomorphicSpeciesList(self.products, 
-                                    other.reactants,checkIdentical = checkIdentical)
+                                    other.reactants,checkIdentical = checkIdentical,
+                                    checkOnlyLabel = checkOnlyLabel)
 
         # should have already returned if it matches forwards, or we're not allowed to match backwards
         return  (reverseReactantsMatch and reverseProductsMatch and ColliderMatch)
@@ -1029,7 +1039,7 @@ class Reaction:
         
         return other
 
-def _isomorphicSpeciesList(list1, list2, checkIdentical=False):
+def _isomorphicSpeciesList(list1, list2, checkIdentical=False, checkOnlyLabel = False):
     """
     This method compares whether lists of species or molecules are isomorphic
     or identical. It is used for the 'isIsomorphic' method of Reaction class.
@@ -1039,12 +1049,15 @@ def _isomorphicSpeciesList(list1, list2, checkIdentical=False):
         list2 - list of species/molecule objects of reaction2
         checkIdentical - if true, uses the 'isIdentical' comparison
                          if false, uses the 'isIsomorphic' comparison
+        checkOnlyLabel - only look at species' labels, no isomorphism checks
                          
     Returns True if the lists are isomorphic/identical & false otherwise
     """
 
-    def comparison_method(other1, other2, checkIdentical=checkIdentical):
-        if checkIdentical:
+    def comparison_method(other1, other2, checkIdentical=checkIdentical, checkOnlyLabel=checkOnlyLabel):
+        if checkOnlyLabel:
+            return str(other1) == str(other2)
+        elif checkIdentical:
             return other1.isIdentical(other2)
         else:
             return other1.isIsomorphic(other2)

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -110,6 +110,12 @@ class TestReactionIsomorphism(unittest.TestCase):
         self.assertFalse(r1.isIsomorphic(self.makeReaction('cde=ab'),eitherDirection=False))
         self.assertFalse(r1.isIsomorphic(self.makeReaction('ab=abc')))
         self.assertFalse(r1.isIsomorphic(self.makeReaction('abe=cde')))
+    def test2to3_usingCheckOnlyLabel(self):
+        r1 = self.makeReaction('AB=CDE')
+        self.assertTrue(r1.isIsomorphic(self.makeReaction('AB=CDE'),checkOnlyLabel=True))
+        self.assertTrue(r1.isIsomorphic(self.makeReaction('BA=EDC'),eitherDirection=False,checkOnlyLabel=True))
+        self.assertFalse(r1.isIsomorphic(self.makeReaction('Ab=CDE'),checkOnlyLabel=True))
+        self.assertFalse(r1.isIsomorphic(self.makeReaction('BA=EDd'),eitherDirection=False,checkOnlyLabel=True))
 
 
 class TestReaction(unittest.TestCase):


### PR DESCRIPTION
This PR allows the chemkin input file created during a cantherm run to be ready to use in chemkin/cantera. The major changes are:

1. changed order of running cantherm jobs to run species and thermo before pdep and kinetics.
2. adding headings and labels for chemkin input files.
3. modified the pdep output to not contain both forward and reverse reactions, so it is valid when output. The unused reactions are commented out.
4. updated documentation explaining the chemkin file and changes to pdep output.

When reviewing this PR, it would be helpful if you could run one of your own cantherm jobs to see if you get the intended outcome. Alternatively, you could run n-butanol and H+C2H4 examples to get complete chemkin files or acetyl+O2 to view the pdep changes. You can test the validity of `chem.inp` files by running `ck2cti --input chem.inp` on them. 