### PR TITLE
Only core degeneracy is accurate

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1487,6 +1487,11 @@ class KineticsFamily(Database):
         reaction.degeneracy = 1
         from rmgpy.rmg.react import findDegeneracies, reduceSameReactantDegeneracy, getMoleculeTuples
 
+        # if reactants are different instances, make deep copy of reaction object
+        if len(reaction.reactants) > 1 and \
+                      len(set([id(r) for r in reaction.reactants])) != \
+                      len(reaction.reactants):
+            reaction = reaction.copy()
         # find combinations of resonance isomers
         specReactants = []
         if isinstance(reaction.reactants[0], Molecule):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1528,10 +1528,8 @@ class KineticsFamily(Database):
             
         # log issues
         if len(reactions) != 1:
-            for reactant in reaction.reactants:
-                logging.error("Reactant: {0!r}".format(reactant))
-            for product in reaction.products:
-                logging.error("Product: {0!r}".format(product))
+            logging.error("The full original reaction object is: {0!r}".format(reaction))
+            logging.error("The reaction objects found are: {0!r}".format(reactions))
             raise KineticsError(('Unable to calculate degeneracy for reaction {0} '
                                  'in reaction family {1}. Expected 1 reaction '
                                  'but generated {2}').format(reaction, self.label, len(reactions)))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1528,11 +1528,14 @@ class KineticsFamily(Database):
             
         # log issues
         if len(reactions) != 1:
-            logging.error("The full original reaction object is: {0!r}".format(reaction))
-            logging.error("The reaction objects found are: {0!r}".format(reactions))
-            raise KineticsError(('Unable to calculate degeneracy for reaction {0} '
+            logging.warning(('Unable to calculate degeneracy for reaction {0} '
                                  'in reaction family {1}. Expected 1 reaction '
                                  'but generated {2}').format(reaction, self.label, len(reactions)))
+            logging.warning("The full original reaction object is: {0!r}".format(reaction))
+            logging.warning("The reaction objects found are: {0!r}".format(reactions))
+            if len(reactions) == 0:
+                return 1.0
+
         return reactions[0].degeneracy
         
     def __generateReactions(self, reactants, products=None, forward=True):

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -370,9 +370,9 @@ class TestReactionDegeneracy(unittest.TestCase):
         spcA = Species().fromSMILES('[H]')
         spcB = Species().fromSMILES('CC=C[CH]C')
         spcB.generateResonanceIsomers(keepIsomorphic=True)
-        spcTuples = [(spcA,spcB)]
+        spcTuple = (spcA,spcB)
         
-        reactionList = list(react(*spcTuples))
+        reactionList = reactSpecies(spcTuple, accurateDegeneracies = True)
         
         # find reaction with a specific product
         specific_product = Species().fromSMILES('[CH2]C=C[CH]C')
@@ -397,8 +397,9 @@ class TestReactionDegeneracy(unittest.TestCase):
         """
         spcA = Species().fromSMILES('C[C]=C')
         spcB = Species().fromSMILES('C=C[CH2]')
-        spcTuples = [(spcA,spcB)]
-        reactionList = list(react(*spcTuples))
+        spcTuple = (spcA,spcB)
+
+        reactionList = reactSpecies(spcTuple, accurateDegeneracies = True)
         # find reaction with a specific product
         specific_products = [Species().fromSMILES('C=C=C'),
                              Species().fromSMILES('CC=C'),]
@@ -456,9 +457,9 @@ class TestReactionDegeneracy(unittest.TestCase):
         spcA = Species().fromSMILES('[H]')
         spcB = Species().fromSMILES('CC=C[CH]C')
         spcB.generateResonanceIsomers(keepIsomorphic=True)
-        spcTuples = [(spcA,spcB)]
+        spcTuple = (spcA,spcB)
         
-        reactionList = list(react(*spcTuples))
+        reactionList = reactSpecies(spcTuple, accurateDegeneracies = True)
         
         # find reaction with a specific product
         specific_product = Species().fromSMILES('CC=C[CH][CH2]')

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -46,6 +46,7 @@ from rmgpy.quantity import Quantity
 import rmgpy.species
 from rmgpy.thermo.thermoengine import submit
 from rmgpy.reaction import Reaction
+from rmgpy.data.rmg import getDB
 from rmgpy.exceptions import ForbiddenStructureException
 from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
@@ -1346,7 +1347,12 @@ class CoreEdgeReactionModel:
         ensure it is supposed to be a core reaction (i.e. all of its reactants
         AND all of its products are in the list of core species).
         """
+        database = getDB('kinetics')
         if rxn not in self.core.reactions:
+            if isinstance(rxn,TemplateReaction):
+                # get accurate degeneracy of core reactions
+                family = database.families[rxn.family]
+                rxn.degeneracy = family.calculateDegeneracy(rxn)
             self.core.reactions.append(rxn)
         if rxn in self.edge.reactions:
             self.edge.reactions.remove(rxn)

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -402,12 +402,12 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
 
         # make species' objects
         spcA = Species().fromSMILES('[H]')
-        spcB = Species().fromSMILES('C=C[CH2]C')
-        spcC = Species().fromSMILES('C=C=CC')
+        spcB = Species().fromSMILES('C=CCC')
+        spcC = Species().fromSMILES('C=C[CH]C')
         spcD = Species().fromSMILES('[H][H]')
         spcA.label = '[H]'
-        spcB.label = 'C=C[CH2]C'
-        spcC.label = 'C=C=CC'
+        spcB.label = 'C=CCC'
+        spcC.label = 'C=C[CH]C'
         spcD.label = '[H][H]'
         spcB.generateResonanceIsomers()
 
@@ -419,14 +419,15 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
                                              products = [spcC, spcD],
                                                 family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+                                                template = ['X_H', 'Y_rad'])
         reaction_in_model.reactants.sort()
         reaction_in_model.products.sort()
 
         reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
                                              products = [spcC, spcD],
                                                 family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+                                                template = ['X_H', 'Y_rad'])
