### PR TITLE
minor: correction to atomic number format for N in qchem.py

### DIFF
--- a/rmgpy/cantherm/qchem.py
+++ b/rmgpy/cantherm/qchem.py
@@ -161,7 +161,6 @@ class QchemLog:
                 number.append('6')
             elif atom[i] == 'N':
                 mass[i] = 14.0030740048
-                number[i] = 7
                 number.append('7')
             elif atom[i] == 'O':
                 mass[i] = 15.99491461956


### PR DESCRIPTION
Seems that this line was left unintentionally from an older version of
this file. Causes an error when using the QchemLog() function in
CanTherm for nitrogen containing species:
```
number[i] = 7
IndexError: list assignment index out of range
```
This line was removed in this commit.