### PR TITLE
Minor kinetics fixes

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -275,7 +275,7 @@ class Database:
         Load the dictionary containing all of the species in a kinetics library or depository.
         """
         from rmgpy.species import Species
-        speciesDict = {}
+        speciesDict = OrderedDict()
         with open(path, 'r') as f:
             adjlist = ''
             for line in f:

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -281,7 +281,7 @@ def find_degenerate_reactions(rxnList, same_reactants=None, kinetics_database=No
     rxnSorted = []
     for rxn0 in rxnList:
         # find resonance structures for rxn0
-        ensure_species_in_reaction(rxn0)
+        rxn0.ensure_species()
         if len(rxnSorted) == 0:
             # This is the first reaction, so create a new sublist
             rxnSorted.append([rxn0])
@@ -347,44 +347,6 @@ def find_degenerate_reactions(rxnList, same_reactants=None, kinetics_database=No
                 rxn.degeneracy = family.calculateDegeneracy(rxn)
 
     return rxnList
-
-
-def ensure_species_in_reaction(reaction):
-    """
-    Modifies a reaction holding Molecule objects to a reaction holding
-    Species objects. Generates resonance structures for reaction products.
-    """
-    # if already species' objects, return none
-    if isinstance(reaction.reactants[0], Species):
-        return None
-    # obtain species with all resonance isomers
-    if reaction.isForward:
-        reaction.reactants = ensure_species(reaction.reactants, resonance=False)
-        reaction.products = ensure_species(reaction.products, resonance=True, keepIsomorphic=True)
-    else:
-        reaction.reactants = ensure_species(reaction.reactants, resonance=True, keepIsomorphic=True)
-        reaction.products = ensure_species(reaction.products, resonance=False)
-
-    # convert reaction.pairs object to species
-    new_pairs = []
-    for reactant, product in reaction.pairs:
-        new_pair = []
-        for reactant0 in reaction.reactants:
-            if reactant0.isIsomorphic(reactant):
-                new_pair.append(reactant0)
-                break
-        for product0 in reaction.products:
-            if product0.isIsomorphic(product):
-                new_pair.append(product0)
-                break
-        new_pairs.append(new_pair)
-    reaction.pairs = new_pairs
-
-    try:
-        ensure_species_in_reaction(reaction.reverse)
-    except AttributeError:
-        pass
-
 
 def reduce_same_reactant_degeneracy(reaction, same_reactants=None):
     """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1877,7 +1877,10 @@ class KineticsFamily(Database):
                 kineticsList.append([deepcopy(entry.data), entry, entry.item.isIsomorphic(reaction, eitherDirection=False)])
         for kinetics, entry, isForward in kineticsList:
             if kinetics is not None:
-                kinetics.comment += "Matched reaction {0} {1} in {2}".format(entry.index, entry.label, depository.label)
+                kinetics.comment += "Matched reaction {0} {1} in {2}\nThis reaction matched rate rule {3}".format(entry.index, 
+                                                      entry.label, 
+                                                      depository.label,
+                                                      '[{0}]'.format(';'.join([g.label for g in template])))
         return kineticsList
     
     def __selectBestKinetics(self, kineticsList):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1881,6 +1881,7 @@ class KineticsFamily(Database):
                                                       entry.label, 
                                                       depository.label,
                                                       '[{0}]'.format(';'.join([g.label for g in template])))
+                kinetics.comment += "\nfamily: {}".format(self.label)
         return kineticsList
     
     def __selectBestKinetics(self, kineticsList):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -52,7 +52,7 @@ from .groups import KineticsGroups
 from .rules import KineticsRules
 from rmgpy.exceptions import InvalidActionError, ReactionPairsError, KineticsError,\
                              UndeterminableKineticsError, ForbiddenStructureException,\
-                             KekulizationError, ActionError
+                             KekulizationError, ActionError, DatabaseError
 
 ################################################################################
 
@@ -2059,7 +2059,7 @@ class KineticsFamily(Database):
             # if there're some mapping available but cannot match the provided products
             # raise exception
             if len(mappings) > 0:
