### PR TITLE
Hydrogen Bonding

### DIFF
--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -627,6 +627,8 @@ class GroupBond(Edge):
                 values.append('T')
             elif value == 1.5:
                 values.append('B')
+            elif value == 0:
+                values.append('H')
             else:
                 raise TypeError('Bond order number {} is not hardcoded as a string'.format(value))
         return values
@@ -646,6 +648,8 @@ class GroupBond(Edge):
                 values.append(3)
             elif value == 'B':
                 values.append(1.5)
+            elif value == 'H':
+                values.append(0)
             else:
                 # try to see if an float disguised as a string was input by mistake
                 try:
@@ -730,6 +734,21 @@ class GroupBond(Edge):
         else:
             return abs(self.order[0]-1.5) <= 1e-9 and len(self.order) == 1
 
+    def isHydrogenBond(self, wildcards = False):
+        """
+        Return ``True`` if the bond represents a hydrogen bond or ``False`` if
+        not. If `wildcards` is ``False`` we return False anytime there is more
+        than one bond order, otherwise we return ``True`` if any of the options
+        are hydrogen bonds.
+        """
+        if wildcards:
+            for order in self.order:
+                if abs(order) <= 1e-9:
+                    return True
+            else: return False
+        else:
+            return abs(self.order[0]) <= 1e-9 and len(self.order) == 1
+        
     def __changeBond(self, order):
         """
         Update the bond group as a result of applying a CHANGE_BOND action,

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -43,6 +43,7 @@ import numpy
 import urllib
 from collections import OrderedDict
 import itertools
+from copy import deepcopy
 
 import element as elements
 try:
@@ -51,6 +52,7 @@ except:
     pass
 from .graph import Vertex, Edge, Graph, getVertexConnectivityValue
 import rmgpy.molecule.group as gr
+from rmgpy.molecule.pathfinder import find_shortest_path
 from .atomtype import AtomType, atomTypes, getAtomType, AtomTypeError
 import rmgpy.constants as constants
 import rmgpy.molecule.parser as parser
@@ -1466,7 +1468,78 @@ class Molecule(Graph):
         from .adjlist import toAdjacencyList
         result = toAdjacencyList(self.vertices, self.multiplicity,  label=label, group=False, removeH=removeH, removeLonePairs=removeLonePairs, oldStyle=oldStyle)
         return result
-
+    
+    def find_H_bonds(self):
+        """
+        generates a list of (new-existing H bonds ignored) possible Hbond coordinates [(i1,j1),(i2,j2),...] where i and j values
+        correspond to the indexes of the atoms involved, Hbonds are allowed if they meet
+        the following constraints:
+           1) between a H and [O,N] atoms
+           2) the hydrogen is covalently bonded to an O or N
+           3) the Hydrogen bond must complete a ring with at least 5 members
+           4) An atom can only be hydrogen bonded to one other atom
+        """
+        potBonds = []
+        
+        ONatoms = [a for a in self.atoms if a.isOxygen() or a.isNitrogen()]
+        ONinds = [n for n,a in enumerate(self.atoms) if a.isOxygen() or a.isNitrogen()]
+        
+        for i,atm1 in enumerate(self.atoms):
+            if atm1.atomType.label == 'H':
+                atm_covs = [q for q in atm1.bonds.keys()] 
+                if len(atm_covs) > 1: #H is already H bonded
+                    continue 
+                else:
+                    atm_cov = atm_covs[0]
+                if (atm_cov.isOxygen() or atm_cov.isNitrogen()): #this H can be H-bonded
+                    for k,atm2 in enumerate(ONatoms):
+                        if all([q.order != 0 for q in atm2.bonds.values()]): #atm2 not already H bonded
+                            dist = len(find_shortest_path(atm1,atm2))-1
+                            if dist > 3:
+                                j = ONinds[k]
+                                potBonds.append((i,j))
+        return potBonds
+    
+    def generate_H_bonded_structures(self):
+        """
+        generates a list of Hbonded molecular structures in addition to the
+        constraints on Hydrogen bonds applied in the find_H_Bonds function
+        the generated structures are constrained to:
+            1) An atom can only be hydrogen bonded to one other atom
+            2) Only two H-bonds can exist in a given molecule
+        the second is done to avoid explosive growth in the number of 
+        structures as without this constraint the number of possible 
+        structures grows 2^n where n is the number of possible H-bonds
+        """
+        structs = []
+        Hbonds = self.find_H_bonds()
+        for i,bd1 in enumerate(Hbonds):
+            molc = deepcopy(self)
+            molc.addBond(Bond(molc.atoms[bd1[0]],molc.atoms[bd1[1]],order=0))
+            structs.append(molc)
+            for j,bd2 in enumerate(Hbonds):
+                if j<i and bd1[0] != bd2[0] and bd1[1] != bd2[1]:
+                    molc = deepcopy(self)
+                    molc.addBond(Bond(molc.atoms[bd1[0]],molc.atoms[bd1[1]],order=0))
+                    molc.addBond(Bond(molc.atoms[bd2[0]],molc.atoms[bd2[1]],order=0))
+                    structs.append(molc)
+        
+        return structs
+    
+    def remove_H_bonds(self):
+        """
+        removes any present hydrogen bonds from the molecule
+        """
+        
+        atoms = self.atoms
+        for i,atm1 in enumerate(atoms):
+            for j,atm2 in enumerate(atoms):
+                if j<i and self.hasBond(atm1,atm2):
+                    bd = self.getBond(atm1,atm2)
+                    if bd.order == 0:
+                        self.removeBond(bd)
+        return
+    
     def isLinear(self):
         """
         Return :data:`True` if the structure is linear and :data:`False`

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -512,6 +512,8 @@ class Bond(Edge):
             return 'D'
         elif self.isTriple():
             return 'T'
