### PR TITLE
Read externalSymmetry and spinMultiplicity from QM job output

### DIFF
--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -113,22 +113,22 @@ will be referred to as the species input file.
 
 The species input file accepts the following parameters:
 
-======================= =========================== ====================================
-Parameter               Required?                   Description
-======================= =========================== ====================================
-``atoms``               yes                         Type and number of atoms in the species
-``bonds``               optional                    Type and number of bonds in the species
-``linear``              yes                         ``True`` if the molecule is linear, ``False`` if not
-``externalSymmetry``    yes                         The external symmetry number for rotation
-``spinMultiplicity``    yes                         The ground-state spin multiplicity (degeneracy)
-``opticalIsomers``      yes                         The number of optical isomers of the species
-``energy``              yes                         The ground-state 0 K atomization energy in Hartree (without zero-point energy)
-                                                    **or**
-                                                    The path to the quantum chemistry output file containing the energy
-``geometry``            yes                         The path to the quantum chemistry output file containing the optimized geometry
-``frequencies``         yes                         The path to the quantum chemistry output file containing the computed frequencies
-``rotors``              optional                    A list of :class:`HinderedRotor()` and/or :class:`FreeRotor()` objects describing the hindered/free rotors
-======================= =========================== ====================================
+======================= ============================= ====================================
+Parameter               Required?                     Description
+======================= ============================= ====================================
+``atoms``               yes                           Type and number of atoms in the species
+``bonds``               optional                      Type and number of bonds in the species
+``linear``              yes                           ``True`` if the molecule is linear, ``False`` if not
+``externalSymmetry``    no, but strongly recommended  The external symmetry number for rotation
+``spinMultiplicity``    no                            The ground-state spin multiplicity (degeneracy)
+``opticalIsomers``      yes                           The number of optical isomers of the species
+``energy``              yes                           The ground-state 0 K atomization energy in Hartree (without zero-point energy)
+                                                      **or**
+                                                      The path to the quantum chemistry output file containing the energy
+``geometry``            yes                           The path to the quantum chemistry output file containing the optimized geometry
+``frequencies``         yes                           The path to the quantum chemistry output file containing the computed frequencies
+``rotors``              optional                      A list of :class:`HinderedRotor()` and/or :class:`FreeRotor()` objects describing the hindered/free rotors
+======================= ============================= ====================================
 
 The ``atom`` and ``bond`` parameters are used to apply atomization energy corrections (AEC), bond corrections (BC), and spin orbit corrections (SOC) for a given ``modelChemistry()`` (see `Model Chemistry`_).
 

--- a/rmgpy/cantherm/gaussian.py
+++ b/rmgpy/cantherm/gaussian.py
@@ -33,6 +33,7 @@ import numpy
 import os.path
 from rmgpy.cantherm.common import checkConformerEnergy
 import rmgpy.constants as constants
+import logging
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 
 ################################################################################
@@ -199,6 +200,7 @@ class GaussianLog:
                     # Read Gaussian's estimate of the external symmetry number
                     elif 'Rotational symmetry number' in line and symmetry is None:
                         symmetry = int(float(line.split()[3]))
+                        logging.info('externalSymmetry (Rotational Symmetry Number) was extracted from gaussian output: {}'.format(symmetry))
 
                     # Read moments of inertia for external rotational modes
                     elif 'Rotational constants (GHZ):' in line:
@@ -236,6 +238,7 @@ class GaussianLog:
                     # Read spin multiplicity if not explicitly given
                     elif 'Electronic' in line and inPartitionFunctions and spinMultiplicity is None:
                         spinMultiplicity = int(float(line.split()[1].replace('D', 'E')))
+                        logging.info('Spin Multiplicity was extracted from gaussian output: {}'.format(spinMultiplicity))
 
                     elif 'Log10(Q)' in line:
                         inPartitionFunctions = True

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -243,12 +243,19 @@ class StatMechJob:
         try:
             externalSymmetry = local_context['externalSymmetry']
         except KeyError:
-            raise InputError('Required attribute "externalSymmetry" not found in species file {0!r}.'.format(path))
+            logging.info('\n')
+            logging.warning('"externalSymmetry" was unspecified in species file {0!r}!\n'\
+                'It is strongly recommended that the externalSymmetry values is supplied by the user rather'\
+                ' than extracted from the quantum job output, which is often erroneous.\n'.format(path))
+            externalSymmetry = None
+            pass
         
         try:
             spinMultiplicity = local_context['spinMultiplicity']
         except KeyError:
-            raise InputError('Required attribute "spinMultiplicity" not found in species file {0!r}.'.format(path))
+            logging.info('"spinMultiplicity" was unspecified in species file {0!r}, attempting to read from job file'.format(path))
+            spinMultiplicity = None
+            pass
        
         try:
             opticalIsomers = local_context['opticalIsomers']


### PR DESCRIPTION
Read externalSymmetry and spinMultiplicity from QM job output if
unspecified in CanTherm input.
Previously an error was thrown if either externalSymmetry or
spinMultiplicity were unspecified in the CanTherm input, although we are
able to read both from the gaussian/QChem outputs.
Since externalSymmetry is often incorrect (at least in QChem), a general
warning is given if this value is unspecified.
Documentation changed as well.