+
         cerm.addReactionToCore(reaction_in_model)
         cerm.registerReaction(reaction_in_model)
 
@@ -444,11 +445,11 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         # make species' objects
         spcA = Species().fromSMILES('[H]')
         spcB = Species().fromSMILES('C=C[CH2]C')
-        spcC = Species().fromSMILES('C=C=CC')
+        spcC = Species().fromSMILES('C=[C][CH]C')
         spcD = Species().fromSMILES('[H][H]')
         spcA.label = '[H]'
         spcB.label = 'C=C[CH2]C'
-        spcC.label = 'C=C=CC'
+        spcC.label = 'C=[C][CH]C'
         spcD.label = '[H][H]'
         spcB.generateResonanceIsomers()
 
@@ -486,11 +487,11 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         # make species' objects
         spcA = Species().fromSMILES('[H]')
         spcB = Species().fromSMILES('C=C[CH2]C')
-        spcC = Species().fromSMILES('C=C=CC')
+        spcC = Species().fromSMILES('C=[C][CH]C')
         spcD = Species().fromSMILES('[H][H]')
         spcA.label = '[H]'
         spcB.label = 'C=C[CH2]C'
-        spcC.label = 'C=C=CC'
+        spcC.label = 'C=[C][CH]C'
         spcD.label = '[H][H]'
         spcB.generateResonanceIsomers()
 
@@ -520,19 +521,21 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
     def test_checkForExistingReaction_keeps_different_template_reactions(self):
         """
         Test that checkForExistingReaction keeps reactions with different templates
+
+        This reaction is a real rxn with multiple TS which we expect to be kept.
         """
         from rmgpy.data.kinetics.family import TemplateReaction
         cerm = CoreEdgeReactionModel()
 
         # make species' objects
