### PR TITLE
moved RMG exception class to specific file

### DIFF
--- a/rmgpy/__init__.py
+++ b/rmgpy/__init__.py
@@ -36,14 +36,8 @@ import os
 import os.path
 import logging
 from .version import __version__
-
+from .exceptions import SettingsError
 ################################################################################
-
-class SettingsError(Exception):
-    """
-    An exception raised when dealing with settings.
-    """
-    pass
 
 class Settings(dict):
     """

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -53,15 +53,7 @@ from rmgpy.statmech.rotation import Rotation, LinearRotor, NonlinearRotor, KRoto
 from rmgpy.statmech.vibration import Vibration, HarmonicOscillator
 from rmgpy.statmech.torsion import Torsion, HinderedRotor, FreeRotor
 from rmgpy.statmech.conformer import Conformer
-
-################################################################################
-
-class InputError(Exception):
-    """
-    An exception raised when parsing an input file for a conformer. Pass a
-    string describing the error.
-    """
-    pass
+from rmgpy.exceptions import InputError
 
 ################################################################################
 

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -55,19 +55,11 @@ from rmgpy.rmg.pdep import PDepNetwork
 from rmgpy.molecule import Molecule
 from rmgpy.molecule.util import retrieveElementCount
 from rmgpy.transport import TransportData
+from rmgpy.exceptions import ChemkinError
 
 __chemkin_reaction_count = None
     
 from rmgpy.util import makeOutputSubdirectory
-
-################################################################################
-
-class ChemkinError(Exception):
-    """
-    An exception class for exceptional behavior involving Chemkin files. Pass a
-    string describing the circumstances that caused the exceptional behavior.
-    """
-    pass
 
 ################################################################################
 

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -44,18 +44,9 @@ except ImportError:
     logging.warning("Upgrade to Python 2.7 or later to ensure your database entries are read and written in the same order each time!")
     OrderedDict = dict
 from rmgpy.molecule import Molecule, Group
-from rmgpy.molecule.adjlist import InvalidAdjacencyListError
 
 from reference import Reference, Article, Book, Thesis
-
-################################################################################
-
-class DatabaseError(Exception):
-    """
-    A exception that occurs when working with an RMG database. Pass a string
-    giving specifics about the exceptional behavior.
-    """
-    pass
+from rmgpy.exceptions import DatabaseError, ForbiddenStructureException, InvalidAdjacencyListError
 
 ################################################################################
 
@@ -1263,12 +1254,6 @@ def getAllCombinations(nodeLists):
     return items
 
 ################################################################################
-
-class ForbiddenStructureException(Exception):
-    """
-    Made a forbidden structure.
-    """
-    pass
 
 class ForbiddenStructures(Database):
     """

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -33,27 +33,11 @@ This module contains classes and functions that are used by multiple modules
 in this subpackage.
 """
 
-from rmgpy.data.base import DatabaseError, LogicNode
-from rmgpy.reaction import Reaction, ReactionError
+from rmgpy.data.base import LogicNode
+from rmgpy.reaction import Reaction
 from rmgpy.molecule import Group
 from rmgpy.species import Species
-
-################################################################################
-
-class KineticsError(Exception):
-    """
-    An exception for problems with kinetics. Pass a string describing the problem.
-    """
-    pass
-
-class UndeterminableKineticsError(ReactionError):
-    """
-    An exception raised when attempts to estimate appropriate kinetic parameters
-    for a chemical reaction are unsuccessful.
-    """
-    def __init__(self, reaction, message=''):
-        new_message = 'Kinetics could not be determined. '+message
-        ReactionError.__init__(self,reaction,new_message)
+from rmgpy.exceptions import DatabaseError, KineticsError
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -41,11 +41,12 @@ from rmgpy.kinetics import Arrhenius, ArrheniusEP, ThirdBody, Lindemann, Troe, \
 from rmgpy.molecule import Molecule, Group
 from rmgpy.species import Species
 from rmgpy.reaction import Reaction
-from rmgpy.data.base import LogicNode, DatabaseError
+from rmgpy.data.base import LogicNode
 
 from .family import  KineticsFamily
 from .library import LibraryReaction, KineticsLibrary
 from .common import filterReactions
+from rmgpy.exceptions import DatabaseError
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -41,35 +41,19 @@ import numpy as np
 
 from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.data.base import Database, Entry, LogicNode, LogicOr, ForbiddenStructures,\
-                            ForbiddenStructureException, getAllCombinations
+                            getAllCombinations
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics import Arrhenius, ArrheniusEP
-from rmgpy.molecule import Bond, GroupBond, Group, Molecule, ActionError
-from rmgpy.molecule.kekulize import KekulizationError
+from rmgpy.molecule import Bond, GroupBond, Group, Molecule
 from rmgpy.species import Species
 
-from .common import KineticsError, UndeterminableKineticsError, saveEntry
+from .common import saveEntry
 from .depository import KineticsDepository
 from .groups import KineticsGroups
 from .rules import KineticsRules
-
-
-
-################################################################################
-
-class InvalidActionError(Exception):
-    """
-    An exception to be raised when an invalid action is encountered in a
-    reaction recipe.
-    """
-    pass
-
-class ReactionPairsError(Exception):
-    """
-    An exception to be raised when an error occurs while working with reaction
-    pairs.
-    """
-    pass
+from rmgpy.exceptions import InvalidActionError, ReactionPairsError, KineticsError,\
+                             UndeterminableKineticsError, ForbiddenStructureException,\
+                             KekulizationError, ActionError
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -38,12 +38,12 @@ import math
 import numpy
 from copy import deepcopy
 
-from rmgpy.data.base import Database, DatabaseError, Entry, Group, LogicNode, getAllCombinations, makeLogicNode
+from rmgpy.data.base import Database, Entry, Group, LogicNode, getAllCombinations, makeLogicNode
 
 from rmgpy.kinetics import Arrhenius, ArrheniusEP, KineticsData
 from rmgpy.species import Species
 from rmgpy.quantity import constants
-from .common import KineticsError, UndeterminableKineticsError
+from rmgpy.exceptions import KineticsError, UndeterminableKineticsError, DatabaseError
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -41,12 +41,13 @@ import math
 import numpy
 from copy import  deepcopy
 
-from rmgpy.data.base import Database, Entry, DatabaseError, getAllCombinations
+from rmgpy.data.base import Database, Entry, getAllCombinations
 
 from rmgpy.quantity import Quantity, ScalarQuantity
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics import ArrheniusEP, Arrhenius
-from .common import KineticsError, saveEntry
+from .common import saveEntry
+from rmgpy.exceptions import KineticsError, DatabaseError
 
 ################################################################################
 

--- a/rmgpy/data/statmechfit.py
+++ b/rmgpy/data/statmechfit.py
@@ -41,6 +41,7 @@ import logging
 import rmgpy.constants as constants
 from rmgpy.statmech import HarmonicOscillator, HinderedRotor
 from pydqed import DQED
+from rmgpy.exceptions import StatmechFitError
 
 ################################################################################
 
@@ -64,16 +65,6 @@ hrBarrUpperBound = 10000.0
 
 # The maximum number of iterations for the optimization solver to use
 maxIter = 200
-
-################################################################################
-
-class StatmechFitError(Exception):
-    """
-    An exception used when attempting to fit molecular degrees of freedom to
-    heat capacity data. Pass a string describing the circumstances of the
-    exceptional behavior.
-    """
-    pass
 
 ################################################################################
 

--- a/rmgpy/exceptions.py
+++ b/rmgpy/exceptions.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2017 Prof. William H. Green (whgreen@mit.edu), 
+#   Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+"""
+This module contains classes which extend Exception for usage in the RMG module
+"""
+
+class ActionError(Exception):
+    """
+    An exception class for errors that occur while applying reaction recipe
+    actions. Pass a string describing the circumstances that caused the
+    exceptional behavior.
+    """
+    pass
+
+class AtomTypeError(Exception):
+    """
+    An exception to be raised when an error occurs while working with atom
+    types. Pass a string describing the circumstances that caused the
+    exceptional behavior.
+    """
+    pass
+
+class ChemicallySignificantEigenvaluesError(Exception):
+    """
+    An exception raised when the reservoir state method is unsuccessful for
+    any reason. Pass a string describing the cause of the exceptional behavior.
+    """
+    pass
+
+class ChemkinError(Exception):
+    """
+    An exception class for exceptional behavior involving Chemkin files. Pass a
+    string describing the circumstances that caused the exceptional behavior.
+    """
+    pass
+
+class CollisionError(Exception):
+    pass
+
+class DatabaseError(Exception):
+    """
+    A exception that occurs when working with an RMG database. Pass a string
+    giving specifics about the exceptional behavior.
+    """
+    pass
+
+class ElementError(Exception):
+    """
+    An exception class for errors that occur while working with elements.
+    Pass a string describing the circumstances that caused the
+    exceptional behavior.
+    """
+    pass
+
+class ForbiddenStructureException(Exception):
+    """
+    Made a forbidden structure.
+    """
+    pass
+
+class ILPSolutionError(Exception):
+    """
+    An exception to be raised when solving an integer linear programming problem if a solution
+    could not be found or the solution is not valid. Can pass a string to indicate the reason
+    that the solution is invalid.
+    """
+    pass
+
+class ImplicitBenzeneError(Exception):
+    """
+    An exception class when encountering a group with too many implicit benzene
+    atoms. These groups are hard to create sample molecules and hard for users
+    to interpret. Pass a string describing the limitation.
+    """
+    pass
+
+class InchiException(Exception):
+    pass
+
+class InputError(Exception):
+    """
+    An exception raised when parsing an input file for RMG or a specific conformer. 
+    Pass a string describing the error.
+    """
+    pass
+
+class InvalidActionError(Exception):
+    """
+    An exception to be raised when an invalid action is encountered in a
+    reaction recipe.
+    """
+    pass
+
+class InvalidAdjacencyListError(Exception):
+    """
+    An exception used to indicate that an RMG-style adjacency list is invalid.
+    Pass a string describing the reason the adjacency list is invalid
+    """
+    pass
+
+class KekulizationError(Exception):
+    """
+    An exception to be raised when encountering an error while kekulizing an aromatic molecule.
+    Can pass a string to indicate the reason for failure.
+    """
+    pass
+
+class KineticsError(Exception):
+    """
+    An exception for problems with kinetics. Pass a string describing the problem.
+    """
+    pass
+
+class ModifiedStrongCollisionError(Exception): 
+    """
+    An exception raised when the modified strong collsion method is unsuccessful
+    for any reason. Pass a string describing the cause of the exceptional 
+    behavior.
+    """
+    pass
+
+class NegativeBarrierException(Exception):
+    """This Exception occurs when the energy barrier for a hindered Rotor is negative.
+    This can occur if the scan or fourier fit is poor. """
+    
+    pass
+
+class NetworkError(Exception): 
+    pass
+
+class OutputError(Exception):
+    """
+    This exception is raised whenever an error occurs while saving output
+    information. Pass a string describing the circumstances of the exceptional
+    behavior.
+    """
+    pass
+
+class PressureDependenceError(Exception):
+    """
+    An exception class to use when an error involving pressure dependence is
+    encountered. Pass a string describing the circumstances of the exceptional
+    behavior.
+    """
+    pass
+
+class QuantityError(Exception):
+    """
+    An exception to be raised when an error occurs while working with physical
+    quantities in RMG. Pass a string describing the circumstances of the
+    exceptional behavior.
+    """
+    pass
+
+class ReactionError(Exception):
+    """
+    An exception class for exceptional behavior involving :class:`Reaction`
+    objects. Pass a string describing the circumstances that caused the
+    exceptional behavior.
+    """
+    pass
+
+class ReactionPairsError(Exception):
+    """
+    An exception to be raised when an error occurs while working with reaction
+    pairs.
+    """
+    pass
+
+class ReservoirStateError(Exception): 
+    """
+    An exception raised when the reservoir state method is unsuccessful for
+    any reason. Pass a string describing the cause of the exceptional behavior.
+    """
+    pass
+
+class SettingsError(Exception):
+    """
+    An exception raised when dealing with settings.
+    """
+    pass
+
+class SpeciesError(Exception):
+    """
+    An exception class for exceptional behavior that occurs while working with
+    chemical species. Pass a string describing the circumstances that caused the
+    exceptional behavior.
+    """
+    pass
+
+class StatmechFitError(Exception):
+    """
+    An exception used when attempting to fit molecular degrees of freedom to
+    heat capacity data. Pass a string describing the circumstances of the
+    exceptional behavior.
+    """
+    pass
+
+class UnexpectedChargeError(Exception):
+    """
+    An exception class when encountering a group/molecule with unexpected charge
+    Curently in RMG, we never expect to see -2/+2 or greater magnitude charge,
+    we only except +1/-1 charges on nitrogen, oxygen, sulfur or specifically
+    carbon monoxide/monosulfide.
+
+    Attributes:
+    `graph` is the molecule or group object with the unexpected charge
+    """
+    def __init__(self, graph):
+        self.graph = graph
+
+class VF2Error(Exception):
+    """
+    An exception raised if an error occurs within the VF2 graph isomorphism
+    algorithm. Pass a string describing the error.
+    """
+    pass
+
+################## move classes that extend off previous exceptions here
+
+class InvalidMicrocanonicalRateError(NetworkError):
+    """
+    Used in pressure dependence when the k(E) calculation does not give 
+    the correct kf(T) or Kc(T)
+    """
+    def __init__(self,message, k_ratio=1.0, Keq_ratio=1.0):
+        self.message = message
+        self.k_ratio = k_ratio
+        self.Keq_ratio = Keq_ratio
+    def badness(self):
+        """
+        How bad is the error?
+
+        Returns the max of the absolute logarithmic errors of kf and Kc
+        """
+        import math
+        return max(abs(math.log10(self.k_ratio)), abs(math.log10(self.Keq_ratio)))
+
+class UndeterminableKineticsError(ReactionError):
+    """
+    An exception raised when attempts to estimate appropriate kinetic parameters
+    for a chemical reaction are unsuccessful.
+    """
+    def __init__(self, reaction, message=''):
+        new_message = 'Kinetics could not be determined. '+message
+        ReactionError.__init__(self,reaction,new_message)

--- a/rmgpy/exceptions.py
+++ b/rmgpy/exceptions.py
@@ -50,8 +50,9 @@ class AtomTypeError(Exception):
 
 class ChemicallySignificantEigenvaluesError(Exception):
     """
