### PR TITLE
Cantherm pdep debug

### DIFF
--- a/rmgpy/cantherm/kinetics.py
+++ b/rmgpy/cantherm/kinetics.py
@@ -127,6 +127,8 @@ class KineticsJob:
             self.save(outputFile)
             if plot:
                 self.plot(os.path.dirname(outputFile))
+        logging.debug('Finished kinetics job for reaction {0}.'.format(self.reaction))
+        logging.debug(repr(self.reaction))
     
     def generateKinetics(self,Tlist=None):
         """

--- a/rmgpy/cantherm/kinetics.py
+++ b/rmgpy/cantherm/kinetics.py
@@ -144,10 +144,12 @@ class KineticsJob:
             tunneling.E0_TS = (self.reaction.transitionState.conformer.E0.value_si*0.001,"kJ/mol")
             tunneling.E0_prod = (sum([product.conformer.E0.value_si for product in self.reaction.products])*0.001,"kJ/mol")
         elif tunneling is not None:
-            raise ValueError('Unknown tunneling model {0!r}.'.format(tunneling))
-        
-        logging.info('Generating {0} kinetics model for {0}...'.format(kineticsClass, self.reaction))
-        
+            if tunneling.frequency is not None:
+                # Frequency was given by the user
+                pass
+            else:
+                raise ValueError('Unknown tunneling model {0!r} for reaction {1}.'.format(tunneling, self.reaction))
+        logging.debug('Generating {0} kinetics model for {1}...'.format(kineticsClass, self.reaction))
         if Tlist is None:
             Tlist = 1000.0/numpy.arange(0.4, 3.35, 0.05)
         klist = numpy.zeros_like(Tlist)

--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -238,6 +238,8 @@ class PressureDependenceJob(object):
             self.save(outputFile)
             if plot:
                 self.plot(os.path.dirname(outputFile))
+        logging.debug('Finished pdep job for reaction {0}.'.format(self.network.label))
+        logging.debug(repr(self.network))
 
     def generateTemperatureList(self):
         """
@@ -362,7 +364,7 @@ class PressureDependenceJob(object):
                 order = len(reaction.reactants)
                 kdata *= 1e6 ** (order-1)
                 kunits = {1: 's^-1', 2: 'cm^3/(mol*s)', 3: 'cm^6/(mol^2*s)'}[order]
-                
+                logging.debug('Fitting master eqn data to kinetics for reaction {}.'.format(reaction))
                 reaction.kinetics = self.fitInterpolationModel(Tdata, Pdata, kdata, kunits)
                 
                 self.network.netReactions.append(reaction)

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -174,6 +174,8 @@ class StatMechJob:
         self.load()
         if outputFile is not None:
             self.save(outputFile)
+        logging.debug('Finished statmech job for species {0}.'.format(self.species))
+        logging.debug(repr(self.species))
     
     def load(self):
         """

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -32,6 +32,7 @@ from libc.math cimport exp, log, sqrt, log10
 
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
+from rmgpy.exceptions import KineticsError
 ################################################################################
 
 cdef class Arrhenius(KineticsModel):
@@ -140,6 +141,10 @@ cdef class Arrhenius(KineticsModel):
         """
         import numpy.linalg
         import scipy.stats
+
+        assert len(Tlist) == len(klist), "length of temperatures and rates must be the same"
+        if len(Tlist) < 3+threeParams:
+            raise KineticsError('Not enough degrees of freedom to fit this Arrhenius expression')
         if threeParams:
             A = numpy.zeros((len(Tlist),3), numpy.float64)
             A[:,0] = numpy.ones_like(Tlist)

--- a/rmgpy/kinetics/chebyshev.pyx
+++ b/rmgpy/kinetics/chebyshev.pyx
@@ -32,7 +32,8 @@ from libc.math cimport exp, log, sqrt, log10
 
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
-
+import logging
+from rmgpy.exceptions import KineticsError
 ################################################################################
 
 cdef class Chebyshev(PDepKineticsModel):
@@ -181,6 +182,18 @@ cdef class Chebyshev(PDepKineticsModel):
         cdef int t1, p1, t2, p2
         cdef double T, P
 
