### PR TITLE
estimate highly unsaturated bicyclic correction via heuristic method

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1604,15 +1604,24 @@ class ThermoDatabase(object):
         be applied.
         """
         # look up polycylic tree directly
-        matched_group_thermodata, _, isPartialMatch = self.__addRingCorrectionThermoDataFromTree(None, self.groups['polycyclic'], molecule, polyring)
+        matched_group_thermodata, matched_group, isPartialMatch = self.__addRingCorrectionThermoDataFromTree(None, self.groups['polycyclic'], molecule, polyring)
         
         # if partial match (non-H atoms number same between 
         # polycylic ring in molecule and match group)
         # otherwise, apply heuristic algorithm
         if not isPartialMatch:
-            thermoData = addThermoData(thermoData, matched_group_thermodata, groupAdditivity=True, verbose=True)
-            # By setting verbose=True, we turn on the comments of polycyclic correction to pass the unittest.
-            # Typically this comment is very short and also very helpful to check if the ring correction is calculated correctly.
+            if isBicyclic(polyring) and matched_group.label in self.groups['polycyclic'].genericNodes:
+                # apply secondary decompostion formula
+                # to get a estimated_group_thermodata
+                estimated_bicyclic_thermodata = self.getBicyclicCorrectionThermoDataFromHeuristic(polyring)
+                if not estimated_bicyclic_thermodata:
+                    estimated_bicyclic_thermodata = matched_group_thermodata
+                thermoData = addThermoData(thermoData, estimated_bicyclic_thermodata, groupAdditivity=True, verbose=True)
+            else:
+                # keep matched_group_thermodata as is
+                thermoData = addThermoData(thermoData, matched_group_thermodata, groupAdditivity=True, verbose=True)
+                # By setting verbose=True, we turn on the comments of polycyclic correction to pass the unittest.
+                # Typically this comment is very short and also very helpful to check if the ring correction is calculated correctly.
         else:
             self.__addPolyRingCorrectionThermoDataFromHeuristic(thermoData, polyring)
             
@@ -1633,8 +1642,19 @@ class ThermoDatabase(object):
         
         # loop over 2-ring cores
         for bicyclic in bicyclicsMergedFromRingPair:
-            self.__addRingCorrectionThermoDataFromTree(thermoData, 
+            matched_group_thermodata, matched_group, _ = self.__addRingCorrectionThermoDataFromTree(None, 
                 self.groups['polycyclic'], bicyclic, bicyclic.atoms)
+
+            if matched_group.label in self.groups['polycyclic'].genericNodes:
+                # apply secondary decompostion formula
+                # to get a estimated_group_thermodata
+                estimated_bicyclic_thermodata = self.getBicyclicCorrectionThermoDataFromHeuristic(bicyclic.atoms)
+                if not estimated_bicyclic_thermodata:
+                    estimated_bicyclic_thermodata = matched_group_thermodata 
+                thermoData = addThermoData(thermoData, estimated_bicyclic_thermodata, groupAdditivity=True)
+            else:
+                # keep matched_group_thermodata as is
+                thermoData = addThermoData(thermoData, matched_group_thermodata, groupAdditivity=True)
 
         # loop over 1-ring 
         for singleRingTuple, occurance in ringOccurancesDict.iteritems():

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -496,6 +496,31 @@ def splitBicyclicIntoSingleRings(bicyclic_submol):
     return [convertRingToSubMolecule(SSSR[0])[0], 
                 convertRingToSubMolecule(SSSR[1])[0]]
 
+def saturateRingBonds(ring_submol):
+    """
+    Given a ring submolelcule (`Molecule`), makes a deep copy and converts non-single bonds 
+    into single bonds, returns a new saturated submolecule (`Molecule`)
+    """
+    atomsMapping = {}
+    for atom in ring_submol.atoms:
+        if atom not in atomsMapping:
+            atomsMapping[atom] = atom.copy()
+
+    mol0 = Molecule(atoms=atomsMapping.values())
+
+    alreadySaturated = True
+    for atom in ring_submol.atoms:
+        for bondedAtom, bond in atom.edges.iteritems():
+            if bondedAtom in ring_submol.atoms:
+                if bond.order > 1.0: alreadySaturated = False
+                if not mol0.hasBond(atomsMapping[atom],atomsMapping[bondedAtom]):
+                    mol0.addBond(Bond(atomsMapping[atom],atomsMapping[bondedAtom],order=1.0))
+    
+    mol0.updateAtomTypes()
+    mol0.updateMultiplicity()
+    mol0.updateConnectivityValues()
+    return mol0, alreadySaturated
+
 ################################################################################
 
 class ThermoDepository(Database):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -485,6 +485,17 @@ def bicyclicDecompositionForPolyring(polyring):
         bicyclicsMergedFromRingPair.append(mergedRing)
 
     return bicyclicsMergedFromRingPair, ringOccurancesDict
+
+def splitBicyclicIntoSingleRings(bicyclic_submol):
+    """
+    Splits a given bicyclic submolecule into two individual single 
+    ring submolecules (a list of `Molecule`s ).
+    """
+    SSSR = bicyclic_submol.getDeterministicSmallestSetOfSmallestRings()
+
+    return [convertRingToSubMolecule(SSSR[0])[0], 
+                convertRingToSubMolecule(SSSR[1])[0]]
+
 ################################################################################
 
 class ThermoDepository(Database):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1652,6 +1652,68 @@ class ThermoDatabase(object):
                 # Typically this comment is very short and also very helpful to check if the ring correction is calculated correctly.
 
 
+    def getBicyclicCorrectionThermoDataFromHeuristic(self, bicyclic):
+
+        # saturate if the bicyclic has unsaturated bonds
+        # otherwise return None
+        bicyclic_submol = convertRingToSubMolecule(bicyclic)[0]
+        saturated_bicyclic_submol, alreadySaturated = saturateRingBonds(bicyclic_submol)
+
+        if alreadySaturated:
+            return None
+        # split bicyclic into two single ring submols
+        single_ring_submols = splitBicyclicIntoSingleRings(bicyclic_submol)
+
+        # split saturated bicyclic into two single ring submols
+        saturated_single_ring_submols = splitBicyclicIntoSingleRings(saturated_bicyclic_submol)
+
+        # apply formula: 
+        # bicyclic correction ~= saturated bicyclic correction - 
+        # saturated single ring corrections + single ring corrections
+        saturated_bicyclic_thermoData = self.__addRingCorrectionThermoDataFromTree(None, 
+                self.groups['polycyclic'], saturated_bicyclic_submol, saturated_bicyclic_submol.atoms)[0]
+
+        estimated_bicyclic_thermodata = saturated_bicyclic_thermoData
+        
+        for submol in saturated_single_ring_submols:
+            
+            if not isAromaticRing(submol):
+                aromaticBonds = findAromaticBondsFromSubMolecule(submol)
+                for aromaticBond in aromaticBonds:
+                    aromaticBond.setOrderNum(1)
+                
+                submol.update()
+                single_ring_thermoData = self.__addRingCorrectionThermoDataFromTree(None,
+                                            self.groups['ring'], submol, submol.atoms)[0]
+                
+            else:
+                submol.update()
+                single_ring_thermoData = self.__addRingCorrectionThermoDataFromTree(None,
+                                                self.groups['ring'], submol, submol.atoms)[0]
+            estimated_bicyclic_thermodata = removeThermoData(estimated_bicyclic_thermodata,
+                                                    single_ring_thermoData, groupAdditivity=True)
+
+        for submol in single_ring_submols:
+
+            if not isAromaticRing(submol):
+                aromaticBonds = findAromaticBondsFromSubMolecule(submol)
+                for aromaticBond in aromaticBonds:
+                    aromaticBond.setOrderNum(1)
+                
+                submol.update()
+                single_ring_thermoData = self.__addRingCorrectionThermoDataFromTree(None,
+                                            self.groups['ring'], submol, submol.atoms)[0]
+                
+            else:
+                submol.update()
+                single_ring_thermoData = self.__addRingCorrectionThermoDataFromTree(None,
+                                                self.groups['ring'], submol, submol.atoms)[0]
+                
+            estimated_bicyclic_thermodata = addThermoData(estimated_bicyclic_thermodata,
+                                                    single_ring_thermoData, groupAdditivity=True)
+
+        return estimated_bicyclic_thermodata
+
     def __addRingCorrectionThermoDataFromTree(self, thermoData, ring_database, molecule, ring):
         """
         Determine the ring correction group additivity thermodynamic data for the given

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -313,6 +313,16 @@ def isAromaticRing(submol):
                     return False
     return True
 
