### PR TITLE
Minor thermo isotope tweaks

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1622,7 +1622,7 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
     string += '{0!s:<51} '.format(reaction_string)
 
     if isinstance(kinetics, _kinetics.Arrhenius):
-        string += '{0:<9.3e} {1:<9.3f} {2:<9.3f}'.format(
+        string += '{0:<9.6e} {1:<9.3f} {2:<9.3f}'.format(
             kinetics.A.value_si/ (kinetics.T0.value_si ** kinetics.n.value_si) * 1.0e6 ** (numReactants - 1),
             kinetics.n.value_si,
             kinetics.Ea.value_si / 4184.
@@ -1686,7 +1686,7 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
         for P, arrhenius in zip(kinetics.pressures.value_si, kinetics.arrhenius):
             if isinstance(arrhenius, _kinetics.MultiArrhenius):
                 for arrh in arrhenius.arrhenius:
-                    string += '    PLOG/ {0:<9.3f} {1:<9.3e} {2:<9.3f} {3:<9.3f}/\n'.format(P / 101325.,
+                    string += '    PLOG/ {0:<9.6f} {1:<9.3e} {2:<9.3f} {3:<9.3f}/\n'.format(P / 101325.,
                     arrh.A.value_si / (arrh.T0.value_si ** arrh.n.value_si) * 1.0e6 ** (numReactants - 1),
                     arrh.n.value_si,
                     arrh.Ea.value_si / 4184.

--- a/rmgpy/molecule/draw.py
+++ b/rmgpy/molecule/draw.py
@@ -864,8 +864,11 @@ class MoleculeDrawer:
         self.symbols = symbols = [atom.symbol for atom in atoms]
         for i in range(len(symbols)):
             # Don't label carbon atoms, unless there are only one or two heavy atoms
+            # or they are isotopically labeled
             if symbols[i] == 'C' and len(symbols) > 2:
-                if len(atoms[i].bonds) > 1 or (atoms[i].radicalElectrons == 0 and atoms[i].charge == 0):
+                if (len(atoms[i].bonds) > 1 or \
+                        (atoms[i].radicalElectrons == 0 and atoms[i].charge == 0))\
+                        and atoms[i].element.isotope== -1:
                     symbols[i] = ''
         # Do label atoms that have only double bonds to one or more labeled atoms
         changed = True
@@ -1165,7 +1168,8 @@ class MoleculeDrawer:
             boundingRect = [x1, y1, x2, y2]
     
             # Set color for text
-            if   heavyAtom == 'C':  cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+            if   atom.element.isotope != -1: cr.set_source_rgba(0.0, 0.5, 0.0, 1.0)
+            elif heavyAtom == 'C':  cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
             elif heavyAtom == 'N':  cr.set_source_rgba(0.0, 0.0, 1.0, 1.0)
             elif heavyAtom == 'O':  cr.set_source_rgba(1.0, 0.0, 0.0, 1.0)
             elif heavyAtom == 'F':  cr.set_source_rgba(0.5, 0.75, 1.0, 1.0)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -135,7 +135,11 @@ class Atom(Vertex):
             'atomType': self.atomType.label if self.atomType else None,
             'lonePairs': self.lonePairs,
         }
-        return (Atom, (self.element.symbol, self.radicalElectrons, self.charge, self.label), d)
+        if self.element.isotope == -1:
+            element2pickle = self.element.symbol
+        else:
+            element2pickle = self.element
+        return (Atom, (element2pickle, self.radicalElectrons, self.charge, self.label), d)
 
     def __setstate__(self, d):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -317,7 +317,8 @@ class CoreEdgeReactionModel:
         spec.generate_resonance_structures()
         spec.molecularWeight = Quantity(spec.molecule[0].getMolecularWeight()*1000.,"amu")
         
-        submit(spec,self.solventName)
+        if not spec.thermo:
+            submit(spec,self.solventName)
         
         if spec.label == '':
             if spec.thermo and spec.thermo.label != '': #check if thermo libraries have a name for it

--- a/rmgpy/thermo/nasa.pxd
+++ b/rmgpy/thermo/nasa.pxd
@@ -47,6 +47,8 @@ cdef class NASAPolynomial(HeatCapacityModel):
     
     cpdef changeBaseEnthalpy(self, double deltaH)
 
+    cpdef changeBaseEntropy(self, double deltaS)
+
     cdef double integral2_T0(self, double T)
     
     cdef double integral2_TM1(self, double T)
@@ -70,3 +72,5 @@ cdef class NASA(HeatCapacityModel):
     cpdef Wilhoit toWilhoit(self)
     
     cpdef NASA changeBaseEnthalpy(self, double deltaH)
+
+    cpdef NASA changeBaseEntropy(self, double deltaS)

--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -136,6 +136,12 @@ cdef class NASAPolynomial(HeatCapacityModel):
         """
         self.c5 += deltaH / constants.R
 
+    cpdef changeBaseEntropy(self, double deltaS):
+        """
+        Add deltaS in J/molK to the base entropy of formation S298.
+        """
+        self.c6 += deltaS / constants.R
+
     cdef double integral2_T0(self, double T):
         """
         Return the value of the dimensionless integral
@@ -350,7 +356,16 @@ cdef class NASA(HeatCapacityModel):
         for poly in self.polynomials:
             poly.changeBaseEnthalpy(deltaH)
         return self
-    
+
+    cpdef NASA changeBaseEntropy(self, double deltaS):
+        """
+        Add deltaS in J/molK to the base entropy of formation S298 and return the
+        modified NASA object
+        """
+        for poly in self.polynomials:
+            poly.changeBaseEntropy(deltaS)
+        return self
+
     def toCantera(self):
         """
         Return the cantera equivalent NasaPoly2 object from this NASA object.


### PR DESCRIPTION
This PR improves thermo generation and isotope representation (put into one PR since each is small leading to hassle with re-basing before each merge). 

Thermo fixes:

* Adds a method that modifies the entropy of a NASA object without converting it to wilholt, which leads to some extra conversion error.
* Only submit thermo calculations if thermo is not already provided (for example if it is loaded from a file)

Isotope fixes:

* Color the element of enriched carbon when drawing isotopes
* Allow isotopes to be properly pickled when they are elements in molecules

etc:

* Increase the sig-figs output to the chemkin file. 3 decimal places was too much error when comparing isotope effects. 