### PR TITLE
Stop calculate degeneracy errors

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1577,13 +1577,14 @@ class KineticsFamily(Database):
             
         # log issues
         if len(reactions) != 1:
-            for reactant in reaction.reactants:
-                logging.error("Reactant: {0!r}".format(reactant))
-            for product in reaction.products:
-                logging.error("Product: {0!r}".format(product))
-            raise KineticsError(('Unable to calculate degeneracy for reaction {0} '
+            logging.warning(('Unable to calculate degeneracy for reaction {0} '
                                  'in reaction family {1}. Expected 1 reaction '
                                  'but generated {2}').format(reaction, self.label, len(reactions)))
+            logging.warning("The full original reaction object is: {0!r}".format(reaction))
+            logging.warning("The reaction objects found are: {0!r}".format(reactions))
+            if len(reactions) == 0:
+                return 1.0
+
         return reactions[0].degeneracy
         
     def __generateReactions(self, reactants, products=None, forward=True):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1533,6 +1533,11 @@ class KineticsFamily(Database):
         reaction.degeneracy = 1
         from rmgpy.rmg.react import findDegeneracies, getMoleculeTuples
 
+        # if reactants are different instances, make deep copy of reaction object
+        if len(reaction.reactants) > 1 and \
+                      len(set([id(r) for r in reaction.reactants])) != \
+                      len(reaction.reactants):
+            reaction = reaction.copy()
         # find combinations of resonance isomers
         specReactants = []
         if isinstance(reaction.reactants[0], Molecule):


### PR DESCRIPTION
This PR will prevent calculate degeneracy from throwing an error and will just warn the user that the degeneracy is incorrect. This is due to issues in aramatic vs. kekulized structures using different rates.

These commits were pulled from `only_core_degeneracy`, but moved here to speed up merging of bug fixes.