### PR TITLE
Added method from arrhenius to Arrhenius ep

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1037,20 +1037,14 @@ class KineticsFamily(Database):
                 label = ';'.join([g.label for g in template]),
                 item=Reaction(reactants=[g.item for g in template],
                                                    products=[]),
-                data = ArrheniusEP(
-                    A = deepcopy(data.A),
-                    n = deepcopy(data.n),
-                    alpha = 0,
-                    E0 = deepcopy(data.Ea),
-                    Tmin = deepcopy(data.Tmin),
-                    Tmax = deepcopy(data.Tmax),
-                    comment = "{0} from training reaction {1}".format(';'.join([g.label for g in template]), entry.index),
-                ),
+                data = data.toArrheniusEP(),
                 rank = entry.rank,
                 reference=entry.reference,
                 shortDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.shortDesc,
                 longDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.longDesc,
             )
+            new_entry.data.comment = "{0} from training reaction {1}".format(';'.join([g.label for g in template]), entry.index)
+
             new_entry.data.A.value_si /= entry.item.degeneracy
             try:
                 self.rules.entries[new_entry.label].append(new_entry)
@@ -1091,20 +1085,14 @@ class KineticsFamily(Database):
                 label = ';'.join([g.label for g in template]),
                 item=Reaction(reactants=[g.item for g in template],
                                                    products=[]),
-                data = ArrheniusEP(
-                    A = deepcopy(data.A),
-                    n = deepcopy(data.n),
-                    alpha = 0,
-                    E0 = deepcopy(data.Ea),
-                    Tmin = deepcopy(data.Tmin),
-                    Tmax = deepcopy(data.Tmax),
-                    comment = "{0} from training reaction {1}".format(';'.join([g.label for g in template]), entry.index),
-                ),
+                data = data.toArrheniusEP(),
                 rank = entry.rank,
                 reference=entry.reference,
                 shortDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.shortDesc,
                 longDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.longDesc,
             )
+            new_entry.data.comment = "{0} from training reaction {1}".format(';'.join([g.label for g in template]), entry.index)
+
             new_entry.data.A.value_si /= new_degeneracy
             try:
                 self.rules.entries[new_entry.label].append(new_entry)

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -45,7 +45,7 @@ from rmgpy.data.base import Database, Entry, DatabaseError, getAllCombinations
 
 from rmgpy.quantity import Quantity, ScalarQuantity
 from rmgpy.reaction import Reaction
-from rmgpy.kinetics import ArrheniusEP
+from rmgpy.kinetics import ArrheniusEP, Arrhenius
 from .common import KineticsError, saveEntry
 
 ################################################################################
@@ -77,6 +77,8 @@ class KineticsRules(Database):
                   treeDistances=None
                   ):
             
+        if isinstance(kinetics,Arrhenius):
+            kinetics = kinetics.toArrheniusEP()
         entry = Entry(
             index = index,
             label = label,

--- a/rmgpy/kinetics/arrhenius.pxd
+++ b/rmgpy/kinetics/arrhenius.pxd
@@ -49,6 +49,8 @@ cdef class Arrhenius(KineticsModel):
     
     cpdef changeRate(self, double factor)
 
+    cpdef ArrheniusEP toArrheniusEP(self)
+
 ################################################################################
 
 cdef class ArrheniusEP(KineticsModel):

--- a/rmgpy/kinetics/arrhenius.pxd
+++ b/rmgpy/kinetics/arrhenius.pxd
@@ -49,7 +49,7 @@ cdef class Arrhenius(KineticsModel):
     
     cpdef changeRate(self, double factor)
 
-    cpdef ArrheniusEP toArrheniusEP(self)
+    cpdef ArrheniusEP toArrheniusEP(self, double alpha=?, double dHrxn=?)
 
 ################################################################################
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -249,7 +249,23 @@ cdef class Arrhenius(KineticsModel):
 
         # Set the rate parameter to a cantera Arrhenius object
         ctReaction.rate = self.toCanteraKinetics()
-    
+
+    cpdef ArrheniusEP toArrheniusEP(self):
+        """
+        Converts an Arrhenius object to ArrheniusEP by setting alpha to 0
+        and E0 = Ea
+        """
+        self.changeT0(1)
+        aep = ArrheniusEP(A = self.A,
+                          n = self.n,
+                          alpha = 0.0,
+                          E0 = self.Ea,
+                          Tmin = self.Tmin,
+                          Tmax = self.Tmax,
+                          Pmin = self.Pmin,
+                          Pmax = self.Pmax,
+                          comment = self.comment)
+        return aep
 ################################################################################
 
 cdef class ArrheniusEP(KineticsModel):
@@ -367,6 +383,8 @@ cdef class ArrheniusEP(KineticsModel):
             T0 = (1,"K"),
             Tmin = self.Tmin,
             Tmax = self.Tmax,
+            Pmin = self.Pmin,
+            Pmax = self.Pmax,
             comment = self.comment,
         )
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -32,7 +32,6 @@ from libc.math cimport exp, log, sqrt, log10
 
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
-
 ################################################################################
 
 cdef class Arrhenius(KineticsModel):