-        spcA = Species().fromSMILES('[H]')
-        spcB = Species().fromSMILES('C=C[CH2]C')
-        spcC = Species().fromSMILES('C=C=CC')
-        spcD = Species().fromSMILES('[H][H]')
-        spcA.label = '[H]'
-        spcB.label = 'C=C[CH2]C'
-        spcC.label = 'C=C=CC'
-        spcD.label = '[H][H]'
+        spcA = Species().fromSMILES('CCC[CH2]')
+        spcB = Species().fromSMILES('C[CH]CC')
+        spcC = Species().fromSMILES('CCCC')
+        spcD = Species().fromSMILES('[CH2]C[CH]C')
+        spcA.label = 'CCC[CH2]'
+        spcB.label = 'C[CH]CC'
+        spcC.label = 'CCCC'
+        spcD.label = '[CH2]C[CH]C'
         spcB.generateResonanceIsomers()
 
         cerm.addSpeciesToCore(spcA)
@@ -543,14 +546,14 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
                                              products = [spcC, spcD],
                                                 family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+                                                template = ['X_H', 'Y_rad'])
         reaction_in_model.reactants.sort()
         reaction_in_model.products.sort()
 
         reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
                                              products = [spcC, spcD],
                                                 family = 'H_Abstraction',
-                                                template = ['Cs12345','H'])
+                                                template = ['C/H3/Cs', 'Y_rad'])
         cerm.addReactionToCore(reaction_in_model)
         cerm.registerReaction(reaction_in_model)
 
