### PR TITLE
Add additional markers for line breaks in kinetics comments

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -550,7 +550,8 @@ def _removeLineBreaks(comments):
                                 'dGrxn(298 K) = ','Both directions are estimates',
                                 'Other direction matched ','Both directions matched ',
                                 'This direction matched an entry in ', 'From training reaction',
-                                'This reaction matched rate rule','family: ',
+                                'This reaction matched rate rule','family: ','Warning:',
+                                'Chemkin file stated explicit reverse rate:'
                                 ]
     for indicator in new_statement_indicators:
         comments = comments.replace(' ' + indicator, '\n' + indicator,1)


### PR DESCRIPTION
These are added by readKineticsEntry, which can sometimes end up being saved to a Chemkin file again, e.g. via a library.

The NC example on RMG-tests was encountering this error due to usage of the FFCM1(-) library, which contains warnings about removing SRI parameters. Those lines were originally written from [here](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/chemkin.py#L270), probably because the library was created from a Chemkin file.

I also added the comment about explicit reverse reactions to the list just in case.

This can probably be tested by running the NC example and trying to load the Chemkin file.