+        if nT <= degreeT or nP <= degreeP:
+            raise KineticsError(
+                    "The master equation data needs more temperature and pressure data "\
+                    "points than are placed into Chebyshev polynomial. Currently, the "\
+                    "data has {0} temperatures and the polynomial is set to have {1}. "\
+                    "The data has {2} pressures and the polynomial is set ot have {3}"\
+                    "".format(nT,degreeT,nP,degreeP))
+        elif nT < 1.25*degreeT or nP < 1.25*degreeP:
+            logging.warning(
+                    'This Chebyshev fitting has few degrees of freedom and may not be '\
+                    'accurate between data points. Consider increasing the number of '\
+                    'temperature and pressure values in the fitting parameters.')
         # Set temperature and pressure ranges
         self.Tmin = (Tmin,"K")
         self.Tmax = (Tmax,"K")

--- a/rmgpy/kinetics/chebyshevTest.py
+++ b/rmgpy/kinetics/chebyshevTest.py
@@ -36,7 +36,7 @@ import unittest
 import numpy
 
 from rmgpy.kinetics.chebyshev import Chebyshev
-
+from rmgpy.exceptions import KineticsError
 ################################################################################
 
 class TestChebyshev(unittest.TestCase):
@@ -153,7 +153,23 @@ class TestChebyshev(unittest.TestCase):
             for p in range(nP):
                 kfit = chebyshev.getRateCoefficient(Tdata[t], Pdata[p]) * 1e6
                 self.assertAlmostEqual(kfit, kdata[t,p], delta=1e-4*kdata[t,p])
