### PR TITLE
Fix ch3no2 example

### DIFF
--- a/examples/rmg/ch3no2/input.py
+++ b/examples/rmg/ch3no2/input.py
@@ -79,6 +79,7 @@ model(
     maximumEdgeSpecies=10000
 )
 
+simulator(atol=1e-16,rtol=1e-8)
 options(
     units='si',
     saveRestartPeriod=None,


### PR DESCRIPTION
Adds a simulator block to the ch3no2 example.  This is necessary after the Accelerator Tools pull request that enables model concatenation