### PR TITLE
Fixed info of reaction type in PDep network files

### DIFF
--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -629,13 +629,11 @@ class PressureDependenceJob(object):
                 f.write('    products = [{0}],\n'.format(', '.join([repr(str(spec)) for spec in rxn.products])))
                 f.write('    transitionState = {0!r},\n'.format(rxn.transitionState.label))
                 if rxn.kinetics is not None:
+                    if isinstance(rxn, LibraryReaction) and 'Reaction library:' not in rxn.kinetics.comment:
+                        rxn.kinetics.comment += 'Reaction library: {0!r}'.format(rxn.library)
                     f.write('    kinetics = {0!r},\n'.format(rxn.kinetics))
                 if ts.tunneling is not None:
                     f.write('    tunneling = {0!r},\n'.format(ts.tunneling.__class__.__name__))
-                if isinstance(rxn,LibraryReaction):
-                    f.write('    comment = "Library reaction: {0!r}",\n'.format(rxn.library))
-                else:
-                    f.write('    comment = "Template reaction: {0!r}",\n'.format(rxn.family))
                 f.write(')\n\n')
             
             # Write network


### PR DESCRIPTION
Relocated the library/family comment from Reaction to kinetics to avoid ending up with two `comment` instances in PDep network files.

Thanks @jimchu10 for [pointing this issue up](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/1ae3a89b24122f7cdedf0bbfd6dd568e1da5ea9e#commitcomment-23796076).