+        elif self.isHydrogenBond():
+            return 'H'
         else:
             raise ValueError("Bond order {} does not have string representation.".format(self.order))
         
@@ -527,6 +529,8 @@ class Bond(Edge):
             self.order = 3
         elif newOrder == 'B':
             self.order = 1.5
+        elif newOrder == 'H':
+            self.order = 0
         else:
             # try to see if an float disguised as a string was input by mistake
             try:
@@ -564,7 +568,7 @@ class Bond(Edge):
 
     def isOrder(self, otherOrder):
         """
-        Return ``True`` if the bond represents a single bond or ``False`` if
+        Return ``True`` if the bond is of order otherOrder or ``False`` if
         not. This compares floats that takes into account floating point error
         
         NOTE: we can replace the absolute value relation with math.isclose when
@@ -600,7 +604,14 @@ class Bond(Edge):
         not.
         """
         return self.isOrder(1.5)
-
+    
+    def isHydrogenBond(self):
+        """
+        Return ``True`` if the bond represents a hydrogen bond or ``False`` if
+        not.
+        """
+        return self.isOrder(0)
+    
     def incrementOrder(self):
         """
         Update the bond as a result of applying a CHANGE_BOND action to

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -658,6 +658,9 @@ class TestMolecule(unittest.TestCase):
             """
         self.molecule.append(Molecule().fromAdjacencyList(self.adjlist_2,saturateH=True))
         
