### PR TITLE
Updated BAC for CBS-QB3 according to Paraskevas2013

### DIFF
--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -699,16 +699,13 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
             'O-H':  0.07, 'C-O': 0.25, 'C=O': -0.03, 'O-O': 0.26, 'C-N': -0.20,
             'C=N': -0.30, 'C#N': -1.33, 'N-O': 1.01, 'N_O': -0.03, 'N=O': -0.26,
             'N-H':  0.06, 'N-N': -0.23, 'N=N': -0.37, 'N#N': -0.64,}
-    
-    # BAC corrections from Table IX in http://dx.doi.org/10.1063/1.477794 for CBS-Q method
-    # H-Cl correction from CBS-QB3 enthalpy difference with Gurvich 1989, HF298=-92.31 kJ
-    # 'N=O', 'N-N', 'N=N', 'N-O' corrections taken from Table 2 in R. Ashcraft, S. Raman, W.H. Green J. Phys. Chem. B, Vol. 111, No. 41, 2007; doi: 10.1021/jp073539t
-    elif modelChemistry == 'CBS-QB3':
-        bondEnergies = { 'C-H': -0.11, 'C-C': -0.3, 'C=C': -0.08, 'C#C': -0.64,
-            'O-H': 0.02, 'C-O': 0.33, 'C=O': 0.55, 'N#N': -2.0, 'O=O': -0.2,
-            'H-H': 1.1, 'C#N': -0.89, 'C-S': 0.43, 'O=S': -0.78, 'S-H': 0.0,
-            'N-H': -0.42, 'C-N': -0.13, 'N=O': 1.11, 'N-N': -1.87, 'N=N': -1.58,
-            'N-O': 0.35, }
+    elif modelChemistry == 'CBS-QB3': 
+        bondEnergies = { 
+            'C-C': -0.495, 'C-H': -0.045, 'C=C': -0.825, 'C-O': 0.378, 'C=O': 0.743, 'O-H': -0.423, #Table2: Paraskevas, PD (2013). Chemistry-A European J., DOI: 10.1002/chem.201301381
+            'C#C': -0.64,  'C#N': -0.89,  'C-S': 0.43,   'O=S': -0.78, 'S-H': 0.0,   'C-N': -0.13, # Table IX: Petersson GA (1998) J. of Chemical Physics, DOI: 10.1063/1.477794 
+            'N-H': -0.42,  'N=O': 1.11,   'N-N': -1.87,  'N=N': -1.58, 'N-O': 0.35, #Table 2: Ashcraft R (2007) J. Phys. Chem. B; DOI: 10.1021/jp073539t
+            'N#N': -2.0,   'O=O': -0.2,   'H-H': 1.1, # Unknown source
+             }
     elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'DFT_G03_b3lyp','B3LYP/6-311+G(3df,2p)']:
         bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
             'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44, 


### PR DESCRIPTION
I updated CBS-QB3 BAC corrections according to the work of Paraskevas et al.
http://onlinelibrary.wiley.com/doi/10.1002/chem.201301381/full
This update was recommended by Professor Sabbe at Ghent University.