### PR TITLE
Ring Perception

### DIFF
--- a/documentation/source/users/rmg/installation/dependencies.rst
+++ b/documentation/source/users/rmg/installation/dependencies.rst
@@ -16,15 +16,20 @@ Briefly, RMG depends on the following packages, almost all of which can be found
 * **cairocffi:** a set of Python bindings and object-oriented API for cairo
 * **coverage:** code coverage measurement for Python
 * **cython:** compiling Python modules to C for speed up
+* **ffmpeg:** (optional) used to encode videos, necessary for generating video flux diagrams
 * **gaussian:** (optional) commerical software program for quantum mechanical calculations.  Must be installed separately.
 * **gcc:** GNU compiler collection for C,C++, and Fortran. (MinGW is used in windows)
 * **gprof2dot:** converts Python profiling output to a dot graph
 * **graphviz:** generating flux diagrams
 * **jinja2:** Python templating language for html rendering
+* **jupyter:** (optional) for using IPython notebooks
+* **lpsolve:** mixed integer linear programming solver, used for resonance structure generation. Must also install Python extension.
 * **markupsafe:** implements XML/HTML/XHTML markup safe strings for Python
 * **matplotlib:** library for making plots
-* **ffmpeg:** (optional) used to encode videos, necessary for generating video flux diagrams
+* **mock:** for unit-testing
 * **mopac:** semi-empirical software package for QM calculations
+* **muq:** (optional) MIT Uncertainty Quantification library, used for global uncertainty analysis
+* **networkx:** (optional) network analysis for reaction-path analysis IPython notebook
 * **nose:** advanced unit test controls
 * **numpy:** fast matrix operations
 * **openbabel:** chemical toolbox for speaking the many languages of chemical data
@@ -33,6 +38,7 @@ Briefly, RMG depends on the following packages, almost all of which can be found
 * **pydot:** interface to Dot graph language
 * **pydqed:** constrained nonlinear optimization
 * **pyparsing:** a general parsing module for python
+* **pyrdl:** RingDecomposerLib for graph ring perception
 * **pyzmq:** Python bindings for zeroMQ
 * **quantities:** unit conversion
 * **rdkit:** open-source cheminformatics toolkit

--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -49,9 +49,9 @@ source code updates and patches through Github.
     updatingSourceCode
 
 For Developers: Direct Installation by Source without Anaconda
-=================================================================
+==============================================================
 
-The installation approach in this section is not recommended and also not maintained by RMG developer team. This is only a record for people who don't want to use Anaconda.
+The installation approach in this section is not recommended and also not maintained by RMG developer team. This is only a record for people who cannot use Anaconda.
 
 .. toctree::
     :maxdepth: 1

--- a/documentation/source/users/rmg/installation/linux.rst
+++ b/documentation/source/users/rmg/installation/linux.rst
@@ -5,7 +5,9 @@ Linux Installation
 ******************
 
 RMG-Py and all of its dependencies may be easily installed through a short series of Terminal commands.
-The instructions listed below have been confirmed on a fresh Ubuntu 12.04 installation and should generally apply to other distributions.
+The instructions listed below were written for Ubuntu 12.04 and should generally apply to other distributions.
+
+Warning: This installation method is no longer actively maintained, and is not guaranteed to work as written.
 
 * Install compilers and libraries: ::
 
@@ -22,7 +24,7 @@ The instructions listed below have been confirmed on a fresh Ubuntu 12.04 instal
 
 * Install dependencies: ::
 
-	sudo apt-get install libpng-dev libfreetype6-dev graphviz mencoder
+	sudo apt-get install libpng-dev libfreetype6-dev graphviz
 	
 	sudo pip install numpy		# install NumPy before other packages
 	
@@ -61,6 +63,12 @@ The instructions listed below have been confirmed on a fresh Ubuntu 12.04 instal
   	export RDBASE=$HOME/rdkit # CHECK THIS (maybe you put RDKit somewhere else)
   	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RDBASE/lib
   	export PYTHONPATH=$PYTHONPATH:$RDBASE  # (or some other way to make sure it's on your Python path)
