### PR TITLE
Added info of reaction type to PDep network files

### DIFF
--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -44,6 +44,7 @@ import rmgpy.quantity as quantity
 from rmgpy.kinetics import Chebyshev, PDepArrhenius
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics.tunneling import Wigner, Eckart
+from rmgpy.data.kinetics.library import LibraryReaction
 
 from rmgpy.cantherm.output import prettify
 from rmgpy.chemkin import writeKineticsEntry
@@ -623,6 +624,10 @@ class PressureDependenceJob(object):
                     f.write('    kinetics = {0!r},\n'.format(rxn.kinetics))
                 if ts.tunneling is not None:
                     f.write('    tunneling = {0!r},\n'.format(ts.tunneling.__class__.__name__))
+                if isinstance(rxn,LibraryReaction):
+                    f.write('    comment = "Library reaction: {0!r}",\n'.format(rxn.library))
+                else:
+                    f.write('    comment = "Template reaction: {0!r}",\n'.format(rxn.family))
                 f.write(')\n\n')
             
             # Write network

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -48,6 +48,7 @@ cdef class Reaction:
     cdef public bint duplicate
     cdef public float _degeneracy
     cdef public list pairs
+    cdef public str comment
     cdef public dict k_effective_cache
     
     cpdef bint isIsomerization(self)

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -89,6 +89,7 @@ class Reaction:
     `duplicate`         ``bool``                    ``True`` if the reaction is known to be a duplicate, ``False`` if not
     `degeneracy`        :class:`double`             The reaction path degeneracy for the reaction
     `pairs`             ``list``                    Reactant-product pairings to use in converting reaction flux to species flux
+    `comment`           ``str``                     A description of the reaction source (optional)
     =================== =========================== ============================
     
     """
@@ -104,7 +105,8 @@ class Reaction:
                  transitionState=None,
                  duplicate=False,
                  degeneracy=1,
-                 pairs=None
+                 pairs=None,
+                 comment=''
                  ):
         self.index = index
         self.label = label
@@ -117,6 +119,7 @@ class Reaction:
         self.transitionState = transitionState
         self.duplicate = duplicate
         self.pairs = pairs
+        self.comment = comment
         
         if diffusionLimiter.enabled:
             self.k_effective_cache = {}
@@ -138,6 +141,7 @@ class Reaction:
         if self.duplicate: string += 'duplicate={0}, '.format(self.duplicate)
         if self.degeneracy != 1: string += 'degeneracy={0:.1f}, '.format(self.degeneracy)
         if self.pairs is not None: string += 'pairs={0}, '.format(self.pairs)
+        if self.comment != '': string += 'comment={0!r}, '.format(self.comment)
         string = string[:-2] + ')'
         return string
 
@@ -167,7 +171,8 @@ class Reaction:
                            self.transitionState,
                            self.duplicate,
                            self.degeneracy,
-                           self.pairs
+                           self.pairs,
+                           self.comment
                            ))
 
     def __getDegneneracy(self):
@@ -1020,6 +1025,7 @@ class Reaction:
         other.transitionState = deepcopy(self.transitionState)
         other.duplicate = self.duplicate
         other.pairs = deepcopy(self.pairs)
+        other.comment = deepcopy(self.comment)
         
         return other
 


### PR DESCRIPTION
Previously no info of the reaction type (library/family) was given in network.py files generated by Cantherm during an RMG run. This small PR adds such a comment to each reaction() function in PDep network files.