### PR TITLE
Enable RCCSD(T)-F12 energies in Cantherm

### DIFF
--- a/rmgpy/cantherm/kinetics.py
+++ b/rmgpy/cantherm/kinetics.py
@@ -185,7 +185,7 @@ class KineticsJob:
         f.write('#   ======= =========== =========== =========== ===============\n')
         
         if self.Tlist is None:
-            Tlist = [300,400,500,600,800,1000,1500,2000]
+            Tlist = numpy.array([300,400,500,600,800,1000,1500,2000])
         else:
             Tlist =self.Tlist.value_si
 

--- a/rmgpy/cantherm/molepro.py
+++ b/rmgpy/cantherm/molepro.py
@@ -66,14 +66,17 @@ class MoleProLog:
         E0=None
         if f12a:
             while line!='':
-                #first one is for radicals second is for non radicals
-                if 'RHF-UCCSD(T)-F12a energy' in line or 'CCSD(T)-F12a total energy  ' in line:
+                if ('RHF-UCCSD(T)-F12a energy' in line
+                    or 'RHF-RCCSD(T)-F12a energy' in line
+                    or 'CCSD(T)-F12a total energy  ' in line):
                     E0=float(line.split()[-1])
                     break
                 line=f.readline()
         else:
             while line!='':
-                if 'RHF-UCCSD(T)-F12b energy' in line or 'CCSD(T)-F12b total energy  ' in line:
+                if ('RHF-UCCSD(T)-F12b energy' in line
+                    or 'RHF-RCCSD(T)-F12b energy' in line
+                    or 'CCSD(T)-F12b total energy  ' in line):
                     E0=float(line.split()[-1])
                     break
                 line=f.readline()


### PR DESCRIPTION
There's no reason not to have functionality for reading RCCSD(T)-F12 energies from Molpro output files, so this PR enables that functionality.

Also fixes a Cantherm error related to the data format of the Tlist when no Tlist is specified explicitly in the Cantherm input file.