### PR TITLE
removes the ThermoData.label for HBI

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1424,7 +1424,9 @@ class ThermoDatabase(object):
                     try:
                         self.__addGroupThermoData(thermoData,self.groups['longDistanceInteraction_cyclic'], molecule, {'*1':atomPair[0], '*2':atomPair[1]})
                     except KeyError: pass
-
+        
+        thermoData.label = '' #prevents the original thermo species name being used for the HBI corrected radical in species generation
+        
         return thermoData
         
         


### PR DESCRIPTION
this prevents the pre-HBI corrected thermo label from being used for the HBI corrected thermo