### PR TITLE
Do not consider template differences from resonance structures as multiple TS

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -267,7 +267,7 @@ def ensure_independent_atom_ids(input_species, resonance=True):
             species.generate_resonance_structures(keepIsomorphic=True)
 
 
-def find_degenerate_reactions(rxnList, same_reactants=None, kinetics_database=None, kinetics_family=None):
+def find_degenerate_reactions(rxnList, same_reactants=None, template=None, kinetics_database=None, kinetics_family=None):
     """
     given a list of Reaction object with Molecule objects, this method
     removes degenerate reactions and increments the degeneracy of the
@@ -278,11 +278,24 @@ def find_degenerate_reactions(rxnList, same_reactants=None, kinetics_database=No
     This algorithm used to exist in family.__generateReactions, but was moved
     here because it didn't have any family dependence.
     """
+    # If a specific reaction template is requested, filter by that template
+    if template is not None:
+        selected_rxns = []
+        template = frozenset(template)
+        for rxn in rxnList:
+            if template == frozenset(rxn.template):
+                selected_rxns.append(rxn)
+        if not selected_rxns:
+            # Only log a warning here. If a non-empty output is expected, then the caller should raise an exception
+            logging.warning('No reactions matched the specified template, {0}'.format(template))
+            return []
+    else:
+        selected_rxns = rxnList
 
     # We want to sort all the reactions into sublists composed of isomorphic reactions
     # with degenerate transition states
     rxnSorted = []
