### PR TITLE
Accelerator Tools 2 (Accelerator Tools part 4)

### DIFF
--- a/examples/rmg/minimal_multisurf/input.py
+++ b/examples/rmg/minimal_multisurf/input.py
@@ -1,0 +1,68 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simpleReactor(
+    temperature=(1000,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=100,
+    toleranceInterruptSimulation=100,
+    maximumEdgeSpecies=100000,
+    toleranceMoveEdgeReactionToSurface=2.0,
+    toleranceMoveSurfaceReactionToCore=100,
+    toleranceMoveSurfaceSpeciesToCore=1e-6,
+    maxNumObjsPerIter=0,
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=True,
+)

--- a/examples/rmg/minimal_staged/input.py
+++ b/examples/rmg/minimal_staged/input.py
@@ -50,9 +50,9 @@ model(#first stage
 model( #second stage
     toleranceKeepInEdge=0.0,
     toleranceMoveToCore=0.1,
-    toleranceInterruptSimulation=0.1,
+    toleranceInterruptSimulation=1.0,
     maximumEdgeSpecies=100000,
-    maxNumObjsPerIter=2,
+    maxNumObjsPerIter=3,
     maxNumSpecies = 100,
 )
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -234,7 +234,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -251,8 +251,7 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,toleranceThermoKeepSpeciesInEdge))
-
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,terminateAtMaxObjects,toleranceThermoKeepSpeciesInEdge))
     
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -63,7 +63,7 @@ class ModelSettings(object):
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
-          toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -78,7 +78,8 @@ class ModelSettings(object):
         self.toleranceMoveSurfaceSpeciesToCore = toleranceMoveSurfaceSpeciesToCore
         self.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
         self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
-        
+        self.terminateAtMaxObjects = terminateAtMaxObjects
+
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation
         else:

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -69,6 +69,7 @@ cdef class ReactionSystem(DASx):
     #surface information
     cdef public numpy.ndarray surfaceSpeciesIndices
     cdef public numpy.ndarray surfaceReactionIndices
+    cdef public numpy.ndarray validLayeringIndices
     
     # The reaction and species rates at the current time (in mol/m^3*s)
     cdef public numpy.ndarray coreSpeciesRates
@@ -119,7 +120,7 @@ cdef class ReactionSystem(DASx):
      
     cpdef logConversions(self, speciesIndex, y0)
     
-    cpdef maxIndUnderSurfaceLayeringConstraint(self,numpy.ndarray[numpy.float64_t,ndim=1] arr,numpy.ndarray[numpy.int_t,ndim=1] surfSpeciesIndices)
+    cpdef getLayeringIndices(self)
     
     cpdef initialize_surface(self,list coreSpecies,list coreReactions,list surfaceSpecies,list surfaceReactions)
     

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -53,6 +53,8 @@ import itertools
 from cpython cimport bool
 from rmgpy.quantity import Quantity
 from rmgpy.chemkin import getSpeciesIdentifier
+from rmgpy.reaction import Reaction
+from rmgpy.species import Species
 
 ################################################################################
 
@@ -523,22 +525,24 @@ cdef class ReactionSystem(DASx):
         cdef int maxSurfaceAccumReactionIndex, maxSurfaceSpeciesIndex
         cdef object maxSurfaceAccumReaction, maxSurfaceSpecies
         cdef numpy.ndarray[numpy.float64_t,ndim=1] surfaceSpeciesProduction, surfaceSpeciesConsumption
-        cdef numpy.ndarray[numpy.float64_t,ndim=1] surfaceTotalDivAccumNums, surfaceSpeciesRates
+        cdef numpy.ndarray[numpy.float64_t,ndim=1] surfaceTotalDivAccumNums, surfaceSpeciesRateRatios
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
         cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