-    An exception raised when the reservoir state method is unsuccessful for
-    any reason. Pass a string describing the cause of the exceptional behavior.
+    An exception raised when the chemically significant eigenvalue method is 
+    unsuccessful for any reason. 
+    Pass a string describing the cause of the exceptional behavior.
     """
     pass
 
@@ -63,6 +64,11 @@ class ChemkinError(Exception):
     pass
 
 class CollisionError(Exception):
+    """
+    An exception class for when RMG is unable to calculate collision efficiencies
+    for the single exponential down pressure dependent solver. 
+    Pass a string describing the circumstances that caused the exceptional behavior.
+    """
     pass
 
 class DatabaseError(Exception):
@@ -82,7 +88,8 @@ class ElementError(Exception):
 
 class ForbiddenStructureException(Exception):
     """
-    Made a forbidden structure.
+    An exception passed when RMG encounters a forbidden structure. These are usually
+    caught and the reaction that created it is ignored.
     """
     pass
 
@@ -103,11 +110,16 @@ class ImplicitBenzeneError(Exception):
     pass
 
 class InchiException(Exception):
+    """
+    An exception used when encountering a non-valid Inchi expression are encountered.
+    Pass a string describing the error.
+    """
     pass
 
 class InputError(Exception):
     """
-    An exception raised when parsing an input file for RMG or a specific conformer. 
+    An exception raised when parsing an input file for any module in RMG:
+    mechanism generation, cantherm, conformer creation, etc.
     Pass a string describing the error.
     """
     pass
@@ -135,25 +147,30 @@ class KekulizationError(Exception):
 
 class KineticsError(Exception):
     """
