### PR TITLE
Add ring attribute to atoms

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1300,6 +1300,8 @@ class KineticsFamily(Database):
         for struct in productStructures:
             if isinstance(struct, Molecule):
                 struct.update()
+            else:
+                struct.resetRingMembership()
 
         # Return the product structures
         return productStructures

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -621,10 +621,17 @@ def fromAdjacencyList(adjlist, group=False, saturateH=False):
                 isotope = int(iState[1:])
                 index += 1
 
+        # Next ring membership info (if provided)
+        props = {}
+        if len(data) > index:
+            rState = data[index]
+            if rState[0] == 'r':
+                props['inRing'] = bool(int(rState[1]))
+                index += 1
 
         # Create a new atom based on the above information
         if group:
-            atom = GroupAtom(atomType, unpairedElectrons, partialCharges, label, lonePairs)
+            atom = GroupAtom(atomType, unpairedElectrons, partialCharges, label, lonePairs, props)
         else:
             atom = Atom(atomType[0], unpairedElectrons[0], partialCharges[0], label, lonePairs[0])
             if isotope != -1:
@@ -754,6 +761,7 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
     atomLonePairs = {}
     atomCharge = {}
     atomIsotope = {}
+    atomProps = {}
     if group:
         for atom in atomNumbers:
             # Atom type(s)
@@ -786,7 +794,13 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
                 atomCharge[atom] = '[{0}]'.format(','.join(['+'+str(charge) if charge > 0 else ''+str(charge) for charge in atom.charge]))
 
             # Isotopes
-            atomIsotope[atom] = -1    
+            atomIsotope[atom] = -1
+
+            # Other props
+            props = []
+            if 'inRing' in atom.props:
+                props.append(' r{0}'.format(int(atom.props['inRing'])))
+            atomProps[atom] = props
     else:
         for atom in atomNumbers:
             # Atom type
@@ -831,6 +845,9 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
         # Isotopes
         if atomIsotope[atom] != -1:
             adjlist += ' i{0}'.format(atomIsotope[atom])
+        if group and len(atomProps[atom]) > 0:
+            for prop in atomProps[atom]:
+                adjlist += prop
 
         # Bonds list
         atoms2 = atom.bonds.keys()

--- a/rmgpy/molecule/adjlistTest.py
+++ b/rmgpy/molecule/adjlistTest.py
@@ -152,6 +152,23 @@ class TestGroupAdjLists(unittest.TestCase):
 
         self.assertEqual(adjlist.strip(), adjlist2.strip())
 
+    def testAtomProps(self):
+        """Test that the atom props attribute can be properly read and written."""
+        adjlist = """
+1 *1 R!H u1 r0 {2,S}
+2 *4 R!H u0 r0 {1,S} {3,S}
+3 *2 Cb  u0 r1 {2,S} {4,B}
+4 *3 Cb  u0 r1 {3,B}
+        """
+        group = Group().fromAdjacencyList(adjlist)
+        for atom in group.atoms:
+            if atom.atomType[0].label == 'R!H':
+                self.assertFalse(atom.props['inRing'])
+            elif atom.atomType[0].label == 'Cb':
+                self.assertTrue(atom.props['inRing'])
+        adjlist2 = group.toAdjacencyList()
+
+        self.assertEqual(adjlist.strip(), adjlist2.strip())
 
 class TestMoleculeAdjLists(unittest.TestCase):
     """

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -279,6 +279,7 @@ def fromOBMol(mol, obmol):
     mol.updateConnectivityValues()
     mol.updateAtomTypes()
     mol.updateMultiplicity()
+    mol.identifyRingMembership()
 
     # Assume this is always true
     # There are cases where 2 radicalElectrons is a singlet, but

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -38,6 +38,7 @@ cdef class GroupAtom(Vertex):
     cdef public list charge
     cdef public str label
     cdef public list lonePairs
+    cdef public dict props
 
     cpdef Vertex copy(self)
 

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -190,3 +190,4 @@ cdef class Group(Graph):
 
     cpdef Group mergeGroups(self, Group other)
 
+    cpdef resetRingMembership(self)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -373,13 +373,18 @@ class GroupAtom(Vertex):
                     if charge1 == charge2: break
                 else:
                     return False
+        # Other properties must have an equivalent in other (and vice versa)
+        # Absence of the 'inRing' prop indicates a wildcard
+        if 'inRing' in self.props and 'inRing' in group.props:
+            if self.props['inRing'] != group.props['inRing']:
+                return False
         # Otherwise the two atom groups are equivalent
         return True
 
     def isSpecificCaseOf(self, other):
         """
