### PR TITLE
model core reaction reduction

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -234,7 +234,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False, toleranceThermoKeepSpeciesInEdge=numpy.inf,
+          toleranceNeglectCoreReaction=0.0,removeNeglectedReactions=False):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -251,7 +252,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,terminateAtMaxObjects,toleranceThermoKeepSpeciesInEdge))
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,
+          terminateAtMaxObjects,toleranceThermoKeepSpeciesInEdge,toleranceNeglectCoreReaction,removeNeglectedReactions))
     
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -661,6 +661,8 @@ class RMG(util.Subject):
                     # species from the edge
                     if allTerminated:
                         self.reactionModel.prune(self.reactionSystems, modelSettings.fluxToleranceKeepInEdge, modelSettings.maximumEdgeSpecies, modelSettings.minSpeciesExistIterationsForPrune)
+                        if modelSettings.removeNeglectedReactions:
+                            self.reactionModel.removeNeglectableReactions(self.reactionSystems,modelSettings.toleranceNeglectCoreReaction)
                         # Perform garbage collection after pruning
                         collected = gc.collect()
                         logging.info('Garbage collector: collected %d objects.' % (collected))

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -64,6 +64,7 @@ from pdep import PDepNetwork
 import rmgpy.util as util
 
 from rmgpy.chemkin import ChemkinWriter
+from rmgpy.chemkin import saveChemkinFile
 from rmgpy.rmg.output import OutputHTMLWriter
 from rmgpy.rmg.listener import SimulationProfileWriter, SimulationProfilePlotter
 from rmgpy.restart import RestartWriter
@@ -619,6 +620,7 @@ class RMG(util.Subject):
                         surfaceReactions = self.reactionModel.surface.reactions,
                         pdepNetworks = self.reactionModel.networkList,
                         prune = prune,
+                        reduction = True,
                         modelSettings=modelSettings,
                         simulatorSettings = simulatorSettings,
                     )
@@ -631,11 +633,18 @@ class RMG(util.Subject):
                             logging.error(prettify(repr(self.reactionModel.core.reactions)))
                         self.makeSeedMech()
                         raise
-
+                    
                     if self.generateSeedEachIteration:
                         self.makeSeedMech()
-                        
+             
                     self.done = self.reactionModel.addNewSurfaceObjects(obj,newSurfaceSpecies,newSurfaceReactions,reactionSystem)
+                    
+                    if modelSettings.toleranceNeglectCoreReaction > 0.0 and not modelSettings.removeNeglectedReactions: #doing reduction, but not removing on the fly
+                        saveChemkinFile(os.path.join(self.outputDirectory,'chemkin','chem_annotated_reduced.inp'),
+                                        self.reactionModel.core.species,
+                                        self.reactionModel.getNonNegligibleReactions(self.reactionSystems,modelSettings.toleranceNeglectCoreReaction),
+                                        verbose=True,
+                                        checkForDuplicates=True)
                     
                     allTerminated = allTerminated and terminated
                     logging.info('')
@@ -694,6 +703,7 @@ class RMG(util.Subject):
                                     surfaceSpecies = self.reactionModel.surface.species,
                                     surfaceReactions = self.reactionModel.surface.reactions,
                                     pdepNetworks = self.reactionModel.networkList,
+                                    reduction = True,
                                     modelSettings = tempModelSettings,
                                     simulatorSettings = simulatorSettings,
                                 )
@@ -766,6 +776,7 @@ class RMG(util.Subject):
                     surfaceReactions = [],
                     pdepNetworks = self.reactionModel.networkList,
                     sensitivity = True,
+                    reduction = True,
                     sensWorksheet = sensWorksheet,
                     modelSettings = self.modelSettingsList[-1],
                     simulatorSettings = self.simulatorSettingsList[-1],
@@ -777,6 +788,8 @@ class RMG(util.Subject):
         try:
             self.generateCanteraFiles(os.path.join(self.outputDirectory, 'chemkin', 'chem.inp'))
             self.generateCanteraFiles(os.path.join(self.outputDirectory, 'chemkin', 'chem_annotated.inp'))
+            if modelSettings.toleranceNeglectCoreReaction > 0.0 and not modelSettings.removeNeglectedReactions: #doing reduction, but not removing on the fly 
+                self.generateCanteraFiles(os.path.join(self.outputDirectory, 'chemkin', 'chem_annotated_reduced.inp'))
         except EnvironmentError:
             logging.error('Could not generate Cantera files due to EnvironmentError. Check read\write privileges in output directory.')
                 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1177,6 +1177,45 @@ class CoreEdgeReactionModel:
                     del(self.networkDict[source])
                 self.networkList.remove(network)
                     