+def isBicyclic(polyring):
+    """
+    Given a polyring (a list of `Atom`s)
+    returns True if it's a bicyclic, False otherwise
+    """
+    submol, _ = convertRingToSubMolecule(polyring)
+    sssr = submol.getSmallestSetOfSmallestRings()
+
+    return len(sssr) == 2
+
 def findAromaticBondsFromSubMolecule(submol):
     """
     This method finds all the aromatic bonds within a input submolecule and 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1708,14 +1708,23 @@ class ThermoDatabase(object):
         # apply formula: 
         # bicyclic correction ~= saturated bicyclic correction - 
         # saturated single ring corrections + single ring corrections
+
+        estimated_bicyclic_thermodata = ThermoData(
+            Tdata = ([300,400,500,600,800,1000,1500],"K"),
+            Cpdata = ([0.0,0.0,0.0,0.0,0.0,0.0,0.0],"J/(mol*K)"),
+            H298 = (0.0,"kJ/mol"),
+            S298 = (0.0,"J/(mol*K)")
+        )
         
         saturated_bicyclic_thermoData = self.__addRingCorrectionThermoDataFromTree(None, 
                 self.groups['polycyclic'], saturated_bicyclic_submol, saturated_bicyclic_submol.atoms)[0]
-
-        saturated_bicyclic_thermoData.comment = "Estimated bicyclic component: " + saturated_bicyclic_thermoData.comment 
-
-        estimated_bicyclic_thermodata = saturated_bicyclic_thermoData
         
+        estimated_bicyclic_thermodata = addThermoData(estimated_bicyclic_thermodata,
+                                                    saturated_bicyclic_thermoData , 
+                                                    groupAdditivity=True)
+
+        estimated_bicyclic_thermodata.comment = "Estimated bicyclic component: " + saturated_bicyclic_thermoData.comment
+
         for submol in saturated_single_ring_submols:
             
             if not isAromaticRing(submol):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -357,6 +357,8 @@ def convertRingToSubMolecule(ring):
                 if not mol0.hasBond(atomsMapping[atom],atomsMapping[bondedAtom]):
                     mol0.addBond(Bond(atomsMapping[atom],atomsMapping[bondedAtom],order=bond.order))
     
+    mol0.updateMultiplicity()
+    mol0.updateConnectivityValues()
     return mol0, atomsMapping
 
 def combineTwoRingsIntoSubMolecule(ring1, ring2):
@@ -386,6 +388,9 @@ def combineTwoRingsIntoSubMolecule(ring1, ring2):
                 if not mol0.hasBond(atomsMapping[atom],atomsMapping[bondedAtom]):
                     mol0.addBond(Bond(atomsMapping[atom],atomsMapping[bondedAtom],order=bond.order))
     
+    mol0.updateMultiplicity()
+    mol0.updateConnectivityValues()
+
     return mol0, atomsMapping
 
 def getCopyForOneRing(ring):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -522,9 +522,12 @@ def saturateRingBonds(ring_submol):
     for atom in ring_submol.atoms:
         for bondedAtom, bond in atom.edges.iteritems():
             if bondedAtom in ring_submol.atoms:
-                if bond.order > 1.0: alreadySaturated = False
+                if bond.order > 1.0 and not bond.isBenzene(): alreadySaturated = False
                 if not mol0.hasBond(atomsMapping[atom],atomsMapping[bondedAtom]):
-                    mol0.addBond(Bond(atomsMapping[atom],atomsMapping[bondedAtom],order=1.0))
+                    bond_order = 1.0
+                    if bond.isBenzene():
+                        bond_order = 1.5
+                    mol0.addBond(Bond(atomsMapping[atom],atomsMapping[bondedAtom],order=bond_order))
     
     mol0.updateAtomTypes()
     mol0.updateMultiplicity()

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1659,10 +1659,10 @@ class ThermoDatabase(object):
                 estimated_bicyclic_thermodata = self.getBicyclicCorrectionThermoDataFromHeuristic(bicyclic.atoms)
                 if not estimated_bicyclic_thermodata:
                     estimated_bicyclic_thermodata = matched_group_thermodata 
-                thermoData = addThermoData(thermoData, estimated_bicyclic_thermodata, groupAdditivity=True)
+                thermoData = addThermoData(thermoData, estimated_bicyclic_thermodata, groupAdditivity=True, verbose=True)
             else:
                 # keep matched_group_thermodata as is
-                thermoData = addThermoData(thermoData, matched_group_thermodata, groupAdditivity=True)
+                thermoData = addThermoData(thermoData, matched_group_thermodata, groupAdditivity=True, verbose=True)
 
         # loop over 1-ring 
         for singleRingTuple, occurance in ringOccurancesDict.iteritems():
@@ -1751,7 +1751,7 @@ class ThermoDatabase(object):
                                                 self.groups['ring'], submol, submol.atoms)[0]
                 
             estimated_bicyclic_thermodata = addThermoData(estimated_bicyclic_thermodata,
-                                                    single_ring_thermoData, groupAdditivity=True)
+                                                    single_ring_thermoData, groupAdditivity=True, verbose=True)
 
         return estimated_bicyclic_thermodata
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1708,8 +1708,11 @@ class ThermoDatabase(object):
         # apply formula: 
         # bicyclic correction ~= saturated bicyclic correction - 
         # saturated single ring corrections + single ring corrections
+        
         saturated_bicyclic_thermoData = self.__addRingCorrectionThermoDataFromTree(None, 
                 self.groups['polycyclic'], saturated_bicyclic_submol, saturated_bicyclic_submol.atoms)[0]
+
+        saturated_bicyclic_thermoData.comment = "Estimated bicyclic component: " + saturated_bicyclic_thermoData.comment 
 
         estimated_bicyclic_thermodata = saturated_bicyclic_thermoData
         
@@ -1729,7 +1732,7 @@ class ThermoDatabase(object):
                 single_ring_thermoData = self.__addRingCorrectionThermoDataFromTree(None,
                                                 self.groups['ring'], submol, submol.atoms)[0]
             estimated_bicyclic_thermodata = removeThermoData(estimated_bicyclic_thermodata,
-                                                    single_ring_thermoData, groupAdditivity=True)
+                                                    single_ring_thermoData, groupAdditivity=True, verbose=True)
 
         for submol in single_ring_submols:
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -716,6 +716,82 @@ class TestCyclicThermo(unittest.TestCase):
         self.assertIn('s2_6_6_ane', polycyclicGroupLabels)
         self.assertIn('s2_3_6_ane', polycyclicGroupLabels)
 
+    def testAddPolyRingCorrectionThermoDataFromHeuristicUsingHighlyUnsaturatedPolycyclics1(self):
+        """
+        Test proper thermo estimation for highly unsaturated polycyclic whose decomposed 
+        bicyclics are not stored in database. Those bicyclics thermo will be estimated through
+        a heuristic formula.
+
+        In the future, the test assertion may be updated if some of the decomposed bicyclics
+        have been added to database.
+        """
+        # create testing molecule
+        smiles = '[CH]=C1C2=C=C3C=CC1C=C32'
+        mol = Molecule().fromSMILES(smiles)
+        
+        # extract polyring from the molecule
+        polyring = mol.getDisparateRings()[1][0]
+
+        thermoData = ThermoData(
+            Tdata = ([300,400,500,600,800,1000,1500],"K"),
+            Cpdata = ([0.0,0.0,0.0,0.0,0.0,0.0,0.0],"J/(mol*K)"),
+            H298 = (0.0,"kJ/mol"),
+            S298 = (0.0,"J/(mol*K)"),
+        )
+
+        self.database._ThermoDatabase__addPolyRingCorrectionThermoDataFromHeuristic(
+            thermoData, polyring)
+
+        ringGroups, polycyclicGroups = self.database.getRingGroupsFromComments(thermoData)
+
+        ringGroupLabels = [ringGroup.label for ringGroup in ringGroups]
+        polycyclicGroupLabels = [polycyclicGroup.label for polycyclicGroup in polycyclicGroups]
+
+        self.assertIn('1,4-Cyclohexadiene', ringGroupLabels)
+        self.assertIn('Cyclopentene', ringGroupLabels)
+        self.assertIn('cyclobutadiene_13', ringGroupLabels)
+        self.assertIn('s3_5_6_ane', polycyclicGroupLabels)
+        self.assertIn('s2_4_6_ane', polycyclicGroupLabels)
+        self.assertIn('s2_4_5_ane', polycyclicGroupLabels)
+
+    def testAddPolyRingCorrectionThermoDataFromHeuristicUsingHighlyUnsaturatedPolycyclics2(self):
+        """
+        Test proper thermo estimation for highly unsaturated polycyclic whose decomposed 
+        bicyclics are not stored in database. Those bicyclics thermo will be estimated through
+        a heuristic formula.
+        
+        In the future, the test assertion may be updated if some of the decomposed bicyclics
+        have been added to database.
+        """
+        # create testing molecule
+        smiles = 'C1=C2C#CC3C=CC1C=C23'
+        mol = Molecule().fromSMILES(smiles)
+        
+        # extract polyring from the molecule
+        polyring = mol.getDisparateRings()[1][0]
+
+        thermoData = ThermoData(
+            Tdata = ([300,400,500,600,800,1000,1500],"K"),
+            Cpdata = ([0.0,0.0,0.0,0.0,0.0,0.0,0.0],"J/(mol*K)"),
+            H298 = (0.0,"kJ/mol"),
+            S298 = (0.0,"J/(mol*K)"),
+        )
+
+        self.database._ThermoDatabase__addPolyRingCorrectionThermoDataFromHeuristic(
+            thermoData, polyring)
+
+        ringGroups, polycyclicGroups = self.database.getRingGroupsFromComments(thermoData)
+
+        ringGroupLabels = [ringGroup.label for ringGroup in ringGroups]
+        polycyclicGroupLabels = [polycyclicGroup.label for polycyclicGroup in polycyclicGroups]
+
+        self.assertIn('1,4-Cyclohexadiene', ringGroupLabels)
+        self.assertIn('Cyclopentyne', ringGroupLabels)
+        self.assertIn('Cyclopentadiene', ringGroupLabels)
+        self.assertIn('s3_5_6_ane', polycyclicGroupLabels)
+        self.assertIn('s2_5_6_ane', polycyclicGroupLabels)
+        self.assertIn('s2_5_5_ane', polycyclicGroupLabels)
+
     def testGetBicyclicCorrectionThermoDataFromHeuristic1(self):
         """
         Test bicyclic correction estimated properly from heuristic formula

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -904,6 +904,30 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         self.assertEqual(isAromaticRing(ring2mol), False)
         self.assertEqual(isAromaticRing(ring3mol), True)
 