+
+    def test_fitToData2(self):
+        """
+        Test the Chebyshev.fitToData() method throws error without enough degrees of freedom.
         
+        Here only 3 temperatures are given, but the polynomial desired has 6 parameters.
+        """
+        Tdata = numpy.array([300,1200,2000])
+        Pdata = numpy.array([1e5,3e5,1e6,3e7])
+        nT = len(Tdata); nP = len(Pdata)
+        kdata = numpy.zeros((nT,nP))
+        for t in range(nT):
+            for p in range(nP):
+                kdata[t,p] = self.chebyshev.getRateCoefficient(Tdata[t], Pdata[p])
+        with self.assertRaises(KineticsError):
+            Chebyshev().fitToData(Tdata, Pdata, kdata, kunits="cm^3/(mol*s)", degreeT=12, degreeP=8, Tmin=300, Tmax=2000, Pmin=0.1, Pmax=10.)
+
     def test_pickle(self):
         """
         Test that a Chebyshev object can be pickled and unpickled with no loss

--- a/rmgpy/pdep/configuration.pyx
+++ b/rmgpy/pdep/configuration.pyx
@@ -68,6 +68,17 @@ cdef class Configuration:
     def __str__(self):
         return ' + '.join([str(spec) for spec in self.species])
         
+    def __repr__(self):
+        string = 'Configuration('
+        string += 'species="{0!r}", '.format(self.species)
+        if self.Elist is not None: string += 'Elist={0}, '.format(self.Elist)
+        if self.densStates is not None: string += 'densStates={0}, '.format(self.densStates)
+        if self.sumStates is not None: string += 'sumStates={0}, '.format(self.sumStates)
+        string += 'activeKRotor={0}, '.format(self.activeKRotor)
+        string += 'activeJRotor={0}, '.format(self.activeJRotor)
+        string += ')'
+        return string
+
     property E0:
         """The ground-state energy of the configuration in J/mol."""
         def __get__(self):

--- a/rmgpy/pdep/configurationTest.py
+++ b/rmgpy/pdep/configurationTest.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This script contains unit tests of the :mod:`rmgpy.pdep.network` module.
+"""
+
+import unittest
+
+from rmgpy.pdep.configuration import Configuration
+from rmgpy.transport import TransportData
+from rmgpy.statmech.translation import IdealGasTranslation
+from rmgpy.statmech.rotation import NonlinearRotor
+from rmgpy.statmech.vibration import HarmonicOscillator
+from rmgpy.statmech.torsion import HinderedRotor
+from rmgpy.statmech.conformer import Conformer
+from rmgpy.species import Species
+from rmgpy.pdep.collision import SingleExponentialDown
+
+################################################################################
+
+class TestConfiguration(unittest.TestCase):
+    """
+    Contains unit tests of the :class:`Network` class.
+    """
+    
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        self.nC4H10O = Species(
+            label = 'n-C4H10O',
+            conformer = Conformer(
+                E0 = (-317.807,'kJ/mol'),
+                modes = [
+                    IdealGasTranslation(mass=(74.07,"g/mol")),
+                    NonlinearRotor(inertia=([41.5091,215.751,233.258],"amu*angstrom^2"), symmetry=1),
+                    HarmonicOscillator(frequencies=([240.915,341.933,500.066,728.41,809.987,833.93,926.308,948.571,1009.3,1031.46,1076,1118.4,1184.66,1251.36,1314.36,1321.42,1381.17,1396.5,1400.54,1448.08,1480.18,1485.34,1492.24,1494.99,1586.16,2949.01,2963.03,2986.19,2988.1,2995.27,3026.03,3049.05,3053.47,3054.83,3778.88],"cm^-1")),
+                    HinderedRotor(inertia=(0.854054,"amu*angstrom^2"), symmetry=1, fourier=([[0.25183,-1.37378,-2.8379,0.0305112,0.0028088], [0.458307,0.542121,-0.599366,-0.00283925,0.0398529]],"kJ/mol")),
+                    HinderedRotor(inertia=(8.79408,"amu*angstrom^2"), symmetry=1, fourier=([[0.26871,-0.59533,-8.15002,-0.294325,-0.145357], [1.1884,0.99479,-0.940416,-0.186538,0.0309834]],"kJ/mol")),
+                    HinderedRotor(inertia=(7.88153,"amu*angstrom^2"), symmetry=1, fourier=([[-4.67373,2.03735,-6.25993,-0.27325,-0.048748], [-0.982845,1.76637,-1.57619,0.474364,-0.000681718]],"kJ/mol")),
+                    HinderedRotor(inertia=(2.81525,"amu*angstrom^2"), symmetry=3, barrier=(2.96807,"kcal/mol")),
+                ],
+                spinMultiplicity = 1,
+                opticalIsomers = 1,
+            ),
+            molecularWeight = (74.07,"g/mol"),
+            transportData=TransportData(sigma=(5.94, 'angstrom'), epsilon=(559, 'K')),
+            energyTransferModel = SingleExponentialDown(alpha0=(447.5*0.011962,"kJ/mol"), T0=(300,"K"), n=0.85),
+        )
+        
+        self.nC4H8 = Species(
+            label = 'n-C4H8',
+            conformer = Conformer(
+                E0 = (-17.8832,'kJ/mol'),
+                modes = [
+                    IdealGasTranslation(mass=(56.06,"g/mol")),
+                    NonlinearRotor(inertia=([22.2748,122.4,125.198],"amu*angstrom^2"), symmetry=1),
+                    HarmonicOscillator(frequencies=([308.537,418.67,636.246,788.665,848.906,936.762,979.97,1009.48,1024.22,1082.96,1186.38,1277.55,1307.65,1332.87,1396.67,1439.09,1469.71,1484.45,1493.19,1691.49,2972.12,2994.31,3018.48,3056.87,3062.76,3079.38,3093.54,3174.52],"cm^-1")),
+                    HinderedRotor(inertia=(5.28338,"amu*angstrom^2"), symmetry=1, fourier=([[-0.579364,-0.28241,-4.46469,0.143368,0.126756], [1.01804,-0.494628,-0.00318651,-0.245289,0.193728]],"kJ/mol")),
+                    HinderedRotor(inertia=(2.60818,"amu*angstrom^2"), symmetry=3, fourier=([[0.0400372,0.0301986,-6.4787,-0.0248675,-0.0324753], [0.0312541,0.0538,-0.493785,0.0965968,0.125292]],"kJ/mol")),
+                ],
+                spinMultiplicity = 1,
+                opticalIsomers = 1,
+            ),
+        )
+        
+        self.H2O = Species(
+            label = 'H2O',
+            conformer = Conformer(
+                E0 = (-269.598,'kJ/mol'),
+                modes = [
+                    IdealGasTranslation(mass=(18.01,"g/mol")),
+                    NonlinearRotor(inertia=([0.630578,1.15529,1.78586],"amu*angstrom^2"), symmetry=2),
+                    HarmonicOscillator(frequencies=([1622.09,3771.85,3867.85],"cm^-1")),
+                ],
+                spinMultiplicity = 1,
+                opticalIsomers = 1,
+            ),
+        )
+
+        self.configuration = Configuration(self.nC4H8, self.H2O)
+
+    def test_repr(self):
+        """
+        Test that the `repr` representation contains desired properties.
+        """
+        output= repr(self.configuration)
+        # ensure species strings
+        labels = ['H2O','n-C4H8']
+        for label in labels:
+            self.assertIn(label, output)
+
+        # ensure classes are used as well
+        attributes = ['Configuration','Species','Conformer','NonlinearRotor',
+                   'HarmonicOscillator','frequencies','IdealGasTranslation',
+                   'HinderedRotor','E0','mass','symmetry','fourier']
+        for label in attributes:
+            self.assertIn(label, output)
+
+    def test_str(self):
+        """
+        Test that the string representation contains desired properties.
+        """
+        output = str(self.configuration)
+        # ensure species strings
+        labels = ['H2O','n-C4H8']
+        for label in labels:
+            self.assertIn(label, output)
+
+        # ensure this extra fluff is not in Network string
+        attributes = ['Species','Conformer','Molecule','NonlinearRotor',
+                   'HarmonicOscillator','frequencies','spinMultiplicity','TransportData',
+                   'molecularWeight','SingleExponentialDown']
+        for label in attributes:
+            self.assertNotIn(label, output)
+
+
+################################################################################
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -75,32 +75,43 @@ class Network:
     
     """
     
-    def __init__(self, label='', isomers=None, reactants=None, products=None, pathReactions=None, bathGas=None):
+    def __init__(self, label='', isomers=None, reactants=None, products=None,
+                 pathReactions=None, bathGas=None, netReactions=None, T=0.0, P =0.0,
+                 Elist = None, Jlist = None, Ngrains = 0, NJ = 0, activeKRotor = True,
+                 activeJRotor = True, grainSize=0.0, grainCount = 0, E0 = None):
+        """
+        To initialize a Network object for running a pressure dependent job,
+        only label, isomers, reactants, products pathReactions and bathGas are useful,
+        since the other attributes will be created during the run.
+
+        The other attributes are used to reinstantiate the created network object
+        for debugging and testing.
+        """
         self.label = label
         self.isomers = isomers or []
         self.reactants = reactants or []
         self.products = products or []
         self.pathReactions = pathReactions or []
         self.bathGas = bathGas or {}
-        self.netReactions = []
+        self.netReactions = netReactions or []
         
-        self.T = 0.0
-        self.P = 0.0
-        self.Elist = None
-        self.Jlist = None
+        self.T = T
+        self.P = P
+        self.Elist = Elist
+        self.Jlist = Jlist
         
         self.Nisom = len(self.isomers)
         self.Nreac = len(self.reactants)
         self.Nprod = len(self.products)
-        self.Ngrains = 0
-        self.NJ = 0
+        self.Ngrains = Ngrains
+        self.NJ = NJ
 
-        self.activeKRotor = True
-        self.activeJRotor = True
+        self.activeKRotor = activeKRotor
+        self.activeJRotor = activeJRotor
 
-        self.grainSize = 0.0
-        self.grainCount = 0
-        self.E0 = None
+        self.grainSize = grainSize
+        self.grainCount = grainCount
+        self.E0 = E0
 
         self.valid = False
 

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -215,6 +215,8 @@ class Network:
         self.rmgmode = rmgmode
         
         self.calculateDensitiesOfStates()
+        logging.debug('Finished initialization for network {0}.'.format(self.label))
+        logging.debug('The nework now has values of {0}'.format(repr(self)))
 
     def calculateRateCoefficients(self, Tlist, Plist, method, errorCheck=True):
         
@@ -284,7 +286,9 @@ class Network:
                                 logging.info(K[t,p,0:Nisom+Nreac+Nprod,0:Nisom+Nreac])
                                 K[t,p,:,:] = 0 * K[t,p,:,:]
                                 self.K = 0 * self.K
-
+        logging.debug('Finished calculating rate coefficients for network {0}.'.format(self.label))
+        logging.debug('The nework now has values of {0}'.format(repr(self)))
+        logging.debug('Master equation matrix found for network {0} is {1}'.format(self.label, K))
         return K
 
     def setConditions(self, T, P, ymB=None):
@@ -370,6 +374,8 @@ class Network:
             # Update parameters that depend on temperature and pressure if necessary
             if temperatureChanged or pressureChanged:
                 self.calculateCollisionModel()
+        logging.debug('Finished setting conditions for network {0}.'.format(self.label))
+        logging.debug('The nework now has values of {0}'.format(repr(self)))
 
     def __getEnergyGrains(self, Emin, Emax, grainSize=0.0, grainCount=0):
         """

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -68,6 +68,9 @@ class Network:
     `Ngrains`               The number of energy grains
     `NJ`                    The number of angular momentum grains
     ----------------------- ----------------------------------------------------