-    for rxn0 in rxnList:
+    for rxn0 in selected_rxns:
         # find resonance structures for rxn0
         rxn0.ensure_species()
         if len(rxnSorted) == 0:

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -294,36 +294,39 @@ def find_degenerate_reactions(rxnList, same_reactants=None, kinetics_database=No
                 # Try to determine if the current rxn0 is identical or isomorphic to any reactions in the sublist
                 isomorphic = False
                 identical = False
-                sameTemplate = False
+                sameTemplate = True
                 for rxn in rxnList1:
                     isomorphic = rxn0.isIsomorphic(rxn, checkIdentical=False, checkTemplateRxnProducts=True)
-                    if not isomorphic:
-                        identical = False
-                    else:
+                    if isomorphic:
                         identical = rxn0.isIsomorphic(rxn, checkIdentical=True, checkTemplateRxnProducts=True)
-                    sameTemplate = frozenset(rxn.template) == frozenset(rxn0.template)
-                    if not isomorphic:
-                        # a different product was found, go to next list
+                        if identical:
+                            # An exact copy of rxn0 is already in our list, so we can move on
+                            break
+                        sameTemplate = frozenset(rxn.template) == frozenset(rxn0.template)
+                    else:
+                        # This sublist contains a different product
                         break
-                    elif not sameTemplate:
-                        # a different transition state was found, mark as duplicate and
-                        # go to the next sublist
-                        rxn.duplicate = True
+
+                # Process the reaction depending on the results of the comparisons
+                if identical:
+                    # This reaction does not contribute to degeneracy
+                    break
+                elif isomorphic:
+                    if sameTemplate:
+                        # We found the right sublist, and there is no identical reaction
+                        # We should add rxn0 to the sublist as a degenerate rxn, and move on to the next rxn
+                        rxnList1.append(rxn0)
+                        break
+                    else:
+                        # We found an isomorphic sublist, but the reaction templates are different
+                        # We need to mark this as a duplicate and continue searching the remaining sublists
                         rxn0.duplicate = True
-                        break
-                    elif identical:
-                        # An exact copy of rxn0 is already in our list, so we can move on to the next rxn
-                        break
-                    else: # sameTemplate and isomorphic but not identical
-                        # This is the right sublist for rxn0, but continue to see if there is an identical rxn
+                        rxnList1[0].duplicate = True
                         continue
                 else:
-                    # We did not break, so this is the right sublist, but there is no identical reaction
-                    # This means that we should add rxn0 to the sublist as a degenerate rxn
-                    rxnList1.append(rxn0)
-                if isomorphic and sameTemplate:
-                    # We already found the right sublist, so we can move on to the next rxn
-                    break
+                    # This is not an isomorphic sublist, so we need to continue searching the remaining sublists
+                    # Note: This else statement is not technically necessary but is included for clarity
+                    continue
             else:
                 # We did not break, which means that there was no isomorphic sublist, so create a new one
                 rxnSorted.append([rxn0])

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1554,7 +1554,6 @@ class KineticsFamily(Database):
         identical reactants (since you will be reducing them later in the algorithm), add
         `ignoreSameReactants= True` to this method.
         """
-        reaction.degeneracy = 1
         # Check if the reactants are the same
         # If they refer to the same memory address, then make a deep copy so
         # they can be manipulated independently
@@ -1576,19 +1575,8 @@ class KineticsFamily(Database):
             reactions.extend(self.__generateReactions(combo, products=reaction.products, forward=True))
 
         # remove degenerate reactions
-        reactions = find_degenerate_reactions(reactions, same_reactants, kinetics_family=self)
+        reactions = find_degenerate_reactions(reactions, same_reactants, template=reaction.template, kinetics_family=self)
 
-        # remove reactions with different templates (only for TemplateReaction)
-        if isinstance(reaction, TemplateReaction):
-            index = 0
-            while index < len(reactions):
-                if reaction.template and \
-                        frozenset(reactions[index].template) != frozenset(reaction.template):
-                    # remove reaction with different template
-                    del reactions[index]
-                    continue
-                index += 1
-            
         # log issues
         if len(reactions) != 1:
             for reactant in reaction.reactants:

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -59,7 +59,8 @@ def setUpModule():
             'R_Recombination',
             'Disproportionation',
             'R_Addition_MultipleBond',
-            'H_Abstraction'
+            'H_Abstraction',
+            'intra_H_migration',
         ],
         testing=True,
         depository=False,
@@ -518,6 +519,33 @@ class TestReactionDegeneracy(unittest.TestCase):
         reaction_list = self.assert_correct_reaction_degeneracy(reactants, correct_rxn_num, correct_degeneracy, family_label, products)
 
         self.assertEqual(set(reaction_list[0].template), {'C_rad/H2/Cd', 'Cmethyl_Csrad/H/Cd'})
+
+    def test_degeneracy_multiple_ts_different_template(self):
+        """Test that reactions from different transition states are marked as duplicates."""
+        family_label = 'intra_H_migration'
+        reactants = ['CCCC[CH]CCCCC']
+        products = ['[CH2]CCCCCCCCC']
+
+        correct_rxn_num = 2
+        correct_degeneracy = {3}
+
+        reaction_list = self.assert_correct_reaction_degeneracy(reactants, correct_rxn_num, correct_degeneracy, family_label, products)
+
+        self.assertTrue(reaction_list[0].duplicate)
+        self.assertTrue(reaction_list[1].duplicate)
+
+    def test_degeneracy_multiple_resonance_different_template(self):
+        """Test that reactions from different resonance structures are not kept."""
+        family_label = 'H_Abstraction'
+        reactants = ['c1ccccc1', '[CH3]']
+
+        correct_rxn_num = 1
+        correct_degeneracy = {6}
+
+        reaction_list = self.assert_correct_reaction_degeneracy(reactants, correct_rxn_num, correct_degeneracy, family_label)
+
+        self.assertFalse(reaction_list[0].duplicate)
+
 
 class TestKineticsCommentsParsing(unittest.TestCase):
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -393,34 +393,16 @@ class CoreEdgeReactionModel:
         for rxn0 in shortlist:
             rxn_id0 = generateReactionId(rxn0)
 
-            if (rxn_id == rxn_id0) and isinstance(familyObj, KineticsLibrary):
-                # If the reaction comes from a kinetics library, then we can 
-                # retain duplicates if they are marked
-                if areIdenticalSpeciesReferences(rxn, rxn0) and not rxn.duplicate:
+            if rxn_id == rxn_id0 and areIdenticalSpeciesReferences(rxn, rxn0):
+                if isinstance(familyObj, KineticsLibrary) or isinstance(familyObj, KineticsFamily):
+                    if not rxn.duplicate:
+                        return True, rxn0
+                else:
                     return True, rxn0
-            elif ((rxn_id == rxn_id0) or (rxn_id == rxn_id0[::-1])) and \
-                        isinstance(familyObj, KineticsFamily):
-                # ensure TemplateReactions have the same templates and families in order
-                # to classify this as existing reaction. Also checks for reverse
-                # direction matching. Marks duplicate if identical species and different
-                # templates or families
-                if areIdenticalSpeciesReferences(rxn, rxn0):
-                    if rxn.family == rxn0.family:
-                        equal_templates = frozenset(rxn.template) == frozenset(rxn0.template)
-                        # check reverse template
-                        if not equal_templates and familyObj.ownReverse and \
-                                    rxn.reverse is not None:
-                            equal_templates = frozenset(rxn.reverse.template) == frozenset(rxn0.template)
-                        if equal_templates:
-                            return True, rxn0
-                        else:
-                            rxn.duplicate = True
-                            rxn0.duplicate = True
-                    else:
-                        rxn.duplicate = True
-                        rxn0.duplicate = True
-            elif (rxn_id == rxn_id0):
-                if areIdenticalSpeciesReferences(rxn, rxn0):
+            elif (isinstance(familyObj, KineticsFamily)
+                  and rxn_id == rxn_id0[::-1]
+                  and areIdenticalSpeciesReferences(rxn, rxn0)):
+                if not rxn.duplicate:
                     return True, rxn0
 
         # Now check seed mechanisms

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -394,9 +394,9 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         for rxn in rxns:
             self.assertTrue(rxn.isBalanced())
 
-    def test_checkForExistingReaction_elminates_duplicate(self):
+    def test_checkForExistingReaction_eliminates_identical_reactions(self):
         """
-        Test that checkForExistingReaction catches duplicate reactions
+        Test that checkForExistingReaction catches identical reactions.
         """
         cerm = CoreEdgeReactionModel()
 
@@ -416,17 +416,17 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         cerm.addSpeciesToCore(spcC)
         cerm.addSpeciesToCore(spcD)
 
-        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+        reaction_in_model = TemplateReaction(reactants=[spcA, spcB],
+                                             products=[spcC, spcD],
+                                             family='H_Abstraction',
+                                             template=['Csd', 'H'])
         reaction_in_model.reactants.sort()
         reaction_in_model.products.sort()
 
-        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+        reaction_to_add = TemplateReaction(reactants=[spcA, spcB],
+                                           products=[spcC, spcD],
+                                           family='H_Abstraction',
+                                           template=['Csd', 'H'])
         cerm.addReactionToCore(reaction_in_model)
         cerm.registerReaction(reaction_in_model)
 
@@ -434,11 +434,10 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
 
         self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction')
 
-    def test_checkForExistingReaction_keeps_different_template_reactions(self):
+    def test_checkForExistingReaction_keeps_identical_reactions_with_duplicate_flag(self):
         """
-        Test that checkForExistingReaction keeps reactions with different templates
+        Test that checkForExistingReaction keeps reactions with different templates and duplicate=True.
         """
-        from rmgpy.data.kinetics.family import TemplateReaction
         cerm = CoreEdgeReactionModel()
 
         # make species' objects
@@ -457,30 +456,30 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         cerm.addSpeciesToCore(spcC)
         cerm.addSpeciesToCore(spcD)
         
-        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+        reaction_in_model = TemplateReaction(reactants=[spcA, spcB],
+                                             products=[spcC, spcD],
+                                             family='H_Abstraction',
+                                             template=['Csd', 'H'],
+                                             duplicate=True)
         reaction_in_model.reactants.sort()
         reaction_in_model.products.sort()
 
-        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Cs12345','H'])
+        reaction_to_add = TemplateReaction(reactants=[spcA, spcB],
+                                           products=[spcC, spcD],
+                                           family='H_Abstraction',
+                                           template=['Cs12345', 'H'],
+                                           duplicate=True)
         cerm.addReactionToCore(reaction_in_model)
         cerm.registerReaction(reaction_in_model)
 
         found, rxn = cerm.checkForExistingReaction(reaction_to_add)
 
-        self.assertFalse(found, 'checkForExistingReaction failed to identify reactions with different templates')
+        self.assertFalse(found, 'checkForExistingReaction failed to identify duplicate template reactions')
 
-    def test_checkForExistingReaction_removes_duplicates_in_opposite_directions(self):
+    def test_checkForExistingReaction_eliminates_identical_reactions_without_duplicate_flag(self):
         """
-        Test that checkForExistingReaction will remove duplicates if reaction.reverse
-        would be a duplicate
+        Test that checkForExistingReaction eliminates reactions with different templates and duplicate=false
         """
-        from rmgpy.data.kinetics.family import TemplateReaction
         cerm = CoreEdgeReactionModel()
 
         # make species' objects
@@ -499,71 +498,30 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         cerm.addSpeciesToCore(spcC)
         cerm.addSpeciesToCore(spcD)
 
-        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+        reaction_in_model = TemplateReaction(reactants=[spcA, spcB],
+                                             products=[spcC, spcD],
+                                             family='H_Abstraction',
+                                             template=['Csd', 'H'],
+                                             duplicate=False)
         reaction_in_model.reactants.sort()
         reaction_in_model.products.sort()
 
-        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Csd','H'])
+        reaction_to_add = TemplateReaction(reactants=[spcA, spcB],
+                                           products=[spcC, spcD],
+                                           family='H_Abstraction',
+                                           template=['Cs12345', 'H'],
+                                           duplicate=False)
         cerm.addReactionToCore(reaction_in_model)
         cerm.registerReaction(reaction_in_model)
 
         found, rxn = cerm.checkForExistingReaction(reaction_to_add)
 
-        self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction')
-
-    def test_checkForExistingReaction_keeps_different_template_reactions(self):
-        """
-        Test that checkForExistingReaction keeps reactions with different templates
-        """
-        from rmgpy.data.kinetics.family import TemplateReaction
-        cerm = CoreEdgeReactionModel()
-
-        # make species' objects
-        spcA = Species().fromSMILES('[H]')
-        spcB = Species().fromSMILES('C=C[CH2]C')
-        spcC = Species().fromSMILES('C=C=CC')
-        spcD = Species().fromSMILES('[H][H]')
-        spcA.label = '[H]'
-        spcB.label = 'C=C[CH2]C'
-        spcC.label = 'C=C=CC'
-        spcD.label = '[H][H]'
-        spcB.generate_resonance_structures()
-
-        cerm.addSpeciesToCore(spcA)
-        cerm.addSpeciesToCore(spcB)
-        cerm.addSpeciesToCore(spcC)
-        cerm.addSpeciesToCore(spcD)
-        
-        reaction_in_model = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Csd','H'])
-        reaction_in_model.reactants.sort()
-        reaction_in_model.products.sort()
-
-        reaction_to_add = TemplateReaction(reactants=[spcA,spcB],
-                                             products = [spcC, spcD],
-                                                family = 'H_Abstraction',
-                                                template = ['Cs12345','H'])
-        cerm.addReactionToCore(reaction_in_model)
-        cerm.registerReaction(reaction_in_model)
-
-        found, rxn = cerm.checkForExistingReaction(reaction_to_add)
-
-        self.assertFalse(found, 'checkForExistingReaction failed to identify reactions with different templates')
+        self.assertTrue(found, 'checkForExistingReaction failed to eliminate reactions without duplicate tag')
 
     def test_checkForExistingReaction_removes_duplicates_in_opposite_directions(self):
         """
-        Test that checkForExistingReaction will remove duplicates if reaction.reverse
-        would be a duplicate
+        Test that checkForExistingReaction removes duplicate reverse reactions
         """
-        from rmgpy.data.kinetics.family import TemplateReaction
         cerm = CoreEdgeReactionModel()
 
         # make species' objects
@@ -576,31 +534,29 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         s3.label = 'HH'
         s4.label = 'C[CH2]'
 
-        rxn_f = TemplateReaction(reactants = [s1, s2],
-                                    products = [s3, s4],
-                                    template = ['C/H3/Cs\H3','H_rad'],
-                                    degeneracy = 6,
-                                    family = 'H_Abstraction',
-                                    reverse = TemplateReaction(reactants = [s3, s4],
-                                                            products = [s1, s2],
-                                                            template = ['H2', 'C_rad/H2/Cs\\H3'],
-                                                            degeneracy = 2,
-                                                            family = 'H_Abstraction',
-                                                            )
-                                    )
+        rxn_f = TemplateReaction(reactants=[s1, s2],
+                                 products=[s3, s4],
+                                 template=['C/H3/Cs/H3', 'H_rad'],
+                                 degeneracy=6,
+                                 family='H_Abstraction',
+                                 reverse=TemplateReaction(reactants=[s3, s4],
+                                                          products=[s1, s2],
+                                                          template=['H2', 'C_rad/H2/Cs/H3'],
+                                                          degeneracy=2,
+                                                          family='H_Abstraction')
+                                 )
 
-        rxn_r = TemplateReaction(reactants = [s3, s4],
-                                    products = [s1, s2],
-                                    template = ['H2', 'C_rad/H2/Cs\\H3'],
-                                    degeneracy = 2,
-                                    family = 'H_Abstraction',
-                                    reverse = TemplateReaction(reactants = [s1, s2],
-                                                            products = [s3, s4],
-                                                            template = ['C/H3/Cs\H3','H_rad'],
-                                                            degeneracy = 6,
-                                                            family = 'H_Abstraction',
-                                                            )
-                                    )
+        rxn_r = TemplateReaction(reactants=[s3, s4],
+                                 products=[s1, s2],
+                                 template=['H2', 'C_rad/H2/Cs/H3'],
+                                 degeneracy=2,
+                                 family='H_Abstraction',
+                                 reverse=TemplateReaction(reactants=[s1, s2],
+                                                          products=[s3, s4],
+                                                          template=['C/H3/Cs/H3', 'H_rad'],
+                                                          degeneracy=6,
+                                                          family='H_Abstraction')
+                                 )
 
         rxn_f.reactants.sort()
         rxn_f.products.sort()
@@ -609,11 +565,11 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         cerm.registerReaction(rxn_f)
 
         reactions = cerm.searchRetrieveReactions(rxn_r)
-        self.assertEqual(1, len(reactions),'cerm.searchRetrieveReactions could not identify reverse reaction')
+        self.assertEqual(1, len(reactions), 'cerm.searchRetrieveReactions could not identify reverse reaction')
 
         found, rxn = cerm.checkForExistingReaction(rxn_r)
 
-        self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction when it is in the reverse direction')
+        self.assertTrue(found, 'checkForExistingReaction failed to identify existing reaction in the reverse direction')
         self.assertEqual(rxn, rxn_f)
 
     @classmethod

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -30,6 +30,7 @@
 
 import os
 import unittest
+from external.wip import work_in_progress
 
 from .main import RMG, CoreEdgeReactionModel
 from .model import Species
@@ -76,6 +77,7 @@ class TestRMGWorkFlow(unittest.TestCase):
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
         
+    @work_in_progress
     def testDeterministicReactionTemplateMatching(self):
         """
         Test RMG work flow can match reaction template for kinetics estimation 
@@ -83,15 +85,19 @@ class TestRMGWorkFlow(unittest.TestCase):
 
         In this test, a change of molecules order in a reacting species should 
         not change the reaction template matched.
+
+        However, this is inherently impossible with the existing reaction
+        generation algorithm. Currently, the first reaction will be the one
+        that is kept if the reactions are identical. If different templates
+        are a result of different transition states, all are kept.
         
-        H + C=C=C=O -> O=C[C]=C
+        {O=C-[C]=C, [O]-C=C=C} -> H + C=C=C=O
         """
 
         # react
         spc = Species().fromSMILES("O=C[C]=C")
         spc.generate_resonance_structures()
-        newReactions = []		
-        newReactions.extend(react((spc,)))
+        newReactions = react((spc,))
 
         # try to pick out the target reaction 
         mol_H = Molecule().fromSMILES("[H]")
@@ -112,7 +118,7 @@ class TestRMGWorkFlow(unittest.TestCase):
         self.assertEqual(len(target_rxns_reverse), 2)
 
         # whatever order of molecules in spc, the reaction template matched should be same
-        self.assertEqual(target_rxns[0].template, target_rxns_reverse[-1].template)
+        self.assertEqual(target_rxns[0].template, target_rxns_reverse[0].template)
 
     def testCheckForExistingSpeciesForBiAromatics(self):
         """

--- a/rmgpy/test_data/testing_database/kinetics/families/H_Abstraction/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/H_Abstraction/groups.py
@@ -231,6 +231,46 @@ entry(
 )
 
 entry(
+    index = 28,
+    label = "Cd_H",
+    group =
+"""
+1 *1 C     u0 {2,D} {3,S} {4,S}
+2    [C,N] u0 {1,D}
+3 *2 H     u0 {1,S}
+4    R     u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 40,
+    label = "Cb_H",
+    group =
+"""
+1 *1 Cb       u0 {2,B} {3,B} {4,S}
+2    [Cb,Cbf] u0 {1,B}
+3    [Cb,Cbf] u0 {1,B}
+4 *2 H        u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 60,
+    label = "Cs_H",
+    group =
+"""
+1 *1 C u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 H u0 {1,S}
+3    R u0 {1,S}
+4    R u0 {1,S}
+5    R u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
     index = 63,
     label = "C/H3/Cs",
     group = 
@@ -286,9 +326,12 @@ L1: X_H_or_Xrad_H_Xbirad_H_Xtrirad_H
         L3: NH_singlet_H
     L2: Xrad_H
     L2: X_H
-        L3: C/H3/Cs
-        L3: C/H3/Cdot
-        L3: C/H3/Cd
+        L3: Cd_H
+        L3: Cb_H
+        L3: Cs_H
+            L4: C/H3/Cs
+            L4: C/H3/Cdot
+            L4: C/H3/Cd
 L1: Y_rad_birad_trirad_quadrad
     L2: Y_1centerquadrad
         L3: C_quintet


### PR DESCRIPTION
The multiple TS pull request (#1055) created duplicate reactions any time isomorphic reactions had different reaction templates. That led to cases where there could be 6 or more duplicates of a single reaction due to different resonance structures. This pull request reverses that change for reactions which have different reaction templates due to different resonance structures.

The new algorithm takes advantage of the isIdentical method to distinguish between cases where templates are different due to resonance structures vs. different transition states. This was previously used to distinguish between reactions which contribute to degeneracy vs. ones which don't. The logic is similar for multiple transition states, in that if the exact same atoms are participating in the reaction in the same way, then we can assume that it's just one transition state.

As a side effect of the change, the old issue with non-deterministic kinetics is raised again, since we choose to keep the first reaction we encounter instead of all of them. However, the true issue behind that is non-deterministic resonance structure order. Reaction generation and template matching is reasonably deterministic, but the order in which reactions are generated depends on the order of resonance structures.

In most cases, the order is determined by sorting by H298, which is fairly deterministic, although there are definitely cases where it is inaccurate. Overall, it seems reasonable to trade excessive duplicates for a chance of non-deterministic-ness.