### PR TITLE
Degeneracy speedup

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -77,7 +77,8 @@ class TemplateReaction(Reaction):
                 family=None,
                 template=None,
                 estimator=None,
-                reverse=None
+                reverse=None,
+                isForward=None,
                 ):
         Reaction.__init__(self,
                           index=index,
@@ -95,6 +96,7 @@ class TemplateReaction(Reaction):
         self.template = template
         self.estimator = estimator
         self.reverse = reverse
+        self.isForward = isForward
 
     def __reduce__(self):
         """
@@ -114,6 +116,7 @@ class TemplateReaction(Reaction):
                                    self.template,
                                    self.estimator,
                                    self.reverse,
+                                   self.isForward
                                    ))
 
     def __repr__(self):
@@ -174,6 +177,7 @@ class TemplateReaction(Reaction):
         other.template = self.template
         other.estimator = self.estimator
         other.reverse = self.reverse
+        other.isForward = self.isForward
         
         return other
 
@@ -1391,6 +1395,7 @@ class KineticsFamily(Database):
             degeneracy = 1,
             reversible = True,
             family = self.label,
+            isForward = isForward,
         )
         
         # Store the labeled atoms so we can recover them later

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1456,14 +1456,8 @@ class KineticsFamily(Database):
         from rmgpy.rmg.react import findDegeneracies, getMoleculeTuples
 
         if self.ownReverse:
-            # make sure to react all resonance structures.
-            tuples = getMoleculeTuples(rxn.products)
-            reactionList = []
-            for tup in tuples:
-                moltup = [mol_and_index[0] for mol_and_index in tup]
-                reactionList.extend(self.__generateReactions(moltup,
-                                                             products=rxn.reactants,
-                                                             forward=True))
+            reactionList = self.__generateReactions([spc.molecule for spc in rxn.products],
+                                                    products=rxn.reactants, forward=True)
             reactions = findDegeneracies(reactionList)
             if len(reactions) == 0:
                 logging.error("Expecting one matching reverse reaction, not zero in reaction family {0} for forward reaction {1}.\n".format(self.label, str(rxn)))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1665,6 +1665,8 @@ class KineticsFamily(Database):
             if isinstance(products[0],Molecule):
                 products = [product.generateResonanceIsomers() for product in products]
             elif isinstance(products[0],Species):
+                for product in products:
+                    product.generateResonanceIsomers(keepIsomorphic=False)
                 products = [product.molecule for product in products]
             else:
                 raise TypeError('products input to __generateReactions must be Species or Molecule Objects')

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1493,7 +1493,7 @@ class KineticsFamily(Database):
                     # Delete this reaction, since it should probably also be forbidden in the initial direction
                     # Hack fix for now
                     del rxn
-            elif len(reactions) > 1 and not all([reactions[0].isIsomorphic(other) for other in reactions]):
+            elif len(reactions) > 1 and not all([reactions[0].isIsomorphic(other, checkTemplateRxnProducts=True) for other in reactions]):
                 logging.error("Expecting one matching reverse reaction. Recieved {0} reactions with multiple non-isomorphic ones in reaction family {1} for forward reaction {2}.\n".format(len(reactions), self.label, str(rxn)))
                 logging.info("Found the following reverse reactions")
                 for rxn0 in reactions:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -57,10 +57,18 @@ from rmgpy.exceptions import InvalidActionError, ReactionPairsError, KineticsErr
 
 class TemplateReaction(Reaction):
     """
-    A Reaction object generated from a reaction family template. In addition to
-    the usual attributes, this class includes a `family` attribute to store the
-    family that it was created from, as well as a `estimator` attribute to indicate
-    whether it came from a rate rules or a group additivity estimate.
+    A Reaction object generated from a reaction family template. In addition
+    to attributes inherited from :class:`Reaction`, this class includes the
+    following attributes:
+
+    =========== ========================= =====================================
+    Attribute   Type                      Description
+    =========== ========================= =====================================
+    `family`    ``str``                   The kinetics family that the reaction was created from.
+    `estimator` ``str``                   Whether the kinetics came from rate rules or group additivity.
+    `reverse`   :class:`TemplateReaction` The reverse reaction, for families that are their own reverse.
+    `isForward` ``bool``                  Whether the reaction was generated in the forward direction of the family.
+    =========== ========================= =====================================
     """
 
     def __init__(self,

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -201,7 +201,7 @@ class TestReactionDegeneracy(unittest.TestCase):
         reactionList = findDegeneracies(reactionList)
 
         self.assertEqual(len(reactionList), 1)
-        self.assertEqual(reactionList[0].degeneracy, 1)
+        self.assertEqual(reactionList[0].degeneracy, 0.5)
 
     def test_degeneracy_for_methyl_methyl_recombination(self):
         """Test that the proper degeneracy is calculated for methyl + methyl recombination"""

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -698,8 +698,8 @@ class TestReactionDegeneracy(unittest.TestCase):
         reverse_reactions = findDegeneracies(reverse_reactions)
 
         # correct reverse reaction degeneracy
-        correctDegeneracyOfReverseReactions(forward_reactions, reactants = [molA, molB])
-        correctDegeneracyOfReverseReactions(reverse_reactions, reactants = [molC, molD])
+        correctDegeneracyOfReverseReactions(forward_reactions)
+        correctDegeneracyOfReverseReactions(reverse_reactions)
 
         self.assertEqual(forward_reactions[0].degeneracy, reverse_reactions[0].degeneracy,
                          'the kinetics from forward and reverse directions had different degeneracies, {} and {} respectively'.format(forward_reactions[0].degeneracy, reverse_reactions[0].degeneracy))

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -36,7 +36,7 @@ from rmgpy.data.base import DatabaseError
 import numpy
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.data.rmg import RMGDatabase
-from rmgpy.rmg.react import findDegeneracies, reduceSameReactantDegeneracy, react, reactSpecies, _labelListOfSpecies
+from rmgpy.rmg.react import findDegeneracies, react, reactSpecies, _labelListOfSpecies
 from rmgpy.data.base import ForbiddenStructures
 from rmgpy.species import Species
 ###################################################
@@ -354,7 +354,6 @@ class TestReactionDegeneracy(unittest.TestCase):
         for reactant in reactants: reactant.assignAtomIDs()
         reactions = family.generateReactions(reactants)
         reactions = findDegeneracies(reactions)
-        reduceSameReactantDegeneracy(reactions)
         self.assertEqual(len(reactions), num_independent_reactions,'only {1} reaction(s) should be produced. Produced reactions {0}'.format(reactions,num_independent_reactions))
 
         return sum([reaction.degeneracy for reaction in reactions]), reactions
@@ -676,7 +675,6 @@ class TestReactionDegeneracy(unittest.TestCase):
         Ensure the returned kinetics have the same degeneracy irrespective of
         whether __generateReactions has forward = True or False
         """
-        from rmgpy.rmg.react import correctDegeneracyOfReverseReactions
 
         family = database.kinetics.families['Disproportionation']
 
@@ -696,10 +694,6 @@ class TestReactionDegeneracy(unittest.TestCase):
 
         forward_reactions = findDegeneracies(forward_reactions)
         reverse_reactions = findDegeneracies(reverse_reactions)
-
-        # correct reverse reaction degeneracy
-        correctDegeneracyOfReverseReactions(forward_reactions)
-        correctDegeneracyOfReverseReactions(reverse_reactions)
 
         self.assertEqual(forward_reactions[0].degeneracy, reverse_reactions[0].degeneracy,
                          'the kinetics from forward and reverse directions had different degeneracies, {} and {} respectively'.format(forward_reactions[0].degeneracy, reverse_reactions[0].degeneracy))

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -27,17 +27,16 @@
 
 import os
 import unittest 
-from external.wip import work_in_progress
 import itertools
+import numpy
 
 from rmgpy import settings
+from rmgpy.chemkin import loadChemkinFile
 from rmgpy.data.kinetics.database import KineticsDatabase
-from rmgpy.data.base import DatabaseError
-import numpy
-from rmgpy.molecule.molecule import Molecule
+from rmgpy.data.base import Entry, DatabaseError, ForbiddenStructures
 from rmgpy.data.rmg import RMGDatabase
-from rmgpy.rmg.react import findDegeneracies, react, reactSpecies, _labelListOfSpecies
-from rmgpy.data.base import ForbiddenStructures
+from rmgpy.rmg.react import findDegeneracies, react, reactSpecies
+from rmgpy.molecule.molecule import Molecule
 from rmgpy.species import Species
 ###################################################
 
@@ -729,8 +728,6 @@ class TestKineticsCommentsParsing(unittest.TestCase):
         self.database = database
 
     def testParseKinetics(self):
-        from rmgpy.chemkin import loadChemkinFile
-        import rmgpy
         species, reactions = loadChemkinFile(os.path.join(settings['test_data.directory'], 'parsing_data','chem_annotated.inp'),
                                              os.path.join(settings['test_data.directory'], 'parsing_data','species_dictionary.txt')
                                                        )
@@ -816,7 +813,6 @@ class TestKinetics(unittest.TestCase):
     
     @classmethod
     def setUpClass(self):
-        from rmgpy.chemkin import loadChemkinFile
         """A function that is run ONCE before all unit tests in this class."""
 
         global database
@@ -877,8 +873,6 @@ class TestKinetics(unittest.TestCase):
         tests that save entry can run
         """
         from rmgpy.data.kinetics.common import saveEntry
-        import os
-        from rmgpy.data.base import Entry
         
         reactions=self.reactions
         

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -63,7 +63,7 @@ cdef class Reaction:
     
     cpdef bint matchesMolecules(self, list reactants)
 
-    cpdef bint isIsomorphic(self, Reaction other, bint eitherDirection=?, bint checkIdentical=?, bint checkOnlyLabel=?)
+    cpdef bint isIsomorphic(self, Reaction other, bint eitherDirection=?, bint checkIdentical=?, bint checkOnlyLabel=?, bint checkTemplateRxnProducts=?)
 
     cpdef double getEnthalpyOfReaction(self, double T)
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -384,7 +384,7 @@ class Reaction:
         return False
 
     def isIsomorphic(self, other, eitherDirection=True, checkIdentical = False,
-                     checkOnlyLabel = False):
+                     checkOnlyLabel = False, checkTemplateRxnProducts=False):
         """
         Return ``True`` if this reaction is the same as the `other` reaction,
         or ``False`` if they are different. The comparison involves comparing
@@ -397,7 +397,21 @@ class Reaction:
                         checking degeneracy
         `checkOnlyLabel` indicates that the string representation will be 
                         checked, ignoring the molecular structure comparisons
+        `checkTemplateRxnProducts` indicates that only the products of the
+                        reaction are checked for isomorphism. This is used when
+                        we know the reactants are identical, i.e. in generating
+                        reactions.
         """
+        if checkTemplateRxnProducts:
+            try:
+                species1 = self.products if self.isForward else self.reactants
+                species2 = other.products if other.isForward else other.reactants
+            except AttributeError:
+                raise TypeError('Only use checkTemplateRxnProducts flag for TemplateReactions.')
+
+            return _isomorphicSpeciesList(species1, species2,
+                                          checkIdentical=checkIdentical,
+                                          checkOnlyLabel=checkOnlyLabel)
 
         # Compare reactants to reactants
         forwardReactantsMatch = _isomorphicSpeciesList(self.reactants, 

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -198,11 +198,11 @@ def findDegeneracies(rxnList, useSpeciesReaction = True):
                 identical = False
                 sameTemplate = False
                 for rxn in rxnList1:
-                    isomorphic = rxn0.isIsomorphic(rxn,checkIdentical=False)
+                    isomorphic = rxn0.isIsomorphic(rxn, checkIdentical=False, checkTemplateRxnProducts=True)
                     if not isomorphic:
                         identical = False
                     else:
-                        identical = rxn0.isIsomorphic(rxn,checkIdentical=True)
+                        identical = rxn0.isIsomorphic(rxn, checkIdentical=True, checkTemplateRxnProducts=True)
                     sameTemplate = frozenset(rxn.template) == frozenset(rxn0.template)
                     if not isomorphic:
                         # a different product was found, go to next list

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -251,11 +251,13 @@ def convertToSpeciesObjects(reaction):
     # obtain species with all resonance isomers
     for i, mol in enumerate(reaction.reactants):
         spec = Species(molecule = [mol])
-        spec.generateResonanceIsomers(keepIsomorphic=True)
+        if not reaction.isForward:
+            spec.generateResonanceIsomers(keepIsomorphic=True)
         reaction.reactants[i] = spec
     for i, mol in enumerate(reaction.products):
         spec = Species(molecule = [mol])
-        spec.generateResonanceIsomers(keepIsomorphic=True)
+        if reaction.isForward:
+            spec.generateResonanceIsomers(keepIsomorphic=True)
         reaction.products[i] = spec
 
     # convert reaction.pairs object to species

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -85,7 +85,7 @@ def reactSpecies(speciesTuple):
             family.addReverseAttribute(rxn)
     # fix the degneracy of (not ownReverse) reactions found in the backwards
     # direction
-    correctDegeneracyOfReverseReactions(reactions, list(speciesTuple))
+    correctDegeneracyOfReverseReactions(reactions)
     reduceSameReactantDegeneracy(reactions)
     # get a molecule list with species indexes
     zippedList = []
@@ -295,7 +295,7 @@ def reduceSameReactantDegeneracy(rxnList):
             reaction.reverse.degeneracy *= 0.5
             logging.debug('Degeneracy of reaction {} was decreased by 50% to {} since the reactants are identical'.format(reaction.reverse,reaction.reverse.degeneracy))
 
-def correctDegeneracyOfReverseReactions(reactionList, reactants):
+def correctDegeneracyOfReverseReactions(reactionList):
     """
     This method corrects the degeneracy of reactions found when the backwards
     template is used. Given the following parameters:
@@ -308,21 +308,12 @@ def correctDegeneracyOfReverseReactions(reactionList, reactants):
     This does not adjust for identical reactants, you need to use `reduceSameReactantDegeneracy`
     to adjust for that.
     """
-    from rmgpy.reaction import _isomorphicSpeciesList
-    from rmgpy.reaction import ReactionError
-
     for rxn in reactionList:
-        if _isomorphicSpeciesList(rxn.reactants, reactants):
-            # was forward reaction so ignore
-            continue
-        elif _isomorphicSpeciesList(rxn.products, reactants):
+        if not rxn.isForward:
             # was reverse reaction so should find degeneracy
             family = getDB('kinetics').families[rxn.family]
             if not family.ownReverse: 
                 rxn.degeneracy = family.calculateDegeneracy(rxn, ignoreSameReactants=True)
-        else:
-            # wrong reaction was sent here
-            raise ReactionError('Reaction in reactionList did not match reactants. Reaction: {}, Reactants: {}'.format(rxn,reactants))
 
 def deflate(rxns, species, reactantIndices):
     """


### PR DESCRIPTION
This PR is to speed up reaction generation and degeneracy calculation without a loss in accuracy by reducing unnecessary computation:

1) Only generate and compare product resonance structures, since the reactants molecules are implicitly resonance structures of the same species.
2) Save a flag indicating whether the reaction was generated in the forward or reverse direction instead of making the determination using isomorphism.

