### PR TITLE
Allow a kinetic family to be irreversible

### DIFF
--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -590,7 +590,7 @@ class TestGenerateReactions(unittest.TestCase):
             path=os.path.join(settings['test_data.directory'], 'testing_database'),
             thermoLibraries=[],
             reactionLibraries=[],
-            kineticsFamilies=['H_Abstraction', 'R_Addition_MultipleBond'],
+            kineticsFamilies=['H_Abstraction', 'R_Addition_MultipleBond','Singlet_Val6_to_triplet'],
             depository=False,
             solvation=False,
             testing=True,
@@ -673,3 +673,10 @@ multiplicity 2
                 mapping[atom] = product.molecule[0].getLabeledAtom(label)
 
             self.assertTrue(expected_products[i].isIsomorphic(product.molecule[0], mapping))
+
+    def test_irreversible_reaction(self):
+        """Test that the Singlet_Val6_to_triplet and 1,2-Birad_to_alkene families generate irreversible reactions."""
+
+        reactant = [Molecule(SMILES='O=O')]
+        reactionList = self.database.kinetics.families['Singlet_Val6_to_triplet'].generateReactions(reactant)
+        self.assertFalse(reactionList[0].reversible)

--- a/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/groups.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Singlet_Val6_to_triplet/groups"
+shortDesc = u""
+longDesc = u"""
+This family makes the transition from the excited O2 singlet state to the ground triplet state.
+It also covers S2 and SO which are isoelectronic with O2 and behave similarly.
+This family consists of these three transitions only, and cannot be generalized for structures other than O2, S2, or SO.
+"""
+
+template(reactants=["singlet"], products=["triplet"], ownReverse=False)
+
+reverse = None
+reversible = False
+
+recipe(actions=[
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['GAIN_RADICAL', '*1', '1'],
+    ['GAIN_RADICAL', '*2', '1'],
+])
+
+entry(
+    index = 1,
+    label = "singlet",
+    group =
+"""
+1 *1 [Od,Sd] u0 p2 c0 {2,D}
+2 *2 [Od,Sd] u0 p2 c0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "O2",
+    group =
+"""
+1 *1 Od u0 p2 c0 {2,D}
+2 *2 Od u0 p2 c0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "S2",
+    group =
+"""
+1 *1 Sd u0 p2 c0 {2,D}
+2 *2 Sd u0 p2 c0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "SO",
+    group =
+"""
+1 *1 Sd u0 p2 c0 {2,D}
+2 *2 Od u0 p2 c0 {1,D}
+""",
+    kinetics = None,
+)
+
+tree(
+"""
+L1: singlet
+    L2: O2
+    L2: S2
+    L2: SO
+"""
+)

--- a/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/rules.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/rules.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Singlet_Val6_to_triplet/rules"
+shortDesc = u""
+longDesc = u"""
+"""
+
+entry(
+    index = 1,
+    label = "singlet",
+    kinetics = Arrhenius(A=(4.5E+10, 's^-1'), n=0, Ea=(397, 'cal/mol')),
+    rank = 1,
+    shortDesc = u"""Default""",
+    longDesc =
+u"""
+taken from:
+R. Atkinson, D.L. Baulch, R.A. Cox, R.F. Hampson, J.A. Kerr, J. Troe,
+Evaluated Kinetic and Photochemical Data for Atmospheric Chemistry: Supplement IV.
+IUPAC Subcommittee on Gas Kinetic Data Evaluation for Atmospheric Chemistry
+Journal of Physical and Chemical Reference Data 21, 1125 (1992)
+doi: 10.1063/1.555918
+
+Adjusted to a first order reaction at 1 atm by alongd:
+n/V = P/RT = 1 bar / (83 cm^3 bar K^-1 mol^-1 * 300 K) = 4E-05 mol cm^-3
+1.81E+06 mol cm^-3 S^-1 / 4E-05 mol cm^-3 = 4.5E+10 s^-1
+Original reaction is O2(1D) + M => O2 + M
+""",
+)

--- a/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/training/dictionary.txt
+++ b/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/training/dictionary.txt
@@ -1,0 +1,8 @@
+O2(S)
+1 *1 O u0 p2 c0 {2,D}
+2 *2 O u0 p2 c0 {1,D}
+
+O2(T)
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}

--- a/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/training/reactions.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Singlet_Val6_to_triplet/training/reactions.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Singlet_Val6_to_triplet/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+"""
+
+entry(
+    index = 1,
+    label = "O2(S) => O2(T)",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(4.5E+10, 's^-1'), n=0, Ea=(397, 'cal/mol')),
+    rank = 1,
+    shortDesc = u"""""",
+    longDesc =
+u"""
+taken from:
+R. Atkinson, D.L. Baulch, R.A. Cox, R.F. Hampson, J.A. Kerr, J. Troe,
+Evaluated Kinetic and Photochemical Data for Atmospheric Chemistry: Supplement IV.
+IUPAC Subcommittee on Gas Kinetic Data Evaluation for Atmospheric Chemistry
+Journal of Physical and Chemical Reference Data 21, 1125 (1992)
+doi: 10.1063/1.555918
+
+Adjusted to a first order reaction at 1 atm by alongd:
+n/V = P/RT = 1 bar / (83 cm^3 bar K^-1 mol^-1 * 300 K) = 4E-05 mol cm^-3
+1.81E+06 mol cm^-3 S^-1 / 4E-05 mol cm^-3 = 4.5E+10 s^-1
+Original reaction is O2(1D) + M => O2 + M
+""",
+)

--- a/rmgpy/test_data/testing_database/kinetics/families/recommended.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/recommended.py
@@ -41,6 +41,7 @@ recommendedFamilies = {
 'R_Recombination':True,
 'SubstitutionS':False,
 'Substitution_O':False,
+'Singlet_Val6_to_triplet':True,
 'intra_H_migration':True,
 'intra_NO2_ONO_conversion':True,
 'intra_OH_migration':True,


### PR DESCRIPTION
This PR makes it possible to define a family with a `reversible = False` attribute (and sets it to True by default). As a result, all reactions generated by that family will be irreversible (`=>`).
This is meant to be used for families that involve a photon emission such as triplet/singlet conversions. Used correctly, this does not defy thermodynamics.

Since we don't keep track of photons in our system (yet? :smiley:), we cannot and should not try to calculate the reverse rate. The solver/Chemkin should also treat these families as irreversible.

A unit test was added (along with a demo family that is part of the [twin -database PR](https://github.com/ReactionMechanismGenerator/RMG-database/pull/239)).

For the reviewer: checkout the [ twin -database branch](https://github.com/ReactionMechanismGenerator/RMG-database/pull/239) as well, and run a job with species that match the new families (e.g., `O=O` or adjacent birad alkanes). The relevant reactions in the Chemkin output should be unidirectional.