### PR TITLE
remove collisionModel Attribute definition

### DIFF
--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -540,9 +540,8 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         bathGas = [spec for spec in reactionModel.core.species if not spec.reactive]
         self.bathGas = {}
         for spec in bathGas:
-            # is this really the only/best way to weight them? And what is alpha0?
+            # is this really the only/best way to weight them?
             self.bathGas[spec] = 1.0 / len(bathGas)
-            spec.collisionModel = SingleExponentialDown(alpha0=(4.86,'kcal/mol'))
 
         # Save input file
         if not self.label: self.label = str(self.index)


### PR DESCRIPTION
The attribute is unused and its definition is the cause of #1220.  It started causing #1220 because now that both Species classes have been combined into one cythonized Species calss it can no longer add new attributes to the object as it did when it was added to the uncythonized Species class.  