-    An exception for problems with kinetics. Pass a string describing the problem.
+    An exception class for problems with kinetics. This can be used when finding 
+    degeneracy in reaction generation, modifying KineticsData objects, or finding the
+    kinetics of reactions. Unable Pass a string describing the problem.
     """
     pass
 
 class ModifiedStrongCollisionError(Exception): 
     """
-    An exception raised when the modified strong collsion method is unsuccessful
+    An exception raised when the modified strong collision method is unsuccessful
     for any reason. Pass a string describing the cause of the exceptional 
     behavior.
     """
     pass
 
 class NegativeBarrierException(Exception):
-    """This Exception occurs when the energy barrier for a hindered Rotor is negative.
+    """ This Exception occurs when the energy barrier for a hindered Rotor is negative.
     This can occur if the scan or fourier fit is poor. """
     
     pass
 
 class NetworkError(Exception): 
+    """
+    Raised when an error occurs while working with a pressure-dependent reaction network
+    """
     pass
 
 class OutputError(Exception):

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -36,7 +36,7 @@ import re
 from .molecule import Atom, Bond, getAtomType
 from .group import GroupAtom, GroupBond
 from .element import getElement, PeriodicSystem
-#import chempy.molecule.atomtype as atomtypes
+from rmgpy.exceptions import InvalidAdjacencyListError
 
 class Saturator(object):
     @staticmethod
