### PR TITLE
Use thermo library names

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1267,6 +1267,7 @@ class ThermoDatabase(object):
             for molecule in species.molecule:
                 if molecule.isIsomorphic(entry.item) and entry.data is not None:
                     thermoData = deepcopy(entry.data)
+                    thermoData.label = entry.label
                     findCp0andCpInf(species, thermoData)
                     match = (thermoData, library, entry)
                     break

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -307,14 +307,6 @@ class CoreEdgeReactionModel:
         # Check that the structure is not forbidden
 
         # If we're here then we're ready to make the new species
-        if label == '': 
-            # Use SMILES as default format for label
-            # However, SMILES can contain slashes (to describe the
-            # stereochemistry around double bonds); since RMG doesn't 
-            # distinguish cis and trans isomers, we'll just strip these out
-            # so that we can use the label in file paths
-            label = molecule.toSMILES().replace('/','').replace('\\','')
-        logging.debug('Creating new species {0}'.format(label))
         if reactive:
             self.speciesCounter += 1   # count only reactive species
             speciesIndex = self.speciesCounter
@@ -331,7 +323,22 @@ class CoreEdgeReactionModel:
         spec.molecularWeight = Quantity(spec.molecule[0].getMolecularWeight()*1000.,"amu")
         
         submit(spec)
-
+        
+        if spec.label == '':
+            if spec.thermo and spec.thermo.label != '': #check if thermo libraries have a name for it
+                logging.info('Species with SMILES of {0} named {1} based on thermo library name'.format(molecule.toSMILES().replace('/','').replace('\\',''),spec.thermo.label))
+                spec.label = spec.thermo.label
+                label = spec.label
+            else:
+                # Use SMILES as default format for label
+                # However, SMILES can contain slashes (to describe the
+                # stereochemistry around double bonds); since RMG doesn't 
+                # distinguish cis and trans isomers, we'll just strip these out
+                # so that we can use the label in file paths
+                label = molecule.toSMILES().replace('/','').replace('\\','')
+                
+        logging.debug('Creating new species {0}'.format(label))
+        
         spec.generateEnergyTransferModel()
         formula = molecule.getFormula()
         if formula in self.speciesDict:

--- a/rmgpy/thermo/model.pxd
+++ b/rmgpy/thermo/model.pxd
@@ -30,7 +30,7 @@ from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 cdef class HeatCapacityModel:
     
     cdef public ScalarQuantity _Tmin, _Tmax, _E0, _Cp0, _CpInf
-    cdef public str comment
+    cdef public str comment,label
     
     cpdef bint isTemperatureValid(self, double T) except -2
 

--- a/rmgpy/thermo/model.pyx
+++ b/rmgpy/thermo/model.pyx
@@ -54,12 +54,13 @@ cdef class HeatCapacityModel:
 
     """
     
-    def __init__(self, Tmin=None, Tmax=None, E0=None, Cp0=None, CpInf=None, comment=''):
+    def __init__(self, Tmin=None, Tmax=None, E0=None, Cp0=None, CpInf=None, label='', comment=''):
         self.Tmin = Tmin
         self.Tmax = Tmax
         self.E0 = E0
         self.Cp0 = Cp0
         self.CpInf = CpInf
+        self.label = label
         self.comment = comment
         
     def __repr__(self):
@@ -67,13 +68,14 @@ cdef class HeatCapacityModel:
         Return a string representation that can be used to reconstruct the
         HeatCapacityModel object.
         """
-        return 'HeatCapacityModel(Tmin={0!r}, Tmax={1!r}, E0={2!r}, Cp0={3!r}, Cp0={4!r}, comment="""{5}""")'.format(self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.comment)
+        return 'HeatCapacityModel(Tmin={0!r}, Tmax={1!r}, E0={2!r}, Cp0={3!r}, Cp0={4!r}, label="""{5}""", comment="""{6}""")'.format(self.Tmin,
+                                 self.Tmax, self.E0, self.Cp0, self.CpInf, self.label, self.comment)
 
     def __reduce__(self):
         """
         A helper function used when pickling a HeatCapacityModel object.
         """
