### PR TITLE
New Flux Diagram Features

### DIFF
--- a/rmgpy/tools/fluxdiagram.py
+++ b/rmgpy/tools/fluxdiagram.py
@@ -324,16 +324,20 @@ def simulate(reactionModel, reactionSystem, settings=None):
     edgeReactionRates = []
 
     nextTime = initialTime
+    stepTime = initialTime
     terminated = False
+
     while not terminated:
         # Integrate forward in time to the next time point
-        reactionSystem.advance(nextTime)
-        
-        time.append(reactionSystem.t)
-        coreSpeciesConcentrations.append(reactionSystem.coreSpeciesConcentrations)
-        coreReactionRates.append(reactionSystem.coreReactionRates)
-        edgeReactionRates.append(reactionSystem.edgeReactionRates)
-        
+        reactionSystem.step(stepTime)
+
+        if reactionSystem.t >= 0.9999 * nextTime:
+            nextTime *= timeStep
+            time.append(reactionSystem.t)
+            coreSpeciesConcentrations.append(reactionSystem.coreSpeciesConcentrations)
+            coreReactionRates.append(reactionSystem.coreReactionRates)
+            edgeReactionRates.append(reactionSystem.edgeReactionRates)
+
         # Finish simulation if any of the termination criteria are satisfied
         for term in reactionSystem.termination:
             if isinstance(term, TerminationTime):
@@ -347,14 +351,14 @@ def simulate(reactionModel, reactionSystem, settings=None):
                     break
 
         # Increment destination step time if necessary
-        if reactionSystem.t >= 0.9999 * nextTime:
-            nextTime *= timeStep
+        if reactionSystem.t >= 0.9999 * stepTime:
+            stepTime *= 10.0
 
     time = numpy.array(time)
     coreSpeciesConcentrations = numpy.array(coreSpeciesConcentrations)
     coreReactionRates = numpy.array(coreReactionRates)
     edgeReactionRates = numpy.array(edgeReactionRates)
-    
+
     return time, coreSpeciesConcentrations, coreReactionRates, edgeReactionRates
 
 ################################################################################

--- a/rmgpy/tools/fluxdiagram.py
+++ b/rmgpy/tools/fluxdiagram.py
@@ -321,7 +321,6 @@ def simulate(reactionModel, reactionSystem, settings=None):
     time = []
     coreSpeciesConcentrations = []
     coreReactionRates = []
-    edgeReactionRates = []
 
     nextTime = initialTime
     stepTime = initialTime
@@ -336,7 +335,6 @@ def simulate(reactionModel, reactionSystem, settings=None):
             time.append(reactionSystem.t)
             coreSpeciesConcentrations.append(reactionSystem.coreSpeciesConcentrations)
             coreReactionRates.append(reactionSystem.coreReactionRates)
-            edgeReactionRates.append(reactionSystem.edgeReactionRates)
 
         # Finish simulation if any of the termination criteria are satisfied
         for term in reactionSystem.termination:
@@ -357,9 +355,8 @@ def simulate(reactionModel, reactionSystem, settings=None):
     time = numpy.array(time)
     coreSpeciesConcentrations = numpy.array(coreSpeciesConcentrations)
     coreReactionRates = numpy.array(coreReactionRates)
-    edgeReactionRates = numpy.array(edgeReactionRates)
 
-    return time, coreSpeciesConcentrations, coreReactionRates, edgeReactionRates
+    return time, coreSpeciesConcentrations, coreReactionRates
 
 ################################################################################
 
@@ -372,13 +369,11 @@ def loadChemkinOutput(outputFile, reactionModel):
     from rmgpy.quantity import Quantity
 
     coreReactions = reactionModel.core.reactions
-    edgeReactions = reactionModel.edge.reactions    
     speciesList = reactionModel.core.species
 
     time = []
     coreSpeciesConcentrations = []
     coreReactionRates = []
-    edgeReactionRates = []
 
     with open(outputFile, 'r') as f:
 
@@ -420,28 +415,22 @@ def loadChemkinOutput(outputFile, reactionModel):
                 totalConcentration = P.value_si/constants.R/T.value_si
                 coreSpeciesConcentrations.append([molefrac*totalConcentration for molefrac in molefractions])
                 coreRates = []
