### PR TITLE
extend docstring for Atom, Bond, Molecule

### DIFF
--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -50,6 +50,7 @@ cdef class Vertex(object):
     `connectivity1`     ``int``         The number of nearest neighbors
     `connectivity2`     ``int``         The sum of the neighbors' `connectivity1` values
     `connectivity3`     ``int``         The sum of the neighbors' `connectivity2` values
+    `edges`             ``dict``        Dictionary of edges with keys being neighboring vertices
     `sortingLabel`      ``int``         An integer label used to sort the vertices
     =================== =============== ========================================
     
@@ -140,9 +141,8 @@ cpdef short getVertexSortingLabel(Vertex vertex) except -1:
 
 cdef class Edge(object):
     """
-    A base class for edges in a graph. This class does *not* store the vertex
-    pair that comprises the edge; that functionality would need to be included
-    in the derived class.
+    A base class for edges in a graph. The vertices which comprise the edge can be
+    accessed using the `vertex1` and `vertex2` attributes.
     """
 
     def __init__(self, vertex1, vertex2):
@@ -201,12 +201,11 @@ cdef VF2 vf2 = VF2()
 cdef class Graph:
     """
     A graph data type. The vertices of the graph are stored in a list
-    `vertices`; this provides a consistent traversal order. The edges of the
-    graph are stored in a dictionary of dictionaries `edges`. A single edge can
-    be accessed using ``graph.edges[vertex1][vertex2]`` or the :meth:`getEdge`
-    method; in either case, an exception will be raised if the edge does not
-    exist. All edges of a vertex can be accessed using ``graph.edges[vertex]``
-    or the :meth:`getEdges` method.
+    `vertices`; this provides a consistent traversal order. A single edge can
+    be accessed using the :meth:`getEdge` method or by accessing specific
+    vertices using ``vertex1.edges[vertex2]``; in either case, an exception
+    will be raised if the edge does not exist. All edges of a vertex can be
+    accessed using the :meth:`getEdges` method or ``vertex.edges``.
     """
 
     def __init__(self, vertices=None):

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -125,8 +125,6 @@ cdef class Molecule(Graph):
     cdef public str InChI
     cdef public dict props
     
-    cpdef str getFingerprint(self)
-    
     cpdef addAtom(self, Atom atom)
 
     cpdef addBond(self, Bond bond)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -688,7 +688,7 @@ class Molecule(Graph):
     
     
     def __hash__(self):
-        return hash((self.getFingerprint()))
+        return hash((self.fingerprint))
             
     def __richcmp__(x, y, op):
         if op == 2:#Py_EQ
@@ -702,7 +702,7 @@ class Molecule(Graph):
         """Method to test equality of two Molecule objects."""
         if not isinstance(other, Molecule): return False #different type
         elif self is other: return True #same reference in memory
-        elif self.getFingerprint() != other.getFingerprint(): return False
+        elif self.fingerprint != other.fingerprint: return False
         else:
             return self.isIsomorphic(other)   
 
@@ -737,6 +737,20 @@ class Molecule(Graph):
     def __getAtoms(self): return self.vertices
     def __setAtoms(self, atoms): self.vertices = atoms
     atoms = property(__getAtoms, __setAtoms)
+
+    def __getFingerprint(self):
+        """
+        Return a string containing the "fingerprint" used to accelerate graph
+        isomorphism comparisons with other molecules. The fingerprint is a
+        short string containing a summary of selected information about the 
+        molecule. Two fingerprint strings matching is a necessary (but not
+        sufficient) condition for the associated molecules to be isomorphic.
+        """
+        if self._fingerprint is None:
+            self.fingerprint = self.getFormula()
+        return self._fingerprint
+    def __setFingerprint(self, fingerprint): self._fingerprint = fingerprint
+    fingerprint = property(__getFingerprint, __setFingerprint)
 
     def addAtom(self, atom):
         """
@@ -1063,18 +1077,6 @@ class Molecule(Graph):
                     labeled[atom.label] = atom
         return labeled
 
-    def getFingerprint(self):
-        """
-        Return a string containing the "fingerprint" used to accelerate graph
-        isomorphism comparisons with other molecules. The fingerprint is a
-        short string containing a summary of selected information about the 
-        molecule. Two fingerprint strings matching is a necessary (but not
-        sufficient) condition for the associated molecules to be isomorphic.
-        """
-        if self._fingerprint is None:
-            self._fingerprint = self.getFormula()
-        return self._fingerprint
-    
     def isIsomorphic(self, other, initialMap=None):
         """
         Returns :data:`True` if two graphs are isomorphic and :data:`False`