-        return (HeatCapacityModel, (self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.comment))
+        return (HeatCapacityModel, (self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.label, self.comment))
 
     property E0:
         """The ground state energy (J/mol) at zero Kelvin, including zero point energy, or ``None`` if not yet specified."""

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -54,8 +54,8 @@ cdef class NASAPolynomial(HeatCapacityModel):
 
     """
     
-    def __init__(self, coeffs=None, Tmin=None, Tmax=None, E0=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, comment=comment)
+    def __init__(self, coeffs=None, Tmin=None, Tmax=None, E0=None, label='', comment=''):
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, label=label, comment=comment)
         self.coeffs = coeffs
         
     def __repr__(self):
@@ -71,6 +71,7 @@ cdef class NASAPolynomial(HeatCapacityModel):
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
         if self.E0 is not None: string += ', E0={0!r}'.format(self.E0)
+        if self.label != '': string += ', label="""{0}"""'.format(self.label)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -79,7 +80,7 @@ cdef class NASAPolynomial(HeatCapacityModel):
         """
         A helper function used when pickling an object.
         """
-        return (NASAPolynomial, ([self.cm2, self.cm1, self.c0, self.c1, self.c2, self.c3, self.c4, self.c5, self.c6], self.Tmin, self.Tmax, self.E0, self.comment))
+        return (NASAPolynomial, ([self.cm2, self.cm1, self.c0, self.c1, self.c2, self.c3, self.c4, self.c5, self.c6], self.Tmin, self.Tmax, self.E0, self.label, self.comment))
 
     property coeffs:
         """The set of seven or nine NASA polynomial coefficients."""
@@ -200,8 +201,8 @@ cdef class NASA(HeatCapacityModel):
 
     """
     
-    def __init__(self, polynomials=None, Tmin=None, Tmax=None, E0=None, Cp0=None, CpInf=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, Cp0=Cp0, CpInf=CpInf, comment=comment)
+    def __init__(self, polynomials=None, Tmin=None, Tmax=None, E0=None, Cp0=None, CpInf=None, label='', comment=''):
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, Cp0=Cp0, CpInf=CpInf, label=label, comment=comment)
         self.polynomials = polynomials
     
     def __repr__(self):
@@ -216,6 +217,7 @@ cdef class NASA(HeatCapacityModel):
         if self.E0 is not None: string += ', E0={0!r}'.format(self.E0)
         if self.Cp0 is not None: string += ', Cp0={0!r}'.format(self.Cp0)
         if self.CpInf is not None: string += ', CpInf={0!r}'.format(self.CpInf)
+        if self.label != '': string += ', label="""{0}"""'.format(self.label)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -224,7 +226,7 @@ cdef class NASA(HeatCapacityModel):
         """
         A helper function used when pickling an object.
         """
-        return (NASA, (self.polynomials, self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.comment))
+        return (NASA, (self.polynomials, self.Tmin, self.Tmax, self.E0, self.Cp0, self.CpInf, self.label, self.comment))
 
     property polynomials:
         """The set of one, two, or three NASA polynomials."""
@@ -338,7 +340,7 @@ cdef class NASA(HeatCapacityModel):
         H298 = self.getEnthalpy(298)
         S298 = self.getEntropy(298)
         
-        return Wilhoit(comment=self.comment).fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
+        return Wilhoit(label=self.label,comment=self.comment).fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
     
     cpdef NASA changeBaseEnthalpy(self, double deltaH):
         """

--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -56,8 +56,8 @@ cdef class ThermoData(HeatCapacityModel):
     
     """
 
-    def __init__(self, Tdata=None, Cpdata=None, H298=None, S298=None, Cp0=None, CpInf=None, Tmin=None, Tmax=None, E0=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, Cp0=Cp0, CpInf=CpInf, comment=comment)
+    def __init__(self, Tdata=None, Cpdata=None, H298=None, S298=None, Cp0=None, CpInf=None, Tmin=None, Tmax=None, E0=None, label = '',comment=''):
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, E0=E0, Cp0=Cp0, CpInf=CpInf, label=label, comment=comment)
         self.H298 = H298
         self.S298 = S298
         self.Tdata = Tdata
@@ -74,6 +74,7 @@ cdef class ThermoData(HeatCapacityModel):
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
         if self.E0 is not None: string += ', E0={0!r}'.format(self.E0)
+        if self.label != '': string +=', label="""{0}"""'.format(self.label)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -82,7 +83,7 @@ cdef class ThermoData(HeatCapacityModel):
         """
         A helper function used when pickling a ThermoData object.
         """
