### PR TITLE
kill ssh-agent process after travis deploys RMG-tests 

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -76,3 +76,6 @@ git commit --allow-empty -m rmgpy-$REV
 
 # push to the branch to the RMG/RMG-tests repo:
 git push -f $REPO $RMGTESTSBRANCH > /dev/null
+
+# kill ssh-agent if neccessary
+ssh-agent -k


### PR DESCRIPTION
This PR tries to fix the issue #1091 , where Travis fails to detect that unittests are already finished.

The reason is that in `deploy.sh` we run `ssh-agent -s` which creates a child process that is listened/waited by Travis; even with all the tests finished, travis still thinks there's something going on. 

The solution is to kill `ssh-agent` after all the steps done.