### PR TITLE
Categorize tests into unittests and functional tests and only use unittests for coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ install:
   - make
 
 script: 
-  - make test-all
+  - make test-unittests
+  - make test-functional
   - make test-database
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -74,22 +74,31 @@ decython:
 	find . -name *.so ! \( -name _statmech.so -o -name quantity.so -o -regex '.*rmgpy/solver/.*' \) -exec rm -f '{}' \;
 	find . -name *.pyc -exec rm -f '{}' \;
 
-test-all:
+test-unittests:
 ifeq ($(OS),Windows_NT)
-	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 else
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
-	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 endif
 
-test:
+test test-unittests-non-auth:
 ifeq ($(OS),Windows_NT)
-	nosetests --nocapture --nologcapture --all-modules --attr '!auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+	nosetests --nocapture --nologcapture --all-modules -A 'not functional and not auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 else
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
-	nosetests --nocapture --nologcapture --all-modules --attr '!auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+	nosetests --nocapture --nologcapture --all-modules -A 'not functional and not auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+endif
+
+test-functional:
+ifeq ($(OS),Windows_NT)
+	nosetests --nocapture --nologcapture --all-modules -A 'functional' --verbose --exe rmgpy
+else
+	mkdir -p testing/coverage
+	rm -rf testing/coverage/*
+	nosetests --nocapture --nologcapture --all-modules -A 'functional' --verbose --exe rmgpy
 endif
 
 test-database:

--- a/rmgpy/reduction/reductionTest.py
+++ b/rmgpy/reduction/reductionTest.py
@@ -30,13 +30,14 @@ import unittest
 
 import rmgpy
 from external.wip import work_in_progress
-
+from nose.plugins.attrib import attr
 from .reduction import *
 
 from rmgpy.rmg.model import CoreEdgeReactionModel
 from rmgpy.species import Species
 from rmgpy.rmg.settings import SimulatorSettings
 
+@attr('functional')
 class ReduceFunctionalTest(unittest.TestCase):
 
     #MINIMAL

--- a/rmgpy/rmg/mainTest.py
+++ b/rmgpy/rmg/mainTest.py
@@ -31,7 +31,7 @@
 import os
 import unittest
 import shutil 
-
+from nose.plugins.attrib import attr
 from main import RMG
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase
@@ -40,7 +40,7 @@ from rmgpy.rmg.model import CoreEdgeReactionModel
 ###################################################
 
 originalPath = getPath()
-
+@attr('functional')
 class TestMain(unittest.TestCase):
 
     @classmethod

--- a/rmgpy/tools/fluxtest.py
+++ b/rmgpy/tools/fluxtest.py
@@ -29,10 +29,10 @@ import unittest
 import os
 import os.path
 import shutil
-
+from nose.plugins.attrib import attr
 import rmgpy
 from rmgpy.tools.fluxdiagram import *
-
+@attr('functional')
 class FluxDiagramTest(unittest.TestCase):
 
     def test_avi(self):

--- a/rmgpy/tools/regressionTest.py
+++ b/rmgpy/tools/regressionTest.py
@@ -31,10 +31,10 @@
 import unittest
 import os
 import os.path
-
+from nose.plugins.attrib import attr
 import rmgpy
 from rmgpy.tools.regression import *
-
+@attr('functional')
 class regressionTest(unittest.TestCase):
 
     def test(self):

--- a/rmgpy/tools/testGenerateReactions.py
+++ b/rmgpy/tools/testGenerateReactions.py
@@ -28,11 +28,11 @@
 import unittest
 import os.path
 import shutil
-
+from nose.plugins.attrib import attr
 import rmgpy
 from rmgpy.tools.generate_reactions import *
 
-
+@attr('functional')
 class GenerateReactionsTest(unittest.TestCase):
 
     def test(self):


### PR DESCRIPTION
This PR separates functional tests from the rest of the tests using the attribute 'functional', so that coverage is testing only unittests. The boundary between unittest and functional test is gray, but I drew the cutoff when an external `input.py` file is used to run RMG. 

Overall, 10 (out of 1277) tests became functional. These ten tests took over a third of the runtime for tests. 