This PR tries to address the same issue as #1113, and therefore conflicts with its changes. Performance comparison tables are shown below:

Benchmark: master
New: degeneracy_speedup

example|time benchmark|time new|memory benchmark|memory new
---|---|---|---|---
eg1|00:00:03:12|00:00:02:43|454.98|436.22
eg3|00:00:07:10|00:00:06:10|397.36|398.64
eg5|00:00:01:56|00:00:01:47|353.38|356.46
eg6|00:00:01:16|00:00:01:13|341.50|343.83
eg7|00:00:00:52|00:00:00:51|341.14|338.14
NC|00:00:02:30|00:00:02:16|347.24|346.97
solvent_hexane|00:00:01:10|00:00:01:06|340.41|330.79
MCH|00:00:04:49|00:00:04:26|689.45|690.84

Benchmark: master
New: only_core_degeneracy

example|time benchmark|time new|memory benchmark|memory new
---|---|---|---|---
eg1|00:00:02:17|00:00:02:03|459.15|446.26
eg3|00:00:04:56|00:00:04:37|398.51|401.73
eg5|00:00:01:22|00:00:01:02|356.41|346.31
eg6|00:00:00:52|00:00:00:52|349.24|341.57
eg7|00:00:00:34|00:00:00:35|338.29|338.23
NC|00:00:01:45|00:00:01:35|346.81|343.57
solvent_hexane|00:00:00:50|00:00:00:44|330.12|328.06
MCH|00:00:03:29|00:00:04:22|682.52|751.33

Benchmark: degeneracy_speedup
New: only_core_degeneracy

example|time benchmark|time new|memory benchmark|memory new
---|---|---|---|---
eg1|00:00:02:11|00:00:02:03|435.96|445.46
eg3|00:00:04:45|00:00:04:43|397.18|399.45
eg5|00:00:01:19|00:00:01:00|354.38|343.89
eg6|00:00:00:52|00:00:00:51|342.95|342.18
eg7|00:00:00:35|00:00:00:35|338.62|338.55
NC|00:00:01:46|00:00:01:35|344.34|341.68
solvent_hexane|00:00:00:49|00:00:00:43|332.01|326.36
MCH|00:00:03:26|00:00:04:31|689.83|750.62