### PR TITLE
Check for common MOPAC errors

### DIFF
--- a/rmgpy/exceptions.py
+++ b/rmgpy/exceptions.py
@@ -78,6 +78,13 @@ class DatabaseError(Exception):
     """
     pass
 
+class DependencyError(Exception):
+    """
+    An exception that occurs when an error is encountered with a dependency.
+    Pass a string describing the circumstances that caused the exception.
+    """
+    pass
+
 class ElementError(Exception):
     """
     An exception class for errors that occur while working with elements.

--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -36,6 +36,7 @@ import shutil
 
 from rmgpy.molecule import Molecule
 from molecule import QMMolecule
+from rmgpy.exceptions import DependencyError
 
 
 class Mopac:
@@ -98,7 +99,26 @@ class Mopac:
 
     def testReady(self):
         if not os.path.exists(self.executablePath):
-            raise Exception("Couldn't find MOPAC executable at {0}. Try setting your MOPAC_DIR environment variable.".format(self.executablePath))
+            raise DependencyError("Couldn't find MOPAC executable at {0}. Try setting your MOPAC_DIR environment variable.".format(self.executablePath))
+
+        # Check if MOPAC executable works properly
+        process = Popen(self.executablePath,
+                        stdin=PIPE,
+                        stdout=PIPE,
+                        stderr=PIPE)
+        stdout, stderr = process.communicate()
+
+        self.expired = False
+        if 'has expired' in stderr:
+            # The MOPAC executable is expired
+            logging.warning('\n'.join(stderr.split('\n')[2:7]))
+            self.expired = True
+        elif 'To install the MOPAC license' in stderr:
+            # The MOPAC executable exists, but the license has not been installed
+            raise DependencyError('\n'.join(stderr.split('\n')[0:9]))
+        elif 'MOPAC_LICENSE' in stderr:
+            # The MOPAC executable is in the wrong location on Windows; MOPAC_LICENSE must be set
+            raise DependencyError('\n'.join(stderr.split('\n')[0:11]))
 
     def run(self):
         self.testReady()
@@ -109,8 +129,9 @@ class Mopac:
         tempInpFile = os.path.join(dirpath, os.path.basename(self.inputFilePath))
         shutil.copy(self.inputFilePath, dirpath)      
 
-        process = Popen([self.executablePath, tempInpFile], stderr=PIPE)
-        stdout, stderr = process.communicate()  # necessary to wait for executable termination!
+        process = Popen([self.executablePath, tempInpFile], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        command = '\n' if self.expired else None  # press enter to pass expiration notice
+        stdout, stderr = process.communicate(input=command)  # necessary to wait for executable termination!
         if "ended normally" not in stderr.strip():
             logging.warning("Mopac error message:" + stderr)
 

--- a/rmgpy/qm/mopacTest.py
+++ b/rmgpy/qm/mopacTest.py
@@ -39,18 +39,19 @@ from rmgpy import getPath
 from rmgpy.qm.main import QMCalculator
 from rmgpy.molecule import Molecule
 from rmgpy.qm.mopac import Mopac, MopacMolPM3, MopacMolPM6, MopacMolPM7
+from rmgpy.exceptions import DependencyError
 
-executablePath = Mopac.executablePath
-if not os.path.exists(executablePath):
-    NO_MOPAC = NO_LICENCE = True
-else:
-    NO_MOPAC = False
-    process = subprocess.Popen(executablePath,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate("\n")
-    NO_LICENCE = 'To install the MOPAC license' in stderr
+
+NO_MOPAC = NO_LICENCE = False
+try:
+    Mopac().testReady()
+except DependencyError, e:
+    if "Couldn't find MOPAC executable" in e.message:
+        NO_MOPAC = NO_LICENCE = True
+    elif 'To install the MOPAC license' in e.message or 'MOPAC_LICENSE' in e.message:
+        NO_LICENCE = True
+    else:
+        raise
 
 mol1 = Molecule().fromSMILES('C1=CC=C2C=CC=CC2=C1')
 


### PR DESCRIPTION
This PR adds some additional checks to `Mopac.testReady()`:
- Check if the executable has expired, log a warning if so, but continue by pressing enter
- Raise an exception is the license has not been entered
- Raise an exception if the `MOPAC_LICENSE` environment variable needs to be set (Windows only)

This fixes #1163, and allows Travis to pass with an expired MOPAC executable.

This also addresses the issue on Windows where the test suite would always hang on the MOPAC test.

One thing I'm not sure about, is that the warning for an expired MOPAC exectuable is logged every time `testReady()` is called. In a standard RMG job with QMTP, it would probably be called numerous times. Is it worthwhile to make a module level variable in order to only print the warning once, or is it fine to print it repeatedly?