-        Returns ``True`` if `other` is the same as `self` or is a more
-        specific case of `self`. Returns ``False`` if some of `self` is not
+        Returns ``True`` if `self` is the same as `other` or is a more
+        specific case of `other`. Returns ``False`` if some of `self` is not
         included in `other` or they are mutually exclusive. 
         """
         cython.declare(group=GroupAtom)
@@ -428,6 +433,13 @@ class GroupAtom(Vertex):
                         return False
         else:
             if group.charge: return False
+        # Other properties must have an equivalent in other
+        # Absence of the 'inRing' prop indicates a wildcard
+        if 'inRing' in self.props and 'inRing' in group.props:
+            if self.props['inRing'] != group.props['inRing']:
+                return False
+        elif 'inRing' not in self.props and 'inRing' in group.props:
+            return False
         # Otherwise self is in fact a specific case of other
         return True
 

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2141,3 +2141,13 @@ class Group(Graph):
             mergedGroup.removeBond(bond)
 
         return mergedGroup
+
+    def resetRingMembership(self):
+        """
+        Resets ring membership information in the GroupAtom.props attribute.
+        """
+        cython.declare(ratom=GroupAtom)
+
+        for atom in self.atoms:
+            if 'inRing' in atom.props:
+                del atom.props['inRing']

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -59,6 +59,7 @@ class GroupAtom(Vertex):
     `label`             ``str``             A string label that can be used to tag individual atoms
     `lonePairs`         ``list``            The number of lone electron pairs
     'charge'            ''list''            The partial charge of the atom
+    `props`             ``dict``            Dictionary for storing additional atom properties
     =================== =================== ====================================
 
     Each list represents a logical OR construct, i.e. an atom will match the
@@ -68,7 +69,7 @@ class GroupAtom(Vertex):
     order to match.
     """
 
-    def __init__(self, atomType=None, radicalElectrons=None, charge=None, label='', lonePairs=None):
+    def __init__(self, atomType=None, radicalElectrons=None, charge=None, label='', lonePairs=None, props=None):
         Vertex.__init__(self)
         self.atomType = atomType or []
         for index in range(len(self.atomType)):
@@ -78,6 +79,7 @@ class GroupAtom(Vertex):
         self.charge = charge or []
         self.label = label
         self.lonePairs = lonePairs or []
+        self.props = props or {}
 
     def __reduce__(self):
         """
@@ -125,7 +127,14 @@ class GroupAtom(Vertex):
         Return a deep copy of the :class:`GroupAtom` object. Modifying the
         attributes of the copy will not affect the original.
         """
-        return GroupAtom(self.atomType[:], self.radicalElectrons[:], self.charge[:], self.label, self.lonePairs[:])
+        return GroupAtom(
+            self.atomType[:],
+            self.radicalElectrons[:],
+            self.charge[:],
+            self.label,
+            self.lonePairs[:],
+            deepcopy(self.props),
+        )
 
     def __changeBond(self, order):
         """

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -45,7 +45,7 @@ cdef class Atom(Vertex):
     cdef public numpy.ndarray coords
     cdef public short lonePairs
     cdef public int id
-
+    cdef public dict props
     
     cpdef bint equivalent(self, Vertex other) except -2
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -226,6 +226,8 @@ cdef class Molecule(Graph):
 
     cpdef list generate_resonance_structures(self, bint keepIsomorphic=?)
 
+    cpdef identifyRingMembership(self)
+
     cpdef tuple getAromaticRings(self, list rings=?)
 
     cpdef list getDeterministicSmallestSetOfSmallestRings(self)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -82,6 +82,7 @@ class Atom(Vertex):
     `lonePairs`         ``short``           The number of lone electron pairs
     `id`                ``int``             Number assignment for atom tracking purposes
     `bonds`             ``dict``            Dictionary of bond objects with keys being neighboring atoms
+    `props`             ``dict``            Dictionary for storing additional atom properties
     `mass`              ``int``             atomic mass of element (read only)
     `number`            ``int``             atomic number of element (read only)
     `symbol`            ``str``             atomic symbol of element (read only)
@@ -92,7 +93,7 @@ class Atom(Vertex):
     e.g. ``atom.symbol`` instead of ``atom.element.symbol``.
     """
 
-    def __init__(self, element=None, radicalElectrons=0, charge=0, label='', lonePairs=-100, coords=numpy.array([]), id=-1):
+    def __init__(self, element=None, radicalElectrons=0, charge=0, label='', lonePairs=-100, coords=numpy.array([]), id=-1, props=None):
         Vertex.__init__(self)
         if isinstance(element, str):
             self.element = elements.__dict__[element]
@@ -105,6 +106,7 @@ class Atom(Vertex):
         self.lonePairs = lonePairs
         self.coords = coords
         self.id = id