+
+* The following dependencies are also required for core RMG functions and must be installed from source before building RMG:
+
+  **pyrdl:** RingDecomposerLib, used for ring perception. Download from https://github.com/rareylab/RingDecomposerLib. Requires CMAKE to compile.
+
+  **lpsolve:** Mixed integer linear programming solver. Download from https://sourceforge.net/projects/lpsolve/. Python extension also required.
 
 * Install RMG-Py: ::
 

--- a/documentation/source/users/rmg/installation/macos.rst
+++ b/documentation/source/users/rmg/installation/macos.rst
@@ -14,6 +14,8 @@ but this is optional (without it you may need to add `sudo` before some commands
 You will also need gfortran, Python, Numpy and Scipy. We typically install them using 
 `homebrew-python <https://github.com/Homebrew/homebrew-python>`_  but other methods may work as well.
 
+Warning: This installation method is no longer actively maintained, and is not guaranteed to work as written.
+
 * For example::
 
 	brew tap homebrew/python
@@ -40,6 +42,11 @@ You will also need gfortran, Python, Numpy and Scipy. We typically install them 
 	
 	export RDBASE=/usr/local/share/RDKit
 
+* The following dependencies are also required for core RMG functions and must be installed from source before building RMG:
+
+  **pyrdl:** RingDecomposerLib, used for ring perception. Download from https://github.com/rareylab/RingDecomposerLib. Requires CMAKE to compile.
+
+  **lpsolve:** Mixed integer linear programming solver. Download from https://sourceforge.net/projects/lpsolve/. Python extension also required.
 
 * Make a directory to put everything in::
 

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -22,6 +22,7 @@ dependencies:
   #- argparse # [py26]
   - pyparsing
   - pydot ==1.2.2
+  - pyrdl
   - nose
   - coverage
   - gprof2dot

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -22,6 +22,7 @@ dependencies:
   #- argparse # [py26]
   - pyparsing
   - pydot ==1.2.2
+  - pyrdl
   - nose
   - coverage
   - gprof2dot

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -21,6 +21,7 @@ dependencies:
   - pydas 
   - pydot ==1.2.2
   - pydqed
+  - pyrdl
   - nose
   - coverage
   - gprof2dot

--- a/meta.yaml
+++ b/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - pydot ==1.2.2
     - pydqed >=1.0.1
     - pyparsing
+    - pyrdl
     - python
     - pyzmq
     - quantities
@@ -71,6 +72,7 @@ requirements:
     - pydot ==1.2.2
     - pydqed >=1.0.1
     - pyparsing
+    - pyrdl
     - python
     - pyzmq
     - quantities

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,8 @@ git+https://github.com/soravux/scoop.git@0.7.0
 
 # For unit tests
 mock
+
+# Other required packages which are not available via pip:
+# lpsolve - Download from https://sourceforge.net/projects/lpsolve/
+#           Instructions for python interface: http://lpsolve.sourceforge.net/5.5/Python.htm
+# RingDecomposerLib - Download from https://github.com/rareylab/RingDecomposerLib

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -65,6 +65,10 @@ cdef class Edge(object):
 
 ################################################################################
 
+cdef Vertex _getEdgeVertex1(Edge edge)
+
+cdef Vertex _getEdgeVertex2(Edge edge)
+
 cdef class Graph:
 
     cdef public list vertices

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -73,6 +73,8 @@ cdef class Graph:
 
     cpdef Edge addEdge(self, Edge edge)
 
+    cpdef list getAllEdges(self)
+
     cpdef dict getEdges(self, Vertex vertex)
 
     cpdef Edge getEdge(self, Vertex vertex1, Vertex vertex2)

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -142,6 +142,8 @@ cdef class Graph:
     cpdef list getSmallestSetOfSmallestRings(self)
 
     cpdef list getRelevantCycles(self)
+
+    cpdef list _sortCyclicVertices(self, list vertices)
     
     cpdef list getLargestRing(self, Vertex vertex)
     

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -131,6 +131,8 @@ cdef class Graph:
     
     cpdef tuple getDisparateRings(self)
 
+    cpdef tuple _merge_cycles(self, list cycle_sets)
+
     cpdef list getAllCycles(self, Vertex startingVertex)
 
     cpdef list getAllCyclesOfSize(self, int size)

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -140,6 +140,8 @@ cdef class Graph:
     cpdef list __exploreCyclesRecursively(self, list chain, list cycles)
 
     cpdef list getSmallestSetOfSmallestRings(self)
+
+    cpdef list getRelevantCycles(self)
     
     cpdef list getLargestRing(self, Vertex vertex)
     

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -991,6 +991,14 @@ cdef class Graph:
                     ordered.append(vertex)
                     vertices.remove(vertex)
                     break
+            else:
+                # No connected vertex was found
+                raise RuntimeError('Could not sort cyclic vertices because '
+                                   'not all vertices are connected to two '
+                                   'other vertices in the input list.')
+
+        if not self.hasEdge(ordered[0], ordered[-1]):
+            raise RuntimeError('Input vertices do not comprise a single cycle.')
 
         return ordered
 

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -236,6 +236,21 @@ cdef class Graph:
         edge.vertex2.edges[edge.vertex1] = edge
         return edge
 
+    cpdef list getAllEdges(self):
+        """
+        Returns a list of all edges in the graph.
+        """
+        cdef set edgeSet
+        cdef Vertex vertex
+        cdef Edge edge
+
+        edgeSet = set()
+        for vertex in self.vertices:
+            for edge in vertex.edges.itervalues():
+                edgeSet.add(edge)
+
+        return list(edgeSet)
+
     cpdef dict getEdges(self, Vertex vertex):
         """
         Return a dictionary of the edges involving the specified `vertex`.

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -34,6 +34,7 @@ are the components of a graph.
 """
 
 import logging
+import py_rdl
 from .vf2 cimport VF2
 
 ################################################################################
@@ -197,6 +198,12 @@ cdef class Edge(object):
 ################################################################################
 
 cdef VF2 vf2 = VF2()
+
+cdef  Vertex _getEdgeVertex1(Edge edge):
+    return edge.vertex1
+
+cdef Vertex _getEdgeVertex2(Edge edge):
+    return edge.vertex2
 
 cdef class Graph:
     """
@@ -904,100 +911,36 @@ cdef class Graph:
 
     cpdef list getSmallestSetOfSmallestRings(self):
         """
-        Return a list of the smallest set of smallest rings in the graph. The
-        algorithm implements was adapted from a description by Fan, Panaye,
-        Doucet, and Barbu (doi: 10.1021/ci00015a002)
+        Returns the smallest set of smallest rings as a list of lists.
+        Uses RingDecomposerLib for ring perception.
 
-        B. T. Fan, A. Panaye, J. P. Doucet, and A. Barbu. "Ring Perception: A
-        New Algorithm for Directly Finding the Smallest Set of Smallest Rings
-        from a Connection Table." *J. Chem. Inf. Comput. Sci.* **33**,
-        p. 657-662 (1993).
+        Kolodzik, A.; Urbaczek, S.; Rarey, M.
+        Unique Ring Families: A Chemically Meaningful Description
+        of Molecular Ring Topologies.
+        J. Chem. Inf. Model., 2012, 52 (8), pp 2013-2021
+
+        Flachsenberg, F.; Andresen, N.; Rarey, M.
+        RingDecomposerLib: An Open-Source Implementation of
+        Unique Ring Families and Other Cycle Bases.
+        J. Chem. Inf. Model., 2017, 57 (2), pp 122-126
         """
-        cdef Graph graph
-        cdef bint done, found
-        cdef list cycleList, cycles, cycle, graphs, neighbors, verticesToRemove, vertices
-        cdef Vertex vertex, rootVertex
+        cdef list sssr
+        cdef object graph, data, cycle
 
-        # Make a copy of the graph so we don't modify the original
-        graph = self.copy(deep=True)
-        vertices = graph.vertices[:]
-        
-        # Step 1: Remove all terminal vertices
-        done = False
-        while not done:
-            verticesToRemove = []
-            for vertex in graph.vertices:
-                if len(vertex.edges) == 1: verticesToRemove.append(vertex)
-            done = len(verticesToRemove) == 0
-            # Remove identified vertices from graph
-            for vertex in verticesToRemove:
-                graph.removeVertex(vertex)
+        graph = py_rdl.Graph.from_edges(
+            self.getAllEdges(),
+            _getEdgeVertex1,
+            _getEdgeVertex2,
+        )
 
-        # Step 2: Remove all other vertices that are not part of cycles
-        verticesToRemove = []
-        for vertex in graph.vertices:
-            found = graph.isVertexInCycle(vertex)
-            if not found:
-                verticesToRemove.append(vertex)
-        # Remove identified vertices from graph
-        for vertex in verticesToRemove:
-            graph.removeVertex(vertex)
+        data = py_rdl.wrapper.DataInternal(graph.get_nof_nodes(), graph.get_edges().iterkeys())
+        data.calculate()
 
-        # Step 3: Split graph into remaining subgraphs
-        graphs = graph.split()
+        sssr = []
+        for cycle in data.get_sssr():
+            sssr.append([graph.get_node_for_index(i) for i in cycle.nodes])
 
-        # Step 4: Find ring sets in each subgraph
-        cycleList = []
-        for graph in graphs:
-
-            while len(graph.vertices) > 0:
-
-                # Choose root vertex as vertex with smallest number of edges
-                rootVertex = None
-                graph.updateConnectivityValues()
-                for vertex in graph.vertices:
-                    if rootVertex is None:
-                        rootVertex = vertex
-                    elif getVertexConnectivityValue(vertex) > getVertexConnectivityValue(rootVertex):
-                        rootVertex = vertex
-
-                # Get all cycles involving the root vertex
-                cycles = graph.getAllCycles(rootVertex)
-                if len(cycles) == 0:
-                    # This vertex is no longer in a ring, so remove it
-                    graph.removeVertex(rootVertex)
-                    continue
-
-                # Keep the smallest of the cycles found above
-                cycle = cycles[0]
-                for c in cycles[1:]:
-                    if len(c) < len(cycle):
-                        cycle = c
-                cycleList.append(cycle)
-                
-                # Remove the root vertex to create single edges, note this will not
-                # function properly if there is no vertex with 2 edges (i.e. cubane)
-                graph.removeVertex(rootVertex)
-
-                # Remove from the graph all vertices in the cycle that have only one edge
-                loneCarbon = True
-                while loneCarbon:
-                    loneCarbon = False
-                    verticesToRemove = []
-                    
-                    for vertex in cycle:
-                        if len(vertex.edges) == 1:
-                            loneCarbon = True
-                            verticesToRemove.append(vertex)
-                    else:
-                        for vertex in verticesToRemove:
-                            graph.removeVertex(vertex)
-
-        # Map atoms in cycles back to atoms in original graph
-        for i in range(len(cycleList)):
-            cycleList[i] = [self.vertices[vertices.index(v)] for v in cycleList[i]]
-
-        return cycleList
+        return sssr
 
     cpdef list getLargestRing(self, Vertex vertex):
         """

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -938,7 +938,7 @@ cdef class Graph:
 
         sssr = []
         for cycle in data.get_sssr():
-            sssr.append([graph.get_node_for_index(i) for i in cycle.nodes])
+            sssr.append(self._sortCyclicVertices([graph.get_node_for_index(i) for i in cycle.nodes]))
 
         return sssr
 
@@ -971,9 +971,28 @@ cdef class Graph:
 
         rc = []
         for cycle in data.get_rcs():
-            rc.append([graph.get_node_for_index(i) for i in cycle.nodes])
+            rc.append(self._sortCyclicVertices([graph.get_node_for_index(i) for i in cycle.nodes]))
 
         return rc
+
+    cpdef list _sortCyclicVertices(self, list vertices):
+        """
+        Given a list of vertices comprising a cycle, sort them such that adjacent
+        entries in the list are connected to each other.
+        Warning: Assumes that the cycle is elementary, ie. no bridges.
+        """
+        cdef list ordered
+        cdef Vertex vertex
+
+        ordered = [vertices.pop()]
+        while vertices:
+            for vertex in vertices:
+                if vertex in ordered[-1].edges:
+                    ordered.append(vertex)
+                    vertices.remove(vertex)
+                    break
+
+        return ordered
 
     cpdef list getLargestRing(self, Vertex vertex):
         """

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -942,6 +942,39 @@ cdef class Graph:
 
         return sssr
 
+    cpdef list getRelevantCycles(self):
+        """
+        Returns the set of relevant cycles as a list of lists.
+        Uses RingDecomposerLib for ring perception.
+
+        Kolodzik, A.; Urbaczek, S.; Rarey, M.
+        Unique Ring Families: A Chemically Meaningful Description
+        of Molecular Ring Topologies.
+        J. Chem. Inf. Model., 2012, 52 (8), pp 2013-2021
+
+        Flachsenberg, F.; Andresen, N.; Rarey, M.
+        RingDecomposerLib: An Open-Source Implementation of
+        Unique Ring Families and Other Cycle Bases.
+        J. Chem. Inf. Model., 2017, 57 (2), pp 122-126
+        """
+        cdef list rc
+        cdef object graph, data, cycle
+
+        graph = py_rdl.Graph.from_edges(
+            self.getAllEdges(),
+            _getEdgeVertex1,
+            _getEdgeVertex2,
+        )
+
+        data = py_rdl.wrapper.DataInternal(graph.get_nof_nodes(), graph.get_edges().iterkeys())
+        data.calculate()
+
+        rc = []
+        for cycle in data.get_rcs():
+            rc.append([graph.get_node_for_index(i) for i in cycle.nodes])
+
+        return rc
+
     cpdef list getLargestRing(self, Vertex vertex):
         """
         returns the largest ring containing vertex. This is typically

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -802,6 +802,51 @@ class TestGraph(unittest.TestCase):
             longest_ring = long_ring2
         
         self.assertEqual(len(longest_ring), len(rings[0]) - 1)
+
+    def testSortCyclicVertices(self):
+        """Test that _sortCyclicVertices works properly for a valid input."""
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[5])
+        self.graph.addEdge(edge)  # To create a cycle
+
+
+        # Sort the vertices
+        original = list(self.graph.vertices)
+        ordered = self.graph._sortCyclicVertices(original)
+
+        # Check that we didn't lose any vertices
+        self.assertEqual(len(self.graph.vertices), len(ordered), 'Sorting changed the number of vertices.')
+
+        # Check that the order is different
+        self.assertNotEqual(self.graph.vertices, ordered, 'Sorting did not change the order of vertices.')
+
+        # Check that subsequent vertices are connected
+        for i in range(5):
+            self.assertTrue(self.graph.hasEdge(ordered[i], ordered[i - 1]))
+
+    def testSortCyclicVerticesInvalid(self):
+        """Test that _sortCyclicVertices raises an error for an invalid input."""
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[4])
+        self.graph.addEdge(edge)  # To create a cycle
+
+        original = list(self.graph.vertices)
+
+        with self.assertRaisesRegexp(RuntimeError, 'do not comprise a single cycle'):
+            self.graph._sortCyclicVertices(original)
+
+    def testSortCyclicVerticesNoncyclic(self):
+        """Test that _sortCyclicVertices raises an error for a noncyclic input."""
+        original = list(self.graph.vertices)
+        with self.assertRaisesRegexp(RuntimeError, 'do not comprise a single cycle'):
+            self.graph._sortCyclicVertices(original)
+
+    def testSortCyclicVerticesUnconnected(self):
+        """Test that _sortCyclicVertices raises an error for an unconnected input."""
+        self.graph.addVertex(Vertex())
+        original = list(self.graph.vertices)
+        with self.assertRaisesRegexp(RuntimeError, 'not all vertices are connected'):
+            self.graph._sortCyclicVertices(original)
+
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -616,6 +616,68 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(len(cycleList), 1)
         self.assertEqual(len(cycleList[0]), 4)
 
