### PR TITLE
Changes to fixBarrierHeight

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -583,19 +583,21 @@ class Reaction:
         if isinstance(self.kinetics, ArrheniusEP):
             Ea = self.kinetics.E0.value_si # temporarily using Ea to store the intrinsic barrier height E0
             self.kinetics = self.kinetics.toArrhenius(H298)
-            if Ea > 0 and self.kinetics.Ea.value_si < 0:
-                self.kinetics.comment += "\nEa raised from {0:.1f} to 0 kJ/mol.".format(self.kinetics.Ea.value_si/1000)
-                logging.info("For reaction {1!s} Ea raised from {0:.1f} to 0 kJ/mol.".format(self.kinetics.Ea.value_si/1000, self))
-                self.kinetics.Ea.value_si = 0
+            if self.kinetics.Ea.value_si < 0.0 and self.kinetics.Ea.value_si < Ea:
+                # Calculated Ea (from Evans-Polanyi) is negative AND below than the intrinsic E0
+                Ea = min(0.0,Ea) # (the lowest we want it to be)
+                self.kinetics.comment += "\nEa raised from {0:.1f} to {1:.1f} kJ/mol.".format(self.kinetics.Ea.value_si/1000., Ea/1000.)
+                logging.info("For reaction {0!s} Ea raised from {1:.1f} to {2:.1f} kJ/mol.".format(self, self.kinetics.Ea.value_si/1000., Ea/1000.))
+                self.kinetics.Ea.value_si = Ea
         if isinstance(self.kinetics, Arrhenius):
             Ea = self.kinetics.Ea.value_si
-            if H0 > 0 and Ea < H0:
+            if H0 >= 0 and Ea < H0:
                 self.kinetics.Ea.value_si = H0
-                self.kinetics.comment += "\nEa raised from {0:.1f} to {1:.1f} kJ/mol to match endothermicity of reaction.".format(Ea/1000,H0/1000)
-                logging.info("For reaction {2!s}, Ea raised from {0:.1f} to {1:.1f} kJ/mol to match endothermicity of reaction.".format(Ea/1000, H0/1000, self))
+                self.kinetics.comment += "\nEa raised from {0:.1f} to {1:.1f} kJ/mol to match endothermicity of reaction.".format(Ea/1000.,H0/1000.)
+                logging.info("For reaction {2!s}, Ea raised from {0:.1f} to {1:.1f} kJ/mol to match endothermicity of reaction.".format(Ea/1000., H0/1000., self))
         if forcePositive and isinstance(self.kinetics, Arrhenius) and self.kinetics.Ea.value_si < 0:
-            self.kinetics.comment += "\nEa raised from {0:.1f} to 0 kJ/mol.".format(self.kinetics.Ea.value_si/1000)
-            logging.info("For reaction {1!s} Ea raised from {0:.1f} to 0 kJ/mol.".format(self.kinetics.Ea.value_si/1000, self))
+            self.kinetics.comment += "\nEa raised from {0:.1f} to 0 kJ/mol.".format(self.kinetics.Ea.value_si/1000.)
+            logging.info("For reaction {1!s} Ea raised from {0:.1f} to 0 kJ/mol.".format(self.kinetics.Ea.value_si/1000., self))
             self.kinetics.Ea.value_si = 0
 
 


### PR DESCRIPTION
Should fix #1086

Now ought to address the problem of exothermic reactions 
giving negative activation energies as a result of Evans-Polanyi
expressions for any value of E0  (previously it only worked if E0>0).

The aim of this code is as follows:
Calculated Ea values are allowed to be as negative as E0 if E0 
is negative, but if E0 is positive then Ea cannot be below 0.