### PR TITLE
Weights

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -234,7 +234,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,
+          useFluxRatioInWeights=False, speciesWeights={}, radicalChangeWeight=0.0):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -251,7 +252,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
     rmg.modelSettingsList.append(ModelSettings(toleranceMoveToCore, toleranceMoveEdgeReactionToCore,toleranceKeepInEdge, toleranceInterruptSimulation, 
           toleranceMoveEdgeReactionToSurface, toleranceMoveSurfaceSpeciesToCore, toleranceMoveSurfaceReactionToCore,
           toleranceMoveEdgeReactionToSurfaceInterrupt,toleranceMoveEdgeReactionToCoreInterrupt, maximumEdgeSpecies, minCoreSizeForPrune, 
-          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,terminateAtMaxObjects,toleranceThermoKeepSpeciesInEdge))
+          minSpeciesExistIterationsForPrune, filterReactions, ignoreOverallFluxCriterion, maxNumSpecies, maxNumObjsPerIter,terminateAtMaxObjects,toleranceThermoKeepSpeciesInEdge,
+          useFluxRatioInWeights,speciesWeights,radicalChangeWeight))
     
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -51,8 +51,12 @@ This module contains settings classes for manipulation of RMG run parameters
     `ignoreOverallFluxCriterion`                    flag indicating that the ordinary flux criterion should be ignored except for pdep purposes
     `maxNumSpecies`                                 Number of core species at which a stage/job will terminate
     `maxNumObjPerIter`                              Maximum number of objects that can be sent for enlargement from a single simulation
-==================================================================================================================================================
+    `useFluxRatioInWeights`                         flag indicating if species weights for the dynamics criterion should be multiplied by their rate ratios
+    `speciesWeights`                                dictionary mapping species labels to weights
+    `radicalChangeWeight`                           power to which the change in number of radicals is taken to and mulitplied by the reaction weight
+===========================================================================================================================================================
 """
+
 import numpy
 
 class ModelSettings(object):
@@ -63,7 +67,7 @@ class ModelSettings(object):
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
-          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf):
+          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,useFluxRatioInWeights=False, speciesWeights={}, radicalChangeWeight=0.0):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -79,7 +83,10 @@ class ModelSettings(object):
         self.toleranceMoveSurfaceReactionToCore = toleranceMoveSurfaceReactionToCore
         self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
         self.terminateAtMaxObjects = terminateAtMaxObjects
-
+        self.useFluxRatioInWeights = useFluxRatioInWeights
+        self.speciesWeights = speciesWeights
+        self.radicalChangeWeightBase = numpy.exp(radicalChangeWeight)
+        
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation
         else:

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -87,7 +87,11 @@ cdef class ReactionSystem(DASx):
     cdef public numpy.ndarray maxNetworkLeakRates
     cdef public numpy.ndarray maxEdgeSpeciesRateRatios
     cdef public numpy.ndarray maxNetworkLeakRateRatios
-
+    
+    # weight variables
+    cdef public numpy.ndarray speciesWeightVec
+    cdef public numpy.ndarray reactionWeightVec
+    
     # sensitivity variables
     # cdef public int sensmethod
     cdef public numpy.ndarray sensitivityCoefficients
@@ -102,6 +106,8 @@ cdef class ReactionSystem(DASx):
     cdef public list snapshots
 
     cdef public list termination
+    
+    cdef public object modelSettings
     
     # reaction threshold settings
     cdef public numpy.ndarray unimolecularThreshold
@@ -125,3 +131,5 @@ cdef class ReactionSystem(DASx):
     cpdef initialize_surface(self,list coreSpecies,list coreReactions,list surfaceSpecies,list surfaceReactions)
     
     cpdef addReactionsToSurface(self,list newSurfaceReactions,list newSurfaceReactionInds,list surfaceSpecies,list surfaceReactions,list edgeSpecies)
+    
+    cpdef generateWeights(self, list coreSpecies, list coreReactions, list edgeReactions)

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -78,6 +78,7 @@ cdef class ReactionSystem(DASx):
     cdef public numpy.ndarray coreSpeciesConsumptionRates
     cdef public numpy.ndarray edgeSpeciesRates
     cdef public numpy.ndarray edgeReactionRates
+    cdef public numpy.ndarray coreSpeciesRateRatios
 
     cdef public numpy.ndarray networkLeakRates    
 
@@ -108,6 +109,7 @@ cdef class ReactionSystem(DASx):
     cdef public list termination
     
     cdef public object modelSettings
+    cdef public object simulatorSettings
     
     # reaction threshold settings
     cdef public numpy.ndarray unimolecularThreshold
@@ -133,3 +135,7 @@ cdef class ReactionSystem(DASx):
     cpdef addReactionsToSurface(self,list newSurfaceReactions,list newSurfaceReactionInds,list surfaceSpecies,list surfaceReactions,list edgeSpecies)
     
     cpdef generateWeights(self, list coreSpecies, list coreReactions, list edgeReactions)
+    
+    cpdef calculateEdgeDynamicsNumbers(self)
+    
+    cpdef calculateSurfaceDynamicsNumbers(self)

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -573,6 +573,10 @@ cdef class ReactionSystem(DASx):
         sensitivityRelativeTolerance = simulatorSettings.sens_rtol
         filterReactions = modelSettings.filterReactions
         maxNumObjsPerIter = modelSettings.maxNumObjsPerIter
+        useFluxRatioInWeights = modelSettings.useFluxRatioInWeights
+        speciesWeights = modelSettings.speciesWeights
+        radicalChangeWeightBase = modelSettings.radicalChangeWeightBase
+        
         #if not pruning always terminate at max objects, otherwise only do so if terminateAtMaxObjects=True
         terminateAtMaxObjects = True if not prune else modelSettings.terminateAtMaxObjects 
         

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -136,7 +136,7 @@ cdef class ReactionSystem(DASx):
         self.coreSpeciesConsumptionRates = None
         self.edgeSpeciesRates = None
         self.edgeReactionRates = None
-
+        self.coreSpeciesRateRatios = None
         self.networkLeakRates = None
         
         #surface indices
@@ -159,7 +159,8 @@ cdef class ReactionSystem(DASx):
         self.senpar = None
 
         # tolerance settings
-
+        self.modelSettings = None
+        self.simulatorSettings = None
         """
         Arrays containing the absolute and relative tolerances.
         The dimension of the arrays correspond to the number of 
