### PR TITLE
Do not log SMILES in updateAtomTypes when AtomTypeError is encountered

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1028,7 +1028,7 @@ class Molecule(Graph):
                 atom.atomType = getAtomType(atom, atom.edges)
             except AtomTypeError:
                 if logSpecies:
-                    logging.error("Could not update atomtypes for {0}.\n{1}".format(self, self.toAdjacencyList()))
+                    logging.error("Could not update atomtypes for this molecule:\n{0}".format(self.toAdjacencyList()))
                 if raiseException:
                     raise
                 atom.atomType = atomTypes['R']


### PR DESCRIPTION
Molecules without atomtypes can encounter other errors during SMILES generation, which obfuscates the actual issue.

This is commonly encountered on the website when users input an incorrect SMILES string. While `AtomTypeError` can be properly handled by the website, this bug causes an `AttributeError` to be raised instead, which breaks the website.