### PR TITLE
automatic seed mechanism generation

### DIFF
--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -150,6 +150,16 @@ model(
 )
 
 options(
+    	#provides a name for the seed mechanism produced at the end of an rmg run default is 'Seed'
+    name='SeedName',	
+	#if True every iteration it saves the current model as libraries/seeds
+	#(and deletes the old one)
+	#Unlike HTML this is inexpensive time-wise
+	#note a seed mechanism will be generated at the end of a completed run and some incomplete 
+	#runs even if this is set as False
+    generateSeedEachIteration=True,
+	#If True the mechanism will also be saved directly as kinetics and thermo libraries in the database
+    saveSeedToDatabase=False,
 	#only option is 'si'
     units='si',
 	#how often you want to save restart files.  

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -90,10 +90,6 @@ def saveEntry(f, entry):
         #Write out additional data if depository or library
         #kinetic rules would have a Group object for its reactants instead of Species
         if isinstance(entry.item.reactants[0], Species):
-            if entry.label != str(entry.item):
-                raise KineticsError("Reactions are now defined solely by their labels, "
-                                                    "but reaction {0!s} has label {1!r}".format(
-                                                     entry.item, entry.label))
             # Add degeneracy if the reaction is coming from a depository or kinetics library
             f.write('    degeneracy = {0:.1f},\n'.format(entry.item.degeneracy))
             if entry.item.duplicate:

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -241,7 +241,7 @@ class KineticsLibrary(Database):
             rxn = entry.item
             rxn_string = entry.label
             # Convert the reactants and products to Species objects using the speciesDict
-            reactants, products = rxn_string.split('=')
+            reactants, products = rxn_string.split('=>')
             reversible = True
             if '<=>' in rxn_string:
                 reactants = reactants[:-1]

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -150,12 +150,20 @@ class Reaction:
         Return a string representation of the reaction, in the form 'A + B <=> C + D'.
         If a specificCollider exists, the srting representation is 'A + B (+S) <=> C + D (+S)'.
         """
+        return self.toLabeledStr(use_index=True)
+    
+    def toLabeledStr(self, use_index=False):
+        """
+        the same as __str__ except that the labels are assumed to exist and used for reactant and products rather than 
+        the labels plus the index in parentheses
+        """
         arrow = ' <=> '
         if not self.reversible: arrow = ' => '
+        
         if self.specificCollider:
-            return arrow.join([' + '.join([str(s) for s in self.reactants])+' (+'+str(self.specificCollider)+')', ' + '.join([str(s) for s in self.products])+' (+'+str(self.specificCollider)+')'])
+            return arrow.join([' + '.join([str(s) if use_index else s.label for s in self.reactants])+' (+'+str(self.specificCollider)+')', ' + '.join([str(s) if use_index else s.label for s in self.products])+' (+'+str(self.specificCollider)+')'])
         else:
-            return arrow.join([' + '.join([str(s) for s in self.reactants]), ' + '.join([str(s) for s in self.products])])
+            return arrow.join([' + '.join([str(s) if use_index else s.label for s in self.reactants]), ' + '.join([str(s) if use_index else s.label for s in self.products])])
 
     def __reduce__(self):
         """

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -350,8 +350,12 @@ def pressureDependence(
     rmg.pressureDependence.activeKRotor = True
     rmg.pressureDependence.rmgmode = True
 
-def options(name='Seed',units='si', saveRestartPeriod=None, generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, saveEdgeSpecies=False, keepIrreversible=False, wallTime='00:00:00:00'):
+def options(name='Seed', generateSeeds=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None, 
+            generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, 
+            saveEdgeSpecies=False, keepIrreversible=False, wallTime='00:00:00:00'):
     rmg.name = name
+    rmg.generateSeeds=generateSeeds
+    rmg.saveSeedToDatabase=saveSeedToDatabase
     rmg.units = units
     rmg.saveRestartPeriod = Quantity(saveRestartPeriod) if saveRestartPeriod else None
     if generateOutputHTML:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -350,7 +350,8 @@ def pressureDependence(
     rmg.pressureDependence.activeKRotor = True
     rmg.pressureDependence.rmgmode = True
 
-def options(units='si', saveRestartPeriod=None, generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, saveEdgeSpecies=False, keepIrreversible=False, wallTime='00:00:00:00'):
+def options(name='Seed',units='si', saveRestartPeriod=None, generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, saveEdgeSpecies=False, keepIrreversible=False, wallTime='00:00:00:00'):
+    rmg.name = name
     rmg.units = units
     rmg.saveRestartPeriod = Quantity(saveRestartPeriod) if saveRestartPeriod else None
     if generateOutputHTML:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -350,11 +350,11 @@ def pressureDependence(
     rmg.pressureDependence.activeKRotor = True
     rmg.pressureDependence.rmgmode = True
 
-def options(name='Seed', generateSeeds=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None, 
+def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None, 
             generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False, 
             saveEdgeSpecies=False, keepIrreversible=False, wallTime='00:00:00:00'):
     rmg.name = name
-    rmg.generateSeeds=generateSeeds
+    rmg.generateSeedEachIteration=generateSeedEachIteration
     rmg.saveSeedToDatabase=saveSeedToDatabase
     rmg.units = units
     rmg.saveRestartPeriod = Quantity(saveRestartPeriod) if saveRestartPeriod else None

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -825,8 +825,11 @@ class RMG(util.Subject):
                 while name+str(q) in thermoNames or name+str(q) in kineticsNames:
                     q += 1
                 self.name = name + str(q)
-            
-        if not os.path.exists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it
+        
+        if firstTime and not os.path.exists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it
+            os.system('mkdir seed')
+        else:
+            os.system('rm -rf seed') #otherwise delete the old seed and make a new directory
             os.system('mkdir seed')
             
         speciesList = self.reactionModel.core.species

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -874,15 +874,13 @@ class RMG(util.Subject):
         kineticsLibrary.checkForDuplicates(markDuplicates=True)
         kineticsLibrary.convertDuplicatesToMulti()
     
-        # Save in Py formatp
-        databaseDirectory = settings['database.directory']
-        try:
-            os.makedirs(os.path.join(databaseDirectory, 'kinetics', 'libraries',name))
-        except:
-            pass
-        
         #save in database
         if self.saveSeedToDatabase:
+            databaseDirectory = settings['database.directory']
+            try:
+                os.makedirs(os.path.join(databaseDirectory, 'kinetics', 'libraries',name))
+            except:
+                pass
             thermoLibrary.save(os.path.join(databaseDirectory, 'thermo' ,'libraries', name + '.py'))
             kineticsLibrary.save(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'reactions.py'))
             kineticsLibrary.saveDictionary(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'dictionary.txt'))

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -205,6 +205,10 @@ class RMG(util.Subject):
         self.wallTime = '00:00:00:00'
         self.initializationTime = 0
         self.kineticsdatastore = None
+        
+        self.name = None
+        self.generateSeeds = None
+        self.saveSeedToDatabase = None
 
         self.thermoCentralDatabase = None
 
@@ -631,7 +635,8 @@ class RMG(util.Subject):
                 self.reactionModel.surfaceSpecies = surfaceSpecies
                 self.reactionModel.surfaceReactions = surfaceReactions
 
-                self.makeSeedMech()
+                if self.generateSeeds:
+                    self.makeSeedMech()
 
                 allTerminated = allTerminated and terminated
                 logging.info('')
@@ -885,9 +890,10 @@ class RMG(util.Subject):
             pass
         
         #save in database
-        thermoLibrary.save(os.path.join(databaseDirectory, 'thermo' ,'libraries', name + '.py'))
-        kineticsLibrary.save(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'reactions.py'))
-        kineticsLibrary.saveDictionary(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'dictionary.txt'))
+        if self.saveSeedToDatabase:
+            thermoLibrary.save(os.path.join(databaseDirectory, 'thermo' ,'libraries', name + '.py'))
+            kineticsLibrary.save(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'reactions.py'))
+            kineticsLibrary.saveDictionary(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'dictionary.txt'))
         
         seedDir = os.path.join(os.getcwd(),'seed')
         

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -792,13 +792,16 @@ class RMG(util.Subject):
         
         self.finish()
     
