### PR TITLE
Automatically Decrease grain size to keep collision tensor manageable

### DIFF
--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -708,7 +708,15 @@ class Network:
         NJ = 1 if self.Jlist is None else len(self.Jlist)
         
         collFreq = numpy.zeros(Nisom, numpy.float64)
-        Mcoll = numpy.zeros((Nisom,Ngrains,NJ,Ngrains,NJ), numpy.float64)
+        
+        try:
+            Mcoll = numpy.zeros((Nisom,Ngrains,NJ,Ngrains,NJ), numpy.float64)
+        except MemoryError:
+            logging.warning('Collision matrix too large to manage')
+            newNgrains = int(Ngrains/2.0)
+            logging.warning('Adjusting to use {0} grains instead of {1}'.format(newNgrains,Ngrains))
+            self.Elist = self.selectEnergyGrains(self.T,grainCount = newNgrains)
+            return self.calculateCollisionModel()
         
         for i, isomer in enumerate(self.isomers):
             collFreq[i] = isomer.calculateCollisionFrequency(self.T, self.P, self.bathGas)

--- a/rmgpy/pdep/networkTest.py
+++ b/rmgpy/pdep/networkTest.py
@@ -200,6 +200,19 @@ class TestNetwork(unittest.TestCase):
         """
         self.network.initialize(Tmin=300., Tmax=2000., Pmin=1e3, Pmax=1e7, minimumGrainCount=200, maximumGrainSize=4184.0)
     
+    def test_collisionMatrixMemoryHandling(self):
+        net = Network()
+        net.Elist = [1]*10000
+        net.E0 = 1.0
+        niso = 100000000
+        net.isomers = niso*[1]
+        try:
+            net.calculateCollisionModel()
+        except MemoryError:
+            raise AssertionError('Large collision matrix resulted in memory error, handling failed')
+        except:
+            pass
+        
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
If a memory error is obtained when building the collision tensor this pull request causes the number of grains in the network to be decreased by a factor of 2 (which should decrease the tensor size by a factor of 4).  The energy list is reconstructed with the smaller grain size and the function is called recursively within itself until the grain size is small enough that the tensor can be built without a MemoryError.  

Should fix #1129.  