### PR TITLE
improve error message for quantity.py

### DIFF
--- a/rmgpy/quantity.py
+++ b/rmgpy/quantity.py
@@ -226,7 +226,7 @@ class ScalarQuantity(Units):
         Check the uncertainty type is valid, then set it.
         """
         if v not in ['+|-','*|/']:
-            raise QuantityError("Invalid uncertainty type")
+            raise QuantityError('Unexpected uncertainty type "{0}"; valid values are "+|-" and "*|/".'.format(v))
         self._uncertaintyType = v
 
     uncertaintyType = property(getUncertaintyType, setUncertaintyType)
@@ -434,7 +434,7 @@ class ArrayQuantity(Units):
         the units. This ensures you set the type first.
         """
         if v not in ['+|-','*|/']:
-            raise QuantityError("Invalid uncertainty type")
+            raise QuantityError('Unexpected uncertainty type "{0}"; valid values are "+|-" and "*|/".'.format(v))
         self._uncertaintyType = v
 
     uncertaintyType = property(getUncertaintyType, setUncertaintyType)
@@ -642,7 +642,7 @@ class UnitType:
             quantity.value_si *= self.extraDimensionality[dimensionality]
             quantity.units = self.units
         else:
-            raise QuantityError('Invalid units {0!r}.'.format(quantity.units))
+            raise QuantityError('Invalid units {0!r}. Try common units: {1}'.format(quantity.units,self.commonUnits))
         
         # Return the Quantity or ArrayQuantity object object
         return quantity
@@ -737,7 +737,7 @@ def RateCoefficient(*args, **kwargs):
         factor = RATECOEFFICIENT_CONVERSION_FACTORS[dimensionality]
         quantity.value_si *= factor
     except KeyError:
-        raise QuantityError('Invalid units {0!r}.'.format(quantity.units))
+        raise QuantityError('Invalid units {0!r}. Common units are {1}'.format(quantity.units,RATECOEFFICIENT_COMMON_UNITS))
 
     # Return the Quantity or ArrayQuantity object object
     return quantity


### PR DESCRIPTION
Went through quantity.py to improve the error messages by telling
users what options are available when unable to parse the given
units or uncertainty strings