### PR TITLE
make model enlargement occur after each reactor

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -693,6 +693,9 @@ class RMG(util.Subject):
                                         rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
                                         rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold)
                             else:
+                                self.updateReactionThresholdAndReactFlags(
+                                        rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
+                                        rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold, skipUpdate=True)
                                 logging.warn('Reaction thresholds/flags for Reaction System {0} was not updated due to resurrection'.format(index+1))
 
         
@@ -1054,8 +1057,11 @@ class RMG(util.Subject):
             self.unimolecularReact = numpy.ones((numCoreSpecies),bool)
             self.bimolecularReact = numpy.ones((numCoreSpecies, numCoreSpecies),bool)
             # No need to initialize reaction threshold arrays in this case
-
-    def updateReactionThresholdAndReactFlags(self, rxnSysUnimolecularThreshold=None, rxnSysBimolecularThreshold=None):
+    
+    def updateReactionThresholdAndReactFlags(self, rxnSysUnimolecularThreshold=None, rxnSysBimolecularThreshold=None,skipUpdate=False):
+        """
+        updates the length and boolean value of the unimolecular and bimolecular react and threshold flags
+        """
         numCoreSpecies = len(self.reactionModel.core.species)
         prevNumCoreSpecies = len(self.unimolecularReact)
         stale = True if numCoreSpecies > prevNumCoreSpecies else False
@@ -1075,6 +1081,10 @@ class RMG(util.Subject):
                 bimolecularThreshold[:prevNumCoreSpecies,:prevNumCoreSpecies] = self.bimolecularThreshold
                 self.unimolecularThreshold = unimolecularThreshold
                 self.bimolecularThreshold = bimolecularThreshold
+                
+            if skipUpdate:
+                return
+            
             # Always update the react and threshold arrays
             for i in xrange(numCoreSpecies):
                 if not self.unimolecularThreshold[i] and rxnSysUnimolecularThreshold[i]:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -599,7 +599,14 @@ class RMG(util.Subject):
                 allTerminated = True
                 numCoreSpecies = len(self.reactionModel.core.species)
                 
+                prunableSpecies = self.reactionModel.edge.species[:]
+                prunableNetworks = self.reactionModel.networkList[:]
+                
                 for index, reactionSystem in enumerate(self.reactionSystems):
+                    
+                    reactionSystem.prunableSpecies = prunableSpecies
+                    reactionSystem.prunableNetworks = prunableNetworks
+                    
                     reactorDone = True
                     objectsToEnlarge = []
                     self.reactionSystem = reactionSystem

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -82,12 +82,15 @@ cdef class ReactionSystem(DASx):
     cdef public numpy.ndarray networkLeakRates    
 
     # variables that cache maximum rate (ratio) data
-    cdef public numpy.ndarray maxCoreSpeciesRates
-    cdef public numpy.ndarray maxEdgeSpeciesRates
-    cdef public numpy.ndarray maxNetworkLeakRates
     cdef public numpy.ndarray maxEdgeSpeciesRateRatios
     cdef public numpy.ndarray maxNetworkLeakRateRatios
-
+    
+    #for managing prunable edge species
+    cdef public list prunableSpecies
+    cdef public list prunableNetworks
+    cdef public numpy.ndarray prunableSpeciesIndices
+    cdef public numpy.ndarray prunableNetworkIndices
+    
     # sensitivity variables
     # cdef public int sensmethod
     cdef public numpy.ndarray sensitivityCoefficients

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -145,11 +145,14 @@ cdef class ReactionSystem(DASx):
         self.validLayeringIndices = None
         
         # variables that cache maximum rate (ratio) data
-        self.maxCoreSpeciesRates = None
-        self.maxEdgeSpeciesRates = None
-        self.maxNetworkLeakRates = None
         self.maxEdgeSpeciesRateRatios = None
         self.maxNetworkLeakRateRatios = None
+        
+        #for managing prunable edge species
+        self.prunableSpecies = []
+        self.prunableNetworks = []
+        self.prunableSpeciesIndices = None
+        self.prunableNetworkIndices = None
 
         # sensitivity variables
         self.sensmethod = 2 # sensmethod = 1 for staggered corrector sensitivities, 0 (simultaneous corrector), 2 (staggered direct)