-                edgeRates = []
                 for reaction in coreReactions:                    
                     rate = reaction.getRateCoefficient(T.value_si,P.value_si)
                     for reactant in reaction.reactants:
                         rate *= molefractions[speciesList.index(reactant)]*totalConcentration                    
                     coreRates.append(rate)
-                for reaction in edgeReactions:
-                    edgeRates.append(reaction.getRateCoefficient(T.value_si,P.value_si))
 
                 if coreRates:
                     coreReactionRates.append(coreRates)
-                if edgeRates:
-                    edgeReactionRates.append(edgeRates)
             
             line=f.readline()
    
     time = numpy.array(time)
     coreSpeciesConcentrations = numpy.array(coreSpeciesConcentrations)
     coreReactionRates = numpy.array(coreReactionRates)
-    edgeReactionRates = numpy.array(edgeReactionRates)
    
-    return time, coreSpeciesConcentrations, coreReactionRates, edgeReactionRates
+    return time, coreSpeciesConcentrations, coreReactionRates
 
 ################################################################################
 
@@ -473,7 +462,7 @@ def createFluxDiagram(inputFile, chemkinFile, speciesDict, savePath=None, specie
             pass
 
         print 'Extracting species concentrations and calculating reaction rates from chemkin output...'
-        time, coreSpeciesConcentrations, coreReactionRates, edgeReactionRates = loadChemkinOutput(chemkinOutput, rmg.reactionModel)
+        time, coreSpeciesConcentrations, coreReactionRates = loadChemkinOutput(chemkinOutput, rmg.reactionModel)
 
         print 'Generating flux diagram for chemkin output...'
         generateFluxDiagram(rmg.reactionModel, time, coreSpeciesConcentrations, coreReactionRates, outDir, centralSpecies, speciesPath, settings)
@@ -500,7 +489,7 @@ def createFluxDiagram(inputFile, chemkinFile, speciesDict, savePath=None, specie
                 reactionSystem.termination.append(TerminationTime((1e10,'s')))
 
             print 'Conducting simulation of reaction system {0:d}...'.format(index+1)
-            time, coreSpeciesConcentrations, coreReactionRates, edgeReactionRates = simulate(rmg.reactionModel, reactionSystem, settings)
+            time, coreSpeciesConcentrations, coreReactionRates = simulate(rmg.reactionModel, reactionSystem, settings)
 
             print 'Generating flux diagram for reaction system {0:d}...'.format(index+1)
             generateFluxDiagram(rmg.reactionModel, time, coreSpeciesConcentrations, coreReactionRates, outDir,

--- a/rmgpy/tools/fluxdiagram.py
+++ b/rmgpy/tools/fluxdiagram.py
@@ -138,7 +138,7 @@ def generateFluxDiagram(reactionModel, times, concentrations, reactionRates, out
     
     # Determine the nodes and edges to keep
     nodes = []; edges = []
-    if centralSpeciesList is not None:
+    if not superimpose and centralSpeciesList is not None:
         for centralSpeciesIndex in centralSpeciesIndices:
             nodes.append(centralSpeciesIndex)
             addAdjacentNodes(centralSpeciesIndex,
@@ -150,7 +150,7 @@ def generateFluxDiagram(reactionModel, times, concentrations, reactionRates, out
                              maxSpeciesRates,
                              reactionCount=centralReactionCount,
                              rad=radius)
-    if centralSpeciesList is None or superimpose:
+    else:
         for i in range(numSpecies*numSpecies):
             productIndex, reactantIndex = divmod(speciesIndex[-i-1], numSpecies)
             if reactantIndex > productIndex:
@@ -167,6 +167,24 @@ def generateFluxDiagram(reactionModel, times, concentrations, reactionRates, out
                 break
             if len(edges) >= maximumEdgeCount:
                 break
+
+        if superimpose and centralSpeciesList is not None:
+            nodesCopy = nodes[:]
+            for centralSpeciesIndex in centralSpeciesIndices:
+                if centralSpeciesIndex not in nodes:  # Only add central species if it doesn't already exist
+                    nodes.append(centralSpeciesIndex)
+                    # Recursively add nodes until they connect with main graph
+                    addAdjacentNodes(centralSpeciesIndex,
+                                     nodes,
+                                     edges,
+                                     speciesList,
+                                     reactionList,
+                                     maxReactionRates,
+                                     maxSpeciesRates,
+                                     reactionCount=centralReactionCount,
+                                     rad=-1,  # "-1" signifies that we add nodes until they connect to the main graph
+                                     mainNodes=nodesCopy)
+
     # Create the master graph
     # First we're going to generate the coordinates for all of the nodes; for
     # this we use the thickest pen widths for all nodes and edges 
@@ -293,13 +311,17 @@ def generateFluxDiagram(reactionModel, times, concentrations, reactionRates, out
 ################################################################################
 
 def addAdjacentNodes(targetNodeIndex, nodes, edges, speciesList, reactionList, maxReactionRates, maxSpeciesRates,
-                     reactionCount=None, rad=0):
+                     reactionCount=None, rad=0, mainNodes=None):
     """
-    Add adjacent nodes in flux diagram up to a certain radius.
+    Add adjacent nodes in flux diagram up to a certain radius or
+    until they connect with the main graph. Radius should be set to a
+    negative value in the latter case.
     """
-    if rad < 1:  # Base case
+    if rad == 0:  # Base case if using radius
         return
-    else:  # Recurse until all nodes up to desired radius have been added
+    elif rad < 0 and targetNodeIndex in mainNodes:  # Base case if connecting to main graph
+        return
+    else:  # Recurse until all nodes up to desired radius have been added or until they connect to the main graph
         # Select all reactions involving target node
         targetReactionsIndices = []
         for index, reaction in enumerate(reactionList):
@@ -331,7 +353,8 @@ def addAdjacentNodes(targetNodeIndex, nodes, edges, speciesList, reactionList, m
                                          maxReactionRates,
                                          maxSpeciesRates,
                                          reactionCount=reactionCount,
-                                         rad=rad-1)
+                                         rad=rad-1,
+                                         mainNodes=mainNodes)
                     if [reactantIndex, productIndex] not in edges and [productIndex, reactantIndex] not in edges:
                         edges.append([reactantIndex, productIndex])
                 if productIndex == targetNodeIndex:
@@ -345,7 +368,8 @@ def addAdjacentNodes(targetNodeIndex, nodes, edges, speciesList, reactionList, m
                                          maxReactionRates,
                                          maxSpeciesRates,
                                          reactionCount=reactionCount,
-                                         rad=rad-1)
+                                         rad=rad-1,
+                                         mainNodes=mainNodes)
                     if [reactantIndex, productIndex] not in edges and [productIndex, reactantIndex] not in edges:
                         edges.append([reactantIndex, productIndex])
 

--- a/rmgpy/tools/fluxtest.py
+++ b/rmgpy/tools/fluxtest.py
@@ -51,6 +51,7 @@ class FluxDiagramTest(unittest.TestCase):
                     'maximumNodePenWidth': 10.0,
                     'maximumEdgePenWidth': 10.0,
                     'radius': 2,
+                    'centralReactionCount': 2,
                     'timeStep': 10**0.1}
         createFluxDiagram(inputFile, chemkinFile, dictFile,
                           centralSpeciesList=[1], superimpose=True, settings=settings)

--- a/rmgpy/tools/fluxtest.py
+++ b/rmgpy/tools/fluxtest.py
@@ -50,8 +50,10 @@ class FluxDiagramTest(unittest.TestCase):
                     'speciesRateTolerance': 1e-6,
                     'maximumNodePenWidth': 10.0,
                     'maximumEdgePenWidth': 10.0,
+                    'radius': 2,
                     'timeStep': 10**0.1}
-        createFluxDiagram(inputFile, chemkinFile, dictFile, centralSpecies='ethane', settings=settings)
+        createFluxDiagram(inputFile, chemkinFile, dictFile,
+                          centralSpeciesList=[1], superimpose=True, settings=settings)
 
         outputdir = os.path.join(folder,'flux')
         simfile = os.path.join(outputdir,'1','flux_diagram.avi')

--- a/scripts/generateFluxDiagram.py
+++ b/scripts/generateFluxDiagram.py
@@ -63,6 +63,11 @@ def parse_arguments():
     parser.add_argument('-r', '--ratetol', metavar='TOL', type=float, help='Lowest fractional species rate to show')
     parser.add_argument('-t', '--tstep', metavar='S', type=float,
                         help='Multiplicative factor to use between consecutive time points')
+    parser.add_argument('--centralSpecies', metavar='s1,s2,...', type=lambda s: [int(idx) for idx in s.split(',')],
+                        help='List of indices of central species')
+    parser.add_argument('--rad', metavar='R', type=int, help='Graph radius around a central species')
+    parser.add_argument('--super', action='store_true', help='Superimpose central species onto normal flux diagram to'
+                                                             ' ensure that they appear in diagram')
 
     args = parser.parse_args()
 
@@ -74,18 +79,21 @@ def parse_arguments():
     useJava = args.java
     dflag = args.dlim
     checkDuplicates = args.checkDuplicates
+    centralSpeciesList = args.centralSpecies
+    superimpose = args.super
 
-    keys = ('maximumNodeCount', 'maximumEdgeCount', 'concentrationTolerance', 'speciesRateTolerance', 'timeStep')
-    vals = (args.maxnode, args.maxedge, args.conctol, args.ratetol, args.tstep)
+    keys = ('maximumNodeCount', 'maximumEdgeCount', 'concentrationTolerance', 'speciesRateTolerance', 'radius', 'timeStep')
+    vals = (args.maxnode, args.maxedge, args.conctol, args.ratetol, args.rad, args.tstep)
     settings = {k: v for k, v in zip(keys, vals) if v is not None}
     
-    return inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings
+    return inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings, centralSpeciesList, superimpose
 
 def main():
-    inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings = parse_arguments()
+    inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings, centralSpeciesList, superimpose = parse_arguments()
 
     createFluxDiagram(inputFile, chemkinFile, dictFile, speciesPath=speciesPath, java=useJava, settings=settings,
-                      chemkinOutput=chemkinOutput, diffusionLimited=dflag, checkDuplicates=checkDuplicates)
+                      chemkinOutput=chemkinOutput, diffusionLimited=dflag, centralSpeciesList=centralSpeciesList,
+                      superimpose=superimpose, checkDuplicates=checkDuplicates)
 
 if __name__ == '__main__':
     main()

--- a/scripts/generateFluxDiagram.py
+++ b/scripts/generateFluxDiagram.py
@@ -65,12 +65,14 @@ def parse_arguments():
                         help='Multiplicative factor to use between consecutive time points')
     parser.add_argument('--centralSpecies', metavar='s1,s2,...', type=lambda s: [int(idx) for idx in s.split(',')],
                         help='List of indices of central species')