@@ -532,7 +533,116 @@ cdef class ReactionSystem(DASx):
                     surfaceSpecies.append(edgeSpecies[i-numCoreSpecies])
                     
         return surfaceSpecies,surfaceReactions
+    
+    @cython.boundscheck(False)
+    cpdef calculateSurfaceDynamicsNumbers(self):
+        """
+        calculates and returns the dynamics numbers for surface reactions
+        """
+        cdef int spcIndex, index, numCoreSpecies, numCoreReactions, numEdgeReactions
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] surfaceTotalDivLnAccumNums, edgeReactionRates, coreSpeciesConsumptionRates, coreSpeciesRateRatios, coreSpeciesProductionRates, speciesWeightVec, reactionWeightVec
+        cdef numpy.ndarray[numpy.int_t,ndim=2] reactantIndices, productIndices
+        cdef numpy.ndarray[numpy.int_t,ndim=1] surfaceSpeciesIndices, surfaceReactionIndices
+        cdef double reactionRate, consumption, production, absoluteTolerance
+        cdef bool useFluxRatioInWeights
+        
+        edgeReactionRates = self.edgeReactionRates
+        reactantIndices = self.reactantIndices
+        productIndices = self.productIndices
+        numCoreSpecies = self.numCoreSpecies
+        numCoreReactions = self.numCoreReactions
+        numEdgeReactions = self.numEdgeReactions
+        useFluxRatioInWeights = self.modelSettings.useFluxRatioInWeights
+        absoluteTolerance = self.simulatorSettings.atol
+        coreReactionRates = self.coreReactionRates
+        coreSpeciesRateRatios = self.coreSpeciesRateRatios
+        coreSpeciesProductionRates = self.coreSpeciesProductionRates
+        coreSpeciesConsumptionRates = self.coreSpeciesConsumptionRates
+        speciesWeightVec = self.speciesWeightVec
+        surfaceSpeciesIndices = self.surfaceSpeciesIndices
+        surfaceReactionIndices = self.surfaceReactionIndices
+        reactionWeightVec = self.reactionWeightVec
+        surfaceTotalDivLnAccumNums = numpy.zeros(len(surfaceReactionIndices))
+        
+        for i in xrange(len(surfaceReactionIndices)):
+            index = surfaceReactionIndices[i]
+            reactionRate = coreReactionRates[index]
+            
+            for spcIndex in reactantIndices[index,:]:
+                if spcIndex != -1 and spcIndex<numCoreSpecies and not(spcIndex in surfaceSpeciesIndices):
+                    consumption = coreSpeciesConsumptionRates[spcIndex]
+                    if abs(abs(consumption) - abs(reactionRate)) < absoluteTolerance:
+                        surfaceTotalDivLnAccumNums[i] = numpy.inf
+                    elif reactionRate > 0:
+                        if useFluxRatioInWeights:
+                            surfaceTotalDivLnAccumNums[i] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))
+                        else:
+                            surfaceTotalDivLnAccumNums[i] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))    
 