+        
+        self.mHBonds = Molecule().fromSMILES('C(NC=O)OO')
+        
     def testClearLabeledAtoms(self):
         """
         Test the Molecule.clearLabeledAtoms() method.
@@ -988,7 +991,34 @@ class TestMolecule(unittest.TestCase):
         molecule2 = Molecule().fromSMILES('C=CC=C[CH]C')
         self.assertTrue(molecule1.isIsomorphic(molecule2))
         self.assertTrue(molecule2.isIsomorphic(molecule1))
-
+    
+    def test_generate_H_bonded_structures(self):
+        """
+        Test that the correct set of Hydrogen Bonded structures are generated
+        """
+        correctSet = ['1  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}\n2  N u0 p1 c0 {1,S} {3,S} {8,S}\n3  C u0 p0 c0 {2,S} {9,D} {10,S}\n4  O u0 p2 c0 {1,S} {5,S}\n5  O u0 p2 c0 {4,S} {8,H} {11,S}\n6  H u0 p0 c0 {1,S}\n7  H u0 p0 c0 {1,S}\n8  H u0 p0 c0 {2,S} {5,H}\n9  O u0 p2 c0 {3,D}\n10 H u0 p0 c0 {3,S}\n11 H u0 p0 c0 {5,S}\n',
+ '1  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}\n2  N u0 p1 c0 {1,S} {3,S} {8,S} {11,H}\n3  C u0 p0 c0 {2,S} {9,D} {10,S}\n4  O u0 p2 c0 {1,S} {5,S}\n5  O u0 p2 c0 {4,S} {11,S}\n6  H u0 p0 c0 {1,S}\n7  H u0 p0 c0 {1,S}\n8  H u0 p0 c0 {2,S}\n9  O u0 p2 c0 {3,D}\n10 H u0 p0 c0 {3,S}\n11 H u0 p0 c0 {2,H} {5,S}\n',
+ '1  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}\n2  N u0 p1 c0 {1,S} {3,S} {8,S} {11,H}\n3  C u0 p0 c0 {2,S} {9,D} {10,S}\n4  O u0 p2 c0 {1,S} {5,S}\n5  O u0 p2 c0 {4,S} {8,H} {11,S}\n6  H u0 p0 c0 {1,S}\n7  H u0 p0 c0 {1,S}\n8  H u0 p0 c0 {2,S} {5,H}\n9  O u0 p2 c0 {3,D}\n10 H u0 p0 c0 {3,S}\n11 H u0 p0 c0 {2,H} {5,S}\n',
+ '1  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}\n2  N u0 p1 c0 {1,S} {3,S} {8,S}\n3  C u0 p0 c0 {2,S} {9,D} {10,S}\n4  O u0 p2 c0 {1,S} {5,S}\n5  O u0 p2 c0 {4,S} {11,S}\n6  H u0 p0 c0 {1,S}\n7  H u0 p0 c0 {1,S}\n8  H u0 p0 c0 {2,S}\n9  O u0 p2 c0 {3,D} {11,H}\n10 H u0 p0 c0 {3,S}\n11 H u0 p0 c0 {5,S} {9,H}\n',
+ '1  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}\n2  N u0 p1 c0 {1,S} {3,S} {8,S}\n3  C u0 p0 c0 {2,S} {9,D} {10,S}\n4  O u0 p2 c0 {1,S} {5,S}\n5  O u0 p2 c0 {4,S} {8,H} {11,S}\n6  H u0 p0 c0 {1,S}\n7  H u0 p0 c0 {1,S}\n8  H u0 p0 c0 {2,S} {5,H}\n9  O u0 p2 c0 {3,D} {11,H}\n10 H u0 p0 c0 {3,S}\n11 H u0 p0 c0 {5,S} {9,H}\n']
+        
+        mols = [Molecule().fromAdjacencyList(k) for k in correctSet]
+        
+        self.assertEqual(set(mols),set(self.mHBonds.generate_H_bonded_structures()))
+    
+    def test_remove_H_bonds(self):
+        """
+        test that remove HBonds removes all hydrogen bonds from a given molecule
+        """
+        testMol = self.mHBonds.generate_H_bonded_structures()[0]
+        testMol.remove_H_bonds()
+        
+        for i,atm1 in enumerate(testMol.atoms):
+            for j,atm2 in enumerate(testMol.atoms):
+                if j<i and testMol.hasBond(atm1,atm2):
+                    bd = testMol.getBond(atm1,atm2)
+                    self.assertNotAlmostEqual(bd.order,0)
+                    
     def testSSSR(self):
         """
         Test the Molecule.getSmallestSetOfSmallestRings() method with a complex


### PR DESCRIPTION
This is the first part of the implementation of a scheme for accounting for hydrogen bonding in thermo.  This provides a framework for defining and manipulating hydrogen bonds.  Hydrogen bonds are allowed under the following constraints:  

1) The bond must be between a H and an N or O
2) The H must be covalently bonded to an N or O
3) An atom can only be hydrogen bonded to one other atom
4) Formation of an individual H-bond in the un-H-bonded compound should create no rings with less than five members
5) Only two H-bonds can exist in a given molecule

The last prevents explosion of configurations that thermo would need evaluated for.  
