### PR TITLE
fix uncertainty parsing issue

### DIFF
--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -393,7 +393,7 @@ This reaction matched rate rule [C_methyl;C_methyl]
 Reaction index: Chemkin #2; RMG #4
 Template reaction: R_Recombination
 Flux pairs: [CH3], CC; [CH3], CC; 
-From training reaction 21 for rate rule [C_rad/H2/Cs;C_methyl]
+From training reaction 21 used for C_rad/H2/Cs;C_methyl
 Exact match found for rate rule [C_rad/H2/Cs;C_methyl]
 Euclidian distance = 0
 """]

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1067,7 +1067,7 @@ class KineticsFamily(Database):
                 shortDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.shortDesc,
                 longDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.longDesc,
             )
-            new_entry.data.comment = "From training reaction {1} for rate rule {0}".format(';'.join([g.label for g in template]), entry.index)
+            new_entry.data.comment = "From training reaction {1} used for {0}".format(';'.join([g.label for g in template]), entry.index)
 
             new_entry.data.A.value_si /= entry.item.degeneracy
             try:
@@ -1115,7 +1115,7 @@ class KineticsFamily(Database):
                 shortDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.shortDesc,
                 longDesc="Rate rule generated from training reaction {0}. ".format(entry.index) + entry.longDesc,
             )
-            new_entry.data.comment = "From training reaction {1} for rate rule {0}".format(';'.join([g.label for g in template]), entry.index)
+            new_entry.data.comment = "From training reaction {1} used for {0}".format(';'.join([g.label for g in template]), entry.index)
 
             new_entry.data.A.value_si /= new_degeneracy
             try:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2355,7 +2355,12 @@ class KineticsFamily(Database):
         
         # The rate rule string is right after the phrase 'for rate rule'
         rateRuleString = fullCommentString.split("for rate rule",1)[1].split()[0]
-        templateLabel = re.split(regex, rateRuleString)[1]
+        
+        if rateRuleString[0] == '[':
+            templateLabel = re.split(regex, rateRuleString)[1]
+        else:
+            templateLabel = rateRuleString #if has the line 'From training reaction # for rate rule node1;node2'
+            
         template = self.retrieveTemplate(templateLabel.split(';'))
         rules, trainingEntries = self.getSourcesForTemplate(template)
         


### PR DESCRIPTION
Comments of the form:
From training reaction 8 for rate rule C_rad/H2/Cs;HCO
Exact match found for rate rule [C_rad/H2/Cs;HCO]
Euclidian distance = 0
family: CO_Disproportionation

result in C_rad/H2/Cs;HCO being set in rateRuleString instead of [C_rad/H2/Cs;HCO], which threw off the parser
this commit differentiates between the two possible rateRuleString formats