@@ -135,15 +135,6 @@ class ConsistencyChecker(object):
             raise InvalidAdjacencyListError("Violation of hund's rule. Invalid multiplicity of {0} because there is an atom with {1} unpaired electrons"
                                             .format(multiplicity, atom.radicalElectrons))
             
-################################################################################
-
-class InvalidAdjacencyListError(Exception):
-    """
-    An exception used to indicate that an RMG-style adjacency list is invalid.
-    Pass a string describing the reason the adjacency list is invalid
-    """
-    pass
-
 ################################################################################
 
 def fromOldAdjacencyList(adjlist, group=False, saturateH=False):

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -40,16 +40,7 @@ represent, this should be the only module you need to change to do so.
 """
 
 import cython
-
-################################################################################
-
-class AtomTypeError(Exception):
-    """
-    An exception to be raised when an error occurs while working with atom
-    types. Pass a string describing the circumstances that caused the
-    exceptional behavior.
-    """
-    pass
+from rmgpy.exceptions import AtomTypeError
 
 ################################################################################
 

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -43,18 +43,10 @@ comparisons.
 
 import cython
 from rdkit.Chem import GetPeriodicTable
+from rmgpy.exceptions import ElementError
 
 ################################################################################
 
-class ElementError(Exception):
-    """
-    An exception class for errors that occur while working with elements.
-    Pass a string describing the circumstances that caused the
-    exceptional behavior.
-    """
-    pass
-
-################################################################################
 _rdkit_periodic_table = GetPeriodicTable()
 class Element:
     """

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -41,38 +41,7 @@ from .atomtype import atomTypes, allElements, nonSpecifics, getFeatures
 from .element import PeriodicSystem
 import rmgpy.molecule.molecule as mol
 from copy import deepcopy, copy
