### PR TITLE
Update some settings for building documentation

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -39,8 +39,7 @@ setup_github_pages:
 # Turn the build/html directory into a git repository linked to github ready to push to gh-pages branch!
 # Should only need to be run once.
 	rm -rf $(BUILDDIR)/html
-	mkdir -p $(BUILDDIR)/html
-	git clone --shared --branch gh-pages --config remote.official.url=git@github.com:ReactionMechanismGenerator/RMG-Py.git --config remote.official.fetch=+refs/heads/*:refs/remotes/official/* --config branch.gh-pages.remote=official --config branch.gh-pages.merge=refs/heads/gh-pages ../.git $(BUILDDIR)/html
+	git clone --single-branch --branch gh-pages --origin official git@github.com:ReactionMechanismGenerator/RMG-Py.git build/html
 
 publish: $(BUILDDIR)/html/.git
 # Commit changes to gh-pages and push to github, to publish the results!

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -43,7 +43,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'RMG Py'
-copyright = u'2002-2015, William H. Green, Richard H. West, and the RMG Team'
+copyright = u'2002-2017, William H. Green, Richard H. West, and the RMG Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ Cython.Compiler.Options.annotate = True
 # Turn on profiling capacity for all Cython modules
 #Cython.Compiler.Options.directive_defaults['profile'] = True
 
+# Embed docstrings in cythonized files - enable when building documentation
+#Cython.Compiler.Options._directive_defaults['embedsignature'] = True
+
 ################################################################################
 
 def getMainExtensionModules():


### PR DESCRIPTION
Mostly self explanatory.
- Change the setup_github_pages make target
- Update copyright date
- Add cython directive to embed docstrings, eliminates 95% of sphinx warnings

Should be tested before merging.