+            for spcIndex in productIndices[index,:]:
+                if spcIndex != -1 and spcIndex<numCoreSpecies and not(spcIndex in surfaceSpeciesIndices):
+                    production = coreSpeciesProductionRates[spcIndex]
+                    if abs(abs(production) - abs(reactionRate)) < absoluteTolerance:
+                        surfaceTotalDivLnAccumNums[i] = numpy.inf
+                    elif reactionRate > 0:
+                        if useFluxRatioInWeights:
+                            surfaceTotalDivLnAccumNums[i] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
+                        else:
+                            surfaceTotalDivLnAccumNums[i] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
+
+            surfaceTotalDivLnAccumNums[i] *= reactionWeightVec[index]
+        
+        return surfaceTotalDivLnAccumNums
+    
+    @cython.boundscheck(False)
+    cpdef calculateEdgeDynamicsNumbers(self):
+        """
+        calculates and returns the dynamics numbers for edge reactions
+        """
+        cdef int spcIndex,index,numCoreSpecies,numCoreReactions,numEdgeReactions
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] totalDivLnAccumNums,edgeReactionRates, coreSpeciesConsumptionRates, coreSpeciesRateRatios, coreSpeciesProductionRates, speciesWeightVec
+        cdef numpy.ndarray[numpy.int_t,ndim=2] reactantIndices,productIndices
+        cdef double reactionRate,consumption,production
+        cdef bool useFluxRatioInWeights
+        
+        edgeReactionRates = self.edgeReactionRates
+        reactantIndices = self.reactantIndices
+        productIndices = self.productIndices
+        numCoreSpecies = self.numCoreSpecies
+        numCoreReactions = self.numCoreReactions
+        numEdgeReactions = self.numEdgeReactions
+        useFluxRatioInWeights = self.modelSettings.useFluxRatioInWeights
+        coreSpeciesProductionRates = self.coreSpeciesProductionRates
+        coreSpeciesConsumptionRates = self.coreSpeciesConsumptionRates
+        speciesWeightVec = self.speciesWeightVec
+        
+        if useFluxRatioInWeights:
+            coreSpeciesRateRatios = self.coreSpeciesRateRatios
+        
+        totalDivLnAccumNums = numpy.zeros(numEdgeReactions)
+        
+        for index in xrange(numEdgeReactions):
+            reactionRate = edgeReactionRates[index]
+            for spcIndex in reactantIndices[index+numCoreReactions,:]:
+                if spcIndex != -1 and spcIndex<numCoreSpecies:
+                    consumption = coreSpeciesConsumptionRates[spcIndex]
+                    if useFluxRatioInWeights:
+                        totalDivLnAccumNums[index] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))
+                    else:
+                        totalDivLnAccumNums[index] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))
+    
+            for spcIndex in self.productIndices[index+numCoreReactions,:]:
+                if spcIndex != -1 and spcIndex<numCoreSpecies:
+                    production = coreSpeciesProductionRates[spcIndex]
+                    if useFluxRatioInWeights:
+                        totalDivLnAccumNums[index] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
+                    else:
+                        totalDivLnAccumNums[index] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
+
+        totalDivLnAccumNums *= self.reactionWeightVec[numCoreReactions:]
+        
+        return totalDivLnAccumNums
+    
     @cython.boundscheck(False)
     cpdef simulate(self, list coreSpecies, list coreReactions, list edgeSpecies, 
         list edgeReactions,list surfaceSpecies, list surfaceReactions,
@@ -597,6 +707,7 @@ cdef class ReactionSystem(DASx):
         assert set(coreSpecies) >= set(surfaceSpecies), 'given surface species are not a subset of core species' 
         
         self.modelSettings = modelSettings
+        self.simulatorSettings = simulatorSettings
         toleranceKeepInEdge = modelSettings.fluxToleranceKeepInEdge if prune else 0
         toleranceMoveToCore = modelSettings.fluxToleranceMoveToCore
         toleranceMoveEdgeReactionToCore = modelSettings.toleranceMoveEdgeReactionToCore
@@ -722,7 +833,7 @@ cdef class ReactionSystem(DASx):
             coreSpeciesProductionRates = self.coreSpeciesProductionRates
             edgeSpeciesRates = numpy.abs(self.edgeSpeciesRates)
             networkLeakRates = numpy.abs(self.networkLeakRates)
-            coreSpeciesRateRatios = numpy.abs(self.coreSpeciesRates/charRate)
+            self.coreSpeciesRateRatios = numpy.abs(self.coreSpeciesRates/charRate)
             edgeSpeciesRateRatios = numpy.abs(self.edgeSpeciesRates/charRate)
             networkLeakRateRatios = numpy.abs(self.networkLeakRates/charRate)
             numEdgeReactions = self.numEdgeReactions
@@ -759,33 +870,12 @@ cdef class ReactionSystem(DASx):
                 break
             
             if useDynamics:
+
                 #######################################################
                 # Calculation of dynamics criterion for edge reactions#
                 #######################################################
 
-                totalDivLnAccumNums = numpy.zeros(numEdgeReactions)
-
-                for index in xrange(numEdgeReactions):
-                    reactionRate = edgeReactionRates[index]
-                    for spcIndex in self.reactantIndices[index+numCoreReactions,:]:
-                        if spcIndex != -1 and spcIndex<numCoreSpecies:
-                            consumption = coreSpeciesConsumptionRates[spcIndex]
-                            if consumption != 0:
-                                if useFluxRatioInWeights:
-                                    totalDivLnAccumNums[index] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))
-                                else:
-                                    totalDivLnAccumNums[index] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))
-
-                    for spcIndex in self.productIndices[index+numCoreReactions,:]:
-                        if spcIndex != -1 and spcIndex<numCoreSpecies:
-                            production = coreSpeciesProductionRates[spcIndex]
-                            if production != 0:
-                                if useFluxRatioInWeights:
-                                    totalDivLnAccumNums[index] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
-                                else:
-                                    totalDivLnAccumNums[index] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
-                
-                totalDivLnAccumNums *= reactionWeightVec[numCoreReactions:]
+                totalDivLnAccumNums = self.calculateEdgeDynamicsNumbers()
                 
                 surfaceSpeciesIndices = self.surfaceSpeciesIndices
                 surfaceReactionIndices = self.surfaceReactionIndices