-        cdef bool zeroProduction, zeroConsumption, firstTime, useDynamics
+        cdef bool zeroProduction, zeroConsumption, firstTime, useDynamics, terminateAtMaxObjects, schanged
         cdef numpy.ndarray[numpy.float64_t, ndim=1] edgeReactionRates
         cdef double reactionRate, production, consumption
         cdef numpy.ndarray[numpy.int_t,ndim=1] surfaceSpeciesIndices, surfaceReactionIndices
         # cython declations for sensitivity analysis
         cdef numpy.ndarray[numpy.int_t, ndim=1] sensSpeciesIndices
         cdef numpy.ndarray[numpy.float64_t, ndim=1] moleSens, dVdk, normSens
-        cdef list time_array, normSens_array, newSurfaceReactions, newSurfaceReactionInds
+        cdef list time_array, normSens_array, newSurfaceReactions, newSurfaceReactionInds, newObjects, newObjectInds
         
         zeroProduction = False
         zeroConsumption = False
         pdepNetworks = pdepNetworks or []
-
+        
+        schanged = False
+        
         numCoreSpecies = len(coreSpecies)
         numEdgeSpecies = len(edgeSpecies)
         numPdepNetworks = len(pdepNetworks)
@@ -550,8 +554,8 @@ cdef class ReactionSystem(DASx):
         toleranceKeepInEdge = modelSettings.fluxToleranceKeepInEdge if prune else 0
         toleranceMoveToCore = modelSettings.fluxToleranceMoveToCore
         toleranceMoveEdgeReactionToCore = modelSettings.toleranceMoveEdgeReactionToCore
-        toleranceInterruptSimulation =  modelSettings.fluxToleranceInterrupt if prune else modelSettings.fluxToleranceMoveToCore
-        toleranceMoveEdgeReactionToCoreInterrupt=  modelSettings.toleranceMoveEdgeReactionToCore if prune else modelSettings.toleranceMoveEdgeReactionToCore
+        toleranceInterruptSimulation = modelSettings.fluxToleranceInterrupt
+        toleranceMoveEdgeReactionToCoreInterrupt= modelSettings.toleranceMoveEdgeReactionToCore
         toleranceMoveEdgeReactionToSurface = modelSettings.toleranceMoveEdgeReactionToSurface
         toleranceMoveSurfaceSpeciesToCore = modelSettings.toleranceMoveSurfaceSpeciesToCore
         toleranceMoveSurfaceReactionToCore = modelSettings.toleranceMoveSurfaceReactionToCore
@@ -563,6 +567,8 @@ cdef class ReactionSystem(DASx):
         sensitivityRelativeTolerance = simulatorSettings.sens_rtol
         filterReactions = modelSettings.filterReactions
         maxNumObjsPerIter = modelSettings.maxNumObjsPerIter
+        #if not pruning always terminate at max objects, otherwise only do so if terminateAtMaxObjects=True
+        terminateAtMaxObjects = True if not prune else modelSettings.terminateAtMaxObjects 
         
         useDynamics = not (toleranceMoveEdgeReactionToCore == numpy.inf and toleranceMoveEdgeReactionToSurface == numpy.inf)
         
@@ -729,71 +735,8 @@ cdef class ReactionSystem(DASx):
                                 infAccumNumIndex = spcIndex
                                 break
                     
-                #Get edge reaction with greatest total difference in Ln(accumulation number)
+                totalDivLnAccumNums = numpy.log(totalDivAccumNums)
                 