-    parser.add_argument('--rad', metavar='R', type=int, help='Graph radius around a central species')
+    parser.add_argument('--rad', metavar='R', type=int, help='Graph radius around a central species (only useful if'
+                                                             ' not using super)')
     parser.add_argument('--centralReactionCount', metavar='N', type=int, default=1,
                         help='Maximum number of reactions to show from each central species (default = 1).'
                              ' If rad > 1, then this is the number of reactions from every species')
     parser.add_argument('--super', action='store_true', help='Superimpose central species onto normal flux diagram to'
-                                                             ' ensure that they appear in diagram')
+                                                             ' ensure that they appear in diagram (might result in more'
+                                                             ' nodes and edges than given by maxnode and maxedge)')
 
     args = parser.parse_args()
 

--- a/scripts/generateFluxDiagram.py
+++ b/scripts/generateFluxDiagram.py
@@ -66,6 +66,9 @@ def parse_arguments():
     parser.add_argument('--centralSpecies', metavar='s1,s2,...', type=lambda s: [int(idx) for idx in s.split(',')],
                         help='List of indices of central species')
     parser.add_argument('--rad', metavar='R', type=int, help='Graph radius around a central species')
+    parser.add_argument('--centralReactionCount', metavar='N', type=int, default=1,
+                        help='Maximum number of reactions to show from each central species (default = 1).'
+                             ' If rad > 1, then this is the number of reactions from every species')
     parser.add_argument('--super', action='store_true', help='Superimpose central species onto normal flux diagram to'
                                                              ' ensure that they appear in diagram')
 