-
-################################################################################
-
-class ActionError(Exception):
-    """
-    An exception class for errors that occur while applying reaction recipe
-    actions. Pass a string describing the circumstances that caused the
-    exceptional behavior.
-    """
-    pass
-
-class ImplicitBenzeneError(Exception):
-    """
-    An exception class when encountering a group with too many implicit benzene
-    atoms. These groups are hard to create sample molecules and hard for users
-    to interpret. Pass a string describing the limitation.
-    """
-    pass
-
-class UnexpectedChargeError(Exception):
-    """
-    An exception class when encountering a group/molecule with unexpected charge
-    Curently in RMG, we never expect to see -2/+2 or greater magnitude charge,
-    we only except +1/-1 charges on nitrogen, oxygen, sulfur or specifically
-    carbon monoxide/monosulfide.
-
-    Attributes:
-    `graph` is the molecule or group object with the unexpected charge
-    """
-    def __init__(self, graph):
-        self.graph = graph
-
+from rmgpy.exceptions import ActionError, ImplicitBenzeneError, UnexpectedChargeError
 ################################################################################
 
 class GroupAtom(Vertex):

--- a/rmgpy/molecule/inchi.py
+++ b/rmgpy/molecule/inchi.py
@@ -27,6 +27,7 @@
 
 import cython
 import re