-                raise Exception('Something wrong with products that RMG cannot find a match!')
+                raise ActionError('Something wrong with products that RMG cannot find a match!')
             return (None, None)
         elif len(reactants0) == 2:
             moleculeA = reactants0[0]
@@ -2091,10 +2091,10 @@ class KineticsFamily(Database):
             # if there're some mapping available but cannot match the provided products
             # raise exception
             if len(mappingsA)*len(mappingsB) > 0:
-                raise Exception('Something wrong with products that RMG cannot find a match!')
+                raise ActionError('Something wrong with products that RMG cannot find a match!')
             return (None, None)
         else:
-            raise Exception('You have {0} reactants, which is unexpected!'.format(len(reactants)))
+            raise IndexError('You have {0} reactants, which is unexpected!'.format(len(reactants)))
         
     def addAtomLabelsForReaction(self, reaction):
         """
@@ -2111,7 +2111,7 @@ class KineticsFamily(Database):
                 # Check for swapped reactants if there are more than 1
                 labeledReactants, labeledProducts = self.getLabeledReactantsAndProducts(list(reversed(reactants)), products)
         if not labeledReactants and not labeledProducts:
-            raise Exception("RMG could not label atoms for this reaction in {}.".format(self.label))
+            raise ActionError("RMG could not label atoms for this reaction in {}.".format(self.label))
         
         labeledProducts_spcs = []
         labeledReactants_spcs = []
@@ -2130,7 +2130,7 @@ class KineticsFamily(Database):
             if depository.label.endswith('training'):
                 return depository
         else:
-            raise Exception('Could not find training depository in family {0}.'.format(self.label))
+            raise DatabaseError('Could not find training depository in family {0}.'.format(self.label))
         
     def retrieveOriginalEntry(self, templateLabel):
         """
@@ -2210,7 +2210,7 @@ class KineticsFamily(Database):
                     else:
                         rules.append((ruleEntry,1))
                 else:
-                    raise Exception('Could not parse unexpected line found in kinetics comment: {}'.format(comment))
+                    raise ValueError('Could not parse unexpected line found in kinetics comment: {}'.format(comment))
             else:
                 comment = ' '.join(lines[:-1])
                 # Clean up line for exec
@@ -2291,7 +2291,7 @@ class KineticsFamily(Database):
                 trainingEntry = depository.entries[trainingReactionIndex]
                 # Perform sanity check that the training reaction's label matches that of the comments
                 if trainingEntry.label not in line:
-                    raise Exception('Reaction {0} uses kinetics from training reaction {1} but does not match the training reaction {1} from the {2} family.'.format(reaction,trainingReactionIndex,self.label))
+                    raise AssertionError('Reaction {0} uses kinetics from training reaction {1} but does not match the training reaction {1} from the {2} family.'.format(reaction,trainingReactionIndex,self.label))
                 
                 # Sometimes the matched kinetics could be in the reverse direction..... 
                 if reaction.isIsomorphic(trainingEntry.item, eitherDirection=False):
@@ -2318,7 +2318,7 @@ class KineticsFamily(Database):
         
 
         if not template:
-            raise Exception('Could not extract kinetics source from comments for reaction {}.'.format(reaction))
+            raise ValueError('Could not extract kinetics source from comments for reaction {}.'.format(reaction))
         
         sourceDict = {'template':template, 'degeneracy':degeneracy, 'exact':exact, 
                        'rules':rules,'training':trainingEntries }

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -105,4 +105,6 @@ cdef class Reaction:
     
     cpdef copy(self)
 
+    cpdef ensure_species(self)
+
 cpdef bint _isomorphicSpeciesList(list list1, list list2, bint checkIdentical=?, bint checkOnlyLabel=?)

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -105,6 +105,6 @@ cdef class Reaction:
     
     cpdef copy(self)
 
-    cpdef ensure_species(self)
+    cpdef ensure_species(self, bint reactant_resonance=?, bint product_resonance=?)
 
 cpdef bint _isomorphicSpeciesList(list list1, list list2, bint checkIdentical=?, bint checkOnlyLabel=?)

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1049,14 +1049,16 @@ class Reaction:
         
         return other
 
