### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-virtualenv:
-    system_site_packages: true
 env:
   global:
     - secure: "L2ja+ZnV83w4qG3E8FwTjm0D6IWNOnj5wuFOjYTwbzQP4OAgLAWBzCMtxzWy5sMxFLtRgkswBH1d5f5kg8Ab7GIyAMFgQwe8UFqMJ+N05QNszE1mJkAvJtv2XN7669XXQhTt5EXfHrCcGZaODVnI2CEA8GB5DxiHO2Lcqf/xvgE="
@@ -12,29 +10,24 @@ env:
     - secure: "cfosGf5hvUhIlPoGJu0d/HFddrMwIFU7FfLwd8yRrMGkYv0ePOwAW9kmhFSxUYvuXkxzgD75cIICMFY2fSm6VXBXXzfPQD7vwzoApXf7a8vi0C64XhinXhdEyUYb5/v8fswa0zheUENYhUS1tOqDXT/h8EPNZT5wKizaA3O2Wa8="
     - secure: "QXuqKYuwCocqsTMePBc5OugBbQC4/t+335TYLdkletiateP/rF/eDsVRG792/BVq5gKRZgz3NH9ipTNm5pZoCbAEPt9+eDpfts8WeAbxmjdcEjfBxxwZ69wUTPAVrezTGn2k7W2UBdFrWeUNKPAVCKIkoviXqOHFitqJEC+c6JY="
     - secure: "jIyBEzR10l5SWvY5ouEYzA8YzPHIZNMXMBdcXwuwte8NCU8GBYUqhHA1L67nTaBdLhWbrZ2NireVKPQWJp3ctcI0IB6xZzaYlVpgN/udGPO+1MZd9Xhp9TWuJWrGZ9EoWGB9L5H+O7RYwcDMVH5CUrCIBdsSJuyE8aDpky1/IVE="
-addons:
-  apt:
-    packages:
-    - git
 
 before_install:
-  # Set up anaconda
-  - wget http://repo.continuum.io/miniconda/Miniconda2-4.0.5-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $HOME/miniconda
-  - export PATH=$HOME/miniconda/bin:$PATH
-  - export PYTHONPATH=$TRAVIS_BUILD_DIR/RMG-Py:$PYTHONPATH
-  # Update conda itself
-  - conda update --yes conda
   - cd ..
+  # Install miniconda
+  - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH=$HOME/miniconda/bin:$PATH
+  - conda update --yes conda
+  - conda info -a
+  # Clone RMG-database
   - git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
   - cd RMG-Py
 
 install:
-  - conda env create -f environment_linux.yml
+  - conda env create -q -f environment_linux.yml
   - source activate rmg_env
+  - conda install -y -c conda-forge codecov
   - conda list
-  - pip install codecov
   - yes 'Yes' | $HOME/miniconda/envs/rmg_env/bin/mopac $MOPACKEY > /dev/null
   - make
 


### PR DESCRIPTION
This PR addresses the recent issues with Travis and also includes other minor changes to `travis.yml`.

The actual issue seems to have to do with an IOError when writing to stdout and has been also been reported by others (conda/conda#6473, travis-ci/travis-ci#8934). The start of the build failures seemed to coincide with the rollout of the new [Trusty images](https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch), although other people have stated that switching to the old images did not resolve the issue.

The solution I implemented is simply adding a quiet (`-q`) flag to the `conda env create` command to suppress all output for that command, which circumvents the issue. Other solutions include switching stdout to blocking mode, or setting `filter_secrets: false` in `travis.yml`.
