### PR TITLE
only one Species class

### DIFF
--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -42,7 +42,7 @@ from transport import TransportDatabase
 from rmgpy.data.kinetics.database import KineticsDatabase
 from statmech import StatmechDatabase
 from solvation import SolvationDatabase
-
+from rmgpy.exceptions import DatabaseError
 from rmgpy.scoop_framework.util import get, broadcast
 
 # Module-level variable to store the (only) instance of RMGDatabase in use.
@@ -265,9 +265,9 @@ def getDB(name):
             if db:
                 return db
             else:
-                raise Exception
-        except Exception, e:
+                raise DatabaseError
+        except DatabaseError, e:
             logging.debug("Did not find a way to obtain the broadcasted database for {}.".format(name))
             raise e
 
-    raise Exception('Could not get database with name: {}'.format(name))
+    raise DatabaseError('Could not get database with name: {}'.format(name))

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -53,12 +53,6 @@ class TestSoluteDatabase(TestCase):
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
         
-        from rmgpy.rmg.model import Species as DifferentSpecies
-        DifferentSpecies.solventData = None
-        DifferentSpecies.solventName = None
-        DifferentSpecies.solventStructure = None
-        DifferentSpecies.solventViscosity = None
-        
     def runTest(self):
         pass
     

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -43,7 +43,7 @@ from rmgpy.display import display
 import rmgpy.constants as constants
 from rmgpy.constraints import failsSpeciesConstraints
 from rmgpy.quantity import Quantity
-import rmgpy.species
+from rmgpy.species import Species
 from rmgpy.thermo.thermoengine import submit
 from rmgpy.reaction import Reaction
 from rmgpy.exceptions import ForbiddenStructureException
@@ -56,31 +56,8 @@ import rmgpy.data.rmg
 from .react import reactAll
 
 from pdep import PDepReaction, PDepNetwork
+
 # generateThermoDataFromQM under the Species class imports the qm package
-
-################################################################################
-
-class Species(rmgpy.species.Species):
-    solventName = None
-    solventData = None
-    # solventStructure is the instance of species class whose molecule attribute corresponds to the solvent SMILES.
-    # If the solvent library does not contain the SMILES of the solvent, then the solventStructure is None
-    solventStructure = None
-    solventViscosity = None
-    isSolvent = False # returns True if the species is the solvent and False if not
-    diffusionTemp = None
-
-    def __init__(self, index=-1, label='', thermo=None, conformer=None, 
-                 molecule=None, transportData=None, molecularWeight=None, 
-                 energyTransferModel=None, reactive=True, props=None, creationIteration=0):
-        rmgpy.species.Species.__init__(self, index, label, thermo, conformer, molecule, transportData, molecularWeight, energyTransferModel, reactive, props)
-        self.creationIteration = creationIteration
-
-    def __reduce__(self):
-        """
-        A helper function used when pickling an object.
-        """
-        return (Species, (self.index, self.label, self.thermo, self.conformer, self.molecule, self.transportData, self.molecularWeight, self.energyTransferModel, self.reactive, self.props,self.creationIteration),)
 
 ################################################################################
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -196,6 +196,7 @@ class CoreEdgeReactionModel:
     `networkList`              A list of pressure-dependent reaction networks (:class:`Network` objects)
     `networkCount`             A counter for the number of pressure-dependent networks created
     `indexSpeciesDict`         A dictionary with a unique index pointing to the species objects
+    `solventName`              String describing solvent name for liquid reactions. Empty for non-liquid estimation
     =========================  ==============================================================
 
 
@@ -249,7 +250,8 @@ class CoreEdgeReactionModel:
         self.newSurfaceRxnsAdd = set()
         self.newSurfaceSpcsLoss = set()
         self.newSurfaceRxnsLoss = set()
-    
+        self.solventName = ''
+
     def checkForExistingSpecies(self, molecule):
         """
         Check to see if an existing species contains the same
@@ -338,7 +340,7 @@ class CoreEdgeReactionModel:
         spec.generateResonanceIsomers()
         spec.molecularWeight = Quantity(spec.molecule[0].getMolecularWeight()*1000.,"amu")
         
-        submit(spec)
+        submit(spec,self.solventName)
         
         if spec.label == '':
             if spec.thermo and spec.thermo.label != '': #check if thermo libraries have a name for it
@@ -1448,7 +1450,7 @@ class CoreEdgeReactionModel:
 
         for spec in self.newSpeciesList:            
             if spec.reactive:
-                submit(spec)
+                submit(spec,self.solventName)
 
             self.addSpeciesToCore(spec)
 
@@ -1458,7 +1460,7 @@ class CoreEdgeReactionModel:
                 # we need to make sure the barrier is positive.
                 # ...but are Seed Mechanisms run through PDep? Perhaps not.
                 for spec in itertools.chain(rxn.reactants, rxn.products):
-                    submit(spec)
+                    submit(spec,self.solventName)
 
                 rxn.fixBarrierHeight(forcePositive=True)
             self.addReactionToCore(rxn)
@@ -1514,7 +1516,7 @@ class CoreEdgeReactionModel:
 
         for spec in self.newSpeciesList:
             if spec.reactive: 
-                submit(spec)
+                submit(spec,self.solventName)
 
             self.addSpeciesToEdge(spec)
 

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -460,9 +460,3 @@ class LiquidReactorCheck(unittest.TestCase):
 
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
-
-        from rmgpy.rmg.model import Species as DifferentSpecies
-        DifferentSpecies.solventData = None
-        DifferentSpecies.solventName = None
-        DifferentSpecies.solventStructure = None
-        DifferentSpecies.solventViscosity = None

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -49,7 +49,9 @@ cdef class Species:
     cdef public dict props
     cdef public str aug_inchi
     cdef public float symmetryNumber
-    
+    cdef public bint isSolvent
+    cdef public int creationIteration
+
     cpdef generateResonanceIsomers(self,bint keepIsomorphic=?)
     
     cpdef bint isIsomorphic(self, other) except -2

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -533,7 +533,7 @@ class Species(object):
         candidates.sort()
         return candidates[0] 
 
-    def getThermoData(self):
+    def getThermoData(self, solventName = ''):
         """
         Returns a `thermoData` object of the current Species object.
 