@@ -1091,7 +1093,7 @@ class Molecule(Graph):
         # Do the quick isomorphism comparison using the fingerprint
         # Two fingerprint strings matching is a necessary (but not
         # sufficient!) condition for the associated molecules to be isomorphic
-        if self.getFingerprint() != other.getFingerprint():
+        if self.fingerprint != other.fingerprint:
             return False
         # check multiplicity
         if self.multiplicity != other.multiplicity:
@@ -1117,7 +1119,7 @@ class Molecule(Graph):
         # Do the quick isomorphism comparison using the fingerprint
         # Two fingerprint strings matching is a necessary (but not
         # sufficient!) condition for the associated molecules to be isomorphic
-        if self.getFingerprint() != other.getFingerprint():
+        if self.fingerprint != other.fingerprint:
             return []
         # check multiplicity
         if self.multiplicity != other.multiplicity:

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -83,6 +83,10 @@ class Atom(Vertex):
     `coords`            ``numpy array``     The (x,y,z) coordinates in Angstrom
     `lonePairs`         ``short``           The number of lone electron pairs
     `id`                ``int``             Number assignment for atom tracking purposes
+    `bonds`             ``dict``            Dictionary of bond objects with keys being neighboring atoms
+    `mass`              ``int``             atomic mass of element (read only)
+    `number`            ``int``             atomic number of element (read only)
+    `symbol`            ``str``             atomic symbol of element (read only)
     =================== =================== ====================================
 
     Additionally, the ``mass``, ``number``, and ``symbol`` attributes of the
@@ -442,6 +446,8 @@ class Bond(Edge):
     Attribute           Type                Description
     =================== =================== ====================================
     `order`             ``float``             The :ref:`bond type <bond-types>`
+    `atom1`             ``Atom``              An Atom object connecting to the bond
+    `atom2`             ``Atom``              An Atom object connecting to the bond
     =================== =================== ====================================
 
     """
@@ -660,8 +666,7 @@ class Bond(Edge):
 class Molecule(Graph):
     """
     A representation of a molecular structure using a graph data type, extending
-    the :class:`Graph` class. The `atoms` and `bonds` attributes are aliases
-    for the `vertices` and `edges` attributes. Other attributes are:
+    the :class:`Graph` class. Attributes are:
 
     ======================= =========== ========================================
     Attribute               Type        Description
@@ -669,6 +674,9 @@ class Molecule(Graph):
     `symmetryNumber`        ``int``     The (estimated) external + internal symmetry number of the molecule
     `multiplicity`          ``int``     The multiplicity of this species, multiplicity = 2*total_spin+1
     `props`                 ``dict``    A list of properties describing the state of the molecule.
+    `InChI`                 ``str``     A string representation of the molecule in InChI
+    `atoms`                 ``list``    A list of Atom objects in the molecule
+    `fingerprint`           ``str``     A representation for fast comparison, set as molecular formula
     ======================= =========== ========================================
 
     A new molecule object can be easily instantiated by passing the `SMILES` or

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2114,6 +2114,15 @@ multiplicity 2
         mol.assignAtomIDs()
         self.assertTrue(mol.atomIDValid())
 
+    def testFingerprintProperty(self):
+        """Test that the Molecule.fingerprint property works"""
+        # Test getting fingerprint
+        self.assertEqual(self.molecule[0].fingerprint, 'CH2NO2')
+
+        # Test setting fingerprint
+        self.molecule[0].fingerprint = 'nitronate'
+        self.assertEqual(self.molecule[0].fingerprint, 'nitronate')
+
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
the docstrings for Atom, Bond, and Molecule were missing some
attributes, so this commit/PR adds them to the docstring to improve
code readability and usability.