+    def findNeglectableCoreReactionIndices(self,reactionSystems,toleranceNeglectCoreReaction):
+        """
+        finds the indices of all core reactions with dynamics number smaller than toleranceNeglectCoreReaction
+        for all reactionSystems
+        """
+        numCoreReactions = len(self.core.reactions)
+        numRxnSys = len(reactionSystems)
+        maxCoreDynNums = numpy.zeros((numCoreReactions,numRxnSys),numpy.float64)
+        
+        for index,rsys in enumerate(reactionSystems):
+            maxCoreDynNums[:,index] = rsys.maxCoreDivLnAccumNums
+            
+        maxCoreDynNums.max(axis=1)
+        
+        inds = numpy.nonzero(maxCoreDynNums < toleranceNeglectCoreReaction)
+        
+        return inds
+    
+    def removeNeglectableReactions(self,reactionSystems,toleranceNeglectCoreReaction):
+        """
+        removes all core reactions with maximum dynamics numbers less than toleranceNeglectCoreReaction
+        """
+        inds = self.findNeglectableCoreReactionIndices(reactionSystems,toleranceNeglectCoreReaction)
+        
+        inds = inds[::-1]
+        for ind in inds:
+            self.core.reactions.pop(ind)
+        
+    def getNonNegligibleReactions(self,reactionSystems,toleranceNeglectCoreReaction):
+        """
+        returns all core reactions with maximum dynamics numbers greater than toleranceNeglectReaction
+        """
+        numCoreReactions = len(self.core.reactions)
+        coreReactions = self.core.reactions
+        
+        negInds = self.findNeglectableCoreReactionIndices(reactionSystems,toleranceNeglectCoreReaction)
+        rxns = [coreReactions[ind] for ind in xrange(numCoreReactions) if ind not in negInds]
+        return rxns
+        
     def prune(self, reactionSystems, toleranceKeepInEdge, maximumEdgeSpecies, minSpeciesExistIterationsForPrune):
         """
         Remove species from the model edge based on the simulation results from

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -63,7 +63,7 @@ class ModelSettings(object):
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
-          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          terminateAtMaxObjects=False, toleranceThermoKeepSpeciesInEdge=numpy.inf, toleranceNeglectCoreReaction=0.0, removeNeglectedReactions=False):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -79,7 +79,9 @@ class ModelSettings(object):
         self.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
         self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
         self.terminateAtMaxObjects = terminateAtMaxObjects
-
+        self.toleranceNeglectCoreReaction = toleranceNeglectCoreReaction
+        self.removeNeglectedReactions = removeNeglectedReactions
+        
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation
         else:

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -87,7 +87,8 @@ cdef class ReactionSystem(DASx):
     cdef public numpy.ndarray maxNetworkLeakRates
     cdef public numpy.ndarray maxEdgeSpeciesRateRatios
     cdef public numpy.ndarray maxNetworkLeakRateRatios
-
+    cdef public numpy.ndarray maxCoreDivLnAccumNums
+    
     # sensitivity variables
     # cdef public int sensmethod
     cdef public numpy.ndarray sensitivityCoefficients

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -114,7 +114,7 @@ cdef class ReactionSystem(DASx):
 
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, 
         list edgeReactions,list surfaceSpecies, list surfaceReactions,
-        list pdepNetworks=?, bool prune=?, bool sensitivity=?, list sensWorksheet=?, object modelSettings=?,
+        list pdepNetworks=?, bool reduction=?, bool prune=?, bool sensitivity=?, list sensWorksheet=?, object modelSettings=?,
         object simulatorSettings=?)
 
     cpdef logRates(self, double charRate, object species, double speciesRate, double maxDifLnAccumNum, object network, double networkRate)

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -512,7 +512,7 @@ cdef class ReactionSystem(DASx):
         ``None`` is returned.
         """
         cdef double toleranceKeepInEdge,toleranceMoveToCore,toleranceMoveEdgeReactionToCore,toleranceInterruptSimulation
-        cdef double toleranceMoveEdgeReactionToCoreInterrupt,toleranceMoveEdgeReactionToSurface
+        cdef double toleranceMoveEdgeReactionToCoreInterrupt,toleranceMoveEdgeReactionToSurface, toleranceNeglectCoreReaction
         cdef double toleranceMoveSurfaceSpeciesToCore,toleranceMoveSurfaceReactionToCore
         cdef double toleranceMoveEdgeReactionToSurfaceInterrupt
         cdef bool ignoreOverallFluxCriterion, filterReactions
@@ -568,6 +568,7 @@ cdef class ReactionSystem(DASx):
         toleranceMoveSurfaceSpeciesToCore = modelSettings.toleranceMoveSurfaceSpeciesToCore
         toleranceMoveSurfaceReactionToCore = modelSettings.toleranceMoveSurfaceReactionToCore
         toleranceMoveEdgeReactionToSurfaceInterrupt = modelSettings.toleranceMoveEdgeReactionToSurfaceInterrupt
+        toleranceNeglectCoreReaction = modelSettings.toleranceNeglectCoreReaction
         ignoreOverallFluxCriterion=modelSettings.ignoreOverallFluxCriterion
         absoluteTolerance = simulatorSettings.atol
         relativeTolerance = simulatorSettings.rtol

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -499,7 +499,7 @@ cdef class ReactionSystem(DASx):
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, 
         list edgeReactions,list surfaceSpecies, list surfaceReactions,
-        list pdepNetworks=None, bool prune=False, bool sensitivity=False, list sensWorksheet=None, object modelSettings=None,
+        list pdepNetworks=None, bool reduction = False, bool prune=False, bool sensitivity=False, list sensWorksheet=None, object modelSettings=None,
         object simulatorSettings=None):
         """
         Simulate the reaction system with the provided reaction model,


### PR DESCRIPTION
This pull request enables two types of model core reaction reduction based on the dynamics criterion of core reactions:
New Input Parameters:  
toleranceNeglectCoreReaction
removeNeglectedReactions (flag)

1)  if removeNeglectedReactions = True, core reactions will be removed in the same way edge species are pruned-if the simulation goes all the way through all of the core reactions under tolerance for all time and all reaction systems will be removed permanently

2) if removeNeglectedReactions = False, (and toleranceNeglectCoreReaction > 0.0) then a chem_annotated_reduced.inp chemkin file will be produced each iteration containing only core reactions that passed reduction, note that if the simulation didn't go close to all the way through the reduction may be very poor.  

I'm in the process of adding a post-processing script to do this as well.  

This is based from #1082.  