+        self.props = props or {}
 
     def __str__(self):
         """
@@ -267,6 +269,7 @@ class Atom(Vertex):
         a.lonePairs = self.lonePairs
         a.coords = self.coords[:]
         a.id = self.id
+        a.props = deepcopy(self.props)
         return a
 
     def isHydrogen(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -207,6 +207,9 @@ class Atom(Vertex):
                     if self.charge == charge: break
                 else:
                     return False
+            if 'inRing' in self.props and 'inRing' in ap.props:
+                if self.props['inRing'] != ap.props['inRing']:
+                    return False
             return True
     
     def getDescriptor(self):
@@ -249,6 +252,11 @@ class Atom(Vertex):
                     if self.charge == charge: break
                 else:
                     return False
+            if 'inRing' in self.props and 'inRing' in atom.props:
+                if self.props['inRing'] != atom.props['inRing']:
+                    return False
+            elif 'inRing' not in self.props and 'inRing' in atom.props:
+                return False
             return True
 
     def copy(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1839,6 +1839,22 @@ class Molecule(Graph):
         
         return group
 
+    def identifyRingMembership(self):
+        """
+        Performs ring perception and saves ring membership information to the Atom.props attribute.
+        """
+        cython.declare(rc=list, atom=Atom, ring=list)
+
+        # Get the set of relevant cycles
+        rc = self.getRelevantCycles()
+        # Identify whether each atom is in a ring
+        for atom in self.atoms:
+            atom.props['inRing'] = False
+            for ring in rc:
+                if atom in ring:
+                    atom.props['inRing'] = True
+                    break
+
     def getAromaticRings(self, rings=None):
         """
         Returns all aromatic rings as a list of atoms and a list of bonds.

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -885,6 +885,7 @@ class Molecule(Graph):
         self.updateAtomTypes()
         self.updateMultiplicity()
         self.sortAtoms()
+        self.identifyRingMembership()
 
     def getFormula(self):
         """
@@ -1372,6 +1373,7 @@ class Molecule(Graph):
         
         self.vertices, self.multiplicity = fromAdjacencyList(adjlist, group=False, saturateH=saturateH)
         self.updateAtomTypes()
+        self.identifyRingMembership()
         
         # Check if multiplicity is possible
         n_rad = self.getRadicalCount() 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -967,6 +967,22 @@ class TestMolecule(unittest.TestCase):
                 self.assertTrue(key in molecule.atoms)
                 self.assertTrue(value in group.atoms)
 
+    def testSubgraphIsomorphismRings(self):
+        molecule = Molecule(SMILES='C1CCCC1CCC')
+        groupNoRing = Group().fromAdjacencyList("""
+1 *1 C u0 p0 c0 r0
+        """)
+        groupRing = Group().fromAdjacencyList("""
+1 *1 C u0 p0 c0 r1
+        """)
+
+        self.assertTrue(molecule.isSubgraphIsomorphic(groupNoRing))
+        mapping = molecule.findSubgraphIsomorphisms(groupNoRing)
+        self.assertEqual(len(mapping), 3)
+        self.assertTrue(molecule.isSubgraphIsomorphic(groupRing))
+        mapping = molecule.findSubgraphIsomorphisms(groupRing)
+        self.assertEqual(len(mapping), 5)
+
     def testAdjacencyList(self):
         """
         Check the adjacency list read/write functions for a full molecule.

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2223,6 +2223,15 @@ multiplicity 2
         result3 = mol3.get_element_count()
         self.assertEqual(expected3, result3)
 
+    def testRingPerception(self):
+        """Test that identifying ring membership of atoms works properly."""
+        mol = Molecule(SMILES='c12ccccc1cccc2')
+        mol.identifyRingMembership()
+        for atom in mol.atoms:
+            if atom.element == 'C':
+                self.assertTrue(atom.props['inRing'])
+            elif atom.element == 'H':
+                self.assertFalse(atom.props['inRing'])
 
 ################################################################################
 


### PR DESCRIPTION
This PR enables specification of ring membership for Atoms and GroupAtoms. The level of implementation is currently very basic, but can easily be extended in the future.

Essentially, Group adjacency lists now support a ring property, denoted by `r0` or `r1`, indicating whether or not an atom is part of a ring, e.g.
```
1 R!H u0 p0 c0 r0 {2,S}
2 R!H u0 p0 c0 r1 {1,S}
```
This allows greater specificity when designing groups and can help with ring perception issues when estimating rates.

Internally, this property is stored in a `props` dictionary attribute of Atom and GroupAtom with the `inRing` key. Adjacency list support was not added for Molecules since this is a derived property and not essential to the representation.