### PR TITLE
Fix bug with automatic debugging of addReverseAttribute

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1494,14 +1494,13 @@ class KineticsFamily(Database):
                     reactions = findDegeneracies(reactionList)
                 finally:
                     self.forbidden = tempObject
-                if len(reactions) != 1:
+                if len(reactions) == 1 or (len(reactions) > 1 and all([reactions[0].isIsomorphic(other, checkTemplateRxnProducts=True) for other in reactions])):
+                    logging.error("Error was fixed, the product is a forbidden structure when used as a reactant in the reverse direction.")
+                    # This reaction should be forbidden in the forward direction as well
+                    del rxn
+                else:
                     logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                     raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
-                else:
-                    logging.error("Error was fixed, the product is a forbidden structure when used as a reactant in the reverse direction.")
-                    # Delete this reaction, since it should probably also be forbidden in the initial direction
-                    # Hack fix for now
-                    del rxn
             elif len(reactions) > 1 and not all([reactions[0].isIsomorphic(other, checkTemplateRxnProducts=True) for other in reactions]):
                 logging.error("Expecting one matching reverse reaction. Recieved {0} reactions with multiple non-isomorphic ones in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                 logging.info("Found the following reverse reactions")

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1460,6 +1460,9 @@ class KineticsFamily(Database):
         """
         For rxn (with species' objects) from families with ownReverse, this method adds a `reverse`
         attribute that contains the reverse reaction information (like degeneracy)
+
+        Returns `True` if successful and `False` if the reverse reaction is forbidden.
+        Will raise a `KineticsError` if unsuccessful for other reasons.
         """
         from rmgpy.rmg.react import findDegeneracies
 
@@ -1497,7 +1500,7 @@ class KineticsFamily(Database):
                 if len(reactions) == 1 or (len(reactions) > 1 and all([reactions[0].isIsomorphic(other, checkTemplateRxnProducts=True) for other in reactions])):
                     logging.error("Error was fixed, the product is a forbidden structure when used as a reactant in the reverse direction.")
                     # This reaction should be forbidden in the forward direction as well
-                    del rxn
+                    return False
                 else:
                     logging.error("Still experiencing error: Expecting one matching reverse reaction, not {0} in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                     raise KineticsError("Did not find reverse reaction in reaction family {0} for reaction {1}.".format(self.label, str(rxn)))
@@ -1515,6 +1518,7 @@ class KineticsFamily(Database):
                 raise KineticsError("Found multiple reverse reactions in reaction family {0} for reaction {1}, likely due to inconsistent resonance structure generation".format(self.label, str(rxn)))
             else:
                 rxn.reverse = reactions[0]
+                return True
 
     def calculateDegeneracy(self, reaction):
         """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1489,7 +1489,9 @@ class KineticsFamily(Database):
                 tempObject = self.forbidden
                 self.forbidden = ForbiddenStructures()  # Initialize with empty one
                 try:
-                    reactions = self.__generateReactions(rxn.products, products=rxn.reactants, forward=True)
+                    reactionList = self.__generateReactions([spc.molecule for spc in rxn.products],
+                                                            products=rxn.reactants, forward=True)
+                    reactions = findDegeneracies(reactionList)
                 finally:
                     self.forbidden = tempObject
                 if len(reactions) != 1:

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -84,10 +84,16 @@ def reactSpecies(speciesTuple):
     # remove reverse reaction
     reactions = findDegeneracies(reactions, sameReactants)
     # add reverse attribute to families with ownReverse
-    for rxn in reactions:
+    toDelete = []
+    for i, rxn in enumerate(reactions):
         family = getDB('kinetics').families[rxn.family]
         if family.ownReverse:
-            family.addReverseAttribute(rxn)
+            successful = family.addReverseAttribute(rxn)
+            if not successful:
+                toDelete.append(i)
+    # delete reactions which we could not find a reverse reaction for
+    for i in reversed(toDelete):
+        del reactions[i]
     # get a molecule list with species indexes
     zippedList = []
     for spec in speciesTuple:


### PR DESCRIPTION
This follows up on the last item in #1182 and updates Connie's fix for debugging cases where the reverse reaction is forbidden.

The debugging portion now calls `findDegeneracies` and accounts for multiple transition states. The method for deleting the forward reaction in cases where the reverse reaction is forbidden has also been changed. It seems like the previous method did not actually delete the forward reaction.

As a side note, #1142 should be merged in soon as well, since it actually does prevent most reactions from reaching this point by identifying that they're forbidden during the reaction generation process.