+from rmgpy.exceptions import InchiException
 
 # search for (*) PARENTHESES
 PARENTHESES = re.compile( r'\((.[^\(\)]*)\)')
@@ -298,9 +299,6 @@ def parse_N_layer(auxinfo):
     indices = map(int, atom_numbers.split(','))
 
     return indices
-        
-class InchiException(Exception):
-    pass
 
 class InChI(str):
     """InChI is a type of string in which the InChI=1 prefix is ignored."""

--- a/rmgpy/molecule/kekulize.pyx
+++ b/rmgpy/molecule/kekulize.pyx
@@ -56,8 +56,7 @@ import logging
 
 from .molecule cimport Atom, Bond, Molecule
 from .element import PeriodicSystem
-from .atomtype import AtomTypeError
-
+from rmgpy.exceptions import KekulizationError, AtomTypeError
 
 cpdef kekulize(Molecule mol):
     """
@@ -345,10 +344,3 @@ cdef class AromaticBond(object):
 
         self.endoDOF = endoDOF
         self.exoDOF = exoDOF
-
-class KekulizationError(Exception):
-    """
-    An exception to be raised when encountering an error while kekulizing an aromatic molecule.
-    Can pass a string to indicate the reason for failure.
-    """
-    pass

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -53,10 +53,9 @@ import itertools
 
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 from .molecule import Atom, Bond, Molecule
-from .kekulize import kekulize, KekulizationError
-from .atomtype import AtomTypeError
+from .kekulize import kekulize
 import rmgpy.molecule.pathfinder as pathfinder
-
+from rmgpy.exceptions import ILPSolutionError, KekulizationError, AtomTypeError
 
 def populateResonanceAlgorithms(features=None):
     """
@@ -883,12 +882,3 @@ def _clarTransformation(mol, aromaticRing):
 
     for bond in bondList:
         bond.order = 1.5
-
-
-class ILPSolutionError(Exception):
-    """
-    An exception to be raised when solving an integer linear programming problem if a solution
-    could not be found or the solution is not valid. Can pass a string to indicate the reason
-    that the solution is invalid.
-    """
-    pass

--- a/rmgpy/molecule/vf2.pyx
+++ b/rmgpy/molecule/vf2.pyx
@@ -32,14 +32,9 @@ algorithm of Vento and Foggia.
 
 cimport cython
 from rmgpy.molecule.graph import Graph
-################################################################################
+from rmgpy.exceptions import VF2Error
 
