### PR TITLE
Increase Cantera version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 install:
   - conda env create -f environment_linux.yml
   - source activate rmg_env
+  - conda list
   - pip install codecov
   - yes 'Yes' | $HOME/miniconda/envs/rmg_env/bin/mopac $MOPACKEY > /dev/null
   - make

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -6,7 +6,7 @@ dependencies:
   - libgcc # [unix]
   - python
   - numpy >=1.10.0
-  - cantera >=2.2
+  - cantera >=2.3.0a3
   - coolprop
   - cython >=0.25.2
   - matplotlib >=1.5

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -6,7 +6,7 @@ dependencies:
   - libgcc # [unix]
   - python
   - numpy >=1.10.0
-  - cantera >=2.2
+  - cantera >=2.3.0a3
   - coolprop
   - cython >=0.25.2
   - matplotlib >=1.5

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -6,7 +6,7 @@ dependencies:
   - mingwpy
   - python
   - numpy >=1.10.0
-  - cantera >=2.2
+  - cantera >=2.3.0a3
   - coolprop
   - cython >=0.25.2
   - matplotlib >=1.5


### PR DESCRIPTION
This fixes issues with Travis builds failing due to installation of an older version of Cantera.

See #1208.