### PR TITLE
Restored test-all in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,15 @@ decython:
 	find . -name *.so ! \( -name _statmech.so -o -name quantity.so -o -regex '.*rmgpy/solver/.*' \) -exec rm -f '{}' \;
 	find . -name *.pyc -exec rm -f '{}' \;
 
+test-all:
+ifeq ($(OS),Windows_NT)
+	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+else
+	mkdir -p testing/coverage
+	rm -rf testing/coverage/*
+	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
+endif
+
 test-unittests:
 ifeq ($(OS),Windows_NT)
 	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy


### PR DESCRIPTION
Since the latest Makefile test, the RMG-db repository could not pass Travis since its .travis.yml file has the command `- make test-all`.
Consulting with @nyee and @mliu49 , we decided it is probably a good idea to restore the `test-all` in the Makefile.