### PR TITLE
force to use older version of cython

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera >=2.2
   - coolprop
-  - cython >=0.25.2
+  - cython == 0.25.2
   - matplotlib >=1.5
   - rdkit >=2015.09.2
   - pydas >=1.0.1

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera >=2.2
   - coolprop
-  - cython >=0.25.2
+  - cython == 0.25.2
   - matplotlib >=1.5
   - rdkit >=2015.09.2
   - pydas >=1.0.1

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy >=1.10.0
   - cantera >=2.2
   - coolprop
-  - cython >=0.25.2
+  - cython == 0.25.2
   - matplotlib >=1.5
   - rdkit >=2015.09.2
   - lpsolve55


### PR DESCRIPTION
The latest version of cython 0.26.0 appears to be the cause of #1109.  While I work out the actual source of the issue I think it best that we force RMG to use 0.25.2 so that the travis builds will work correctly.  