-        return (ThermoData, (self.Tdata, self.Cpdata, self.H298, self.S298, self.Cp0, self.CpInf, self.Tmin, self.Tmax, self.E0, self.comment))
+        return (ThermoData, (self.Tdata, self.Cpdata, self.H298, self.S298, self.Cp0, self.CpInf, self.Tmin, self.Tmax, self.E0, self.label, self.comment))
 
     property Tdata:
         """An array of temperatures at which the heat capacity is known."""
@@ -354,10 +355,11 @@ cdef class ThermoData(HeatCapacityModel):
         Cp0 = self._Cp0.value_si
         CpInf = self._CpInf.value_si
         
+        
         if B:
-            return Wilhoit(comment=self.comment).fitToDataForConstantB(Tdata, Cpdata, Cp0, CpInf, H298, S298, B=B)
+            return Wilhoit(label=self.label,comment=self.comment).fitToDataForConstantB(Tdata, Cpdata, Cp0, CpInf, H298, S298, B=B)
         else:
-            return Wilhoit(comment=self.comment).fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
+            return Wilhoit(label=self.label,comment=self.comment).fitToData(Tdata, Cpdata, Cp0, CpInf, H298, S298)
 
     cpdef NASA toNASA(self, double Tmin, double Tmax, double Tint, bint fixedTint=False, bint weighting=True, int continuity=3):
         """

--- a/rmgpy/thermo/thermodataTest.py
+++ b/rmgpy/thermo/thermodataTest.py
@@ -215,6 +215,7 @@ class TestThermoData(unittest.TestCase):
         self.assertEqual(self.thermodata.Tmax.units, thermodata.Tmax.units)
         self.assertAlmostEqual(self.thermodata.E0.value, thermodata.E0.value, 4)
         self.assertEqual(self.thermodata.E0.units, thermodata.E0.units)
+        self.assertEqual(self.thermodata.label,thermodata.label)
         self.assertEqual(self.thermodata.comment, thermodata.comment)
     
     def test_repr(self):
@@ -246,4 +247,5 @@ class TestThermoData(unittest.TestCase):
         self.assertEqual(self.thermodata.Tmax.units, thermodata.Tmax.units)
         self.assertAlmostEqual(self.thermodata.E0.value, thermodata.E0.value, 4)
         self.assertEqual(self.thermodata.E0.units, thermodata.E0.units)
+        self.assertEqual(self.thermodata.label, thermodata.label)
         self.assertEqual(self.thermodata.comment, thermodata.comment)

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -59,8 +59,8 @@ cdef class Wilhoit(HeatCapacityModel):
     
     """
 
-    def __init__(self, Cp0=None, CpInf=None, a0=0.0, a1=0.0, a2=0.0, a3=0.0, H0=None, S0=None, B=None, Tmin=None, Tmax=None, comment=''):
-        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Cp0=Cp0, CpInf=CpInf, comment=comment)
+    def __init__(self, Cp0=None, CpInf=None, a0=0.0, a1=0.0, a2=0.0, a3=0.0, H0=None, S0=None, B=None, Tmin=None, Tmax=None, label='', comment=''):
+        HeatCapacityModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Cp0=Cp0, CpInf=CpInf, label=label, comment=comment)
         self.B = B
         self.a0 = a0
         self.a1 = a1
@@ -78,6 +78,7 @@ cdef class Wilhoit(HeatCapacityModel):
             self.Cp0, self.CpInf, self.a0, self.a1, self.a2, self.a3, self.H0, self.S0, self.B)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
+        if self.label != '': string += ', label="""{0}"""'.format(self.label)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -86,7 +87,7 @@ cdef class Wilhoit(HeatCapacityModel):
         """
         A helper function used when pickling a Wilhoit object.
         """
-        return (Wilhoit, (self.Cp0, self.CpInf, self.a0, self.a1, self.a2, self.a3, self.H0, self.S0, self.B, self.Tmin, self.Tmax, self.comment))
+        return (Wilhoit, (self.Cp0, self.CpInf, self.a0, self.a1, self.a2, self.a3, self.H0, self.S0, self.B, self.Tmin, self.Tmax, self.label, self.comment))
 
     property B:
         """The Wilhoit scaled temperature coefficient."""
@@ -566,6 +567,7 @@ cdef class Wilhoit(HeatCapacityModel):
             E0 = self.E0,
             Cp0 = self.Cp0,
             CpInf = self.CpInf,
+            label = self.label,
             comment = self.comment,
         )
     


### PR DESCRIPTION
This causes RMG to use the names associated with thermo library entries rather than smiles when a thermo library entry is available (and if not already assigned by a seed mechanism or reaction library).  