-                if len(totalDivAccumNums) > 0:
-                    maxDifLnAccumNum = numpy.inf
-                    if zeroConsumption:
-                        for index in xrange(numEdgeReactions):
-                            maxEdgeReactionAccum = 0.0
-                            maxAccumReactionIndex = -1
-                            if infAccumNumIndex in self.reactantIndices[index+numCoreReactions]:
-                                reactionRate = edgeReactionRates[index]
-                                if reactionRate > maxEdgeReactionAccum:
-                                    maxEdgeReactionAccum = reactionRate
-                                    maxAccumReactionIndex = index
-                        maxAccumReaction = edgeReactions[maxAccumReactionIndex]
-                    elif zeroProduction:
-                        for index in xrange(numEdgeReactions):
-                            maxEdgeReactionAccum = 0.0
-                            maxAccumReactionIndex = -1
-                            if infAccumNumIndex in self.productIndices[index+numCoreReactions]:
-                                reactionRate = edgeReactionRates[index]
-                                if reactionRate > maxEdgeReactionAccum:
-                                    maxEdgeReactionAccum = reactionRate
-                                    maxAccumReactionIndex = index
-                        maxAccumReaction = edgeReactions[maxAccumReactionIndex]
-                    elif len(totalDivAccumNums)>0: 
-                        maxAccumReactionIndex = numpy.argmax(totalDivAccumNums)
-                        maxAccumReaction = edgeReactions[maxAccumReactionIndex]
-                        maxDifLnAccumNum = numpy.log(totalDivAccumNums[maxAccumReactionIndex])
-                else:
-                    maxAccumReactionIndex = -1
-                    maxAccumReaction = None
-                    maxDifLnAccumNum = 0.0
-                
-                #get the reaction with the greatest total difference in Ln(accumulation number) under the surface layering constraint
-                maxLayeringReactionIndex = self.maxIndUnderSurfaceLayeringConstraint(totalDivAccumNums,surfaceSpeciesIndices)
-                if maxLayeringReactionIndex>=0: #found 
-                    maxLayeringReaction = edgeReactions[maxLayeringReactionIndex]
-                    maxLayeringDifLnAccumNum = numpy.log(totalDivAccumNums[maxLayeringReactionIndex])
-                else: 
-                    maxLayeringReaction = None
-                    maxLayeringDifLnAccumNum = 0
-            else:
-                maxAccumReactionIndex = -1
-                maxAccumReaction = None
-                maxDifLnAccumNum = 0.0
-                maxLayeringDifLnAccumNum = 0.0
-                maxLayeringReaction = None
-                maxLayeringReactionIndex = -1
-              
-            # Get the edge species with the highest flux
-            if numEdgeSpecies > 0:
-                maxSpeciesIndex = numpy.argmax(edgeSpeciesRates)
-                maxSpecies = edgeSpecies[maxSpeciesIndex]
-                maxSpeciesRate = edgeSpeciesRates[maxSpeciesIndex]
-            else:
-                maxSpeciesIndex = -1
-                maxSpecies = None
-                maxSpeciesRate = 0.0
-            if pdepNetworks:
-                maxNetworkIndex = numpy.argmax(networkLeakRates)
-                maxNetwork = pdepNetworks[maxNetworkIndex]
-                maxNetworkRate = networkLeakRates[maxNetworkIndex]
-                
-            #calculate criteria for surface species
-            if useDynamics:
                 surfaceTotalDivAccumNums = numpy.ones(len(surfaceReactionIndices))
                 
                 for i in xrange(len(surfaceReactionIndices)):
@@ -831,76 +774,50 @@ cdef class ReactionSystem(DASx):
                                 zeroProduction = True #otherwise include edge reaction with most flux
                                 infAccumNumIndex = spcIndex
                                 break
-    
-                #Get surface reaction with greatest total difference in Ln(accumulation number)
+                            
+                surfaceTotalDivAccumNums = numpy.log(surfaceTotalDivAccumNums)
+                    
+                surfaceObjects = []
+                surfaceObjectIndices = []
+                surfaceSpeciesIndices = self.surfaceSpeciesIndices
+                surfaceReactionIndices = self.surfaceReactionIndices
                 