+     `grainSize`            Maximum size of separation between energies
+     `grainCount`           Minimum number of descrete energies separated
+     `E0`                   A list of ground state energies of isomers, reactants, and products
     `activeKRotor`          ``True`` if the K-rotor is treated as active, ``False`` if treated as adiabatic
     `activeJRotor`          ``True`` if the J-rotor is treated as active, ``False`` if treated as adiabatic
     `rmgmode`               ``True`` if in RMG mode, ``False`` otherwise

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -115,6 +115,40 @@ class Network:
 
         self.valid = False
 
+    def __repr__(self):
+        string = 'Network('
+        if self.label != '': string += 'label="{0}", '.format(self.label)
+        if self.isomers: string += 'isomers="{0!r}", '.format(self.isomers)
+        if self.reactants: string += 'reactants="{0!r}", '.format(self.reactants)
+        if self.products: string += 'products="{0!r}", '.format(self.products)
+        if self.pathReactions: string += 'pathReactions="{0!r}", '.format(self.pathReactions)
+        if self.bathGas: string += 'bathGas="{0!r}", '.format(self.bathGas)
+        if self.netReactions: string += 'netReactions="{0!r}", '.format(self.netReactions)
+        if self.T != 0.0: string += 'T="{0}", '.format(self.T)
+        if self.P != 0.0: string += 'P="{0}", '.format(self.P)
+        if self.Elist: string += 'Elist="{0}", '.format(self.Elist)
+        if self.Jlist: string += 'Jlist="{0}", '.format(self.Jlist)
+        if self.Ngrains != 0: string += 'Ngrains="{0}", '.format(self.Ngrains)
+        if self.NJ != 0: string += 'NJ="{0}", '.format(self.NJ)
+        string += 'activeKRotor="{0}", '.format(self.activeKRotor)
+        string += 'activeJRotor="{0}", '.format(self.activeJRotor)
+        if self.grainSize != 0.0: string += 'grainSize="{0}", '.format(self.grainSize)
+        if self.grainCount != 0: string += 'grainCount="{0}", '.format(self.grainCount)
+        if self.E0: string += 'E0="{0}", '.format(self.E0)
+        string += ')'
+        return string
+
+    def __str__(self):
+        """return Network like it would be seen in cantherm input file"""
+        return "Network(label = '{0}', isomers = {1}, reactants = {2}, products = {3}, "\
+                        "pathReactions = {4}, bathGas = {5}, "\
+                        "netReactions = {6})".format(self.label, [i.species[0].label for i in self.isomers],
+                        [[r.label for r in pair.species] for pair in self.reactants],
+                        [[p.label for p in pair.species] for pair in self.products],
+                        [r.label for r in self.pathReactions],
+                        dict([(s.label, value) for s, value in self.bathGas.items()]),
+                        [r.toLabeledStr() for r in self.netReactions])
+
     def invalidate(self):
         """
         Mark the network as in need of a new calculation to determine the

--- a/rmgpy/pdep/networkTest.py
+++ b/rmgpy/pdep/networkTest.py
@@ -193,13 +193,41 @@ class TestNetwork(unittest.TestCase):
         Test that the network `netReactions` property was properly set.
         """
         self.assertEqual(0, len(self.network.netReactions))
