### PR TITLE
Fixed two example files and a bug in statmech.py

### DIFF
--- a/examples/cantherm/species/Toulene/input_toluene_FreeRotor.py
+++ b/examples/cantherm/species/Toulene/input_toluene_FreeRotor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-modelChemistry = "CBS-QB3"
+modelChemistry = 'CBS-QB3'
 frequencyScaleFactor = 0.99
 useHinderedRotors = True
 useBondCorrections = True

--- a/examples/cantherm/species/Toulene/toluene_FreeRotor.py
+++ b/examples/cantherm/species/Toulene/toluene_FreeRotor.py
@@ -9,7 +9,7 @@ atoms = {
 bonds = {
     'C-C': 4, 
     'C-H': 8,
-    'C=H': 3,
+    'C=C': 3,
 }
 
 linear = False

--- a/examples/cantherm/species/Toulene/toluene_HinderedRotor.py
+++ b/examples/cantherm/species/Toulene/toluene_HinderedRotor.py
@@ -9,7 +9,7 @@ atoms = {
 bonds = {
     'C-C': 4, 
     'C-H': 8,
-    'C=H': 3,
+    'C=C': 3,
 }
 
 linear = False

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -552,7 +552,7 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
     # Note: If your model chemistry does not include spin orbit coupling, you should add the corrections to the energies here
     if modelChemistry == 'CBS-QB3':
         atomEnergies = {'H':-0.499818 + SOC['H'], 'N':-54.520543 + SOC['N'], 'O':-74.987624+ SOC['O'], 'C':-37.785385+ SOC['C'], 'P':-340.817186+ SOC['P'], 'S': -397.657360+ SOC['S']}
-    if modelChemistry == 'M06-2X/cc-pVTZ':
+    elif modelChemistry == 'M06-2X/cc-pVTZ':
         atomEnergies = {'H':-0.498135 + SOC['H'], 'N':-54.586780 + SOC['N'], 'O':-75.064242+ SOC['O'], 'C':-37.842468+ SOC['C'], 'P':-341.246985+ SOC['P'], 'S': -398.101240+ SOC['S']}
     elif modelChemistry == 'G3':
         atomEnergies = {'H':-0.5010030, 'N':-54.564343, 'O':-75.030991, 'C':-37.827717, 'P':-341.116432, 'S': -397.961110}


### PR DESCRIPTION
Two example files for cantherm had C=H. Those were correctly changed to C=C.

In statmech.py, there is an elif statement that was written as an if statement, causing CBS-QB3 atom corrections to be ignored. This was corrected.