+    def testIsBicyclic1(self):
+        """
+        Test isBicyclic identifies bicyclic correctly
+        The test molecule is bicyclic, we expect isBicyclic()
+        returns True.
+        """
+        smiles = 'C1=CCC2C1=C2'
+        mol = Molecule().fromSMILES(smiles)
+        polyring = mol.getDisparateRings()[1][0]
+
+        self.assertTrue(isBicyclic(polyring))
+
+    def testIsBicyclic2(self):
+        """
+        Test isBicyclic identifies bicyclic correctly
+        The test molecule is tetracyclic, we expect 
+        isBicyclic() returns False
+        """
+        smiles = 'C1C=C2C=CC=C3C=CC4=CC=CC=1C4=C23'
+        mol = Molecule().fromSMILES(smiles)
+        polyring = mol.getDisparateRings()[1][0]
+
+        self.assertFalse(isBicyclic(polyring))
+
     def testFindAromaticBondsFromSubMolecule(self):
 
         smiles = "C1=CC=C2C=CC=CC2=C1"

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -1073,6 +1073,33 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         self.assertTrue(single_ring_submol_a.isIsomorphic(expected_submol_a))
         self.assertTrue(single_ring_submol_b.isIsomorphic(expected_submol_b))
 
+    def testSaturateRingBonds1(self):
+        """
+        Test unsaturated bonds can be saturated properly
+        """
+        smiles = 'C1=CCC2=C1C2'
+        mol = Molecule().fromSMILES(smiles)
+        ring_submol = convertRingToSubMolecule(mol.getDisparateRings()[1][0])[0]
+
+        saturated_ring_submol, alreadySaturated = saturateRingBonds(ring_submol)
+
+        expected_saturated_ring_submol = Molecule().fromSMILES('C1CCC2C1C2')
+        # remove hydrogen
+        atomsToRemove = []
+        for atom in expected_saturated_ring_submol.atoms:
+            if atom.isHydrogen(): 
+                atomsToRemove.append(atom)
+
+        for atom in atomsToRemove:
+            expected_saturated_ring_submol.removeAtom(atom)
+        
+        expected_saturated_ring_submol.updateConnectivityValues()
+
+        self.assertFalse(alreadySaturated)
+        self.assertEqual(saturated_ring_submol.multiplicity, \
+                            expected_saturated_ring_submol.multiplicity)
+        self.assertTrue(saturated_ring_submol.isIsomorphic(expected_saturated_ring_submol))
+
 @attr('auth')
 class TestThermoCentralDatabaseInterface(unittest.TestCase):
     """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -716,6 +716,57 @@ class TestCyclicThermo(unittest.TestCase):
         self.assertIn('s2_6_6_ane', polycyclicGroupLabels)
         self.assertIn('s2_3_6_ane', polycyclicGroupLabels)
 
+    def testGetBicyclicCorrectionThermoDataFromHeuristic1(self):
+        """
+        Test bicyclic correction estimated properly from heuristic formula
+        The test molecule "C1=CCC2C1=C2" has a shared atom with Cd atomtype, 
+        but in the correction estimation we stil expect the five-member ring 
+        part to match Cyclopentene
+        """
+        smiles = 'C1=CCC2C1=C2'
+        mol = Molecule().fromSMILES(smiles)
+
+        # extract polyring from the molecule
+        polyring = mol.getDisparateRings()[1][0]
+
+        thermoData = self.database.getBicyclicCorrectionThermoDataFromHeuristic(polyring)
+
+        ringGroups, polycyclicGroups = self.database.getRingGroupsFromComments(thermoData)
+
+        ringGroupLabels = [ringGroup.label for ringGroup in ringGroups]
+        polycyclicGroupLabels = [polycyclicGroup.label for polycyclicGroup in polycyclicGroups]
+
+        self.assertIn('Cyclopentane', ringGroupLabels)
+        self.assertIn('Cyclopropane', ringGroupLabels)
+        self.assertIn('Cyclopentene', ringGroupLabels)
+        self.assertIn('Cyclopropene', ringGroupLabels)
+        self.assertIn('s2_3_5_ane', polycyclicGroupLabels)
+
+    def testGetBicyclicCorrectionThermoDataFromHeuristic2(self):
+        """
+        Test bicyclic correction estimated properly from heuristic formula
+        The test molecule "C1=CCC2=C1C2" doesn't have controversial shared 
+        atomtypes in correction estimation, which is regarded as a simple case.
+        """
+        smiles = 'C1=CCC2=C1C2'
+        mol = Molecule().fromSMILES(smiles)
+
+        # extract polyring from the molecule
+        polyring = mol.getDisparateRings()[1][0]
+
+        thermoData = self.database.getBicyclicCorrectionThermoDataFromHeuristic(polyring)
+
+        ringGroups, polycyclicGroups = self.database.getRingGroupsFromComments(thermoData)
+
+        ringGroupLabels = [ringGroup.label for ringGroup in ringGroups]
+        polycyclicGroupLabels = [polycyclicGroup.label for polycyclicGroup in polycyclicGroups]
+
+        self.assertIn('Cyclopentane', ringGroupLabels)
+        self.assertIn('Cyclopropane', ringGroupLabels)
+        self.assertIn('Cyclopentadiene', ringGroupLabels)
+        self.assertIn('Cyclopropene', ringGroupLabels)
+        self.assertIn('s2_3_5_ane', polycyclicGroupLabels)
+        
 class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
     """
     Contains unit tests for methods of molecular manipulations for thermo estimation

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -295,6 +295,25 @@ multiplicity 2
         self.assertTrue(arom.isIsomorphic(spec.molecule[0]))  # The aromatic structure should now be the first one
         self.assertTrue('library' in thermo.comment, 'Thermo not found from library, test purpose not fulfilled.')
 
