### PR TITLE
add new line to nodal distance comments

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2139,6 +2139,9 @@ class KineticsFamily(Database):
             training = []
             
             lines = kinetics.comment.split('\n')
+            
+            lines = [line for line in lines if not line.startswith('Euclid')] #remove the Euclidean distance line to help parser
+            
             # Discard the last line, unless it's the only line!
             # The last line is 'Estimated using ... for rate rule (originalTemplate)'
             if len(lines) == 1:

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -697,7 +697,7 @@ class KineticsRules(Database):
                     )
                 
         kinetics.comment += ' for rate rule ' + originalLeaves
-        kinetics.comment += ' Euclidian distance = {}.'.format(minNorm)
+        kinetics.comment += '\nEuclidian distance = {}'.format(minNorm)
         kinetics.A.value_si *= degeneracy
         if degeneracy > 1:
             kinetics.comment += "\n"


### PR DESCRIPTION
this PR fixes nodal distance comments so they appear on a new line
in the chemkin comments. This allows accurate parsing of comments
where one line corresponds to one piece of information, and is
necessary for PR #1076 to be successfully merged in.