### PR TITLE
Check vital dependencies after make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,10 @@
 
 DASPK=$(shell python -c 'import pydas.daspk; print pydas.daspk.__file__')
 DASSL=$(shell python -c 'import pydas.dassl; print pydas.dassl.__file__')
-RDKIT_VERSION=$(shell python -c 'import rdkit; print rdkit.__version__')
 
-.PHONY : all minimal main solver cantherm clean decython documentation QM mopac_travis
+.PHONY : all minimal main solver check cantherm clean decython documentation mopac_travis
 
-all: main solver QM
-
-noQM: main solver
+all: main solver check
 
 minimal:
 	python setup.py build_ext minimal --build-lib . --build-temp build --pyrex-c-in-temp
@@ -39,19 +36,8 @@ endif
 cantherm:
 	python setup.py build_ext cantherm --build-lib . --build-temp build --pyrex-c-in-temp
 
-QM:
-	@ echo "Checking if you have symmetry..."
-	@ echo "symmetry -h"
-	@ echo "Checking you have rdkit..."
-	@ python -c 'import rdkit; print rdkit.__file__'
-	@ echo "Checking rdkit version..."
-ifneq ($(RDKIT_VERSION),)
-	@ echo "Found rdkit version $(RDKIT_VERSION)"
-else
-	$(error RDKit version out of date, please install RDKit version 2015.03.1 or later with InChI support);
-endif
-	@ echo "Checking rdkit has InChI support..."
-	@ python -c 'from rdkit import Chem; assert Chem.inchi.INCHI_AVAILABLE, "RDKit installed without InChI Support. Please install with InChI."'
+check:
+	@ python check_dependencies.py
 
 documentation:
 	$(MAKE) -C documentation html
@@ -112,13 +98,13 @@ endif
 
 test-database:
 	nosetests -v -d testing/databaseTest.py	
-eg0: noQM
+eg0: all
 	mkdir -p testing/eg0
 	rm -rf testing/eg0/*
 	cp examples/rmg/superminimal/input.py testing/eg0/input.py
 	@ echo "Running eg0: superminimal (H2 oxidation) example"
 	python rmg.py testing/eg0/input.py
-eg1: noQM
+eg1: all
 	mkdir -p testing/eg1
 	rm -rf testing/eg1/*
 	cp examples/rmg/minimal/input.py testing/eg1/input.py
@@ -168,7 +154,7 @@ eg7: all
 	@ echo "Running eg7: gri_mech_rxn_lib example"
 	python rmg.py testing/eg7/input.py
 	
-scoop: noQM
+scoop: all
 	mkdir -p testing/scoop
 	rm -rf testing/scoop/*
 	cp examples/rmg/minimal/input.py testing/scoop/input.py

--- a/check_dependencies.py
+++ b/check_dependencies.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+This script checks for the major dependencies that RMG-Py requires.
+"""
+
+import re
+import subprocess
+
+missing = False
+
+print '\nChecking vital dependencies...\n'
+print '{0:<15}{1:<15}{2}'.format('Package', 'Version', 'Location')
+
+# Check for symmetry
+try:
+    result = subprocess.check_output('symmetry -h', stderr=subprocess.STDOUT, shell=True)
+except subprocess.CalledProcessError:
+    print '{0:<30}{1}'.format('symmetry', 'Not found. Please install in order to use QM.')
+    missing = True
+else:
+    match = re.search(r'\$Revision: (\S*) \$', result)
+    version = match.group(1)
+    location = subprocess.check_output('which symmetry', shell=True)
+
+    print '{0:<15}{1:<15}{2}'.format('symmetry', version, location.strip())
+
+# Check for RDKit
+try:
+    import rdkit
+    from rdkit import Chem
+except ImportError:
+    print '{0:<30}{1}'.format('RDKit', 'Not found. Please install RDKit version 2015.03.1 or later with InChI support.')
+    missing = True
+else:
+    try:
+        version = rdkit.__version__
+    except AttributeError:
+        version = False
+    location = rdkit.__file__
+    inchi = Chem.inchi.INCHI_AVAILABLE
+
+    if version:
+        print '{0:<15}{1:<15}{2}'.format('RDKit', version, location)
+        if not inchi:
+            print 'RDKit installed without InChI Support. Please install with InChI.'
+            missing = True
+    else:
+        print 'RDKit version out of date, please install RDKit version 2015.03.1 or later with InChI support.'
+        missing = True
+
+# Check for OpenBabel
+try:
+    import openbabel
+except ImportError:
+    print '{0:<30}{1}'.format('OpenBabel', 'Not found. Necessary for SMILES/InChI functionality for nitrogen compounds.')
+    missing = True
+else:
+    location = openbabel.__file__
+    print '{0:<30}{1}'.format('OpenBabel', location)
+
+# Check for lpsolve
+try:
+    import lpsolve55
+except ImportError:
+    print '{0:<30}{1}'.format('lpsolve55', 'Not found. Necessary for generating Clar structures for aromatic species.')
+    missing = True
+else:
+    location = lpsolve55.__file__
+    print '{0:<30}{1}'.format('lpsolve55', location)
+
+# Check for pyrdl
+try:
+    import py_rdl
+except ImportError:
+    print '{0:<30}{1}'.format('pyrdl', 'Not found. Necessary for ring perception algorithms.')
+    missing = True
+else:
+    location = py_rdl.__file__
+    print '{0:<30}{1}'.format('pyrdl', location)
+
+if missing:
+    print """
+There are missing dependencies as listed above. Please install them before proceeding.
+
+Using Anaconda, these dependencies can be installed from the RMG channel as follows:
+
+    conda install -c rmg <package name>
+
+Be sure to activate your conda environment (rmg_env by default) before installing.
+"""
+else:
+    print """
+Everything was found :)
+"""


### PR DESCRIPTION
Thanks to @alongd for the idea for this PR!

This PR refines the dependency checking done at the conclusion of the `make` target. Previously, we would check that `symmetry` and `rdkit` were installed. Now, a script has been added which checks more dependencies and is run at the end of the `make` target. If any of the checked dependencies are missing, the user is asked to install them via anaconda.

The `QM` target has been replaced by the new `check` target since the only thing it was doing was checking the dependencies required for QM (it previously did other stuff that was removed following the transition to anaconda). That functionality is still retained in `check_dependencies.py`.

The idea is that only dependencies that are vital to running RMG jobs are checked here. If there are any others that I missed, please comment.