+    def testThermoEstimationNotAffectDatabase(self):
+
+        poly_root = self.database.groups['polycyclic'].entries['PolycyclicRing']
+        previous_enthalpy = poly_root.data.getEnthalpy(298)/4184.0
+        smiles = 'C1C2CC1C=CC=C2'
+        spec = Species().fromSMILES(smiles)
+        spec.generateResonanceIsomers()
+
+        thermo_gav = self.database.getThermoDataFromGroups(spec)
+        _, polycyclicGroups = self.database.getRingGroupsFromComments(thermo_gav)
+
+        polycyclicGroupLabels = [polycyclicGroup.label for polycyclicGroup in polycyclicGroups]
+
+        self.assertIn('PolycyclicRing', polycyclicGroupLabels)
+
+        latter_enthalpy = poly_root.data.getEnthalpy(298)/4184.0
+
+        self.assertAlmostEqual(previous_enthalpy, latter_enthalpy, 2)
+
 
 class TestThermoAccuracy(unittest.TestCase):
     """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -1182,6 +1182,9 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         single_ring_submol_a, single_ring_submol_b = sorted(single_ring_submols,
                                 key=lambda submol: len(submol.atoms))
 
+        single_ring_submol_a.updateAtomTypes()
+        single_ring_submol_b.updateAtomTypes()
+
         expected_submol_a = Molecule().fromSMILES('C1=CC1')
         expected_submol_a.deleteHydrogens()
         expected_submol_a.updateConnectivityValues()
@@ -1210,6 +1213,9 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
 
         single_ring_submol_a, single_ring_submol_b = sorted(single_ring_submols,
                                 key=lambda submol: len(submol.atoms))
+
+        single_ring_submol_a.updateAtomTypes()
+        single_ring_submol_b.updateAtomTypes()
 
         expected_submol_a = Molecule().fromSMILES('C1=CC1')
         # remove hydrogen

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -1015,6 +1015,64 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         joinedCycle=combineCycles(testCycle1,testCycle2)
         self.assertTrue(sorted(mainCycle)==sorted(joinedCycle))
 
+    def testSplitBicyclicIntoSingleRings1(self):
+        """
+        Test bicyclic molecule "C1=CCC2C1=C2" can be divided into 
+        individual rings properly
+        """
+        smiles = 'C1=CCC2C1=C2'
+        mol = Molecule().fromSMILES(smiles)
+        bicyclic = mol.getDisparateRings()[1][0]
+
+        bicyclic_submol = convertRingToSubMolecule(bicyclic)[0]
+        single_ring_submols = splitBicyclicIntoSingleRings(bicyclic_submol)
+        self.assertEqual(len(single_ring_submols), 2)
+
+        single_ring_submol_a, single_ring_submol_b = sorted(single_ring_submols,
+                                key=lambda submol: len(submol.atoms))
+
+        expected_submol_a = Molecule().fromSMILES('C1=CC1')
+        expected_submol_a.deleteHydrogens()
+        expected_submol_a.updateConnectivityValues()
+
+        expected_submol_b = Molecule().fromSMILES('C1=CCCC1')
+        expected_submol_b.deleteHydrogens()
+        expected_submol_b.updateConnectivityValues()
+
+
+        self.assertTrue(single_ring_submol_a.isIsomorphic(expected_submol_a))
+        self.assertTrue(single_ring_submol_b.isIsomorphic(expected_submol_b))
+
+    def testSplitBicyclicIntoSingleRings2(self):
+        """
+        Test bicyclic molecule "C1=CCC2=C1C2" can be divided into 
+        individual rings properly
+        """
+
+        smiles = 'C1=CCC2=C1C2'
+        mol = Molecule().fromSMILES(smiles)
+        bicyclic = mol.getDisparateRings()[1][0]
+
+        bicyclic_submol = convertRingToSubMolecule(bicyclic)[0]
+        single_ring_submols = splitBicyclicIntoSingleRings(bicyclic_submol)
+        self.assertEqual(len(single_ring_submols), 2)
+
+        single_ring_submol_a, single_ring_submol_b = sorted(single_ring_submols,
+                                key=lambda submol: len(submol.atoms))
+
+        expected_submol_a = Molecule().fromSMILES('C1=CC1')
+        # remove hydrogen
+        expected_submol_a.deleteHydrogens()
+        expected_submol_a.updateConnectivityValues()
+
+        expected_submol_b = Molecule().fromSMILES('C1=CC=CC1')
+        # remove hydrogen
+        expected_submol_b.deleteHydrogens()
+        expected_submol_b.updateConnectivityValues()
+
+        self.assertTrue(single_ring_submol_a.isIsomorphic(expected_submol_a))
+        self.assertTrue(single_ring_submol_b.isIsomorphic(expected_submol_b))
+
 @attr('auth')
 class TestThermoCentralDatabaseInterface(unittest.TestCase):
     """

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -1150,7 +1150,7 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
 
     def testSaturateRingBonds1(self):
         """
-        Test unsaturated bonds can be saturated properly
+        Test unsaturated bonds of "C1=CCC2=C1C2" to be saturated properly
         """
         smiles = 'C1=CCC2=C1C2'
         mol = Molecule().fromSMILES(smiles)
