### PR TITLE
Prevent pruning deleting core candidate if maximumEdgeSpecies is low

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -669,7 +669,7 @@ class RMG(util.Subject):
                 # If we reached our termination conditions, then try to prune
                 # species from the edge
                 if allTerminated:
-                    self.reactionModel.prune(self.reactionSystems, self.fluxToleranceKeepInEdge, self.maximumEdgeSpecies, self.minSpeciesExistIterationsForPrune)
+                    self.reactionModel.prune(self.reactionSystems, self.fluxToleranceKeepInEdge, self.fluxToleranceMoveToCore, self.maximumEdgeSpecies, self.minSpeciesExistIterationsForPrune)
                     # Perform garbage collection after pruning
                     collected = gc.collect()
                     logging.info('Garbage collector: collected %d objects.' % (collected))

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -995,7 +995,7 @@ class CoreEdgeReactionModel:
         """
         self.edge.species.append(spec)
 
-    def prune(self, reactionSystems, toleranceKeepInEdge, maximumEdgeSpecies, minSpeciesExistIterationsForPrune):
+    def prune(self, reactionSystems, toleranceKeepInEdge, toleranceMoveToCore, maximumEdgeSpecies, minSpeciesExistIterationsForPrune):
         """
         Remove species from the model edge based on the simulation results from
         the list of `reactionSystems`.
@@ -1051,7 +1051,7 @@ class CoreEdgeReactionModel:
                 speciesToPrune.append((index, spec))
                 pruneDueToRateCounter += 1
             # Keep removing species with the lowest rates until we are below the maximum edge species size
-            elif numEdgeSpecies - len(speciesToPrune) > maximumEdgeSpecies:
+            elif numEdgeSpecies - len(speciesToPrune) > maximumEdgeSpecies and maxEdgeSpeciesRateRatios[index] < toleranceMoveToCore:
                 logging.info('Pruning species {0} to make numEdgeSpecies smaller than maximumEdgeSpecies'.format(spec)) # repeated ~15 lines below
                 speciesToPrune.append((index, spec))
             else:


### PR DESCRIPTION
This PR adds an additional filter in pruning to avoid cases where RMG starts pruning most
important species.