### PR TITLE
Fix uncertainty

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2140,8 +2140,12 @@ class KineticsFamily(Database):
             
             # Discard the last line, unless it's the only line!
             # The last line is 'Estimated using ... for rate rule (originalTemplate)'
-            if len(lines) == 1:
-                comment = lines[0]
+            #if from training reaction is in the first line append it to the end of the second line and skip the first line
+            if not 'Average of' in kinetics.comment:
+                if 'from training reaction' in lines[0]:
+                    comment = lines[1]
+                else:
+                    comment = lines[0]
                 if comment.startswith('Estimated using template'):
                     tokenTemplateLabel = comment.split()[3][1:-1]
                     ruleEntry, trainingEntry = self.retrieveOriginalEntry(tokenTemplateLabel) 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2161,8 +2161,8 @@ class KineticsFamily(Database):
                 evalCommentString = re.sub(r" \+ ", ",",                        # any remaining + signs
                                     re.sub(r"Average of ", "",                  # average of averages
                                     re.sub(r"Average of \[(?!Average)", "['",   # average of groups
-                                    re.sub(r"(\b|\))]", r"\1']",                # initial closing bracket
-                                    re.sub(r"(?<=\b) \+ (?=Average)", "',",     # + sign between non-average and average
+                                    re.sub(r"(\w|\))]", r"\1']",                # initial closing bracket
+                                    re.sub(r"(?<=[\w)]) \+ (?=Average)", "',",  # + sign between non-average and average
                                     re.sub(r"(?<=]) \+ (?!Average)", ",'",      # + sign between average and non-average
                                     re.sub(r"(?<!]) \+ (?!Average)", "','",     # + sign between non-averages
                                     comment)))))))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2243,7 +2243,7 @@ class KineticsFamily(Database):
             elif line.startswith('Estimated'):
                 pass
             elif line.startswith('Multiplied by'):
-                degeneracy = int(line.split()[-1])
+                degeneracy = float(line.split()[-1])
 
         # Extract the rate rule information 
         fullCommentString = reaction.kinetics.comment.replace('\n', ' ')

--- a/rmgpy/test_data/testing_database/forbiddenStructures.py
+++ b/rmgpy/test_data/testing_database/forbiddenStructures.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = ""
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/rmgpy/test_data/testing_database/statmech/depository/depository.py
+++ b/rmgpy/test_data/testing_database/statmech/depository/depository.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Statmech Depository"
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/rmgpy/test_data/testing_database/statmech/groups/groups.py
+++ b/rmgpy/test_data/testing_database/statmech/groups/groups.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Functional Group Values"
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/rmgpy/test_data/testing_database/thermo/depository/radical.py
+++ b/rmgpy/test_data/testing_database/thermo/depository/radical.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Radical Molecules"
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/rmgpy/test_data/testing_database/thermo/depository/stable.py
+++ b/rmgpy/test_data/testing_database/thermo/depository/stable.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Stable Molecules"
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/rmgpy/test_data/testing_database/thermo/groups/other.py
+++ b/rmgpy/test_data/testing_database/thermo/groups/other.py
@@ -26,9 +26,151 @@ u"""
 """,
 )
 
+entry(
+    index = 10,
+    label = "ketene",
+    group = 
+"""
+1 * C u0 {2,D} {3,S} {4,S}
+2   C u0 {1,D} {5,D}
+3   R u0 {1,S}
+4   R u0 {1,S}
+5   O u0 {2,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (0,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""All the corrections from this family are from Sumathi & Green, J. Phys. Chem. A, 2002, 106, 7937-7949""",
+    longDesc = 
+u"""
+
+""",
+)
+
+entry(
+    index = 13,
+    label = "ketene_2C-C",
+    group = 
+"""
+1 * C       u0 {2,D} {3,S} {4,S}
+2   C       u0 {1,D} {5,D}
+3   [Cs,Cd] u0 {1,S} {6,S}
+4   [Cs,Cd] u0 {1,S} {7,S}
+5   O       u0 {2,D}
+6   C       u0 {3,S}
+7   C       u0 {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (-1.6,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""This is correction NN2 from Sumathi & Green, J. Phys. Chem. A, 2002, 106, 7937-7949""",
+    longDesc = 
+u"""
+
+""",
+)
+
+entry(
+    index = 11,
+    label = "ketene_1C-C_1C-H",
+    group = 
+"""
+1 * C       u0 {2,D} {3,S} {4,S}
+2   C       u0 {1,D} {5,D}
+3   [Cs,Cd] u0 {1,S} {6,S}
+4   C       u0 {1,S} {7,S} {8,S} {9,S}
+5   O       u0 {2,D}
+6   C       u0 {3,S}
+7   H       u0 {4,S}
+8   H       u0 {4,S}
+9   H       u0 {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (-0.5,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""This is correction NN1 from Sumathi & Green, J. Phys. Chem. A, 2002, 106, 7937-7949""",
+    longDesc = 
+u"""
+
+""",
+)
+
+entry(
+    index = 14,
+    label = "biketene",
+    group = 
+"""
+1    C   u0 {2,S} {3,S} {4,S} {5,S}
+2    C   u0 {1,S} {6,D}
+3  * C   u0 {1,S} {7,D} {10,S}
+4    R!H u0 {1,S}
+5    R!H u0 {1,S}
+6    C   u0 {2,D} {8,D}
+7    C   u0 {3,D} {9,D}
+8    O   u0 {6,D}
+9    O   u0 {7,D}
+10   R   u0 {3,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (-0.9,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""This is correction NN3 from Sumathi & Green, J. Phys. Chem. A, 2002, 106, 7937-7949""",
+    longDesc = 
+u"""
+
+""",
+)
+
+entry(
+    index = 12,
+    label = "ketene_2C-H",
+    group = 
+"""
+1  * C u0 {2,D} {3,S} {4,S}
+2    C u0 {1,D} {5,D}
+3    C u0 {1,S} {6,S} {7,S} {8,S}
+4    C u0 {1,S} {9,S} {10,S} {11,S}
+5    O u0 {2,D}
+6    H u0 {3,S}
+7    H u0 {3,S}
+8    H u0 {3,S}
+9    H u0 {4,S}
+10   H u0 {4,S}
+11   H u0 {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (0,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""This is correction NN0 from Sumathi & Green, J. Phys. Chem. A, 2002, 106, 7937-7949""",
+    longDesc = 
+u"""
+
+""",
+)
+
 tree(
 """
 L1: R
+    L2: ketene
+        L3: ketene_2C-C
+        L3: ketene_1C-C_1C-H
+        L3: biketene
+        L3: ketene_2C-H
 """
 )
 

--- a/rmgpy/test_data/testing_database/transport/groups/nonring.py
+++ b/rmgpy/test_data/testing_database/transport/groups/nonring.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = ""
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/rmgpy/test_data/testing_database/transport/groups/ring.py
+++ b/rmgpy/test_data/testing_database/transport/groups/ring.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = ""
+shortDesc = u""
+longDesc = u"""
+"""
+

--- a/rmgpy/tools/uncertaintyTest.py
+++ b/rmgpy/tools/uncertaintyTest.py
@@ -1,0 +1,126 @@
+################################################################################
+#
+#   RMG - Reaction Mechanism Generator
+#
+#   Copyright (c) 2002-2017 Prof. William H. Green (whgreen@mit.edu), 
+#   Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the 'Software'),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+
+import os
+import unittest
+import numpy as np
+
+import rmgpy
+from rmgpy.data.rmg import RMGDatabase
+from rmgpy.tools.uncertainty import Uncertainty
+
+
+class TestUncertainty(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """This method is run once before all tests in this class."""
+        test_dir = rmgpy.settings['test_data.directory']
+
+        data_dir = os.path.join(test_dir, 'testing_database')
+        chem_dir = os.path.join(test_dir, 'parsing_data')
+        chemkin_file = os.path.join(chem_dir, 'chem_annotated.inp')
+        spc_dict = os.path.join(chem_dir, 'species_dictionary.txt')
+
+        cls.uncertainty = Uncertainty(outputDirectory='chemDir')
+        cls.uncertainty.loadModel(chemkin_file, spc_dict)
+
+        # load database properly
+        cls.uncertainty.database = RMGDatabase()
+        cls.uncertainty.database.load(
+            data_dir,
+            kineticsFamilies='all',
+            kineticsDepositories=['training'],
+            thermoLibraries=['primaryThermoLibrary'],
+            reactionLibraries=['GRI-Mech3.0'],
+        )
+
+        # Prepare the database by loading training reactions and averaging the rate rules verbosely
+        for family in cls.uncertainty.database.kinetics.families.itervalues():
+            family.addKineticsRulesFromTrainingSet(thermoDatabase=cls.uncertainty.database.thermo)
+            family.fillKineticsRulesByAveragingUp(verbose=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        """This method is run once after all tests in this class."""
+        # Reset module level database
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+
+    def testUncertaintyAssignment(self):
+        """
+        Test that the thermo and kinetic parameter uncertainties can be properly assigned.
+        """
+        # Step 1: parse comments for sources
+        self.uncertainty.extractSourcesFromModel()
+        self.assertEqual(len(self.uncertainty.speciesSourcesDict), len(self.uncertainty.speciesList))
+        self.assertEqual(len(self.uncertainty.reactionSourcesDict), len(self.uncertainty.reactionList))
+
+        # Step 2: compile sources to obtain overall list
+        self.uncertainty.compileAllSources()
+
+        # Check thermo sources
+        grp_expected = {
+            'Os-CsH', 'Os-OsH', 'Od-Cd', 'Cds-OdHH', 'Cds-(Cdd-Od)HH', 'Ct-CtH', 'Cds-CdsHH', 'Cs-OsHHH', 'Cs-CsHHH',
+            'Cdd-CdsOd'
+        }
+        rad_expected = {'Acetyl', 'HOOJ', 'Cds_P', 'CCJ', 'CsJOH', 'CJ3'}
+        other_expected = {'ketene', 'R'}
+        self.assertEqual(set(self.uncertainty.allThermoSources), {'GAV', 'Library', 'QM'})
+        self.assertEqual(set(self.uncertainty.allThermoSources['GAV']), {'group', 'radical', 'other'})
+        grp = set([e.label for e in self.uncertainty.allThermoSources['GAV']['group']])
+        rad = set([e.label for e in self.uncertainty.allThermoSources['GAV']['radical']])
+        other = set([e.label for e in self.uncertainty.allThermoSources['GAV']['other']])
+        self.assertEqual(grp, grp_expected)
+        self.assertEqual(rad, rad_expected)
+        self.assertEqual(other, other_expected)
+        self.assertEqual(sorted(self.uncertainty.allThermoSources['Library']), [0, 1, 5, 13, 14])
+        self.assertFalse(self.uncertainty.allThermoSources['QM'])
+
+        # Check kinetics sources
+        rr_expected = {
+            'O_rad/NonDeO;O_Csrad', 'Ct_rad/Ct;O_Csrad', 'O_atom_triplet;O_Csrad', 'C_rad/H2/Cd;O_Csrad',
+            'CH2_triplet;O_Csrad', 'H_rad;O_Csrad', 'O_rad/NonDeC;O_Csrad', 'C_rad/Cs3;O_Csrad', 'Cd_pri_rad;O_Csrad',
+            'O2b;O_Csrad', 'O_pri_rad;Cmethyl_Csrad', 'C_rad/H/NonDeC;O_Csrad', 'O_pri_rad;O_Csrad',
+            'C_methyl;O_Csrad', 'C_rad/H2/Cs;O_Csrad', 'C_rad/H2/O;O_Csrad', 'CO_pri_rad;O_Csrad'
+        }
+        self.assertEqual(set(self.uncertainty.allKineticSources), {'Rate Rules', 'Training', 'Library', 'PDep'})
+        self.assertEqual(self.uncertainty.allKineticSources['Rate Rules'].keys(), ['Disproportionation'])
+        rr = set([e.label for e in self.uncertainty.allKineticSources['Rate Rules']['Disproportionation']])
+        self.assertEqual(rr, rr_expected)
+        self.assertEqual(self.uncertainty.allKineticSources['Training'].keys(), ['Disproportionation'])
+        self.assertEqual(self.uncertainty.allKineticSources['Library'], [0])
+        self.assertEqual(self.uncertainty.allKineticSources['PDep'], [4])
+
+        # Step 3: assign and propagate uncertainties
+        self.uncertainty.assignParameterUncertainties()
+        
+        thermo_unc = self.uncertainty.thermoInputUncertainties
+        kinetic_unc = self.uncertainty.kineticInputUncertainties
+        
+        np.testing.assert_allclose(thermo_unc, [1.5, 1.5, 2.0, 1.9, 3.1, 1.5, 1.9, 2.0, 2.0, 1.9, 2.2, 1.9, 2.0, 1.5], rtol=1e-4)
+        np.testing.assert_allclose(kinetic_unc, [0.5, 1.5, 5.806571, 0.5, 2.0], rtol=1e-4)


### PR DESCRIPTION
The pull request solves a number of current issues with uncertainty:

1.  Degeneracies can now be floats
2.  The parser doesn't break when the 'from training reaction' statement comes before and on a different line than 'estimated using template'
3.  Uncertainties can now deal with radical HBI corrections when the saturated species of the radical is not a species in the model

I've added a primitive test that checks that the uncertainties module can load the parameter uncertainty engines (effectively that it doesn't fail to estimate any raw thermo or kinetic uncertainties).  This test should be sufficient that things like 1-3 won't happen again.  

I had to add files to testing_database to pass the tests, but all of the new files are empty.  I had to update the other.py thermo group file because the uncertainty test needed one of the groups in it.  