@@ -1160,18 +1160,62 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
 
         expected_saturated_ring_submol = Molecule().fromSMILES('C1CCC2C1C2')
         # remove hydrogen
-        atomsToRemove = []
-        for atom in expected_saturated_ring_submol.atoms:
-            if atom.isHydrogen(): 
-                atomsToRemove.append(atom)
-
-        for atom in atomsToRemove:
-            expected_saturated_ring_submol.removeAtom(atom)
+        expected_saturated_ring_submol.deleteHydrogens()
         
         expected_saturated_ring_submol.updateConnectivityValues()
 
         self.assertFalse(alreadySaturated)
-        self.assertEqual(saturated_ring_submol.multiplicity, \
+        self.assertEqual(saturated_ring_submol.multiplicity,
+                            expected_saturated_ring_submol.multiplicity)
+        self.assertTrue(saturated_ring_submol.isIsomorphic(expected_saturated_ring_submol))
+
+    def testSaturateRingBonds2(self):
+        """
+        Test unsaturated bonds of "C1=CC=C2CCCCC2=C1" to be saturated properly
+        """
+        smiles = 'C1=CC=C2CCCCC2=C1'
+        spe = Species().fromSMILES(smiles)
+        spe.generateResonanceIsomers()
+        mol = spe.molecule[1]
+        ring_submol = convertRingToSubMolecule(mol.getDisparateRings()[1][0])[0]
+
+        saturated_ring_submol, alreadySaturated = saturateRingBonds(ring_submol)
+
+        expected_spe = Species().fromSMILES('C1=CC=C2CCCCC2=C1')
+        expected_spe.generateResonanceIsomers()
+        expected_saturated_ring_submol = expected_spe.molecule[1]
+        # remove hydrogen
+        expected_saturated_ring_submol.deleteHydrogens()
+        
+        expected_saturated_ring_submol.updateConnectivityValues()
+
+        self.assertTrue(alreadySaturated)
+        self.assertEqual(saturated_ring_submol.multiplicity,
+                            expected_saturated_ring_submol.multiplicity)
+        self.assertTrue(saturated_ring_submol.isIsomorphic(expected_saturated_ring_submol))
+
+    def testSaturateRingBonds3(self):
+        """
+        Test unsaturated bonds of "C1=CC=C2CC=CCC2=C1" to be saturated properly
+        """
+        smiles = 'C1=CC=C2CC=CCC2=C1'
+        spe = Species().fromSMILES(smiles)
+        spe.generateResonanceIsomers()
+        mol = spe.molecule[1]
+        ring_submol = convertRingToSubMolecule(mol.getDisparateRings()[1][0])[0]
+
+        saturated_ring_submol, alreadySaturated = saturateRingBonds(ring_submol)
+
+        expected_spe = Species().fromSMILES('C1=CC=C2CCCCC2=C1')
+        expected_spe.generateResonanceIsomers()
+        expected_saturated_ring_submol = expected_spe.molecule[1]
+        # remove hydrogen
+        expected_saturated_ring_submol.deleteHydrogens()
+        
+        expected_saturated_ring_submol.updateConnectivityValues()
+
+        self.assertFalse(alreadySaturated)
+        self.assertEqual(saturated_ring_submol.multiplicity,
                             expected_saturated_ring_submol.multiplicity)
         self.assertTrue(saturated_ring_submol.isIsomorphic(expected_saturated_ring_submol))
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1858,7 +1858,9 @@ class Molecule(Graph):
                 # Keep the smallest of the cycles found above
                 cycleCandidate_tups = []
                 for cycle0 in cycles:
-                    tup = (cycle0, len(cycle0), -sum([originConnDict[v] for v in cycle0]), -sum([v.element.number for v in cycle0]))
+                    tup = (cycle0, len(cycle0), -sum([originConnDict[v] for v in cycle0]), 
+                            -sum([v.element.number for v in cycle0]),
+                            -sum([v.getBondOrdersForAtom() for v in cycle0]))
                     cycleCandidate_tups.append(tup)
                 
                 cycle = sorted(cycleCandidate_tups, key=lambda tup0: tup0[1:])[0][0]


### PR DESCRIPTION
Bicyclic decomposition method works well when our database has comprehensive set of bicyclics and monocyclics. However, this assumption is not exactly true; database has a comprehensice set of saturated bicyclics while only a few of unsaturated ones. As one can imagine, data coverage is quite sparse there since one single bicyclic frame can have multiple ways of placing an unsaturated bond in the rings. It also seems not practical to calculate those unsaturated ones.

We had this idea of estimating unsaturated bicyclic correction from saturated bicyclics and monocyclics (see an example below)

![bicyclic_estimation_formula](https://user-images.githubusercontent.com/2739496/30111722-bfeb4192-92dc-11e7-814c-04b4ca47cd98.png)

This PR adds implemented this idea, which serves as an additional layer to bicyclic decomposition method. I tested the algorithm on 195 unsaturated bicyclics (the dataset is crafted by @zjburas and @adeeljamal, called `zb_bicyclics_195_table` hosted in `Thermo Central Database`). The results below shows little impact on saturated cyclics (the first 6 tables) but great improvements on unsaturated cyclics (the last table), which is exactly what we want it to behave.

 thermo estimation error (kcal/mol) | master-rmgpy & master-db | bicyclic_formula-rmgpy & Aromatics_updates_2-db 
----- | ----- | -----
small_cyclic_table | 3.39 | 3.42 
large_linear_polycyclic_table | 9.10 | 9.05 
large_fused_polycyclic_table | 9.56 | 9.54
small_O_only_polycyclic_table | 6.93 | 6.95
large_linear_O_only_polycyclic_table | 10.31 | 10.31
large_fused_O_only_polycyclic_table | 5.33 | 5.30
zb_bicyclics_195_table | 62.89 | 9.59

This PR should be merged with the database PR (https://github.com/ReactionMechanismGenerator/RMG-database/pull/206) made by @zjburas.