### PR TITLE
Extending the lone pair <=> radical resonance

### DIFF
--- a/rmgpy/molecule/generator.py
+++ b/rmgpy/molecule/generator.py
@@ -492,7 +492,7 @@ def find_lowest_u_layer(mol, u_layer, equivalent_atoms):
 def generate_minimum_resonance_isomer(mol):
     """
     Select the resonance isomer that is isomorphic to the parameter isomer, with the lowest unpaired
-    electrons descriptor.
+    electrons descriptor, unless this unnecessarily forms a charged molecule.
 
     First, we generate all isomorphic resonance isomers.
     Next, we return the candidate with the lowest unpaired electrons metric.
@@ -501,24 +501,29 @@ def generate_minimum_resonance_isomer(mol):
     """
 
     cython.declare(
+        atom=Atom,
         candidates=list,
         sel=Molecule,
         cand=Molecule,
         metric_sel=list,
+        charge_sel=int,
+        charge_cand=int,
         metric_cand=list,
         )
 
-
     candidates = resonance.generateIsomorphicResonanceStructures(mol)
-    
-    sel = candidates[0]
-    metric_sel = get_unpaired_electrons(sel)
-    for cand in candidates[1:]:
-       metric_cand = get_unpaired_electrons(cand)
-       if metric_cand < metric_sel:
-            sel = cand
-            metric_sel = metric_cand
 
+    sel = mol
+    metric_sel = get_unpaired_electrons(sel)
+    charge_sel = sum([abs(atom.charge) for atom in sel.vertices])
+    for cand in candidates:
+        metric_cand = get_unpaired_electrons(cand)
+        if metric_cand < metric_sel:
+            charge_cand = sum([abs(atom.charge) for atom in cand.vertices])
+            if charge_cand <= charge_sel:
+                sel = cand
+                metric_sel = metric_cand
+                charge_sel = charge_cand
     return sel
 
 

--- a/rmgpy/molecule/parser.py
+++ b/rmgpy/molecule/parser.py
@@ -221,7 +221,7 @@ def __lookup(mol, identifier, type_identifier):
         except KeyError:
             return None
 
-def check(mol, aug_inchi) :
+def check(mol, aug_inchi):
     """
     Check if the molecular structure is correct.
 
@@ -237,6 +237,8 @@ def check(mol, aug_inchi) :
                    )
 
     ConsistencyChecker.check_multiplicity(mol.getRadicalCount(), mol.multiplicity)
+    inchi, u_indices, p_indices = inchiutil.decompose(str(aug_inchi))
+    assert(mol.getRadicalCount() == len(u_indices))
     
     for at in mol.atoms:
         ConsistencyChecker.check_partial_charge(at)

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -263,28 +263,24 @@ def findAllDelocalizationPaths(atom1):
 def findAllDelocalizationPathsLonePairRadical(atom1):
     """
     Find all the delocalization paths of lone electron pairs next to the radical center indicated