@@ -82,8 +85,14 @@ def parse_arguments():
     centralSpeciesList = args.centralSpecies
     superimpose = args.super
 
-    keys = ('maximumNodeCount', 'maximumEdgeCount', 'concentrationTolerance', 'speciesRateTolerance', 'radius', 'timeStep')
-    vals = (args.maxnode, args.maxedge, args.conctol, args.ratetol, args.rad, args.tstep)
+    keys = ('maximumNodeCount',
+            'maximumEdgeCount',
+            'concentrationTolerance',
+            'speciesRateTolerance',
+            'radius',
+            'centralReactionCount',
+            'timeStep')
+    vals = (args.maxnode, args.maxedge, args.conctol, args.ratetol, args.rad, args.centralReactionCount, args.tstep)
     settings = {k: v for k, v in zip(keys, vals) if v is not None}
     
     return inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings, centralSpeciesList, superimpose

--- a/scripts/generateFluxDiagram.py
+++ b/scripts/generateFluxDiagram.py
@@ -73,6 +73,8 @@ def parse_arguments():
     parser.add_argument('--super', action='store_true', help='Superimpose central species onto normal flux diagram to'
                                                              ' ensure that they appear in diagram (might result in more'
                                                              ' nodes and edges than given by maxnode and maxedge)')