-class VF2Error(Exception):
-    """
-    An exception raised if an error occurs within the VF2 graph isomorphism
-    algorithm. Pass a string describing the error.
-    """
-    pass
+################################################################################
 
 cdef class VF2:
     """

--- a/rmgpy/pdep/collision.pyx
+++ b/rmgpy/pdep/collision.pyx
@@ -37,11 +37,7 @@ cimport cython
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 from libc.math cimport exp, sqrt
-
-################################################################################
-
-def CollisionError(Exception):
-    pass
+from rmgpy.exceptions import CollisionError
 
 ################################################################################
 

--- a/rmgpy/pdep/cse.pyx
+++ b/rmgpy/pdep/cse.pyx
@@ -41,15 +41,7 @@ from libc.math cimport exp, log, sqrt
 import rmgpy.constants as constants
 
 from rmgpy.pdep.me import generateFullMEMatrix
-
-################################################################################
-
-class ChemicallySignificantEigenvaluesError(Exception):
-    """
-    An exception raised when the reservoir state method is unsuccessful for
-    any reason. Pass a string describing the cause of the exceptional behavior.
-    """
-    pass
+from rmgpy.exceptions import ChemicallySignificantEigenvaluesError
 
 ################################################################################
 

--- a/rmgpy/pdep/msc.pyx
+++ b/rmgpy/pdep/msc.pyx
@@ -36,16 +36,7 @@ cimport numpy
 from libc.math cimport exp, log, sqrt
 
 import rmgpy.constants as constants
-
-################################################################################
-
-class ModifiedStrongCollisionError(Exception): 
-    """
-    An exception raised when the modified strong collsion method is unsuccessful
-    for any reason. Pass a string describing the cause of the exceptional 
-    behavior.
-    """
-    pass
+from rmgpy.exceptions import ModifiedStrongCollisionError
 
 ################################################################################
 

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -39,25 +39,7 @@ import logging
 
 import rmgpy.constants as constants
 from rmgpy.reaction import Reaction
-
-################################################################################
-
-class NetworkError(Exception): 
-    pass
-
-class InvalidMicrocanonicalRateError(NetworkError):
-    """Used when the k(E) calculation does not give the correct kf(T) or Kc(T)"""
-    def __init__(self,message, k_ratio=1.0, Keq_ratio=1.0):
-        self.message = message
-        self.k_ratio = k_ratio
-        self.Keq_ratio = Keq_ratio
-    def badness(self):
-        """
-        How bad is the error?
-        
-        Returns the max of the absolute logarithmic errors of kf and Kc
-        """
-        return max(abs(math.log10(self.k_ratio)), abs(math.log10(self.Keq_ratio)))
+from rmgpy.exceptions import NetworkError, InvalidMicrocanonicalRateError
 
 ################################################################################
 

--- a/rmgpy/pdep/rs.pyx
+++ b/rmgpy/pdep/rs.pyx
@@ -37,15 +37,7 @@ import scipy.linalg
 from libc.math cimport exp, log, sqrt
 
 import rmgpy.constants as constants
-
-################################################################################
-
-class ReservoirStateError(Exception): 
-    """
-    An exception raised when the reservoir state method is unsuccessful for
-    any reason. Pass a string describing the cause of the exceptional behavior.
-    """
-    pass
+from rmgpy.exceptions import ReservoirStateError
 
 ################################################################################
 

--- a/rmgpy/quantity.py
+++ b/rmgpy/quantity.py
@@ -37,6 +37,7 @@ import numpy
 import quantities as pq
 
 import rmgpy.constants as constants
+from rmgpy.exceptions import QuantityError
 
 ################################################################################
 
@@ -63,14 +64,6 @@ NOT_IMPLEMENTED_UNITS = [
                         'degR',
                         'R'
                         ]
-
-class QuantityError(Exception):
-    """
-    An exception to be raised when an error occurs while working with physical
-    quantities in RMG. Pass a string describing the circumstances of the
-    exceptional behavior.
-    """
-    pass
 
 ################################################################################
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -56,18 +56,8 @@ from rmgpy.species import Species
 from rmgpy.kinetics.arrhenius import Arrhenius #PyDev: @UnresolvedImport
 from rmgpy.kinetics import KineticsData, ArrheniusEP, ThirdBody, Lindemann, Troe, Chebyshev, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, getRateCoefficientUnitsFromReactionOrder  #PyDev: @UnresolvedImport
 from rmgpy.pdep.reaction import calculateMicrocanonicalRateCoefficient
-
+from rmgpy.exceptions import ReactionError
 from rmgpy.kinetics.diffusionLimited import diffusionLimiter
-
-################################################################################
-
-class ReactionError(Exception):
-    """
-    An exception class for exceptional behavior involving :class:`Reaction`
-    objects. Pass a string describing the circumstances that caused the
-    exceptional behavior.
-    """
-    pass
 
 ################################################################################
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -44,11 +44,7 @@ from rmgpy.solver.liquid import LiquidReactor
 from model import CoreEdgeReactionModel
 
 from rmgpy.scoop_framework.util import broadcast, get
-
-################################################################################
-
-class InputError(Exception): pass
-
+from rmgpy.exceptions import InputError
 ################################################################################
 
 rmg = None

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -48,7 +48,7 @@ from rmgpy.molecule import Molecule
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 from rmgpy.solver.simple import SimpleReactor
 from rmgpy.data.rmg import RMGDatabase
-from rmgpy.data.base import ForbiddenStructureException, DatabaseError
+from rmgpy.exceptions import ForbiddenStructureException, DatabaseError
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -45,7 +45,7 @@ from rmgpy.quantity import Quantity
 import rmgpy.species
 from rmgpy.thermo.thermoengine import submit
 
-from rmgpy.data.base import ForbiddenStructureException
+from rmgpy.exceptions import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -39,17 +39,7 @@ import re
 import textwrap
 from rmgpy.util import makeOutputSubdirectory
 from rmgpy.chemkin import getSpeciesIdentifier
-
-################################################################################
-
-class OutputError(Exception):
-    """
-    This exception is raised whenever an error occurs while saving output
-    information. Pass a string describing the circumstances of the exceptional
-    behavior.
-    """
-    pass
-
+from rmgpy.exceptions import OutputError
 ################################################################################
 
 def saveOutputHTML(path, reactionModel, partCoreEdge='core'):

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -41,16 +41,7 @@ import rmgpy.reaction
 
 from rmgpy.pdep import Conformer, Configuration
 from rmgpy.rmg.react import react
-
-################################################################################
-
-class PressureDependenceError(Exception):
-    """
-    An exception class to use when an error involving pressure dependence is
-    encountered. Pass a string describing the circumstances of the exceptional
-    behavior.
-    """
-    pass
+from rmgpy.exceptions import PressureDependenceError
 
 ################################################################################
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -52,18 +52,9 @@ import rmgpy.quantity as quantity
 from rmgpy.pdep import SingleExponentialDown
 from rmgpy.statmech.conformer import Conformer
 from rmgpy.thermo import Wilhoit, NASA, ThermoData
+from rmgpy.exceptions import SpeciesError
 #: This dictionary is used to add multiplicity to species label
 _multiplicity_labels = {1:'S',2:'D',3:'T',4:'Q',5:'V',}
-                           
-################################################################################
-
-class SpeciesError(Exception):
-    """
-    An exception class for exceptional behavior that occurs while working with
-    chemical species. Pass a string describing the circumstances that caused the
-    exceptional behavior.
-    """
-    pass
 
 ################################################################################
 

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -46,7 +46,7 @@ cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 cimport rmgpy.statmech.schrodinger as schrodinger 
 import rmgpy.statmech.schrodinger as schrodinger 
-
+from rmgpy.exceptions import NegativeBarrierException
 import logging
 
 ################################################################################
@@ -87,14 +87,6 @@ cdef class Torsion(Mode):
         A helper function used when pickling a Rotation object.
         """
         return (Torsion, (self.symmetry, self.quantum))
-
-################################################################################
-
-class NegativeBarrierException(Exception):
-    """This Exception occurs when the energy barrier for a hindered Rotor is negative.
-    This can occur if the scan or fourier fit is poor. """
-    
-    pass
 
 ################################################################################
 


### PR DESCRIPTION
When importing an RMG exception, before this commit, all the
imported modules for that file are automatically imported, which
can sometimes lead to circular dependency issues (see #1101 ).

This commit centralizes all exceptions within RMG into rmgpy.exceptions
and does not require any imports, to avoid any circular dependency
issues. This also should make it easier for people to find and use
more specific exceptions in RMG in the future.