### PR TITLE
Wallclock error fixes

### DIFF
--- a/ipython/generateReactions.ipynb
+++ b/ipython/generateReactions.ipynb
@@ -135,11 +135,11 @@
    "outputs": [],
    "source": [
     "# Execute generate reactions\n",
-    "from rmgpy.tools.generate_reactions import *\n",
+    "from rmgpy.tools.generate_reactions import RMG, execute\n",
     "kwargs = {\n",
     "            'scratch_directory': '',\n",
     "            'restart': False,\n",
-    "            'walltime': '0',\n",
+    "            'walltime': '00:00:00:00',\n",
     "            'kineticsdatastore': True\n",
     "    }\n",
     "rmg = RMG(inputFile='temp/input.py', outputDirectory='temp')\n",

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -408,9 +408,9 @@ class RMG(util.Subject):
             pass
 
         data = self.wallTime.split(':')
-        self.wallTime = int(data[-1]) + 60 * int(data[-2]) + 3600 * int(data[-3]) + 86400 * int(data[-4])
         if not len(data) == 4:
-            raise ValueError('Invalid format for wall time; should be DD:HH:MM:SS.')
+            raise ValueError('Invalid format for wall time {0}; should be DD:HH:MM:SS.'.format(self.wallTime))
+        self.wallTime = int(data[-1]) + 60 * int(data[-2]) + 3600 * int(data[-3]) + 86400 * int(data[-4])
 
         # Initialize reaction model
         if restart:


### PR DESCRIPTION
Improves error generation for wallclock updates by 

1. changing when an error is thrown by the wallclock
2. fixing the input file for generateReactions.ipynb to use the correct format. 