@@ -250,16 +249,22 @@ cdef class Arrhenius(KineticsModel):
         # Set the rate parameter to a cantera Arrhenius object
         ctReaction.rate = self.toCanteraKinetics()
 
-    cpdef ArrheniusEP toArrheniusEP(self):
+    cpdef ArrheniusEP toArrheniusEP(self, double alpha=0.0, double dHrxn=0.0):
         """
-        Converts an Arrhenius object to ArrheniusEP by setting alpha to 0
-        and E0 = Ea
+        Converts an Arrhenius object to ArrheniusEP
+
+        If setting alpha, you need to also input dHrxn, which must be given 
+        in J/mol (and vise versa).
         """
+
+        if (bool(alpha) ^ bool(dHrxn)):
+            raise Exception('If you set alpha or dHrxn in toArrheniusEP, '\
+                                'you need to set the other value to non-zero.')
         self.changeT0(1)
         aep = ArrheniusEP(A = self.A,
                           n = self.n,
-                          alpha = 0.0,
-                          E0 = self.Ea,
+                          alpha = alpha,
+                          E0 = (self.Ea.value_si-alpha*dHrxn,'J/mol'),
                           Tmin = self.Tmin,
                           Tmax = self.Tmax,
                           Pmin = self.Pmin,

--- a/rmgpy/kinetics/arrheniusTest.py
+++ b/rmgpy/kinetics/arrheniusTest.py
@@ -226,6 +226,21 @@ class TestArrhenius(unittest.TestCase):
         arrEPRate = arrEP.getRateCoefficient(500,10) # the second number should not matter
         self.assertAlmostEqual(arrRate,arrEPRate)
 
+    def test_toArrheniusEP_with_alpha_and_Hrxn(self):
+        """
+        Tests that the Arrhenius object can be converted to ArrheniusEP given parameters
+        """
+        hrxn = 5
+        arrRate = self.arrhenius.getRateCoefficient(500)
+        arrEP = self.arrhenius.toArrheniusEP(alpha=1, dHrxn=hrxn)
+        self.assertAlmostEqual(1.,arrEP.alpha.value_si)
+        arrEPRate = arrEP.getRateCoefficient(500,hrxn)
+        self.assertAlmostEqual(arrRate,arrEPRate)
+
+    def test_toArrheniusEP_throws_error_with_just_alpha(self):
+        with self.assertRaises(Exception):
+            self.arrhenius.toArrheniusEP(alpha=1)
+
 ################################################################################
 
 class TestArrheniusEP(unittest.TestCase):

--- a/rmgpy/kinetics/arrheniusTest.py
+++ b/rmgpy/kinetics/arrheniusTest.py
@@ -217,6 +217,15 @@ class TestArrhenius(unittest.TestCase):
         self.assertAlmostEqual(ctArrhenius.temperature_exponent, 0.5)
         self.assertAlmostEqual(ctArrhenius.activation_energy, 41.84e6)
 
+    def test_toArrheniusEP(self):
+        """
+        Tests that the Arrhenius object can be converted to ArrheniusEP
+        """
+        arrRate = self.arrhenius.getRateCoefficient(500)
+        arrEP = self.arrhenius.toArrheniusEP()
+        arrEPRate = arrEP.getRateCoefficient(500,10) # the second number should not matter
+        self.assertAlmostEqual(arrRate,arrEPRate)
+
 ################################################################################
 
 class TestArrheniusEP(unittest.TestCase):


### PR DESCRIPTION
There are already locations in the code where Arrhenius is converted into ArrheniusEP. This commit allows for one central location to do the conversion. 

I replaced the instances where the conversion currently happens.

I added a new instance when loading rate rules that have Arrhenius objects.

Sidenote: for some reason loading some parts of the database were not working for me (example testGenerateReactions), and this PR fixed it. 