### PR TITLE
Added the C2H4 +O surface as a kinetic library

### DIFF
--- a/documentation/source/users/rmg/database/kinetics.rst
+++ b/documentation/source/users/rmg/database/kinetics.rst
@@ -71,6 +71,8 @@ Below is a list of pre-packaged kinetics library reactions in RMG:
 +---------------------------------------+------------------------------------------------------------------------------------------+
 |BurkeH2O2inN2                          |Comprehensive H2/O2 kinetic model in N2 atmosphere                                        |
 +---------------------------------------+------------------------------------------------------------------------------------------+
+|C2H4+O_Klipp2017                       |C2H4 + O intersystem crossing reactions, probably important for all C/H/O combustion      |
++---------------------------------------+------------------------------------------------------------------------------------------+
 |C10H11                                 |Cyclopentadiene pyrolysis in the presence of ethene                                       |
 +---------------------------------------+------------------------------------------------------------------------------------------+
 |C3                                     |Cyclopentadiene pyrolysis in the presence of ethene                                       |


### PR DESCRIPTION
Added the C2H4+O_Klipp2017 library to documentation.
This is a twin PR of https://github.com/ReactionMechanismGenerator/RMG-database/pull/219