-                if len(surfaceTotalDivAccumNums) > 0:
-                    maxSurfaceDifLnAccumNum = numpy.inf
-                    if zeroConsumption:
-                        for i in xrange(len(surfaceReactionIndices)):
-                            index = surfaceReactionIndices[i]
-                            maxSurfaceReactionAccum = 0.0 
-                            maxSurfaceAccumReactionIndex = -1
-                            if surfaceInfAccumNumIndex in reactantIndices[index]:
-                                reactionRate = coreReactionRates[index]
-                                if reactionRate > maxEdgeReactionAccum:
-                                    maxSurfaceReactionAccum = reactionRate
-                                    maxSurfaceAccumReactionIndex = i
-                        maxSurfaceAccumReaction = surfaceReactions[maxSurfaceAccumReactionIndex]
-                    elif zeroProduction:
-                        for i in xrange(len(surfaceReactionIndices)):
-                            index = surfaceReactionIndices[i]
-                            maxSurfaceReactionAccum = 0.0
-                            maxSurfaceAccumReactionIndex = -1
-                            if surfaceInfAccumNumIndex in productIndices[index]:
-                                reactionRate = coreReactionRates[index]
-                                if reactionRate > maxEdgeReactionAccum:
-                                    maxSurfaceReactionAccum = reactionRate
-                                    maxSurfaceAccumReactionIndex = i
-                        maxSurfaceAccumReaction = surfaceReactions[maxSurfaceAccumReactionIndex]
-                    elif len(surfaceTotalDivAccumNums)>0: 
-                        maxSurfaceAccumReactionIndex = numpy.argmax(surfaceTotalDivAccumNums)
-                        maxSurfaceAccumReaction = surfaceReactions[maxSurfaceAccumReactionIndex]
-                        maxSurfaceDifLnAccumNum = numpy.log(surfaceTotalDivAccumNums[maxSurfaceAccumReactionIndex])
-                else:
-                    maxSurfaceAccumReactionIndex = -1
-                    maxSurfaceAccumReaction = None
-                    maxSurfaceDifLnAccumNum = 0.0
+                #movement from surface to core
+                if surfaceReactionIndices != []:
+                    #manage surface reaction movement "on the fly"
+                    for ind in xrange(len(surfaceTotalDivAccumNums)): #move surface reactions to core
+                        if surfaceTotalDivAccumNums[ind] > toleranceMoveSurfaceReactionToCore:
+                            sind = surfaceReactionIndices[ind]
+                            surfaceObjectIndices.append(sind)
+                            surfaceObjects.append(coreReactions[sind])
                     
-                #manage surface reaction movement "on the fly"
-                if maxSurfaceAccumReaction and maxSurfaceDifLnAccumNum > toleranceMoveSurfaceReactionToCore:
-                    logging.info('Moving reaction {0} from surface to core'.format(maxSurfaceAccumReaction))
-                    surfaceReactions.remove(maxSurfaceAccumReaction)
-                    surfaceSpecies,surfaceReactions =self.initialize_surface(coreSpecies,coreReactions,surfaceSpecies,surfaceReactions)
-                    surfaceSpeciesIndices = self.surfaceSpeciesIndices
-                    surfaceReactionIndices = self.surfaceReactionIndices
-                    logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
-
-                #surface flux calculations
-                surfaceSpeciesRates = numpy.zeros(len(surfaceSpeciesIndices))
-                surfaceSpeciesProduction = coreSpeciesProductionRates[surfaceSpeciesIndices]
-                surfaceSpeciesConsumption = coreSpeciesConsumptionRates[surfaceSpeciesIndices]
-                for i in xrange(len(surfaceSpeciesIndices)):
-                    surfaceSpeciesRates[i] = max(abs(surfaceSpeciesProduction[i]),abs(surfaceSpeciesConsumption[i]))
+                    #surface flux calculations
+                    surfaceSpeciesRateRatios = numpy.zeros(len(surfaceSpeciesIndices))
+                    surfaceSpeciesProduction = coreSpeciesProductionRates[surfaceSpeciesIndices]
+                    surfaceSpeciesConsumption = coreSpeciesConsumptionRates[surfaceSpeciesIndices]
                     
