### PR TITLE
Group extensions

### DIFF
--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -765,6 +765,42 @@ class TestGroup(unittest.TestCase):
             self.assertTrue(atom1 in self.group.atoms)
             self.assertTrue(atom2 in group.atoms)
             self.assertTrue(atom1.equivalent(atom2))
+    
+    def testGenerateExtensions(self):
+        """
+        test that appropriate group extensions are being generated
+        """
+        
+        testGrp = Group().fromAdjacencyList("""
+1    C u0 {2,[S,D]} 
+2    C u[0,1] {1,[S,D]} {3,S}
+3    R!H     u0 {2,S}
+            """)
+        
+        extensions = {tuple([k.toAdjacencyList() for k in a]) for a in testGrp.getExtensions(R=[atomTypes[i] for i in ['C','O','H']])}
+        
+        ans = {('1 C   u0     {2,D}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {2,S}\n',
+  '1 C   u0     {2,S}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {2,S}\n'),
+ ('1 C   u0     {2,S}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {2,S}\n',
+  '1 C   u0     {2,D}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {2,S}\n'),
+ ('1 C   u0     {2,[S,D]}\n2 C   u[0,1] {1,D} {3,S}\n3 R!H u0     {2,S}\n',
+  '1 C   u0     {2,[S,D]}\n2 C   u[0,1] {1,S} {3,S}\n3 R!H u0     {2,S}\n'),
+ ('1 C   u0     {2,[S,D]}\n2 C   u[0,1] {1,S} {3,S}\n3 R!H u0     {2,S}\n',
+  '1 C   u0     {2,[S,D]}\n2 C   u[0,1] {1,D} {3,S}\n3 R!H u0     {2,S}\n'),
+ ('1 C   u0     {2,[S,D]}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {2,S} {4,[S,D,T,B]}\n4 R!H ux     {3,[S,D,T,B]}\n',),
+ ('1 C   u0     {2,[S,D]}\n2 C   u[0,1] {1,[S,D]} {3,S} {4,[S,D,T,B]}\n3 R!H u0     {2,S}\n4 R!H ux     {2,[S,D,T,B]}\n',),
+ ('1 C   u0     {2,[S,D]} {3,[S,D,T,B]}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {1,[S,D,T,B]} {2,S}\n',),
+ ('1 C   u0     {2,[S,D]} {4,[S,D,T,B]}\n2 C   u[0,1] {1,[S,D]} {3,S}\n3 R!H u0     {2,S}\n4 R!H ux     {1,[S,D,T,B]}\n',),
+ ('1 C   u0 {2,[S,D]}\n2 C   u0 {1,[S,D]} {3,S}\n3 R!H u0 {2,S}\n',
+  '1 C   u0 {2,[S,D]}\n2 C   u1 {1,[S,D]} {3,S}\n3 R!H u0 {2,S}\n'),
+ ('1 C   u0 {2,[S,D]}\n2 C   u1 {1,[S,D]} {3,S}\n3 R!H u0 {2,S}\n',
+  '1 C   u0 {2,[S,D]}\n2 C   u0 {1,[S,D]} {3,S}\n3 R!H u0 {2,S}\n'),
+ ('1 C u0     {2,[S,D]}\n2 C u[0,1] {1,[S,D]} {3,S}\n3 C u0     {2,S}\n',
+  '1 C u0     {2,[S,D]}\n2 C u[0,1] {1,[S,D]} {3,S}\n3 O u0     {2,S}\n'),
+ ('1 C u0     {2,[S,D]}\n2 C u[0,1] {1,[S,D]} {3,S}\n3 O u0     {2,S}\n',
+  '1 C u0     {2,[S,D]}\n2 C u[0,1] {1,[S,D]} {3,S}\n3 C u0     {2,S}\n')}
+        
+        self.assertEqual(extensions,ans,'generated extensions did not match expected extensions')
         
     def testPickle(self):
         """


### PR DESCRIPTION
This PR adds functions for generating a set of more specific groups and their respective complements (when possible) for a given group structure.  Allowed extensions are:  
1) atom specification
2) internal bond creation
3) external bond creation (form a bond to a new unspecified atom)
4) bond order specification
5) unpaired electron number specification

This is a step on the way to automatic generation of isomorphic trees.  