### PR TITLE
make bounds for change bonds more flexible

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -601,7 +601,7 @@ class Bond(Edge):
         Update the bond as a result of applying a CHANGE_BOND action to
         increase the order by one.
         """
-        if self.order <=2: 
+        if self.order <=2.0001:
             self.order += 1
         else:
             raise gr.ActionError('Unable to increment Bond due to CHANGE_BOND action: '+\
@@ -612,7 +612,7 @@ class Bond(Edge):
         Update the bond as a result of applying a CHANGE_BOND action to
         decrease the order by one.
         """
-        if self.order >=1: 
+        if self.order >=0.9999:
             self.order -= 1
         else:
             raise gr.ActionError('Unable to decrease Bond due to CHANGE_BOND action: '+\
@@ -625,7 +625,7 @@ class Bond(Edge):
         in bond order, and can be any real number.
         """
         self.order += order
-        if self.order < 0 or self.order >3:
+        if self.order < -0.0001 or self.order >3.0001:
             raise gr.ActionError('Unable to update Bond due to CHANGE_BOND action: Invalid resulting order "{0}".'.format(self.order))
 
     def applyAction(self, action):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -565,7 +565,7 @@ class Bond(Edge):
         NOTE: we can replace the absolute value relation with math.isclose when
         we swtich to python 3.5+
         """
-        return abs(self.order - otherOrder) <= 1e-6
+        return abs(self.order - otherOrder) <= 1e-4
 
         
     def isSingle(self):
@@ -573,28 +573,28 @@ class Bond(Edge):
         Return ``True`` if the bond represents a single bond or ``False`` if
         not.
         """
-        return abs(self.order-1) <= 1e-6
+        return self.isOrder(1)
 
     def isDouble(self):
         """
         Return ``True`` if the bond represents a double bond or ``False`` if
         not.
         """
-        return abs(self.order-2) <= 1e-6
+        return self.isOrder(2)
 
     def isTriple(self):
         """
         Return ``True`` if the bond represents a triple bond or ``False`` if
         not.
         """
-        return abs(self.order-3) <= 1e-6
+        return self.isOrder(3)
 
     def isBenzene(self):
         """
         Return ``True`` if the bond represents a benzene bond or ``False`` if
         not.
         """
-        return abs(self.order-1.5) <= 1e-6
+        return self.isOrder(1.5)
 
     def incrementOrder(self):
         """

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -434,7 +434,7 @@ class TestBond(unittest.TestCase):
             bond = bond0.copy()
             try:
                 bond.applyAction(action)
-                self.fail('Bond.applyAction() unexpectedly processed a BREAK_BOND action.')
+                self.fail('Bond.applyAction() unexpectedly processed a BREAK_BOND action with order {0}.'.format(order0))
             except ActionError:
                 pass
     
@@ -448,7 +448,7 @@ class TestBond(unittest.TestCase):
             bond = bond0.copy()
             try:
                 bond.applyAction(action)
-                self.fail('Bond.applyAction() unexpectedly processed a FORM_BOND action.')
+                self.fail('Bond.applyAction() unexpectedly processed a FORM_BOND action with order {0}.'.format(order0))
             except ActionError:
                 pass
     
@@ -463,7 +463,7 @@ class TestBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue(3 <= order0)
+                self.assertTrue(3 <= order0,'Test failed with order {0}'.format(order0))
                 
     def testApplyActionDecrementBond(self):
         """
@@ -476,7 +476,7 @@ class TestBond(unittest.TestCase):
             try:
                 bond.applyAction(action)
             except ActionError:
-                self.assertTrue(order0 < 1)
+                self.assertTrue(order0 < 1,'Test failed with order {0}'.format(order0))
             
     def testApplyActionGainRadical(self):
         """
@@ -488,7 +488,7 @@ class TestBond(unittest.TestCase):
             bond = bond0.copy()
             try:
                 bond.applyAction(action)
-                self.fail('Bond.applyAction() unexpectedly processed a GAIN_RADICAL action.')
+                self.fail('Bond.applyAction() unexpectedly processed a GAIN_RADICAL action with order {0}.'.format(order0))
             except ActionError:
                 pass
     
@@ -502,7 +502,7 @@ class TestBond(unittest.TestCase):
             bond = bond0.copy()
             try:
                 bond.applyAction(action)
-                self.fail('Bond.applyAction() unexpectedly processed a LOSE_RADICAL action.')
+                self.fail('Bond.applyAction() unexpectedly processed a LOSE_RADICAL action with order {0}.'.format(order0))
             except ActionError:
                 pass
     


### PR DESCRIPTION
Numerical drift was causing errors when adding bonds due to lack
of flexibility in the change bond methods in the Bond class. 

This PR added flexibility to the thousandths place.

This was pulled from `only_core_degeneracy`, but moved here to speed up merging of bug fixes.