### PR TITLE
Fix a CpInf < Cphigh case in getEntropy()

### DIFF
--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -28,6 +28,7 @@
 ################################################################################
 import numpy
 import cython
+import logging
 
 from libc.math cimport sqrt, log
 
@@ -303,6 +304,11 @@ cdef class ThermoData(HeatCapacityModel):
             slope = (Cphigh - Cplow) / (Thigh - Tlow)
             intercept = (Cplow * Thigh - Cphigh * Tlow) / (Thigh - Tlow)
             if slope > 0:
+                if CpInf < Cphigh:
+                    logging.warning("Cphigh is above the theoretical CpInf value for ThermoData object\n{0}."
+                    "\nThe thermo for this species is probably wrong! Setting CpInf = Cphigh for Entropy calculation"
+                    "at T = {1} K...".format(self,T))
+                    CpInf = Cphigh
                 T0 = (CpInf - Cphigh) / slope + Thigh
                 if T <= T0:
                     S += slope * (T - Thigh) + intercept * log(T / Thigh)


### PR DESCRIPTION
If `CpInf` ([a theoretical calculation](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/molecule/molecule.py#L1542)) is lower than `Cphigh`, RMG may not be able to calculate the Entropy at certain temperatures due to `log(negative number)`, e.g.:
[`T0 = (CpInf - Cphigh) / slope + Thigh`](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/thermo/thermodata.pyx#L306)
[`S += slope * (T0 - Thigh) + intercept * log(T0 / Thigh) + CpInf * log(T / T0)`](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/thermo/thermodata.pyx#L310)

In such a case, S will be `NaN` at certain temperatures, and therefore the calculated reverse rate will be corrupt.

This small PR checks whether `CpInf < Cphigh`, and if so sets `CpInf = Cphigh` and outputs a warning to the user.

For testing, this was discovered for the following ThermoData object for `[SH]=O`:
```
ThermoData: ThermoData(Tdata=([300,400,500,600,800,1000,1500],'K'),
Cpdata=([52.2583,55.9139,57.5295,60.3831,62.1558,63.0079,65.2703],'J/(mol*K)'),
H298=(-336.587,'kJ/mol'), S298=(281.425,'J/(mol*K)'), Cp0=(33.2579,'J/(mol*K)'),
CpInf=(58.2013,'J/(mol*K)'),
comment="""Thermo group additivity estimation: group(S2s-OH) + group(O2s-S4dH) + radical(O2sJ-S2s)""")
```

This branch passed the tests locally, but immediately fails on Travis. Is there a current know issue with Travis?