### PR TITLE
allow all resonance structures to be used in deflating

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1704,6 +1704,7 @@ class CoreEdgeReactionModel:
         for obj in itertools.chain(deflatedRxn.reactants, deflatedRxn.products):
             if isinstance(obj, int):
                 return self.getSpecies(obj)
+        raise Exception("No core species were found in either reactants or products of {0}!".format(deflatedRxn))
 
 
 def generateReactionKey(rxn, useProducts=False):

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -366,7 +366,8 @@ def deflate(rxns, species, reactantIndices):
 
     for i, coreIndex in enumerate(reactantIndices):
         if coreIndex != -1:
-            molDict[species[i].molecule[0]] = coreIndex 
+            for mol in species[i].molecule:
+                molDict[mol] = coreIndex
 
     for rxn in rxns:
         deflateReaction(rxn, molDict)


### PR DESCRIPTION
deflate now checks all resonance structures before deflating
reaction objects. This is meant to solve issue #1077, if it is
caused by resonance structures when deflating.

Deflate could use species objects in the future, but we currently
don't have an equals or hash function for species.