-    
-    def test_initialize(self):
+
+    def test_repr(self):
         """
-        Test that the Network.initialize() method.
+        Test that the `repr` representation contains desired properties.
         """
-        self.network.initialize(Tmin=300., Tmax=2000., Pmin=1e3, Pmax=1e7, minimumGrainCount=200, maximumGrainSize=4184.0)
-    
+        output = repr(self.network)
+        # ensure species strings
+        labels = ['dehydration','H2O','N2','TS','n-C4H8','n-C4H10O']
+        for label in labels:
+            self.assertIn(label, output)
+
+        # ensure classes are used as well
+        attributes = ['Configuration','Network','Species','Conformer','NonlinearRotor',
+                   'HarmonicOscillator','frequencies','TransportData',
+                   'molecularWeight','SingleExponentialDown']
+        for label in attributes:
+            self.assertIn(label, output)
+
+    def test_str(self):
+        """
+        Test that the string representation contains desired properties.
+        """
+        output = str(self.network)
+        # ensure species strings
+        labels = ['dehydration','H2O','N2','n-C4H8','n-C4H10O']
+        for label in labels:
+            self.assertIn(label, output)
+
+        # ensure this extra fluff is not in Network string
+        attributes = ['Configuration','Species','Conformer','Molecule','NonlinearRotor',
+                   'HarmonicOscillator','frequencies','spinMultiplicity','TransportData',
+                   'molecularWeight','SingleExponentialDown']
+        for label in attributes:
+            self.assertNotIn(label, output)
+
     def test_collisionMatrixMemoryHandling(self):
         net = Network()
         net.Elist = [1]*10000