@@ -794,41 +884,9 @@ cdef class ReactionSystem(DASx):
                 # Calculation of dynamics criterion for surface reactions#
                 ##########################################################
                 
-
                 #calculate criteria for surface species
-                surfaceTotalDivLnAccumNums = numpy.zeros(len(surfaceReactionIndices))
-                
-                for i in xrange(len(surfaceReactionIndices)):
-                    index = surfaceReactionIndices[i]
-                    reactionRate = coreReactionRates[index]
-                    for spcIndex in reactantIndices[index,:]:
-                        if spcIndex != -1 and spcIndex<numCoreSpecies and not(spcIndex in surfaceSpeciesIndices):
-                            consumption = coreSpeciesConsumptionRates[spcIndex]
-                            if consumption != 0: #if consumption=0 ignore species
-                                if abs(abs(consumption) - abs(reactionRate)) < absoluteTolerance:
-                                    surfaceTotalDivLnAccumNums[i] = numpy.inf
-                                elif reactionRate > 0:
-                                     if useFluxRatioInWeights:
-                                         surfaceTotalDivLnAccumNums[i] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))
-                                     else:
-                                         surfaceTotalDivLnAccumNums[i] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+consumption)/consumption))    
 
-                    for spcIndex in productIndices[index,:]:
-                        if spcIndex != -1 and spcIndex<numCoreSpecies and not(spcIndex in surfaceSpeciesIndices):
-                            production = coreSpeciesProductionRates[spcIndex]
-                            if production != 0: #if production = 0 ignore species
-                                if abs(abs(production) - abs(reactionRate)) < absoluteTolerance:
-                                    surfaceTotalDivLnAccumNums[i] = numpy.inf
-                                elif reactionRate > 0:
-                                    if useFluxRatioInWeights:
-                                         surfaceTotalDivLnAccumNums[i] += coreSpeciesRateRatios[spcIndex]*speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
-                                    else:
-                                         surfaceTotalDivLnAccumNums[i] += speciesWeightVec[spcIndex]*abs(numpy.log((reactionRate+production)/production))
-
-                            
-                surfaceTotalDivAccumNums = numpy.log(surfaceTotalDivAccumNums)
-
-                surfaceTotalDivLnAccumNums[index] *= reactionWeightVec[index]
+                surfaceTotalDivLnAccumNums = self.calculateSurfaceDynamicsNumbers()
 
                 ###############################################
                 # Move objects from surface to core on-the-fly#

