### PR TITLE
Update calculateDegeneracy to deal with identical reactants

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -156,8 +156,8 @@ def filter_reactions(reactants, products, reactionList):
     warnings.warn("The filter_reactions method is no longer used and may be removed in a future version.", DeprecationWarning)
     
     # Convert from molecules to species and generate resonance isomers.
-    reactants = ensure_species(reactants, resonance=True)
-    products = ensure_species(products, resonance=True)
+    ensure_species(reactants, resonance=True)
+    ensure_species(products, resonance=True)
 
     reactions = reactionList[:]
     
@@ -197,11 +197,10 @@ def filter_reactions(reactants, products, reactionList):
 
 def ensure_species(input_list, resonance=False, keepIsomorphic=False):
     """
-    Given an input list of molecules or species, return a list with only
-    species objects.
+    The input list of :class:`Species` or :class:`Molecule` objects is modified
+    in place to only have :class:`Species` objects. Returns None.
     """
-    output_list = []
-    for item in input_list:
+    for index, item in enumerate(input_list):
         if isinstance(item, Molecule):
             new_item = Species(molecule=[item])
         elif isinstance(item, Species):
@@ -210,9 +209,7 @@ def ensure_species(input_list, resonance=False, keepIsomorphic=False):
             raise TypeError('Only Molecule or Species objects can be handled.')
         if resonance:
             new_item.generate_resonance_structures(keepIsomorphic=keepIsomorphic)
-        output_list.append(new_item)
-
-    return output_list
+        input_list[index] = new_item
 
 
 def generate_molecule_combos(input_species):

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -228,13 +228,15 @@ def generate_molecule_combos(input_species):
 
 def ensure_independent_atom_ids(input_species, resonance=True):
     """
-    Given a list or tuple of :class:`Species` objects, ensure that atom ids are
-    independent across all of the species. Optionally, the `resonance` argument
-    can be set to False to not generate resonance structures.
+    Given a list or tuple of :class:`Species` or :class:`Molecule` objects,
+    ensure that atom ids are independent.
+    The `resonance` argument can be set to False to not generate
+    resonance structures.
 
-    Modifies the input species in place, nothing is returned.
+    Modifies the list in place (replacing :class:`Molecule` with :class:`Species`).
+    Returns None.
     """
-
+    ensure_species(input_species, resonance=resonance)
     # Method to check that all species' atom ids are different
     def independent_ids():
         num_atoms = 0

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -386,7 +386,7 @@ library instead, depending on the main bath gas (N2 or Ar/He, respectively)\n"""
         provided `reactants`, which can be either :class:`Molecule` objects or
         :class:`Species` objects.
         """
-        reactants = ensure_species(reactants)
+        ensure_species(reactants)
 
         reaction_list = []
         for entry in library.entries.values():
@@ -435,7 +435,7 @@ library instead, depending on the main bath gas (N2 or Ar/He, respectively)\n"""
                 same_reactants = True
 
         # Convert to Species objects if necessary
-        reactants = ensure_species(reactants)
+        ensure_species(reactants)
 
         # Label reactant atoms for proper degeneracy calculation
         ensure_independent_atom_ids(reactants, resonance=resonance)

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -434,10 +434,9 @@ library instead, depending on the main bath gas (N2 or Ar/He, respectively)\n"""
             elif reactants[0].isIsomorphic(reactants[1]):
                 same_reactants = True
 