-    def ensure_species(self):
+    def ensure_species(self, reactant_resonance=False, product_resonance=True):
         """
         Ensure the reaction contains species objects in its reactant and product
         attributes. If the reaction is found to hold molecule objects, it
         modifies the reactant, product and pairs to hold
         Species objects.
 
-        Generates resonance structures for reaction products.
+        Generates resonance structures for Molecules if the corresponding options,
+        reactant_resonance and/or product_resonance, are True. Does not generate
+        resonance for reactants or products that start as Species objects.
         """
         from rmgpy.data.kinetics.common import ensure_species
         # if already species' objects, return none
@@ -1064,11 +1066,11 @@ class Reaction:
             return None
         # obtain species with all resonance isomers
         if self.isForward:
-            self.reactants = ensure_species(self.reactants, resonance=False)
-            self.products = ensure_species(self.products, resonance=True, keepIsomorphic=True)
+            self.reactants = ensure_species(self.reactants, resonance=reactant_resonance, keepIsomorphic=True)
+            self.products = ensure_species(self.products, resonance=product_resonance, keepIsomorphic=True)
         else:
-            self.reactants = ensure_species(self.reactants, resonance=True, keepIsomorphic=True)
-            self.products = ensure_species(self.products, resonance=False)
+            self.reactants = ensure_species(self.reactants, resonance=product_resonance, keepIsomorphic=True)
+            self.products = ensure_species(self.products, resonance=reactant_resonance, keepIsomorphic=True)
 
         # convert reaction.pairs object to species
         if self.pairs:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -881,9 +881,9 @@ class RMG(util.Subject):
                     data = reaction.kinetics,
                 )
             try:
-        	    entry.longDesc = 'Originally from reaction library: ' + reaction.library + "\n" + reaction.kinetics.comment
-    	    except AttributeError:
-        	    entry.longDesc = reaction.kinetics.comment
+                entry.longDesc = 'Originally from reaction library: ' + reaction.library + "\n" + reaction.kinetics.comment
+            except AttributeError:
+                entry.longDesc = reaction.kinetics.comment
             kineticsLibrary.entries[i+1] = entry
         
         # Mark as duplicates where there are mixed pressure dependent and non-pressure dependent duplicate kinetics

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -212,7 +212,7 @@ class CoreEdgeReactionModel:
         self.pressureDependence = None
         self.quantumMechanics = None
         self.verboseComments = False
-        self.kineticsEstimator = 'group additivity'
+        self.kineticsEstimator = 'rate rules'
         self.indexSpeciesDict = {}
         self.saveEdgeSpecies = False
         self.iterationNum = 0

--- a/rmgpy/test_data/parsing_data/chem_annotated.inp
+++ b/rmgpy/test_data/parsing_data/chem_annotated.inp
@@ -139,6 +139,7 @@ CH(9)+CH2OH(18)=CH2(11)+CH2O(15)                    1.286e+13 -0.010    0.000
 ! Template reaction: Disproportionation
 ! Flux pairs: CH2OH(18), CH2O(15); C2H(21), C2H2(22); 
 ! Matched reaction 0 C2H + CH3O <=> C2H2 + CH2O in Disproportionation/training
+! This reaction matched rate rule [O_pri_rad;Cmethyl_Csrad]
 CH2OH(18)+C2H(21)=CH2O(15)+C2H2(22)                 3.610e+13 0.000     0.000    
 
 ! Reaction index: Chemkin #5; RMG #364


### PR DESCRIPTION
This pull request adds a few changes to kinetics: 

* Replaced general exceptions to more specific ones in `family.py` for better error catching
* Improved the robustness of a method by also checking for reverse reactions
* The template is now output when RMG matches a training reaction (since knowing the template is necessary to relabel reactants if the depository isn't loaded)
* Make the default kinetics estimator 'rate rules' instead of group additivity, which I don't think people use much. This allows for the line to be omitted from input files.
* Fix tab error.