@@ -224,21 +227,40 @@ cdef class ReactionSystem(DASx):
         self.coreSpeciesRates = numpy.zeros((self.numCoreSpecies), numpy.float64)
         self.edgeSpeciesRates = numpy.zeros((self.numEdgeSpecies), numpy.float64)
         self.networkLeakRates = numpy.zeros((self.numPdepNetworks), numpy.float64)
-        self.maxCoreSpeciesRates = numpy.zeros((self.numCoreSpecies), numpy.float64)
-        self.maxEdgeSpeciesRates = numpy.zeros((self.numEdgeSpecies), numpy.float64)
-        self.maxNetworkLeakRates = numpy.zeros((self.numPdepNetworks), numpy.float64)
-        self.maxEdgeSpeciesRateRatios = numpy.zeros((self.numEdgeSpecies), numpy.float64)
-        self.maxNetworkLeakRateRatios = numpy.zeros((self.numPdepNetworks), numpy.float64)
+        self.maxEdgeSpeciesRateRatios = numpy.zeros((len(self.prunableSpecies)), numpy.float64)
+        self.maxNetworkLeakRateRatios = numpy.zeros((len(self.prunableNetworks)), numpy.float64)
         self.sensitivityCoefficients = numpy.zeros((self.numCoreSpecies, self.numCoreReactions), numpy.float64)
         self.unimolecularThreshold = numpy.zeros((self.numCoreSpecies), bool)
         self.bimolecularThreshold = numpy.zeros((self.numCoreSpecies, self.numCoreSpecies), bool)
 
         surfaceSpecies,surfaceReactions = self.initialize_surface(coreSpecies,coreReactions,surfaceSpecies,surfaceReactions)
         
+        self.set_prunable_indices(edgeSpecies, pdepNetworks)
         
     def initialize_solver(self):
         DASx.initialize(self, self.t0, self.y0, self.dydt0, self.senpar, self.atol_array, self.rtol_array)
     