-                if len(surfaceSpeciesIndices) > 0:
-                    maxSurfaceSpeciesIndex = numpy.argmax(surfaceSpeciesRates)
-                    maxSurfaceSpecies = surfaceSpecies[maxSurfaceSpeciesIndex]
-                    maxSurfaceSpeciesRate = surfaceSpeciesRates[maxSurfaceSpeciesIndex]
-                else:
-                    maxSurfaceSpeciesIndex = -1
-                    maxSurfaceSpecies = None
-                    maxSurfaceSpeciesRate = 0.0
-               
-                #manage surface species movement "on the fly"
-                if maxSurfaceSpecies and maxSurfaceSpeciesRate/charRate > toleranceMoveSurfaceSpeciesToCore:
-                    logging.info('Moving species {0} from surface to core'.format(maxSurfaceSpecies))
-                    surfaceSpecies.remove(maxSurfaceSpecies)
-                    surfaceSpecies,surfaceReactions = self.initialize_surface(coreSpecies,coreReactions,surfaceSpecies,surfaceReactions)
-                    surfaceSpeciesIndices = self.surfaceSpeciesIndices
-                    surfaceReactionIndices = self.surfaceReactionIndices
-                    logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
+                    for i in xrange(len(surfaceSpeciesIndices)):
+                        surfaceSpeciesRateRatios[i] = max(abs(surfaceSpeciesProduction[i]),abs(surfaceSpeciesConsumption[i]))/charRate
                     