--- a/rmgpy/pdep/reaction.pyx
+++ b/rmgpy/pdep/reaction.pyx
@@ -165,6 +165,8 @@ def calculateMicrocanonicalRateCoefficient(reaction,
                 if reacDensStates[r,s] != 0:
                     kf[r,s] = kr[r,s] * prodDensStates[r,s] / reacDensStates[r,s]
         kf *= C0inv**(len(reaction.reactants) - len(reaction.products))
+    logging.debug('Finished finding microcanonical rate coefficients for path reaction {}'.format(reaction))
+    logging.debug('The forward and reverse rates are found to be  {0} and {1} respectively.'.format(kf, kr))
      
     return kf, kr
 
@@ -222,7 +224,9 @@ def applyRRKMTheory(transitionState,
         for r in range(Ngrains):
             if sumStates[r,s] > 0 and densStates[r,s] > 0:
                 k[r,s] = sumStates[r,s] / densStates[r,s] * dE
-            
+    logging.debug('Finished applying RRKM for path transition state {}'.format(transitionState))
+    logging.debug('The rate constant is found to be {}'.format(k))
+
     return k
 
 @cython.boundscheck(False)
@@ -318,6 +322,8 @@ def applyInverseLaplaceTransformMethod(transitionState,
                             
     else:
         raise Exception('Unable to use inverse Laplace transform method for non-Arrhenius kinetics or for n < 0.')
+    logging.debug('Finished applying inverse lapace transform for path transition state {}'.format(transitionState))
+    logging.debug('The rate constant is found to be {}'.format(k))
     
     return k
 
@@ -383,6 +389,7 @@ def fitInterpolationModel(reaction, Tlist, Plist, K, model, Tmin, Tmax, Pmin, Pm
         logRMS = sqrt(logRMS / len(Tlist) / len(Plist))
         if logRMS > 0.5:
             logging.warning('RMS error for k(T,P) fit = {0:g} for reaction {1}.'.format(logRMS, reaction))
-    
+    logging.debug('Finished fitting model for path reaction {}'.format(reaction))
+    logging.debug('The kinetics fit is {0!r}'.format(kinetics))
     return kinetics
 


### PR DESCRIPTION
This PR 

* adds default `__repr__` and `__str__` methods to Network and Configuration objects
* allows more inputs into `__init__` for Network objects (so they can recreated from `repr()`)
* prevents throwing an error for cantherm's kinetics method when tunneling values are already set (making it consistent with the pressureDependent method of setting tunneling values)
* added `logging.debug` to see the output from calculations in pdep
* throws an Exception when fitToData does not have any degrees of freedom

For a reviewer, if you could run a pdep cantherm job on this branch in debug mode `-d`, see if the output makes sense. Also you probably want to look at the changes from the commits to see if they make sense.