--- a/rmgpy/solver/baseTest.py
+++ b/rmgpy/solver/baseTest.py
@@ -134,6 +134,101 @@ class ReactionSystemTest(unittest.TestCase):
         
         self.assertEqual(set(surfaceSpecies),set(edgeSpecies)) #all edge species should now be in the surface
         self.assertEqual(set(surfaceReactions),set(edgeReactions)) #all edge reactions should now be in the surface
+    
+    def testEdgeDynamicsNumberCalculations(self):
+        """
+        test an edge dynamics number calculation
+        """
+        reactionSystem = self.rmg.reactionSystems[0]
+        reactionSystem.attach(self.listener)
+        reactionModel = self.rmg.reactionModel
+        species = reactionModel.core.species
+        reactions = reactionModel.core.reactions
+        
+        coreSpecies = species[0:6]
+        coreReactions = [reactions[0]]
+        surfaceSpecies = []
+        surfaceReactions = []
+        edgeSpecies = species[6:]
+        edgeReactions = reactions[1:]
+        
+        reactionSystem.initializeModel(coreSpecies,coreReactions,
+                                       edgeSpecies,edgeReactions,surfaceSpecies,surfaceReactions)
+        
+        reactionSystem.modelSettings = ModelSettings()
+        reactionSystem.simulatorSettings = SimulatorSettings()
+        
+        reactionSystem.step(1.0e-15)
+        
+        logging.info('core spcs was {0}'.format(len(reactionSystem.coreSpeciesProductionRates)))
+        logging.info(reactionSystem.reactantIndices)
+        logging.info(reactionSystem.productIndices)
+        
+        dynNums = reactionSystem.calculateEdgeDynamicsNumbers()
+        
+        #the selected reaction (first edge reaction) has 4 and 5 from the core as reactants
+        #and 6 and 8 for products
+        
+        rate = reactionSystem.edgeReactionRates[0]
+        
+        prod5 = reactionSystem.coreSpeciesProductionRates[5]
+        prod4 = reactionSystem.coreSpeciesProductionRates[4]
+        loss5 = reactionSystem.coreSpeciesConsumptionRates[5]
+        loss4 = reactionSystem.coreSpeciesConsumptionRates[4]
+        logging.info((prod5,prod4,loss5,loss4,rate))
+        
+        lnDyn5 = numpy.log(prod5/loss5)
+        lnDyn5r = numpy.log(prod5/(loss5+rate))
+        
+        lnDyn4 = numpy.log(prod4/loss4)
+        lnDyn4r = numpy.log(prod4/(rate+loss4))
+        logging.info((lnDyn5,lnDyn5r,lnDyn4,lnDyn4r))
+        
+        Dyn = abs(lnDyn5-lnDyn5r) + abs(lnDyn4-lnDyn4r)
+        
+        self.assertAlmostEqual(Dyn,dynNums[0],5)
+    
+    def testSurfaceDynamicsNumberCalculations(self):
+        """
+        test a surface dynamics number calculation
+        """
+        reactionSystem = self.rmg.reactionSystems[0]
+        reactionSystem.attach(self.listener)
+        reactionModel = self.rmg.reactionModel
+        species = reactionModel.core.species
+        reactions = reactionModel.core.reactions
+        
+        coreSpecies = species
+        coreReactions = reactions
+        surfaceSpecies = species[5:]
+        surfaceReactions = reactions
+        edgeSpecies = []
+        edgeReactions = []
+        
+        reactionSystem.initializeModel(coreSpecies,coreReactions,
+                                       edgeSpecies,edgeReactions,surfaceSpecies,surfaceReactions)
+        
+        reactionSystem.modelSettings = ModelSettings()
+        reactionSystem.simulatorSettings = SimulatorSettings()
+        
+        reactionSystem.step(1.0e-15)
+        
+        dynNums = reactionSystem.calculateSurfaceDynamicsNumbers()
+        
+        #the selected reaction (first core reaction) has 6 + 7 from the core as reactants
+        #and 4 as a product, the rate is negative
+        #6 and 7 are in the surface so they are ignored
+        
+        rate = reactionSystem.coreReactionRates[2]
+        prod4 = reactionSystem.coreSpeciesProductionRates[4]
+        loss4 = reactionSystem.coreSpeciesConsumptionRates[4]
+   
+        lnDyn4 = numpy.log(prod4) - numpy.log(loss4)
+        lnDyn4r = numpy.log(prod4) - numpy.log(loss4-rate)
+        
+        Dyn = abs(lnDyn4-lnDyn4r)
+        
+        self.assertAlmostEqual(Dyn,dynNums[2],5)
         
     def testAttachDetach(self):
         """

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -282,7 +282,24 @@ class Species(object):
             ctSpecies.transport = self.transportData.toCantera()
             
         return ctSpecies
-
+    
+    def getRadicalCount(self):
+        """
+        returns the minimum number of radicals on any resonance structure
+        """
+        mols = self.molecule
+        nums = []
+        for mol in mols:
+            rcnt = mol.getRadicalCount()
+            if rcnt == 0:
+                return 0
+            elif rcnt == 1:
+                return 1
+            else:
+                nums.append(rcnt)
+        
+        return min(nums)
+    
     def hasStatMech(self):
         """
         Return ``True`` if the species has statistical mechanical parameters,


### PR DESCRIPTION
This adds the option to add weights for dynamics criterion calculations.  Three different weights are allowed:  
1)  radical change weights:  You set some tolerance t in the input file and for a reaction that changes the number of radicals by dr the weight W is calculated W = exp(t * abs(dr)).  This weight is multiplied by the dynamics number of that reaction during calculations increasing the weight of reactions that change the number of radicals.  

2) Species Specific weights:  You set a dictionary in the input file mapping species labels to a weight.  This weight is multiplied by the contribution of that species in any dynamics number calculation i.e. W_spc,i*abs(Ln(PI_Ac_spc,i))+ W_spc,i+1*abs(Ln(PI_Ac_spc,i+1)) + ...

3) Rate ratio weights:  set useFluxRatioInWeights to True in the input file.  This causes it to use the rate ratio of a given species at a given time as a species weight.  This weight behaves the same and is multiplied by any weight from 2.  

based from #1082 