-    def makeSeedMech(self,name='Seed'):
+    def makeSeedMech(self):
         """
         causes RMG to make a seed mechanism out of the current chem_annotated.inp and species_dictionary.txt
         this seed mechnaism is outputted in a seed folder within the run directory and automatically
         added to as the (or replaces the current) 'Seed' thermo and kinetics libraries in database
         """
         logging.info('Making seed mechanism...')
+        
+        name = self.name
+        
         currentDir = os.getcwd()
         
         if not os.path.lexists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -858,7 +858,7 @@ class RMG(util.Subject):
             reaction = reactionList[i]        
             entry = Entry(
                     index = i+1,
-                    label = str(reaction),
+                    label = reaction.toLabeledStr(),
                     item = reaction,
                     data = reaction.kinetics,
                 )

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -207,7 +207,7 @@ class RMG(util.Subject):
         self.kineticsdatastore = None
         
         self.name = None
-        self.generateSeeds = None
+        self.generateSeedEachIteration = None
         self.saveSeedToDatabase = None
 
         self.thermoCentralDatabase = None
@@ -635,7 +635,7 @@ class RMG(util.Subject):
                 self.reactionModel.surfaceSpecies = surfaceSpecies
                 self.reactionModel.surfaceReactions = surfaceReactions
 