@@ -553,7 +553,7 @@ class Species(object):
             if not isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
                 self.thermo = self.thermo.result()
         else:
-            submit(self)
+            submit(self, solventName)
             if not isinstance(self.thermo, (NASA, Wilhoit, ThermoData)):
                 self.thermo = self.thermo.result()
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -79,15 +79,20 @@ class Species(object):
                                 always considered regardless of this variable
     `props`                 A generic 'properties' dictionary to store user-defined flags
     `aug_inchi`             Unique augmented inchi
+    `isSolvent`             Boolean describing whether this species is the solvent
+    `creationIteration`     Iteration which the species is created within the reaction mechanism generation algorithm
     ======================= ====================================================
 
     note: :class:`rmg.model.Species` inherits from this class, and adds some extra methods.
     """
 
+    # these are class level attributes?
+
+
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 
                  molecule=None, transportData=None, molecularWeight=None, 
                  energyTransferModel=None, reactive=True, props=None, aug_inchi=None,
-                 symmetryNumber = -1):
+                 symmetryNumber = -1, creationIteration = 0):
         self.index = index
         self.label = label
         self.thermo = thermo
@@ -100,13 +105,14 @@ class Species(object):
         self.props = props or {}
         self.aug_inchi = aug_inchi
         self.symmetryNumber = symmetryNumber
+        self.isSolvent = False
+        self.creationIteration = creationIteration
         # Check multiplicity of each molecule is the same
         if molecule is not None and len(molecule)>1:
             mult = molecule[0].multiplicity
             for m in molecule[1:]:
                 if mult != m.multiplicity:
                     raise SpeciesError('Multiplicities of molecules in species {species} do not match.'.format(species=label))
-
         
 
 

--- a/rmgpy/thermo/nasaTest.py
+++ b/rmgpy/thermo/nasaTest.py
@@ -74,12 +74,6 @@ class TestNASA(unittest.TestCase):
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
         
-        from rmgpy.rmg.model import Species as DifferentSpecies
-        DifferentSpecies.solventData = None
-        DifferentSpecies.solventName = None
-        DifferentSpecies.solventStructure = None
-        DifferentSpecies.solventViscosity = None
-        
     def test_polyLow(self):
         """
         Test that the NASA low-temperature polynomial was properly set.

--- a/rmgpy/thermo/thermoengineTest.py
+++ b/rmgpy/thermo/thermoengineTest.py
@@ -67,12 +67,6 @@ def tearDown():
     """
     import rmgpy.data.rmg
     rmgpy.data.rmg.database = None
-    
-    from rmgpy.rmg.model import Species as DifferentSpecies
-    DifferentSpecies.solventData = None
-    DifferentSpecies.solventName = None
-    DifferentSpecies.solventStructure = None
-    DifferentSpecies.solventViscosity = None
 
 def funcSubmit():
     """

--- a/rmgpy/thermo/wilhoitTest.py
+++ b/rmgpy/thermo/wilhoitTest.py
@@ -84,12 +84,6 @@ class TestWilhoit(unittest.TestCase):
         """
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
-        
-        from rmgpy.rmg.model import Species as DifferentSpecies
-        DifferentSpecies.solventData = None
-        DifferentSpecies.solventName = None
-        DifferentSpecies.solventStructure = None
-        DifferentSpecies.solventViscosity = None
 
     def test_Cp0(self):
         """

--- a/rmgpy/tools/sensitivity.py
+++ b/rmgpy/tools/sensitivity.py
@@ -117,8 +117,6 @@ def simulate(rmg, diffusionLimited=True):
             if diffusionLimited:
                 rmg.loadDatabase()
                 Species.solventData = rmg.database.solvation.getSolventData(rmg.solvent)
-                Species.solventName = rmg.solvent
-                Species.solventStructure = rmg.database.solvation.getSolventStructure(rmg.solvent)
                 diffusionLimiter.enable(Species.solventData, rmg.database.solvation)
 
             # Store constant species indices


### PR DESCRIPTION
We previously had two species classes, one inheriting from the other, which was a source of confusion. This PR merges both classes into species.py and moves the class attributes of the other Species class to other areas of the code. 