+    parser.add_argument('--saveStates', action='store_true', help='Save simulation states to disk')
+    parser.add_argument('--readStates', action='store_true', help='Read simulation states from disk')
 
     args = parser.parse_args()
 
@@ -86,6 +88,8 @@ def parse_arguments():
     checkDuplicates = args.checkDuplicates
     centralSpeciesList = args.centralSpecies
     superimpose = args.super
+    saveStates = args.saveStates
+    readStates = args.readStates
 
     keys = ('maximumNodeCount',
             'maximumEdgeCount',
@@ -97,14 +101,39 @@ def parse_arguments():
     vals = (args.maxnode, args.maxedge, args.conctol, args.ratetol, args.rad, args.centralReactionCount, args.tstep)
     settings = {k: v for k, v in zip(keys, vals) if v is not None}
     
-    return inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings, centralSpeciesList, superimpose
+    return (inputFile,
+            chemkinFile,
+            dictFile,
+            speciesPath,
+            chemkinOutput,
+            useJava,
+            dflag,
+            checkDuplicates,
+            settings,
+            centralSpeciesList,
+            superimpose,
+            saveStates,
+            readStates)
 
 def main():
-    inputFile, chemkinFile, dictFile, speciesPath, chemkinOutput, useJava, dflag, checkDuplicates, settings, centralSpeciesList, superimpose = parse_arguments()
+    (inputFile,
+     chemkinFile,
+     dictFile,
+     speciesPath,
+     chemkinOutput,
+     useJava,
+     dflag,
+     checkDuplicates,
+     settings,
+     centralSpeciesList,
+     superimpose,
+     saveStates,
+     readStates) = parse_arguments()
 
     createFluxDiagram(inputFile, chemkinFile, dictFile, speciesPath=speciesPath, java=useJava, settings=settings,
                       chemkinOutput=chemkinOutput, diffusionLimited=dflag, centralSpeciesList=centralSpeciesList,
-                      superimpose=superimpose, checkDuplicates=checkDuplicates)
+                      superimpose=superimpose, saveStates=saveStates, readStates=readStates,
+                      checkDuplicates=checkDuplicates)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR makes some improvements and adds new features to RMG's flux diagram capabilities. The solver algorithm is slightly updated to reflect the algorithm used in `rmgpy/solver/base.pyx`. This is done for consistency because slight differences in the resulting simulation profiles were noticed.

The larger part of this PR deals with the treatment of "central species". Previously, specifying a central species only resulted in a flux diagram containing that species and all species directly connected to it through single reactions. Now, multiple central species can be specified, each of which will appear on the flux diagram whether or not they are connected to each other. It is also possible to specify a graph radius, which will draw the connections up to each central species through a series of reactions. Lastly, one can superimpose all central species onto the entire automatically generated flux diagram to ensure that they appear in it. This is especially useful for systems in which species are produced via low-flux channels but still accumulate to significant concentrations. Identifying high concentration species that would not appear on the flux diagram and specifying them as central species (preferably with a radius larger than 1) ensures that they now appear on the diagram.

Edit: I added another option to save/read the simulation to/from a file. Since I am dealing with many large models, which take a long time to simulate, this prevents me from having to simulate the model over and over again.