-                if self.generateSeeds:
+                if self.generateSeedEachIteration:
                     self.makeSeedMech()
 
                 allTerminated = allTerminated and terminated
@@ -803,7 +803,7 @@ class RMG(util.Subject):
     def makeSeedMech(self,firstTime=False):
         """
         causes RMG to make a seed mechanism out of the current chem_annotated.inp and species_dictionary.txt
-        this seed mechnaism is outputted in a seed folder within the run directory and automatically
+        this seed mechanism is outputted in a seed folder within the run directory and automatically
         added to as the (or replaces the current) 'Seed' thermo and kinetics libraries in database
         
         if run with firstTime=True it will change self.name to be unique within the thermo/kinetics libraries
@@ -816,19 +816,17 @@ class RMG(util.Subject):
         
         currentDir = os.getcwd()
         
-        if self.saveSeedToDatabase:
-            if firstTime: #make sure don't overwrite current libraries
-                thermoNames = self.database.thermo.libraries.keys()
-                kineticsNames = self.database.kinetics.libraries.keys()
+        if self.saveSeedToDatabase and firstTime: #make sure don't overwrite current libraries
+            thermoNames = self.database.thermo.libraries.keys()
+            kineticsNames = self.database.kinetics.libraries.keys()
                 
-                if name in thermoNames or name in kineticsNames: 
-                    q = 1
-                    while name+str(q) in thermoNames or name+str(q) in kineticsNames:
-                        q += 1
-                    name += str(q)
-                    self.name = name
+            if name in thermoNames or name in kineticsNames: 
+                q = 1
+                while name+str(q) in thermoNames or name+str(q) in kineticsNames:
+                    q += 1
+                self.name = name + str(q)
             
-        if not os.path.lexists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it
+        if not os.path.exists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it
             os.system('mkdir seed')
             
         speciesList = self.reactionModel.core.species

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -573,7 +573,10 @@ class RMG(util.Subject):
             bimolecularReact=self.bimolecularReact)
 
         logging.info('Completed initial enlarge edge step...')
+        
         self.saveEverything()
+        
+        self.makeSeedMech(firstTime=True)
         
         # Main RMG loop
         while not self.done:
@@ -792,18 +795,33 @@ class RMG(util.Subject):
         
         self.finish()
     
-    def makeSeedMech(self):
+    def makeSeedMech(self,firstTime=False):
         """
         causes RMG to make a seed mechanism out of the current chem_annotated.inp and species_dictionary.txt
         this seed mechnaism is outputted in a seed folder within the run directory and automatically
         added to as the (or replaces the current) 'Seed' thermo and kinetics libraries in database
+        
+        if run with firstTime=True it will change self.name to be unique within the thermo/kinetics libraries
+        by adding integers to the end of the name to prevent overwritting
         """
+        
         logging.info('Making seed mechanism...')
         
         name = self.name
         
         currentDir = os.getcwd()
         
+        if firstTime: #make sure don't overwrite current libraries
+            thermoNames = self.database.thermo.libraries.keys()
+            kineticsNames = self.database.kinetics.libraries.keys()
+            
+            if name in thermoNames or name in kineticsNames: 
+                q = 1
+                while name+str(q) in thermoNames or name+str(q) in kineticsNames:
+                    q += 1
+                name += str(q)
+                self.name = name
+            
         if not os.path.lexists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it
             os.system('mkdir seed')
             


### PR DESCRIPTION
This pull request causes RMG each iteration to automatically:
1) Generate a seed mechanism based on the current chemkin and species dictionary files
2) save that seed mechanism in a seed folder in the run directory
3) save copies of the associated thermo and kinetic libraries into database under
an input name (new parameter in the options block) (or replace the current thermo and kinetic libraries of that name) 

Makes feature for #881.  