### PR TITLE
Fix seed generation

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -814,8 +814,6 @@ class RMG(util.Subject):
         
         name = self.name
         
-        currentDir = os.getcwd()
-        
         if self.saveSeedToDatabase and firstTime: #make sure don't overwrite current libraries
             thermoNames = self.database.thermo.libraries.keys()
             kineticsNames = self.database.kinetics.libraries.keys()
@@ -826,11 +824,13 @@ class RMG(util.Subject):
                     q += 1
                 self.name = name + str(q)
         
-        if firstTime and not os.path.exists(os.path.join(currentDir,'seed')): #if seed directory does not exist make it
-            os.system('mkdir seed')
+        seedDir = os.path.join(self.outputDirectory,'seed')
+        
+        if firstTime and not os.path.exists(seedDir): #if seed directory does not exist make it
+            os.system('mkdir '+seedDir)
         else:
-            os.system('rm -rf seed') #otherwise delete the old seed and make a new directory
-            os.system('mkdir seed')
+            os.system('rm -rf '+ seedDir) #otherwise delete the old seed and make a new directory
+            os.system('mkdir '+ seedDir)
             
         speciesList = self.reactionModel.core.species
         reactionList = self.reactionModel.core.reactions
@@ -885,8 +885,6 @@ class RMG(util.Subject):
             thermoLibrary.save(os.path.join(databaseDirectory, 'thermo' ,'libraries', name + '.py'))
             kineticsLibrary.save(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'reactions.py'))
             kineticsLibrary.saveDictionary(os.path.join(databaseDirectory, 'kinetics', 'libraries', name, 'dictionary.txt'))
-        
-        seedDir = os.path.join(os.getcwd(),'seed')
         
         #save in output directory
         thermoLibrary.save(os.path.join(seedDir, name + '.py'))

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -206,9 +206,9 @@ class RMG(util.Subject):
         self.initializationTime = 0
         self.kineticsdatastore = None
         
-        self.name = None
-        self.generateSeedEachIteration = None
-        self.saveSeedToDatabase = None
+        self.name = 'Seed'
+        self.generateSeedEachIteration = True
+        self.saveSeedToDatabase = False
 
         self.thermoCentralDatabase = None
 


### PR DESCRIPTION
This should fix #1116 and #1115.  The seed is now produced in the output directory rather than the working directory and the seed option variables are now properly initialized by RMG.clear().  

An alternative fix to #1115 would be to run options() right before input generation, which would make it so that options variables' default values would only be set at one location (the values in RMG.clear() would be irrelevant).  I don't think we currently use RMG.clear() for anything other than initialization, however if we were to do so, being dependent on the options() call to fill in the options variables would be undesirable.  