+    def test_getRelevantCycles(self):
+        """
+        Test the Graph.getRelevantCycles() method.
+        """
+        cycleList = self.graph.getRelevantCycles()
+        self.assertEqual(len(cycleList), 0)
+        # Create a cycle of length 4
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[3])
+        self.graph.addEdge(edge)
+        # Create a second cycle of length 4
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[5])
+        self.graph.addEdge(edge)
+        # Create a bridge forming multiple cycles of length 4
+        edge = Edge(self.graph.vertices[1], self.graph.vertices[4])
+        self.graph.addEdge(edge)
+
+        # SSSR should be 3 cycles of length 4
+        cycleList = self.graph.getSmallestSetOfSmallestRings()
+        self.assertEqual(len(cycleList), 3)
+        sizeList = sorted([len(cycle) for cycle in cycleList])
+        self.assertEqual(sizeList, [4, 4, 4])
+
+        # RC should be 5 cycles of length 4
+        cycleList = self.graph.getRelevantCycles()
+        self.assertEqual(len(cycleList), 5)
+        sizeList = sorted([len(cycle) for cycle in cycleList])
+        self.assertEqual(sizeList, [4, 4, 4, 4, 4])
+
+    def test_cycleListOrderSSSR(self):
+        """
+        Test that getSmallestSetOfSmallestRings return vertices in the proper order.
+
+        There are methods such as symmetry and molecule drawing which rely
+        on the fact that subsequent list entries are connected.
+        """
+        # Create a cycle of length 5
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[4])
+        self.graph.addEdge(edge)
+        # Test SSSR
+        sssr = self.graph.getSmallestSetOfSmallestRings()
+        self.assertEqual(len(sssr), 1)
+        self.assertEqual(len(sssr[0]), 5)
+        for i in range(5):
+            self.assertTrue(self.graph.hasEdge(sssr[0][i], sssr[0][i - 1]))
+
+    def test_cycleListOrderRC(self):
+        """
+        Test that getRelevantCycles return vertices in the proper order.
+
+        There are methods such as symmetry and molecule drawing which rely
+        on the fact that subsequent list entries are connected.
+        """
+        # Create a cycle of length 5
+        edge = Edge(self.graph.vertices[0], self.graph.vertices[4])
+        self.graph.addEdge(edge)
+        # Test RC
+        rc = self.graph.getRelevantCycles()
+        self.assertEqual(len(rc), 1)
+        self.assertEqual(len(rc[0]), 5)
+        for i in range(5):
+            self.assertTrue(self.graph.hasEdge(rc[0][i], rc[0][i - 1]))
+
     def test_getPolycyclicRings(self):
         """
         Test that the Graph.getPolycyclicRings() method returns only polycyclic rings.

--- a/rmgpy/molecule/graphTest.py
+++ b/rmgpy/molecule/graphTest.py
@@ -55,10 +55,17 @@ class TestGraph(unittest.TestCase):
             Edge(vertices[4], vertices[5]),
         ]
         
-        self.graph = Graph()
-        for vertex in vertices: self.graph.addVertex(vertex)
+        self.graph = Graph(vertices)
         for edge in edges: self.graph.addEdge(edge)
-        
+
+    def test_vertices(self):
+        """
+        Test that the vertices attribute can be accessed.
+        """
+        vertices = self.graph.vertices
+        self.assertTrue(isinstance(vertices, list))
+        self.assertEqual(len(vertices), 6)
+
     def test_addVertex(self):
         """
         Test the Graph.addVertex() method.