+    def set_prunable_indices(self,edgeSpecies,pdepNetworks):
+        cdef object spc
+        cdef list temp
+        temp = []
+        for i,spc in enumerate(self.prunableSpecies):
+            try:
+                temp.append(edgeSpecies.index(spc))
+            except ValueError:
+                self.maxEdgeSpeciesRateRatios[i] = numpy.inf #avoid pruning of species that have been moved to core
+        
+        self.prunableSpeciesIndices = numpy.array(temp)
+        
+        temp = []
+        for i,spc in enumerate(self.prunableNetworks):
+            try:
+                temp.append(pdepNetworks.index(spc))
+            except:
+                self.maxNetworkLeakRateRatios[i] = numpy.inf #avoid pruning of lost networks
+                
+        self.prunableNetworkIndices = numpy.array(temp)
+        
     @cython.boundscheck(False)
     cpdef initialize_surface(self,list coreSpecies,list coreReactions,list surfaceSpecies,list surfaceReactions):
         """
@@ -589,6 +611,9 @@ cdef class ReactionSystem(DASx):
                              pdepNetworks, absoluteTolerance, relativeTolerance, sensitivity, sensitivityAbsoluteTolerance, 
                              sensitivityRelativeTolerance, filterReactions)
         
+        prunableSpeciesIndices = self.prunableSpeciesIndices
+        prunableNetworkIndices = self.prunableNetworkIndices
+        
         surfaceSpeciesIndices = self.surfaceSpeciesIndices
         surfaceReactionIndices = self.surfaceReactionIndices
         
@@ -606,9 +631,6 @@ cdef class ReactionSystem(DASx):
         maxNetworkRate = 0.0
         iteration = 0
 
-        maxCoreSpeciesRates = self.maxCoreSpeciesRates
-        maxEdgeSpeciesRates = self.maxEdgeSpeciesRates
-        maxNetworkLeakRates = self.maxNetworkLeakRates
         maxEdgeSpeciesRateRatios = self.maxEdgeSpeciesRateRatios
         maxNetworkLeakRateRatios = self.maxNetworkLeakRateRatios
         forwardRateCoefficients = self.kf
@@ -650,7 +672,7 @@ cdef class ReactionSystem(DASx):
                         if len(edgeSpeciesRateRatios) > 0:
                             ind = numpy.argmax(edgeSpeciesRateRatios)
                             obj = edgeSpecies[ind]
-                            logging.info('At time {0:10.4e} s, species {1} at rate ratio {2} was added to model core in model resurrection process'.format(self.t, obj,maxEdgeSpeciesRates[ind]))
+                            logging.info('At time {0:10.4e} s, species {1} at rate ratio {2} was added to model core in model resurrection process'.format(self.t, obj,edgeSpeciesRates[ind]))
                             invalidObjects.append(obj)
                         
                         if totalDivAccumNums and len(totalDivAccumNums) > 0: #if dynamics data available
@@ -721,21 +743,12 @@ cdef class ReactionSystem(DASx):
             coreSpeciesConcentrations = self.coreSpeciesConcentrations
             
             # Update the maximum species rate and maximum network leak rate arrays
-            for index in xrange(numCoreSpecies):
-                if maxCoreSpeciesRates[index] < coreSpeciesRates[index]:
-                    maxCoreSpeciesRates[index] = coreSpeciesRates[index]
-            for index in xrange(numEdgeSpecies):
-                if maxEdgeSpeciesRates[index] < edgeSpeciesRates[index]:
-                    maxEdgeSpeciesRates[index] = edgeSpeciesRates[index]
-            for index in xrange(numPdepNetworks):
-                if maxNetworkLeakRates[index] < networkLeakRates[index]:
-                    maxNetworkLeakRates[index] = networkLeakRates[index]
-            for index in xrange(numEdgeSpecies):
-                if maxEdgeSpeciesRateRatios[index] < edgeSpeciesRateRatios[index]:
-                    maxEdgeSpeciesRateRatios[index] = edgeSpeciesRateRatios[index]
-            for index in xrange(numPdepNetworks):
-                if maxNetworkLeakRateRatios[index] < networkLeakRateRatios[index]:
-                    maxNetworkLeakRateRatios[index] = networkLeakRateRatios[index]
+            for i,index in enumerate(prunableSpeciesIndices):
+                if maxEdgeSpeciesRateRatios[i] < edgeSpeciesRateRatios[index]:
+                    maxEdgeSpeciesRateRatios[i] = edgeSpeciesRateRatios[index]
+            for i,index in enumerate(prunableNetworkIndices):
+                if maxNetworkLeakRateRatios[i] < networkLeakRateRatios[index]:
+                    maxNetworkLeakRateRatios[i] = networkLeakRateRatios[index]
             
             if charRate == 0 and len(edgeSpeciesRates)>0: #this deals with the case when there is no flux in the system
                 maxSpeciesIndex = numpy.argmax(edgeSpeciesRates)
@@ -1058,9 +1071,6 @@ cdef class ReactionSystem(DASx):
                         row.extend([normSens_array[i][k][j] for j in reactionsAboveThreshold])       
                         worksheet.writerow(row)  
         
-        self.maxCoreSpeciesRates = maxCoreSpeciesRates
-        self.maxEdgeSpeciesRates = maxEdgeSpeciesRates
-        self.maxNetworkLeakRates = maxNetworkLeakRates
         self.maxEdgeSpeciesRateRatios = maxEdgeSpeciesRateRatios
         self.maxNetworkLeakRateRatios = maxNetworkLeakRateRatios
         


### PR DESCRIPTION
After each reactor all of the processing steps except pruning will occur before the next reactor is run.  This severely reduces the number of simulations needed to be run for runs with multiple reactors because it prevents different reactors from picking up the same species.  

Defining a simulation efficiency metric:  Species Per Simulation Time (SPST) that is the number of species added per simulation.  We can see this does very poorly the more reactors you add.  

<img width="421" alt="screen shot 2017-10-20 at 3 14 25 pm" src="https://user-images.githubusercontent.com/7773228/31838130-6a819734-b5a9-11e7-9a0f-8f51f30c1129.png">

For a system where only one species is taken at a time this PR forces SPST = 1, (provided no simulations finish) no matter how many reactors are used.  Accounting for finishing simulations it will decrease from 1 over the mechanism generation process as the model becomes more complete.  