### PR TITLE
fix kinetics comments when modifying reaction.degeneracy

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -103,7 +103,7 @@ class Reaction:
         self.reactants = reactants
         self.products = products
         self.specificCollider = specificCollider
-        self.degeneracy = degeneracy
+        self._degeneracy = degeneracy
         self.kinetics = kinetics
         self.reversible = reversible
         self.transitionState = transitionState
@@ -180,6 +180,13 @@ class Reaction:
                 degeneracyRatio = new
             else:
                 degeneracyRatio = (new*1.0) / self._degeneracy
+            # fix kinetics comment with new degeneracy
+            if 'Multiplied by reaction path degeneracy {}'.format(self._degeneracy) in self.kinetics.comment:
+                self.kinetics.comment = self.kinetics.comment.replace(
+                                                  'Multiplied by reaction path degeneracy {}'.format(self._degeneracy),
+                                                  'Multiplied by reaction path degeneracy {}'.format(float(new)))
+            elif self.kinetics.comment:
+                self.kinetics.comment += 'Multiplied by reaction path degeneracy {}'.format(float(new))
             self.kinetics.changeRate(degeneracyRatio)
         # set new degeneracy
         self._degeneracy = new

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -241,8 +241,11 @@ class TestReaction(unittest.TestCase):
                 Tmax = (2500, 'K'),
             ),
             transitionState = TS,
+            degeneracy = 2,
         )
-    
+        self.reaction.kinetics.comment = '''
+        Multiplied by reaction path degeneracy 2.0
+        '''
         # CC(=O)O[O]
         acetylperoxy = Species(
             label='acetylperoxy',
@@ -1025,6 +1028,16 @@ class TestReaction(unittest.TestCase):
         degeneracyFactor = 2
         self.reaction.degeneracy *= degeneracyFactor
         self.assertAlmostEqual(self.reaction.kinetics.A.value_si, degeneracyFactor * prefactor)
+
+    def testDegeneracyUpdatesKineticsComment(self):
+        """
+        This method tests that a change in degeneracy will result in a modified rate constant
+        """
+
+        newDegeneracy = 8
+        self.reaction.degeneracy = newDegeneracy
+        self.assertIn('Multiplied by reaction path degeneracy 8.0', self.reaction.kinetics.comment)
+
 
 class TestReactionToCantera(unittest.TestCase):
     """


### PR DESCRIPTION
when degeneracy is reset, it should also modify the kinetics
comments to reflect the updated degeneracy values.

This PR adds this change to the reaction.__setDegeneracy method and writes unittests that ensure the method functions. 

For reviewers:

1. ensure the tests all pass
2. read the code changes in reaction.py to see if they make sense.