+                    for ind in xrange(len(surfaceSpeciesIndices)):
+                        if surfaceSpeciesRateRatios[i] > toleranceMoveSurfaceSpeciesToCore:
+                            sind = surfaceSpeciesIndices[ind]
+                            surfaceObjectIndices.append(sind)
+                            surfaceObjects.append(coreSpecies[sind])
+                    
+                    if len(surfaceObjects) > 0:
+                        for ind,obj in enumerate(surfaceObjects):
+                            if isinstance(obj,Reaction):
+                                logging.info('Moving reaction {0} from surface to core'.format(obj))
+                                surfaceReactions.remove(obj)
+                            elif isinstance(obj,Species):
+                                logging.info('Moving species {0} from surface to core'.format(obj))
+                                surfaceSpecies.remove(obj)
+                            else:
+                                raise ValueError
+                        surfaceSpecies,surfaceReactions = self.initialize_surface(coreSpecies,coreReactions,surfaceSpecies,surfaceReactions)
+                        logging.info('Surface now has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
+                
             if filterReactions:
                 # Calculate unimolecular and bimolecular thresholds for reaction
                 # Set the maximum unimolecular rate to be kB*T/h
@@ -918,67 +835,90 @@ cdef class ReactionSystem(DASx):
                             if coreSpeciesConcentrations[i]*coreSpeciesConcentrations[j] > bimolecularThresholdVal:
                                 bimolecularThreshold[i,j] = True
 
-                # Interrupt simulation if that flux exceeds the characteristic rate times a tolerance
-            if (maxSpecies not in invalidObjects) and (not ignoreOverallFluxCriterion) and (maxSpeciesRate > toleranceMoveToCore * charRate) and len(invalidObjects) < maxNumObjsPerIter:
-                logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for moving to model core'.format(self.t, maxSpecies))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
-                logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
-                self.logConversions(speciesIndex, y0)
-                invalidObjects.append(maxSpecies)
-            if len(invalidObjects) >= maxNumObjsPerIter and (not ignoreOverallFluxCriterion) and (maxSpeciesRate > toleranceInterruptSimulation * charRate):
-                logging.info('At time {0:10.4e} s, species {1} exceeded the minimum rate for simulation interruption'.format(self.t, maxSpecies))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
-                self.logConversions(speciesIndex, y0)
-                break
+            newObjectInds = []
+            newObjects = []
+            newSurfaceRxnInds = []
+            interrupt = False
             
-            #Interrupt simulation if the difference in natural log of total accumulation number exceeds tolerance
-            #large tolerance case
-            if (maxAccumReaction not in invalidObjects) and maxDifLnAccumNum > toleranceMoveEdgeReactionToCore and len(invalidObjects) < maxNumObjsPerIter:
-                logging.info('At time {0:10.4e} s, Reaction {1} exceeded the minimum difference in total log(accumulation number) for moving to model core'.format(self.t, maxAccumReaction))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
-                logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
-                self.logConversions(speciesIndex, y0)
-                invalidObjects.append(maxAccumReaction)
-            if len(invalidObjects) >= maxNumObjsPerIter and maxDifLnAccumNum > toleranceMoveEdgeReactionToCoreInterrupt:
-                logging.info('At time {0:10.4e} s, Reaction {1} exceeded the minimum difference in total log(accumulation number) for simulation interruption'.format(self.t, maxAccumReaction))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
-                self.logConversions(speciesIndex, y0)
-                break
+            #if that flux exceeds the characteristic rate times a tolerance
+            if not ignoreOverallFluxCriterion:
+                for ind,obj in enumerate(edgeSpecies):
+                    RR = edgeSpeciesRateRatios[ind]
+                    if RR > toleranceMoveToCore:
+                        if not(obj in newObjects or obj in invalidObjects):
+                            newObjects.append(edgeSpecies[ind])
+                            newObjectInds.append(ind)
+                    if RR > toleranceInterruptSimulation:
+                        logging.info('At time {0:10.4e} s, species {1} at {2} exceeded the minimum rate for simulation interruption of {3}'.format(self.t, obj, RR, toleranceInterruptSimulation))
+                        interrupt = True
+            if useDynamics:     
+                #if the difference in natural log of total accumulation number exceeds tolerance 
+                validLayeringIndices = self.validLayeringIndices
+             
+                for ind,obj in enumerate(edgeReactions):
+                    dlnaccum = totalDivLnAccumNums[ind]
+                    if dlnaccum > toleranceMoveEdgeReactionToCore:
+                        if not(obj in newObjects or obj in invalidObjects):
+                            newObjects.append(edgeReactions[ind])
+                            newObjectInds.append(ind)
+                    elif dlnaccum > toleranceMoveEdgeReactionToSurface and ind in validLayeringIndices:
+                        if not(obj in newObjects or obj in invalidObjects):
+                            newObjects.append(edgeReactions[ind])
+                            newObjectInds.append(ind)
+                            newSurfaceRxnInds.append(len(newObjects)-1)
+                    if dlnaccum > toleranceMoveEdgeReactionToCoreInterrupt:
+                        logging.info('At time {0:10.4e} s, Reaction {1} at {2} exceeded the minimum difference in total log(accumulation number) for simulation interruption of {3}'.format(self.t, obj,dlnaccum,toleranceMoveEdgeReactionToCoreInterrupt))
+                        interrupt = True
             
-            #move species to surface and interrupt if the difference in natural log of total accumulation number exceeds tolerance
-            #small tolerance case
-            if (maxLayeringReaction not in invalidObjects) and maxLayeringDifLnAccumNum > toleranceMoveEdgeReactionToSurface and len(invalidObjects) < maxNumObjsPerIter:
-                invalidObjects.append(maxLayeringReaction)
-                newSurfaceReactions.append(maxLayeringReaction)
-                newSurfaceReactionInds.append(maxLayeringReactionIndex)
-                
-                logging.info('At time {0:10.4e} s, Reaction {1} exceeded the minimum difference in total log(accumulation number) for moving from edge to model surface'.format(self.t, maxAccumReaction))
-                self.logRates(charRate, maxSpecies, maxSpeciesRate, maxLayeringDifLnAccumNum, maxNetwork, maxNetworkRate)
-                logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
-                self.logConversions(speciesIndex, y0)
-                
-
-                if len(invalidObjects) >= maxNumObjsPerIter and maxLayeringDifLnAccumNum > toleranceMoveEdgeReactionToSurfaceInterrupt: 
-                    logging.info('At time {0:10.4e} s, Reaction {1} exceeded the minimum difference in total log(accumulation number) for simulation interruption'.format(self.t, maxAccumReaction))
-                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxLayeringDifLnAccumNum, maxNetwork, maxNetworkRate)
-                    self.logConversions(speciesIndex, y0)
-                    break
-            
-           
-            # If pressure dependence, also check the network leak fluxes
+            #if the network leak rate ratios exceed tolerance
             if pdepNetworks:
-                if (maxNetwork not in invalidObjects) and maxNetworkRate > toleranceMoveToCore * charRate and len(invalidObjects) < maxNumObjsPerIter:
-                    logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} exceeded the minimum rate for exploring'.format(self.t, maxNetwork.index))
-                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
-                    logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
-                    self.logConversions(speciesIndex, y0)
-                    invalidObjects.append(maxNetwork)
-                if len(invalidObjects) >= maxNumObjsPerIter and maxNetworkRate > toleranceInterruptSimulation * charRate:
-                    logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} exceeded the minimum rate for simulation interruption'.format(self.t, maxNetwork.index))
-                    self.logRates(charRate, maxSpecies, maxSpeciesRate, maxDifLnAccumNum, maxNetwork, maxNetworkRate)
-                    logging.info('Surface has {0} Species and {1} Reactions'.format(len(surfaceSpeciesIndices),len(surfaceReactionIndices)))
-                    self.logConversions(speciesIndex, y0)
-                    break
+                for ind,obj in enumerate(pdepNetworks):
+                    LR = networkLeakRateRatios[ind]
+                    if LR > toleranceMoveToCore:
+                        if not(obj in newObjects or obj in invalidObjects):
+                            newObjects.append(pdepNetworks[ind])
+                            newObjectInds.append(ind)
+                    if LR > toleranceInterruptSimulation:
+                        logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} at {2} exceeded the minimum rate for simulation interruption of {3}'.format(self.t, obj.index,LR,toleranceInterruptSimulation))
+                        interrupt = True
+            
+            #remove excess objects
+            if len(invalidObjects) + len(newObjects) > maxNumObjsPerIter:
+                logging.info('Exceeded max number of objects...removing excess objects')
+                num = maxNumObjsPerIter - len(invalidObjects)
+                newObjects = newObjects[:num]
+                newObjectInds = newObjectInds[:num]
+            
+            if terminateAtMaxObjects and len(invalidObjects) >= maxNumObjsPerIter:
+                logging.info('Reached max number of objects...preparing to terminate')
+                interrupt = True
+            
+            if newObjects != []:
+                for i,obj in enumerate(newObjects): #log everything and add reactions to surface
+                    ind = newObjectInds[i]
+                    if isinstance(obj,Species):
+                        logging.info('At time {0:10.4e} s, species {1} at rate ratio {2} exceeded the minimum rate for moving to model core of {3}'.format(self.t, obj,edgeSpeciesRateRatios[ind],toleranceMoveToCore))
+                    elif isinstance(obj,Reaction):
+                        dlnaccum = totalDivLnAccumNums[ind]
+                        if i in newSurfaceRxnInds:
+                            logging.info('At time {0:10.4e} s, Reaction {1} at {2} exceeded the minimum difference in total log(accumulation number) for moving to model surface of {3}'.format(self.t, obj, dlnaccum,toleranceMoveEdgeReactionToSurface))
+                            newSurfaceReactions.append(obj)
+                            newSurfaceReactionInds.append(ind)
+                        else:
+                            logging.info('At time {0:10.4e} s, Reaction {1} at {2} exceeded the minimum difference in total log(accumulation number) for moving to model core of {3}'.format(self.t, obj, dlnaccum,toleranceMoveEdgeReactionToCore))
+                    else: 
+                        logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} at {2} exceeded the minimum rate for exploring of {3}'.format(self.t, maxNetwork.index, networkLeakRateRatios[ind],toleranceMoveToCore))
+    
+                
+                invalidObjects += newObjects
+                
+            if schanged: #reinitialize surface
+                surfaceSpecies,surfaceReactions = self.initialize_surface(coreSpecies,coreReactions,surfaceSpecies,surfaceReactions)
+                schanged = False
+                
+            if interrupt: #breaks while loop terminating iterations
+                logging.info('terminating simulation due to interrupt...')
+                break
 
             # Finish simulation if any of the termination criteria are satisfied
             for term in self.termination:

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -696,7 +696,7 @@ cdef class ReactionSystem(DASx):
                 if maxNetworkLeakRateRatios[index] < networkLeakRateRatios[index]:
                     maxNetworkLeakRateRatios[index] = networkLeakRateRatios[index]
             