@@ -117,6 +124,14 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(len(edges), 2)
         self.assertTrue(self.graph.vertices[1] in edges)
         self.assertTrue(self.graph.vertices[3] in edges)
+
+    def test_getAllEdges(self):
+        """
+        Test the Graph.getAllEdges() method.
+        """
+        edges = self.graph.getAllEdges()
+        self.assertTrue(isinstance(edges, list))
+        self.assertEqual(len(edges), 5)
 
     def test_hasVertex(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1742,7 +1742,8 @@ class Molecule(Graph):
         AROMATIC = BondType.AROMATIC
 
         if rings is None:
-            rings = self.getAllSimpleCyclesOfSize(6)
+            rings = self.getRelevantCycles()
+            rings = [ring for ring in rings if len(ring) == 6]
         if not rings:
             return [], []
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1811,6 +1811,13 @@ class Molecule(Graph):
         For instance, molecule with this SMILES: C1CC2C3CSC(CO3)C2C1, will have non-deterministic
         output from `getSmallestSetOfSmallestRings`, which leads to non-deterministic bycyclic decomposition
         Using this new method can effectively prevent this situation.
+
+        Important Note: This method returns an incorrect set of SSSR in certain molecules (such as cubane).
+        It is recommended to use the main `Graph.getSmallestSetOfSmallestRings` method in new applications.
+        Alternatively, consider using `Graph.getRelevantCycles` for deterministic output.
+
+        In future development, this method should ideally be replaced by some method to select a deterministic
+        set of SSSR from the set of Relevant Cycles, as that would be a more robust solution.
         """
         cython.declare(vertices=list, verticesToRemove=list, rootCandidates_tups=list, graphs=list)
         cython.declare(cycleList=list, cycleCandidate_tups=list, cycles=list, cycle0=list, originConnDict=dict)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1510,10 +1510,10 @@ class Molecule(Graph):
         there will be at least one 6 membered aromatic ring so this algorithm
         will not fail for fused aromatic rings.
         """
-        cython.declare(SSSR=list, vertices=list, polycyclicVertices=list)
-        SSSR = self.getSmallestSetOfSmallestRings()
-        if SSSR:
-            for cycle in SSSR:
+        cython.declare(rc=list, cycle=list, atom=Atom)
+        rc = self.getRelevantCycles()
+        if rc:
+            for cycle in rc:
                 if len(cycle) == 6:
                     for atom in cycle:
                         #print atom.atomType.label

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1709,32 +1709,49 @@ multiplicity 2
         monorings, polyrings = m1.getDisparateRings()
         self.assertEqual(len(monorings), 0)
         self.assertEqual(len(polyrings), 1)
-        self.assertEqual(len(polyrings[0]),7)  # 7 carbons in cycle
-        
+        self.assertEqual(len(polyrings[0]), 7)  # 7 carbons in cycle
+
+        # norbornane + cyclobutane on chain
         m2 = Molecule(SMILES='C(CCC1C2CCC1CC2)CC1CCC1')
         monorings, polyrings = m2.getDisparateRings()
-        self.assertEqual(len(monorings),1)
-        self.assertEqual(len(polyrings),1)
-        self.assertEqual(len(monorings[0]),4)
-        self.assertEqual(len(polyrings[0]),7)
-        
-        
+        self.assertEqual(len(monorings), 1)
+        self.assertEqual(len(polyrings), 1)
+        self.assertEqual(len(monorings[0]), 4)
+        self.assertEqual(len(polyrings[0]), 7)
+
+        # spiro-octane + cyclobutane on chain
         m3 = Molecule(SMILES='C1CCC2(CC1)CC2CCCCC1CCC1')
         monorings, polyrings = m3.getDisparateRings()
         self.assertEqual(len(polyrings), 1)
-        self.assertEqual(len(monorings),1)
-        self.assertEqual(len(monorings[0]),4)
-        self.assertEqual(len(polyrings[0]),8)
-        
+        self.assertEqual(len(monorings), 1)
+        self.assertEqual(len(monorings[0]), 4)
+        self.assertEqual(len(polyrings[0]), 8)
+
+        # butane
         m4 = Molecule(SMILES='CCCC')
         monorings, polyrings = m4.getDisparateRings()
-        self.assertEqual(len(monorings),0)
-        self.assertEqual(len(polyrings),0)
-        
+        self.assertEqual(len(monorings), 0)
+        self.assertEqual(len(polyrings), 0)
+
+        # benzene + cyclopropane on chain + cyclopropane on chain
         m5 = Molecule(SMILES='C1=CC=C(CCCC2CC2)C(=C1)CCCCCC1CC1')
         monorings, polyrings = m5.getDisparateRings()
-        self.assertEqual(len(monorings),3)
-        self.assertEqual(len(polyrings),0)
+        self.assertEqual(len(monorings), 3)
+        self.assertEqual(len(polyrings), 0)
+
+        # octacene
+        m6 = Molecule(SMILES='c1ccc2cc3cc4cc5cc6cc7cc8ccccc8cc7cc6cc5cc4cc3cc2c1')
+        monorings, polyrings = m6.getDisparateRings()
+        self.assertEqual(len(monorings), 0)
+        self.assertEqual(len(polyrings), 1)
+        self.assertEqual(len(polyrings[0]), 34)
+
+        # JP-10
+        m7 = Molecule(SMILES='C1CC2C3CCC(C3)C2C1')
+        monorings, polyrings = m7.getDisparateRings()
+        self.assertEqual(len(monorings), 0)
+        self.assertEqual(len(polyrings), 1)
+        self.assertEqual(len(polyrings[0]), 10)
 
     def testGetSmallestSetOfSmallestRings(self):
         """

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -354,6 +354,7 @@ def calculateCyclicSymmetryNumber(molecule):
     for ring in polycyclicRings: singleRings.append(molecule.getLargestRing(ring[0]))
     # Get symmetry number for each ring in structure & multiply
     for ring in singleRings:
+        ring = molecule._sortCyclicVertices(ring)
         size = len(ring)
         
         # look for twisting rotation


### PR DESCRIPTION
Improved ring handling has been on the to do list for a while, but before adding new features, it seemed important to make sure our ring perception methods are sufficiently robust. This PR introduces a new algorithm for getSmallestSetOfSmallestRings and a new method called getRelevantCycles.

The previous smallest set of smallest rings (SSSR) algorithm was an incomplete implementation of Fan et al.'s algorithm, and failed for molecules with no degree 2 nodes (eg. cubane). Additionally, the SSSR is not always the most useful set of rings. The set of relevant cycles (RC) is often cited as a more "chemically useful" set of rings, and is defined as the union of all possible SSSRs.

Using cubane as an example, intuitively, one would likely say that there are 6 rings. The previous RMG SSSR algorithm would incorrectly return 4 rings. The actual SSSR includes 5 rings, and there are multiple valid choices for which 5 rings are included. The set of RC includes all 6 rings, and is unique.

The new implementation uses the open source [RingDecomposerLib](https://github.com/rareylab/RingDecomposerLib) developed by a group at Hamburg University and [published](http://pubs.acs.org/doi/10.1021/acs.jcim.6b00736?src=recsys&) earlier this year. It implements an extension of a method described by Vismara for enumerating the set of relevant cycles. The package is a C library with a Python wrapper.

This new implementation is about an __order of magnitude faster__ than the previous SSSR algorithm, and we now have access to both the SSSR and RC (as well as the [unique ring families](http://pubs.acs.org/doi/abs/10.1021/ci200629w), if we ever need it).

Notes:
- ~~Conda packages still need to be made for RingDecomposerLib before merging this PR.~~ Done!
- Are there other places where SSSR should be replaced by RC (eg. bicyclic decomposition)?
- Does this eliminate the need for `getDeterministicSmallestSetOfSmallestRings`?