### PR TITLE
print species dictionary with cantherm job

### DIFF
--- a/documentation/source/users/cantherm/output.rst
+++ b/documentation/source/users/cantherm/output.rst
@@ -57,3 +57,11 @@ something unexpected has occurred.
 
 The ``examples/cantherm`` directory contains both CanTherm input files and the resulting
 output files.
+
+Species Dictionary
+==================
+
+Any species that had the ``thermo()`` method called and had the structure defined in the cantherm
+input file will also have an RMG style adjacency list representation in ``species_dictionary.txt``.
+This allows the user to input the corresponding thermo and kinetics into RMG in various ways
+described in the RMG user guide.

--- a/rmgpy/cantherm/thermo.py
+++ b/rmgpy/cantherm/thermo.py
@@ -164,7 +164,7 @@ class ThermoJob:
         f.write('{0}\n\n'.format(prettify(string)))
         
         f.close()
-        
+        # write chemkin file
         f = open(os.path.join(os.path.dirname(outputFile), 'chem.inp'), 'a')
         if isinstance(species, Species):
             if species.molecule and isinstance(species.molecule[0], Molecule):
@@ -179,7 +179,14 @@ class ThermoJob:
         string = writeThermoEntry(species, elementCounts=elementCounts, verbose=False)
         f.write('{0}\n'.format(string))
         f.close()
-    
+
+        # write species dictionary
+        f = open(os.path.join(os.path.dirname(outputFile), 'species_dictionary.txt'), 'a')
+        if isinstance(species, Species):
+            if species.molecule and isinstance(species.molecule[0], Molecule):
+                f.write(species.molecule[0].toAdjacencyList(removeH=False,label=species.label))
+                f.write('\n')
+        f.close()
 
     def plot(self, outputDirectory):
         """


### PR DESCRIPTION
prints the species dictionary for every species given with a
thermo() function in cantherm. This allows the user to 
more easily add kinetics libraries or do other manipulations
in RMG.