-        # Convert to Species objects if necessary
-        ensure_species(reactants)
-
-        # Label reactant atoms for proper degeneracy calculation
+        # Label reactant atoms for proper degeneracy calculation (cannot be in tuple)
+        if isinstance(reactants, tuple):
+            reactants = list(reactants)
         ensure_independent_atom_ids(reactants, resonance=resonance)
 
         combos = generate_molecule_combos(reactants)

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -364,7 +364,7 @@ library instead, depending on the main bath gas (N2 or Ar/He, respectively)\n"""
         reactionList = []
         if only_families is None:
             reactionList.extend(self.generate_reactions_from_libraries(reactants, products))
-        reactionList.extend(self.generate_reactions_from_families(reactants, products, only_families=None, resonance=True))
+        reactionList.extend(self.generate_reactions_from_families(reactants, products, only_families=None, resonance=resonance))
         return reactionList
 
     def generate_reactions_from_libraries(self, reactants, products=None):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1692,7 +1692,7 @@ class KineticsFamily(Database):
         # If products is given, remove reactions from the reaction list that
         # don't generate the given products
         if products is not None:
-            products = ensure_species(products, resonance=prod_resonance)
+            ensure_species(products, resonance=prod_resonance)
 
             rxnList0 = rxnList[:]
             rxnList = []

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -854,12 +854,38 @@ class TestKinetics(unittest.TestCase):
         self.assertEqual(len(reaction_list), 1)
         self.assertEqual(reaction_list[0].degeneracy, 2)
 
-        reaction_list = self.database.kinetics.generate_reactions_from_families(reactants, products, only_families=['H_Abstraction'], resonance=False)
 
+
+    def test_generate_reactions_from_families_product_resonance2(self):
+        """Test that we can specify the no product resonance structure when generating reactions"""
+        reactants = [
+            Molecule().fromSMILES('CCC=C'),
+            Molecule().fromSMILES('[H]'),
+        ]
+        products = [
+            Molecule().fromSMILES('CC=C[CH2]'),
+            Molecule().fromSMILES('[H][H]'),
+        ]
+
+        reaction_list = self.database.kinetics.generate_reactions_from_families(reactants, products, only_families=['H_Abstraction'], resonance=False)
         self.assertEqual(len(reaction_list), 0)
+
+        self.assertTrue(isinstance(products[0],Species))
+        self.assertEqual(len(products[0].molecule),1)
 
     def test_generate_reactions_from_libraries(self):
         """Test that we can generate reactions from libraries"""
+        reactants = [
+            Molecule().fromSMILES('CC=O'),
+            Molecule().fromSMILES('[H]'),
+        ]
+
+        reaction_list = self.database.kinetics.generate_reactions_from_libraries(reactants)
+
+        self.assertEqual(len(reaction_list), 3)
+
+    def test_generate_reactions_from_libraries2(self):
+        """Test that we can generate reactions from libraries specifying products"""
         reactants = [
             Molecule().fromSMILES('CC=O'),
             Molecule().fromSMILES('[H]'),
@@ -868,11 +894,6 @@ class TestKinetics(unittest.TestCase):
             Molecule().fromSMILES('[CH2]C=O'),
             Molecule().fromSMILES('[H][H]'),
         ]
-
-        reaction_list = self.database.kinetics.generate_reactions_from_libraries(reactants)
-
-        self.assertEqual(len(reaction_list), 3)
-
         reaction_list_2 = self.database.kinetics.generate_reactions_from_libraries(reactants, products)
 
         self.assertEqual(len(reaction_list_2), 1)

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -688,6 +688,21 @@ class TestKinetics(unittest.TestCase):
         # checks second resonance structure id
         self.assertNotEqual(s2.molecule[1].atoms[0].id, -1)
 
+    def test_ensure_independent_atom_ids_no_resonance(self):
+        """
+        Ensure ensure_independent_atom_ids does not generate resonance
+        """
+        s1 = Species().fromSMILES('CCC')
+        s2 = Species().fromSMILES('C=C[CH]C')
+        self.assertEqual(s2.molecule[0].atoms[0].id, -1)
+
+        ensure_independent_atom_ids([s1, s2],resonance=False)
+        # checks resonance structures
+        self.assertEqual(len(s2.molecule),1)
+        # checks that atom ids are changed
+        for atom in s2.molecule[0].atoms:
+            self.assertNotEqual(atom.id, -1)
+
     def testSaveEntry(self):
         """
         tests that save entry can run

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1077,11 +1077,11 @@ class Reaction:
             return None
         # obtain species with all resonance isomers
         if self.isForward:
-            self.reactants = ensure_species(self.reactants, resonance=reactant_resonance, keepIsomorphic=True)
-            self.products = ensure_species(self.products, resonance=product_resonance, keepIsomorphic=True)
+            ensure_species(self.reactants, resonance=reactant_resonance, keepIsomorphic=True)
+            ensure_species(self.products, resonance=product_resonance, keepIsomorphic=True)
         else:
-            self.reactants = ensure_species(self.reactants, resonance=product_resonance, keepIsomorphic=True)
-            self.products = ensure_species(self.products, resonance=reactant_resonance, keepIsomorphic=True)
+            ensure_species(self.reactants, resonance=product_resonance, keepIsomorphic=True)
+            ensure_species(self.products, resonance=reactant_resonance, keepIsomorphic=True)
 
         # convert reaction.pairs object to species
         if self.pairs:


### PR DESCRIPTION
calculateDegeneracy did not assess whether two reactants were
actually pointing to the same reference, as did the newly written
database.generate_reactions_from_families method does. This led
calculateDegeneracy not to be able to track atom IDs (since the
molecules had the same values) and get degeneracy incorrect.

This commit adds code which is used in database.generate_reactions_from_families
to calculateDegeneracy, so it can give accurate degeneracy values.