### PR TITLE
ensure identical atoms have identical labels

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -175,7 +175,8 @@ class Atom(Vertex):
                 self.radicalElectrons       == atom.radicalElectrons   and
                 self.lonePairs              == atom.lonePairs           and
                 self.charge                 == atom.charge and
-                self.atomType              is atom.atomType
+                self.atomType               is atom.atomType and
+                self.label                  == atom.label
                 )
         elif isinstance(other, gr.GroupAtom):
             cython.declare(a=AtomType, radical=cython.short, lp=cython.short, charge=cython.short)


### PR DESCRIPTION
this PR makes atoms equivalence check that the atom labels are the same. Not checking made the two adjacency lists, which need to be separate in a training reaction dictionary, identical.

```
HO
multiplicity 2
1 *1 O u1 p2 c0 {2,S}
2    H u0 p0 c0 {1,S}
```

```
HO-2
multiplicity 2
1 *4 H u0 p0 c0 {2,S}
2 *1 O u1 p2 c0 {1,S}
```

Shoutout to RMG's newest member @awaggett for finding this but.