### PR TITLE
ensure database test checks all atom labels

### DIFF
--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -409,7 +409,9 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             for j in range(i+1,len(speciesList)):
                     initialMap = {}
                     try:
-                        for atomLabel in labeledAtoms[i]:
+                        atom_labels = set(list(labeledAtoms[i].keys()) + 
+                                                list(labeledAtoms[j].keys()))
+                        for atomLabel in atom_labels:
                             initialMap[labeledAtoms[i][atomLabel]] = labeledAtoms[j][atomLabel]
                     except KeyError:
                         # atom labels did not match, therefore not a match


### PR DESCRIPTION
this PR improves database test for non-identical adjacency lists in training reactions. The previous method only checked that atom labels of the first reaction were on the second reaction. Not checking all of them made the two adjacency lists throw an error.

```
HO
multiplicity 2
1 *1 O u1 p2 c0 {2,S}
2    H u0 p0 c0 {1,S}
```

```
HO-2
multiplicity 2
1 *4 H u0 p0 c0 {2,S}
2 *1 O u1 p2 c0 {1,S}
```

Shoutout to RMG's newest member @awaggett for finding this bug.