@@ -578,7 +581,7 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
 
         rxn_f = TemplateReaction(reactants = [s1, s2],
                                     products = [s3, s4],
-                                    template = ['C/H3/Cs\H3','H_rad'],
+                                    template = ['C/H3/Cs', 'Y_rad'],
                                     degeneracy = 6,
                                     family = 'H_Abstraction',
                                     reverse = TemplateReaction(reactants = [s3, s4],
@@ -596,7 +599,7 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
                                     family = 'H_Abstraction',
                                     reverse = TemplateReaction(reactants = [s1, s2],
                                                             products = [s3, s4],
-                                                            template = ['C/H3/Cs\H3','H_rad'],
+                                                            template = ['C/H3/Cs', 'Y_rad'],
                                                             degeneracy = 6,
                                                             family = 'H_Abstraction',
                                                             )

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -248,6 +248,21 @@ def convertToSpeciesObjects(reaction):
     # if already species' objects, return none
     if isinstance(reaction.reactants[0],Species):
         return None
+
+    # map reactants and reaction paris before conversion
+    pair_indexes = []
+    for reactant, product in reaction.pairs:
+        newPair = []
+        for r_index, reactant0 in enumerate(reaction.reactants):
+            if id(reactant0) == id(reactant):
+                newPair.append(r_index)
+                break
+        for p_index, product0 in enumerate(reaction.products):
+            if id(product0) == id(product):
+                newPair.append(p_index)
+                break
+        pair_indexes.append(newPair)
+
     # obtain species with all resonance isomers
     for i, mol in enumerate(reaction.reactants):
         spec = Species(molecule = [mol])
@@ -258,19 +273,10 @@ def convertToSpeciesObjects(reaction):
         spec.generateResonanceIsomers(keepIsomorphic=True)
         reaction.products[i] = spec
 
-    # convert reaction.pairs object to species
+    # convert reaction.pairs object to contain species objects
     newPairs=[]
-    for reactant, product in reaction.pairs:
-        newPair = []
-        for reactant0 in reaction.reactants:
-            if reactant0.isIsomorphic(reactant):
-                newPair.append(reactant0)
-                break
-        for product0 in reaction.products:
-            if product0.isIsomorphic(product):
-                newPair.append(product0)
-                break
-        newPairs.append(newPair)
+    for r_index, p_index in pair_indexes:
+        newPairs.append([reaction.reactants[r_index],reaction.products[p_index]])
     reaction.pairs = newPairs
 
     try:

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -240,10 +240,11 @@ def findDegeneracies(rxnList, useSpeciesReaction = True):
         
     return rxnList
 
-def convertToSpeciesObjects(reaction):
+def convertToSpeciesObjects(reaction, make_resonance_structures = True):
     """
     modifies a reaction holding Molecule objects to a reaction holding
-    Species objects, with generated resonance isomers.
+    Species objects, with generated resonance isomers, if `make_resonance_structures`
+    is True.
     """
     # if already species' objects, return none
     if isinstance(reaction.reactants[0],Species):
@@ -261,16 +262,20 @@ def convertToSpeciesObjects(reaction):
             if id(product0) == id(product):
                 newPair.append(p_index)
                 break
+        if len(newPair) != 2:
+            raise ReactionError('Unable to find reaction pairs for {}'.format(reaction))
         pair_indexes.append(newPair)
 
     # obtain species with all resonance isomers
     for i, mol in enumerate(reaction.reactants):
         spec = Species(molecule = [mol])
-        spec.generateResonanceIsomers(keepIsomorphic=True)
+        if make_resonance_structures:
+            spec.generateResonanceIsomers(keepIsomorphic=True)
         reaction.reactants[i] = spec
     for i, mol in enumerate(reaction.products):
         spec = Species(molecule = [mol])
-        spec.generateResonanceIsomers(keepIsomorphic=True)
+        if make_resonance_structures:
+            spec.generateResonanceIsomers(keepIsomorphic=True)
         reaction.products[i] = spec
 
     # convert reaction.pairs object to contain species objects
@@ -280,7 +285,7 @@ def convertToSpeciesObjects(reaction):
     reaction.pairs = newPairs
 
     try:
-        convertToSpeciesObjects(reaction.reverse)
+        convertToSpeciesObjects(reaction.reverse, make_resonance_structures)
     except AttributeError:
         pass
 

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -76,7 +76,7 @@ def reactSpecies(speciesTuple):
 
     reactions = map(reactMolecules,combos)
     reactions = list(itertools.chain.from_iterable(reactions))
-    # remove reverse reaction
+    # find all degeneracies
     reactions = findDegeneracies(reactions)
     # add reverse attribute to families with ownReverse
     for rxn in reactions:
@@ -148,11 +148,11 @@ def getMoleculeTuples(speciesTuple):
 
 def reactMolecules(moleculeTuples):
     """
-    Performs a reaction between
-    the resonance isomers.
+    Finds reactions between the resonance isomers of species.
 
     The parameter contains a list of tuples with each tuple:
     (Molecule, index of the core species it belongs to)
+    This is meant to help with deflating
     """
 
     families = getDB('kinetics').families
@@ -174,8 +174,8 @@ def findDegeneracies(rxnList, useSpeciesReaction = True):
     given a list of Reaction object with Molecule objects, this method 
     removes degenerate reactions and increments the degeneracy of the 
     reaction object. For multiple transition states, this method adds
-    them as separate duplicate reactions. This method modifies
-    rxnList in place and does not return anything.
+    them as separate duplicate reactions. This method returns a list of
+    reactions using species objects with degeneracies modified.
 
     This algorithm used to exist in family.__generateReactions, but was moved
     here because it didn't have any family dependence.

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -63,7 +63,7 @@ def react(*spcTuples):
 
     return reactions
 
-def reactSpecies(speciesTuple):
+def reactSpecies(speciesTuple, accurateDegeneracies = False):
     """
     given one species tuple, will find the reactions and remove degeneracy
     from them.
@@ -76,8 +76,8 @@ def reactSpecies(speciesTuple):
 
     reactions = map(reactMolecules,combos)
     reactions = list(itertools.chain.from_iterable(reactions))
-    # find all degeneracies
-    reactions = findDegeneracies(reactions)
+    # reduce number of reactions by finding degenerate rxns.
+    reactions = findDegeneracies(reactions, accurateDegeneracies)
     # add reverse attribute to families with ownReverse
     for rxn in reactions:
         family = getDB('kinetics').families[rxn.family]
@@ -85,8 +85,9 @@ def reactSpecies(speciesTuple):
             family.addReverseAttribute(rxn)
     # fix the degneracy of (not ownReverse) reactions found in the backwards
     # direction
-    correctDegeneracyOfReverseReactions(reactions, list(speciesTuple))
-    reduceSameReactantDegeneracy(reactions)
+    if accurateDegeneracies:
+        correctDegeneracyOfReverseReactions(reactions, list(speciesTuple))
+        reduceSameReactantDegeneracy(reactions)
     # get a molecule list with species indexes
     zippedList = []
     for spec in speciesTuple:

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -47,9 +47,10 @@ TESTFAMILY = 'H_Abstraction'
 
 class TestReact(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         """
-        A method that is run before each unit test in this class.
+        A method that is run before this class.
         """
         # set-up RMG object
         self.rmg = RMG()
@@ -221,8 +222,53 @@ class TestReact(unittest.TestCase):
         for spc in rxn.products:
             self.assertTrue(isinstance(spc, Species))
 
+    def testconvertToSpeciesObjects(self):
+        """
+        Test that convertToSpeciesObjects returns all resonance structures
+        """
+        molA = Molecule().fromSMILES('C=C[CH]C')
+        molB = Molecule().fromSMILES('C=CC')
+        molC = Molecule().fromSMILES('C=CCC')
+        molD = Molecule().fromSMILES('C=C[CH2]')
+        rxn = Reaction(reactants=[molA, molB], products=[molC,molD],
+        pairs=[(molA, molC), (molB, molD)])
 
-    def tearDown(self):
+        convertToSpeciesObjects(rxn, make_resonance_structures=True)
+
+        resonance_structure_list = [2,1,1,2]
+
+        for index, spec in enumerate(rxn.reactants + rxn.products):
+            self.assertEqual(len(spec.molecule), resonance_structure_list[index])
+
+    def testconvertToSpeciesObjects2(self):
+        """
+        Test that convertToSpeciesObjects returns same molecule objects
+        """
+        molA = Molecule().fromSMILES('C=C[CH]C')
+        molB = Molecule().fromSMILES('C=CC')
+        molC = Molecule().fromSMILES('C=CCC')
+        molD = Molecule().fromSMILES('C=C[CH2]')
+        rxn = Reaction(reactants=[molA, molB], products=[molC,molD],
+        pairs=[(molA, molC), (molB, molD)])
+
+        idA = id(molA)
+        idB = id(molB)
+        idC = id(molC)
+        idD = id(molD)
+        convertToSpeciesObjects(rxn, make_resonance_structures=False)
+
+        self.assertEqual(idA, id(rxn.reactants[0].molecule[0]))
+        self.assertEqual(idB, id(rxn.reactants[1].molecule[0]))
+        self.assertEqual(idC, id(rxn.products[0].molecule[0]))
+        self.assertEqual(idD, id(rxn.products[1].molecule[0]))
+
+        resonance_structure_list = [1,1,1,1]
+
+        for index, spec in enumerate(rxn.reactants + rxn.products):
+            self.assertEqual(len(spec.molecule), resonance_structure_list[index])
+
+    @classmethod
+    def tearDownClass(self):
         """
         Reset the loaded database
         """


### PR DESCRIPTION
This PR tries to fix part of the issue #1079 by allowing degeneracy in the generate reactions step to be done in a similar way to before PR #1055, except that multiple transition states are kept. When a reaction is added to the core, then the degeneracy is found with `family.calculateDegeneracy`. 

This will help fix a slowdown in RMG while minimizing the impact on having uncertain values.

Thanks to @whgreen, @amarkpayne, @rgillis8, @mjohnson541 for comments and suggestions at the meeting this week, which all led to improvements of imlementation.

For reviewer:

* check to see that nothing (or very little) has changed in the RMG-Tests page
* check to see if any time improvement has occurred in the RMG-Tests page
* look through the commits to see if the code makes sense
* (optional) profile performance of longer runs.