-            if useDynamics and charRate == 0 and len(edgeSpeciesRates)>0:
+            if charRate == 0 and len(edgeSpeciesRates)>0:
                 maxSpeciesIndex = numpy.argmax(edgeSpeciesRates)
                 maxSpecies = edgeSpecies[maxSpeciesIndex]
                 maxSpeciesRate = edgeSpeciesRates[maxSpeciesIndex]

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -909,7 +909,7 @@ cdef class ReactionSystem(DASx):
                         else:
                             logging.info('At time {0:10.4e} s, Reaction {1} at {2} exceeded the minimum difference in total log(accumulation number) for moving to model core of {3}'.format(self.t, obj, dlnaccum,toleranceMoveEdgeReactionToCore))
                     else: 
-                        logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} at {2} exceeded the minimum rate for exploring of {3}'.format(self.t, maxNetwork.index, networkLeakRateRatios[ind],toleranceMoveToCore))
+                        logging.info('At time {0:10.4e} s, PDepNetwork #{1:d} at {2} exceeded the minimum rate for exploring of {3}'.format(self.t, obj.index, networkLeakRateRatios[ind],toleranceMoveToCore))
     
                 
                 invalidObjects += newObjects

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -737,6 +737,10 @@ cdef class ReactionSystem(DASx):
                     
                 totalDivLnAccumNums = numpy.log(totalDivAccumNums)
                 
+                surfaceSpeciesIndices = self.surfaceSpeciesIndices
+                surfaceReactionIndices = self.surfaceReactionIndices
+                
+                #calculate criteria for surface species
                 surfaceTotalDivAccumNums = numpy.ones(len(surfaceReactionIndices))
                 
                 for i in xrange(len(surfaceReactionIndices)):
@@ -779,8 +783,6 @@ cdef class ReactionSystem(DASx):
                     
                 surfaceObjects = []
                 surfaceObjectIndices = []
-                surfaceSpeciesIndices = self.surfaceSpeciesIndices
-                surfaceReactionIndices = self.surfaceReactionIndices
                 
                 #movement from surface to core
                 if surfaceReactionIndices != []:

--- a/rmgpy/solver/baseTest.py
+++ b/rmgpy/solver/baseTest.py
@@ -102,10 +102,10 @@ class ReactionSystemTest(unittest.TestCase):
         self.assertEquals(len(reactionSystem.surfaceSpeciesIndices),1) #surfaceSpeciesIndices calculated correctly
         self.assertEquals(reactionSystem.surfaceSpeciesIndices[0],5) #surfaceSpeciesIndices calculated correctly
 
-        arr = numpy.array([5.,1.,2.])
-        ind = reactionSystem.maxIndUnderSurfaceLayeringConstraint(arr,reactionSystem.surfaceSpeciesIndices)
-        
-        self.assertEquals(ind,2) #maxIndUnderSurfaceLayeringConstraint worked correctly
+        inds = reactionSystem.getLayeringIndices()
+
+        self.assertEquals(inds[0],1) #worked correctly
+        self.assertEquals(inds[1],2)
     
     def testAddReactionsToSurface(self):
         """


### PR DESCRIPTION
This pull request implements true adding multiple species at a time.  The original Accelerator Tools only considers the object with the highest value of a given criterion so for it multiple species only applied to objects that had the highest value when they were greater than the set tolerance.  

Since this required entirely restructuring base.pyx this wasn't included in the original Accelerator Tools pull request.  

Now each iteration all new objects violating a tolerance are added to a list and all termination criteria related to tolerances and object number are checked.  Objects exceeding the maximum number of objects are removed from the list (the last objects in the list are removed first).  Then the list of new objects is iterated through and everything is added to invalidObjects, if necessary the surface is reinitialized.  At this point if any of the termination criteria triggered during the process it will interrupt the simulation (after adding objects to invalidObjects/surface reinitialization).  

This is based from #997.  