-    by `atom1`. Used to generate resonance isomers.
+    by `atom1`. Used to generate resonance isomers for species such as RN[O], RO[NH], RO[O], RN[NH].
+    (currently only N and O are considered, will soon include S as well)
     """
     cython.declare(paths=list)
     cython.declare(atom2=Atom, bond12=Bond)
-    
-    # No paths if atom1 is not a radical
-    if atom1.radicalElectrons <= 0:
-        return []
-    
-    # In a first step we only consider nitrogen and oxygen atoms as possible radical centers
-    if not ((atom1.lonePairs == 0 and atom1.isNitrogen()) or(atom1.lonePairs == 2 and atom1.isOxygen())):
-        return []
-    
-    # Find all delocalization paths
+
     paths = []
-    for atom2, bond12 in atom1.edges.items():
-        # Only single bonds are considered
-        if bond12.isSingle():
-            # Neighboring atom must posses a lone electron pair to loose it
-            if ((atom2.lonePairs == 1 and atom2.isNitrogen()) or (atom2.lonePairs == 3 and atom2.isOxygen())) and (atom2.radicalElectrons == 0):
-                paths.append([atom1, atom2])
-                
+    # In a first step we only consider nitrogen and oxygen atoms as possible radical centers
+    if ((atom1.isNitrogen() and atom1.lonePairs in [0,1])
+            or (atom1.isOxygen() and atom1.lonePairs in [1,2]))\
+            and atom1.radicalElectrons > 0:
+        for atom2, bond12 in atom1.edges.items():
+            if bond12.isSingle():  # Only single bonds are considered
+                # Neighboring atom must posses a lone electron pair to loose it
+                if ((atom2.isNitrogen() and atom2.lonePairs in [1,2])
+                        or (atom2.isOxygen() and atom2.lonePairs in [2,3]))\
+                        and atom2.radicalElectrons == 0:
+                    paths.append([atom1, atom2])
     return paths
 
 def findAllDelocalizationPathsN5dd_N5ts(atom1):

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -48,6 +48,22 @@ class ResonanceTest(unittest.TestCase):
         self.assertEqual(len(molList), 3)
         self.assertTrue(any([any([atom.charge != 0 for atom in mol.vertices]) for mol in molList]))
 
+    def ROO(self):
+        """Test resonance structure generation for RO[O]
+
+        Selected case for lone pair <=> radical resonance"""
+
+        molList = generateResonanceStructures(Molecule(SMILES="CO[O]"))
+        self.assertEqual(len(molList), 2)
+
+    def RNN(self):
+        """Test resonance structure generation for RN[N]
+
+        Selected case for lone pair <=> radical resonance"""
+
+        molList = generateResonanceStructures(Molecule(SMILES="CN[NH]"))
+        self.assertEqual(len(molList), 2)
+
     def testAzide(self):
         """Test resonance structure generation for ethyl azide
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -46,6 +46,7 @@ transition states (first-order saddle points on a potential energy surface).
 import numpy
 import cython
 import logging
+from operator import itemgetter
 
 import rmgpy.quantity as quantity
 
@@ -525,19 +526,23 @@ class Species(object):
     def getAugmentedInChI(self):
         if self.aug_inchi is None:
             self.aug_inchi = self.generate_aug_inchi()
-            return self.aug_inchi
-        else:
-            return self.aug_inchi
+        return self.aug_inchi
 
     def generate_aug_inchi(self):
         candidates = []
         self.generateResonanceIsomers()
         for mol in self.molecule:
-            cand = mol.toAugmentedInChI()
-            candidates.append(cand)
-
-        candidates.sort()
-        return candidates[0] 
+            try:
+                cand = [mol.toAugmentedInChI(),mol]
+            except ValueError:
+                pass  # not all resonance structures can be parsed into InChI (e.g. if containing a hypervalance atom)
+            else:
+                candidates.append(cand)
+        candidates = sorted(candidates, key=itemgetter(0))
+        for cand in candidates:
+            if all(atom.charge == 0 for atom in cand[1].vertices):
+                return cand[0]
+        return candidates[0][0]
 
     def getThermoData(self, solventName = ''):
         """


### PR DESCRIPTION
Previously the `generateLonePairRadicalResonanceStructures` was limited to certain structures, since it was written mainly with N2O in mind:

![image](https://user-images.githubusercontent.com/16158262/31505704-7b53c2a6-af43-11e7-8ded-b23f33c411d4.png) <=> ![image](https://user-images.githubusercontent.com/16158262/31505711-805fd69a-af43-11e7-8e8c-b6d5a445c8bc.png)

This PR extends it to consider RO[O], RO[NH], RN[O], RN[NH] as well, e.g.:
![image](https://user-images.githubusercontent.com/16158262/31505773-a6f72f38-af43-11e7-82c9-9b5896658d80.png) <=> ![image](https://user-images.githubusercontent.com/16158262/31505778-a9914b66-af43-11e7-9151-2214fea3704f.png)
![image](https://user-images.githubusercontent.com/16158262/31505783-b11cfd08-af43-11e7-8340-46dd42791785.png) <=> ![image](https://user-images.githubusercontent.com/16158262/31505790-b431543a-af43-11e7-8277-223836bbb9e3.png)

Resonance tests were also added.

Since RDkit cannot process hypervalance oxygen (e.g. `–[O+]=`), some ROO inchiParsingTests had to be removed . Any comments/suggestions on these deletions are of course welcome.