### PR TITLE
Isotope resonance

### DIFF
--- a/documentation/source/users/rmg/modules/index.rst
+++ b/documentation/source/users/rmg/modules/index.rst
@@ -22,3 +22,4 @@ otherwise.
     databaseScripts
     standardizeModelSpeciesNames
     reduction
+    isotopes

--- a/documentation/source/users/rmg/modules/isotopes.rst
+++ b/documentation/source/users/rmg/modules/isotopes.rst
@@ -1,0 +1,84 @@
+.. _isotopes:
+
+********
+Isotopes
+********
+
+Describing isotopes in adjacency lists
+--------------------------------------
+
+Isotopic enrichment can be indicated in a molecular structure's adjacency list. 
+The example below is methane with an isotopically labeled carbon of isotope 
+number 13, which is indicated with ``i13``::
+
+    1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+    2 H u0 p0 c0 {1,S}
+    3 H u0 p0 c0 {1,S}
+    4 H u0 p0 c0 {1,S}
+    5 H u0 p0 c0 {1,S}
+
+
+Running the RMG isotopes algorithm
+----------------------------------
+
+The isotopes script is located in the folder scripts. To run the algorithm, 
+ensure the RMG packages are loaded and type::
+
+    python /path/to/rmg/scripts/isotopes.py /path/to/input/file.py
+
+The input file is identical to a standard RMG input file and should contain the
+conditions you want to run (unless you are inputting an already completed RMG
+model). Without any options, the script will run the original RMG input file to
+generate a model. Once the RMG job is finished, it will create new species for
+all isotopologues of previously generated species and then generate all
+reactions between the isotopologues.
+
+Some arguments can be used to alter the behavior of the script. If you already
+have a model (which includes atom mapping in RMG's format) which you would like
+to add isotope labels to, you can use the option ``--original path/to/model/directory``
+with the desired model files stored within with structure ``chemkin/chem_annotated.inp``
+and ``chemkin/species_dictionary.txt``. With this option, the isotope script
+will use the specified model instead of re-running an RMG job.
+
+If you only desire the reactions contained in the specific RMG job,
+you can add ``--useOriginalReactions`` in addition to ``--original``.
+This will create a full set of isotopically labeled versions of the reactions
+you input and avoid a time-consuming generate reactions proceedure.
+
+The arguement ``--maximumIsotopicAtoms [integer]`` limits the number of enriched
+atoms in any isotopologue in the model. This is beneficial for decreasing model 
+size, runtime of model creation and runtime necessary for analysis.
+
+Adding kinetic isotope effects which are described in this paper can be obtained
+through the argument ``--kineticIsotopeEffect simple``. Currently this is the
+only supported method, though this can be extended to other effects.
+
+If you have a desired output folder, ``--output output_folder_name`` can direct
+all output files to the specified folder. The default is to create a folder
+named 'iso'.
+
+There are some limitations in what can be used in isotope models. In general,
+RMG Reaction libraries and other methods of kinetic estimation that do not
+involve atom mapping to reaction recipes are not compatible (though they can be
+functional if all isotopologues are included in the reaction library). The
+algorithm also does not function with pressure dependent mechanisms generated
+by RMG, and has only been tested for gas phase kinetics. This algorithm currently
+only works for Carbon-13 enrichments.
+
+Following the generation, a number of diagnostics check model accuracy.
+Isotopologues are checked to ensure their symmetries are consistent.
+Then, the reaction path degeneracy among reactions differing only in isotope
+labeling is checked to ensure it is consistent with the symmetry values of reactions.
+If one of these checks throws a warning, the model will likely exhibit non-natural
+fluctuations in enrichment ten to one hundred times larger than from non-hydrogen
+kinetic isotope effects.
+
+Output from script
+------------------
+
+The isotope generation script will output two files inside the nested folders
+``iso/chemkin``, unless ``--output`` is specified. The file
+``species_dictionary.txt`` lists the structure of all isotopologue using the
+RMG adjacency list structure. The other file of importance ``chem_annotated.inp``
+is a chemkin input file containing elements, species, thermo, and reactions of
+the entire system.

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -103,12 +103,4 @@ def failsSpeciesConstraints(species):
         if struct.getSingletCarbeneCount() > 0 and struct.getRadicalCount() > maxCarbeneRadicals:
             return True
 
-    maxIsotopes = speciesConstraints.get('maximumIsotopicAtoms', -1)
-    if maxIsotopes != -1:
-        counter = 0
-        for atom in struct.atoms:
-            if not isclose(atom.mass, getElement(atom.symbol).mass, atol=1e-04):
-                counter += 1
-            if counter > maxIsotopes: return True
-
     return False

--- a/rmgpy/constraintsTest.py
+++ b/rmgpy/constraintsTest.py
@@ -65,7 +65,6 @@ class TestFailsSpeciesConstraints(unittest.TestCase):
             maximumRadicalElectrons=2,
             maximumSingletCarbenes=1,
             maximumCarbeneRadicals=0,
-            maximumIsotopicAtoms=2,
         )
 
     @classmethod
@@ -216,27 +215,5 @@ class TestFailsSpeciesConstraints(unittest.TestCase):
 3 C u1 p0 c0 {1,S} {4,S} {5,S}
 4 H u0 p0 c0 {3,S}
 5 H u0 p0 c0 {3,S}
-""")
-        self.assertTrue(failsSpeciesConstraints(mol2))
-
-    def testIsotopeConstraint(self):
-        """
-        Test that we can constrain the max number of isotopic atoms.
-        """
-        mol1 = Molecule().fromAdjacencyList("""
-1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
-2 D u0 p0 c0 {1,S}
-3 D u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 H u0 p0 c0 {1,S}
-""")
-        self.assertFalse(failsSpeciesConstraints(mol1))
-
-        mol2 = Molecule().fromAdjacencyList("""
-1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
-2 D u0 p0 c0 {1,S}
-3 D u0 p0 c0 {1,S}
-4 D u0 p0 c0 {1,S}
-5 H u0 p0 c0 {1,S}
 """)
         self.assertTrue(failsSpeciesConstraints(mol2))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2182,7 +2182,7 @@ class KineticsFamily(Database):
         if len(reactants0) == 1:
             molecule = reactants0[0]
             mappings = self.__matchReactantToTemplate(molecule, template.reactants[0])
-
+            mappings = [[map0] for map0 in mappings]
             num_mappings = len(mappings)
             reactant_structures = [molecule]
         elif len(reactants0) == 2:

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -94,9 +94,11 @@ class TestFamily(unittest.TestCase):
         Test the getTopLevelGroups() function
         """
         topGroups = self.family.getTopLevelGroups(self.family.groups.entries["RnH"])
-        self.assertEquals(len(topGroups), 2)
+        self.assertEquals(len(topGroups), 4)
         self.assertIn(self.family.groups.entries["R5Hall"], topGroups)
         self.assertIn(self.family.groups.entries["R6Hall"], topGroups)
+        self.assertIn(self.family.groups.entries["R2Hall"], topGroups)
+        self.assertIn(self.family.groups.entries["R3Hall"], topGroups)
 
     def testReactBenzeneBond(self):
         """

--- a/rmgpy/molecule/isomorphismTest.py
+++ b/rmgpy/molecule/isomorphismTest.py
@@ -448,3 +448,32 @@ def test_isomorphism_sulfurGroup_sulfurMolecule():
     assert_true(mol.isSubgraphIsomorphic(gp1))
     
     assert_true(mol.isSubgraphIsomorphic(gp2))
+
+def test_isotope_subgraph_isomorphism_molecule_and_group():
+    """
+    Checks that subgraph isomorphism works with enriched molecules and groups
+    """
+    methanei = Molecule().fromAdjacencyList("""
+    1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+    2 H u0 p0 c0 {1,S}
+    3 H u0 p0 c0 {1,S}
+    4 H u0 p0 c0 {1,S}
+    5 H u0 p0 c0 {1,S}
+    """)
+    methane = Molecule().fromAdjacencyList("""
+    1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+    2 H u0 p0 c0 {1,S}
+    3 H u0 p0 c0 {1,S}
+    4 H u0 p0 c0 {1,S}
+    5 H u0 p0 c0 {1,S}
+    """)
+    group_methane = Group().fromAdjacencyList("""
+    1 C  u0 {2,S} {3,S} {4,S} {5,S}
+    2 H  u0 {1,S}
+    3 H  u0 {1,S}
+    4 H  u0 {1,S}
+    5 H  u0 {1,S}
+    """)
+    assert_true(methanei.isSubgraphIsomorphic(group_methane))
+    assert_true(methane.isSubgraphIsomorphic(group_methane))
+    assert_false(methanei.isIsomorphic(methane))

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1172,7 +1172,7 @@ class Molecule(Graph):
         for atom in self.atoms:
             symbol = atom.element.symbol
             isotope = atom.element.isotope
-            key = symbol if isotope == -1 else (symbol, isotope)
+            key = symbol
             if key in element_count:
                 element_count[key] += 1
             else:
@@ -1246,7 +1246,7 @@ class Molecule(Graph):
         # It only makes sense to compare a Molecule to a Group for subgraph
         # isomorphism, so raise an exception if this is not what was requested
         if not isinstance(other, gr.Group):
-            raise TypeError('Got a {0} object for parameter "other", when a Molecule object is required.'.format(other.__class__))
+            raise TypeError('Got a {0} object for parameter "other", when a Group object is required.'.format(other.__class__))
         group = other
         
         # Check multiplicity

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -456,7 +456,6 @@ def generatedSpeciesConstraints(**kwargs):
         'maximumSingletCarbenes',
         'maximumCarbeneRadicals',
         'allowSingletO2',
-        'maximumIsotopicAtoms'
     ]
 
     for key, value in kwargs.items():

--- a/rmgpy/test_data/testing_database/kinetics/families/H_Abstraction/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/H_Abstraction/groups.py
@@ -271,6 +271,20 @@ entry(
 )
 
 entry(
+    index = 62,
+    label = "C/H4",
+    group =
+"""
+1 *1 C  u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 H  u0 {1,S}
+3    H  u0 {1,S}
+4    H  u0 {1,S}
+5    H  u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
     index = 63,
     label = "C/H3/Cs",
     group = 
@@ -332,6 +346,7 @@ L1: X_H_or_Xrad_H_Xbirad_H_Xtrirad_H
             L4: C/H3/Cs
             L4: C/H3/Cdot
             L4: C/H3/Cd
+            L4: C/H4
 L1: Y_rad_birad_trirad_quadrad
     L2: Y_1centerquadrad
         L3: C_quintet

--- a/rmgpy/test_data/testing_database/kinetics/families/intra_H_migration/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/intra_H_migration/groups.py
@@ -23,7 +23,7 @@ boundaryAtoms = ["*1", "*2"]
 entry(
     index = 0,
     label = "RnH",
-    group = "OR{R5Hall, R6Hall}",
+    group = "OR{R5Hall, R6Hall, R2Hall, R3Hall}",
     kinetics = None,
 )
 
@@ -50,6 +50,31 @@ entry(
 
 entry(
     index = 3,
+    label = "R2Hall",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *2 R!H u0 {1,[S,D,T,B]} {3,S}
+3 *3 H   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 4,
+    label = "R3Hall",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *2 R!H u0 {2,[S,D,T,B]} {4,S}
+4 *3 H   u0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
     label = "R5Hall",
     group = 
 """
@@ -64,7 +89,7 @@ entry(
 )
 
 entry(
-    index = 4,
+    index = 6,
     label = "R5HJ_1",
     group = 
 """
@@ -79,7 +104,7 @@ entry(
 )
 
 entry(
-    index = 5,
+    index = 7,
     label = "R5HJ_2",
     group = 
 """
@@ -94,7 +119,7 @@ entry(
 )
 
 entry(
-    index = 6,
+    index = 8,
     label = "R5HJ_3",
     group = 
 """
@@ -109,7 +134,7 @@ entry(
 )
 
 entry(
-    index = 7,
+    index = 9,
     label = "R5H",
     group = 
 """
@@ -124,7 +149,7 @@ entry(
 )
 
 entry(
-    index = 8,
+    index = 10,
     label = "R6Hall",
     group = 
 """
@@ -140,7 +165,7 @@ entry(
 )
 
 entry(
-    index = 9,
+    index = 11,
     label = "R6HJ_1",
     group = 
 """
@@ -156,7 +181,7 @@ entry(
 )
 
 entry(
-    index = 10,
+    index = 12,
     label = "R6HJ_2",
     group = 
 """
@@ -172,7 +197,7 @@ entry(
 )
 
 entry(
-    index = 11,
+    index = 13,
     label = "R6HJ_3",
     group = 
 """
@@ -188,7 +213,7 @@ entry(
 )
 
 entry(
-    index = 12,
+    index = 14,
     label = "R6HJ_4",
     group = 
 """
@@ -204,7 +229,7 @@ entry(
 )
 
 entry(
-    index = 13,
+    index = 15,
     label = "R6H",
     group = 
 """
@@ -220,7 +245,7 @@ entry(
 )
 
 entry(
-    index = 14,
+    index = 16,
     label = "O_rad_out",
     group = 
 """
@@ -230,7 +255,7 @@ entry(
 )
 
 entry(
-    index = 15,
+    index = 17,
     label = "Cd_rad_out",
     group = 
 """
@@ -240,7 +265,7 @@ entry(
 )
 
 entry(
-    index = 16,
+    index = 18,
     label = "C_rad_out_single",
     group = 
 """
@@ -252,7 +277,7 @@ entry(
 )
 
 entry(
-    index = 17,
+    index = 19,
     label = "O_H_out",
     group = 
 """
@@ -263,7 +288,7 @@ entry(
 )
 
 entry(
-    index = 18,
+    index = 20,
     label = "Cd_H_out_double",
     group = 
 """
@@ -275,7 +300,7 @@ entry(
 )
 
 entry(
-    index = 19,
+    index = 21,
     label = "Cd_H_out_single",
     group = 
 """
@@ -287,7 +312,7 @@ entry(
 )
 
 entry(
-    index = 20,
+    index = 22,
     label = "Cs_H_out",
     group = 
 """
@@ -302,6 +327,8 @@ entry(
 tree(
 """
 L1: RnH
+    L2: R2Hall
+    L2: R3Hall
     L2: R5Hall
         L3: R5HJ_1
         L3: R5HJ_2

--- a/rmgpy/tools/isotopes.py
+++ b/rmgpy/tools/isotopes.py
@@ -490,8 +490,7 @@ def generate_RMG_model(inputFile, outputDirectory):
     initializeLog(logging.INFO, os.path.join(outputDirectory, 'RMG.log'))
     # generate mechanism:
     rmg = RMG(inputFile = os.path.abspath(inputFile),
-            outputDirectory = os.path.abspath(outputDirectory)
-        )
+              outputDirectory = os.path.abspath(outputDirectory))
     rmg.execute()
 
     return rmg
@@ -725,10 +724,10 @@ def ensure_correct_degeneracies(reaction_isotopomer_list, print_data = False, r_
         # add product to list
         symmetry_ratio = product_structures[structure_index].getSymmetryNumber() / float(species.getSymmetryNumber())
         return product_list.append({'product': species,
-                                            'flux': flux,
-                                            'product_struc_index': structure_index,
-                                            'symmetry_ratio': symmetry_ratio},
-                                           ignore_index=True)
+                                    'flux': flux,
+                                    'product_struc_index': structure_index,
+                                    'symmetry_ratio': symmetry_ratio},
+                                   ignore_index=True)
 
     # copy list in case it is called upon
     reaction_isotopomer_list = copy(reaction_isotopomer_list)

--- a/rmgpy/tools/isotopes.py
+++ b/rmgpy/tools/isotopes.py
@@ -57,7 +57,6 @@ import rmgpy.molecule.element
 from rmgpy.kinetics.arrhenius import MultiArrhenius
 from rmgpy.reaction import isomorphic_species_lists
 
-
 def initialize_isotope_model(rmg, isotopes):
     """
     Initialize the RMG object by using the parameter species list
@@ -171,8 +170,6 @@ def generate_isotope_reactions(isotopeless_reactions, isotopes):
             raise TypeError('reactions sent to generate_isotope_reactions must be a TemplateReaction object')
         if rxn.template is None:
             raise AttributeError('isotope reaction {0} does not have a template attribute. The object is:\n\n{1}'.format(str(rxn),repr(rxn)))
-
-    from rmgpy.reaction import _isomorphicSpeciesList
 
     found_reactions = []
     rxn_index = 0
@@ -628,8 +625,7 @@ def get_reduced_mass(labeled_molecules, labels, three_member_ts):
         from rmgpy.exceptions import KineticsError
         raise KineticsError("Did not find a labeled atom in molecules {}".format([mol.toAdjacencyList() for mol in labeled_molecules]))
     if three_member_ts: # actually convert to reduced mass using the mass of hydrogen
-        from rmgpy.molecule import element
-        reduced_mass = 1/element.H.mass + 1/combined_mass
+        reduced_mass = 1/rmgpy.molecule.element.H.mass + 1/combined_mass
     return 1./reduced_mass
 
 def is_enriched(obj):
@@ -662,7 +658,6 @@ def ensure_correct_symmetry(isotopmoper_list, isotopic_element = 'C'):
     m is related to the amount of entropy increased by some isotopomers since they
     lost symmetry.
     """
-    gas_constant = 8.314 # J/molK
     number_elements = 0
     for atom in isotopmoper_list[0].molecule[0].atoms:
         if atom.element.symbol ==isotopic_element:
@@ -673,7 +668,7 @@ def ensure_correct_symmetry(isotopmoper_list, isotopic_element = 'C'):
     count = 0.
     for spec in isotopmoper_list:
         entropy_diff = spec.getEntropy(298) - minimum_entropy
-        count += math.exp(entropy_diff / gas_constant)
+        count += math.exp(entropy_diff / constants.R)
     return abs(count - 2**number_elements) < 0.01
 
 def ensure_correct_degeneracies(reaction_isotopomer_list, print_data = False, r_tol_small_flux=1e-5, r_tol_deviation = 0.0001):
@@ -701,7 +696,6 @@ def ensure_correct_degeneracies(reaction_isotopomer_list, print_data = False, r_
     product_list - a pandas.DataFrame that sotres the fluxes and symmetry values
     """
 
-    from rmgpy.kinetics.arrhenius import MultiArrhenius
     def store_flux_info(species, flux, product_list,  product_structures):
         """
         input:

--- a/rmgpy/tools/isotopes.py
+++ b/rmgpy/tools/isotopes.py
@@ -426,24 +426,23 @@ def ensure_reaction_direction(isotopomerRxns):
             if not compare_isotopomers(rxn, reference, eitherDirection=False):
                 # the reaction is in the oposite direction
                 logging.info('isotope: identified flipped reaction direction in reaction number {} of reaction {}. Altering the direction.'.format(rxn.index, str(rxn)))
-                # reverse reactants and products
+                # obtain reverse attribute with template and degeneracy
+                family.addReverseAttribute(rxn)
+                if frozenset(rxn.reverse.template) != frozenset(reference.template):
+                    logging.warning("Reaction {} did not find proper reverse template, might cause degeneracy error.".format(str(rxn)))
+                # reverse reactants and products of original reaction
                 rxn.reactants, rxn.products = rxn.products, rxn.reactants
                 rxn.pairs = [(p,r) for r,p in rxn.pairs]
-
-                # calculateDegeneracy
-                rxnMols = TemplateReaction(reactants = [spec.molecule[0] for spec in rxn.reactants],
-                                           products = [spec.molecule[0] for spec in rxn.products])
-                forwardDegen = family.calculateDegeneracy(rxnMols)
-
                 # set degeneracy to isotopeless reaction
                 rxn.degeneracy = reference.degeneracy
                 # make this reaction have kinetics of isotopeless reaction
                 newKinetics = deepcopy(reference.kinetics)
                 rxn.kinetics = newKinetics
-
+                rxn.template = reference.template
                 # set degeneracy to new reaction
-                rxn.degeneracy = forwardDegen
-
+                rxn.degeneracy = rxn.reverse.degeneracy
+                #delete reverse attribute
+                rxn.reverse = None
 
 def redo_isotope(atomList):
     """

--- a/rmgpy/tools/isotopes.py
+++ b/rmgpy/tools/isotopes.py
@@ -224,7 +224,7 @@ def generate_isotope_reactions(isotopeless_reactions, isotopes):
         for pair in reactant_pairs:
             # copy species so they don't get modified
             speciesTuple = tuple([spc.copy(deep=True) for spc in pair])
-            unfiltered_rxns = getDB('kinetics').generate_reactions_from_families(speciesTuple)
+            unfiltered_rxns = getDB('kinetics').generate_reactions_from_families(speciesTuple,only_families=[rxn.family])
             # remove reactions whose products don't match the original reactions
             rxn_index5 = 0
             while rxn_index5 < len(unfiltered_rxns):

--- a/rmgpy/tools/isotopes.py
+++ b/rmgpy/tools/isotopes.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This module contains functionality for generating mechanisms with isotopes.
+"""
+
+import os
+import os.path
+import logging
+import numpy as np
+from copy import copy, deepcopy
+import pandas as pd
+import math
+
+import rmgpy.constants as constants
+from rmgpy.molecule import Molecule
+from rmgpy.molecule.element import getElement
+from rmgpy.tools.loader import loadRMGJob
+from rmgpy.chemkin import ChemkinWriter
+from rmgpy.rmg.main import RMG, initializeLog
+from rmgpy.rmg.model import Species
+from rmgpy.species import Species as Species2
+from rmgpy.reaction import Reaction
+from rmgpy.data.kinetics.family import TemplateReaction
+from rmgpy.thermo.thermoengine import processThermoData
+from rmgpy.data.thermo import findCp0andCpInf
+from rmgpy.data.rmg import getDB
+import rmgpy.molecule.element
+from rmgpy.kinetics.arrhenius import MultiArrhenius
+from rmgpy.reaction import isomorphic_species_lists
+
+
+def initialize_isotope_model(rmg, isotopes):
+    """
+    Initialize the RMG object by using the parameter species list
+    as initial species instead of the species from the RMG input file.
+
+    """
+    # Read input file
+    rmg.loadInput(rmg.inputFile)
+
+    # Check input file 
+    rmg.checkInput()
+
+    # Load databases
+    rmg.loadDatabase()
+
+    logging.info("isotope: Adding the isotopomers into the RMG model")
+    for isotopomers in isotopes:
+        for spc in isotopomers:
+            spec, isNew = rmg.reactionModel.makeNewSpecies(spc)
+            spec.thermo = spc.thermo
+            if isNew:
+                rmg.reactionModel.addSpeciesToEdge(spec)
+                rmg.initialSpecies.append(spec)
+    logging.info("isotope: Adding standard species into the model")
+    for spec in rmg.initialSpecies:
+        spec.thermo = processThermoData(spec, spec.thermo)
+        if not spec.reactive:
+            rmg.reactionModel.enlarge(spec)
+    for spec in rmg.initialSpecies:
+        if spec.reactive:
+            rmg.reactionModel.enlarge(spec)
+    logging.info("isotope: Finalizing the species additions")
+    rmg.initializeReactionThresholdAndReactFlags()
+    rmg.reactionModel.initializeIndexSpeciesDict()
+
+
+def generate_isotope_model(outputDirectory, rmg0, isotopes, useOriginalReactions = False,
+                         kineticIsotopeEffect = None):
+    """
+    Replace the core species of the rmg model with the parameter list
+    of species.
+
+    Generate all reactions between new list of core species.
+
+    Returns created RMG object.
+    """
+    logging.debug("isotope: called generateIsotopeModel")
+    rmg = RMG(inputFile=rmg0.inputFile, outputDirectory=outputDirectory)
+    rmg.attach(ChemkinWriter(outputDirectory))
+
+    logging.info("isotope: making the isotope model for with all species")
+    initialize_isotope_model(rmg, isotopes)
+
+    if useOriginalReactions:
+        logging.info("isotope: finding reactions from the original reactions")
+        rxns = generate_isotope_reactions(rmg0.reactionModel.core.reactions, isotopes)
+        rmg.reactionModel.processNewReactions(rxns,newSpecies=[])
+
+    else:
+        logging.info("isotope: enlarging the isotope model")
+        rmg.reactionModel.enlarge(reactEdge=True,
+            unimolecularReact=rmg.unimolecularReact,
+            bimolecularReact=rmg.bimolecularReact)
+
+    logging.info("isotope: clustering reactions")
+    clusters = cluster(rmg.reactionModel.core.reactions)
+    logging.info('isotope: fixing the directions of every reaction to a standard')
+    for isotopomerRxnList in clusters:
+        ensureReactionDirection(isotopomerRxnList)
+
+    consistent = True
+    logging.info("isotope: checking symmetry is consistent among isotopomers")
+    for species_list in cluster(rmg.reactionModel.core.species):
+        if not ensure_correct_symmetry(species_list):
+            logging.info("isotopomers of {} with index {} may have wrong symmetry".format(species_list[0], species_list[0].index))
+            consistent = False
+    logging.info("isotope: checking that reaction degeneracy is consistent among isotopomers")
+    for rxn_list in clusters:
+        if not ensure_correct_degeneracies(rxn_list):
+            logging.info("isotopomers of {} with index {} may have incorrect degeneracy.".format(rxn_list[0], rxn_list[0].index))
+            consistent = False
+    if not consistent:
+        logging.warning("isotope: non-consistent degeneracy and/or symmetry was detected. This may lead to unrealistic deviations in enrichment. check log for more details")
+
+    if kineticIsotopeEffect:
+        logging.info('isotope: modifying reaction rates using kinetic isotope effect method "{0}"'.format(kineticIsotopeEffect))
+        if kineticIsotopeEffect == 'simple':
+            apply_kinetic_isotope_effect_simple(clusters,rmg.database.kinetics)
+        else:
+            logging.warning('isotope: kinetic isotope effect {0} is not supported. skipping adding kinetic isotope effects.')
+    else:
+        logging.info('isotope: not adding kinetic isotope effects since no method was supplied.')
+    logging.info("isotope: saving files")
+    rmg.saveEverything()
+
+    rmg.finish()
+
+    return rmg
+
+def generate_isotope_reactions(isotopeless_reactions, isotopes):
+    """
+    Find the list of isotope reactions based on the reactions in the isotopeless
+    reaction.
+
+    uses the reactSpecies method to find reactions with proper degeneracies and
+    then filters out those that don't match products. the proper reactions are 
+    given kinetics of the previous reaction modified for the degeneracy difference.
+    """
+    # make sure all isotopeless reactions have templates and are TemplateReaction objects
+    for rxn in isotopeless_reactions:
+        assert isinstance(rxn,TemplateReaction)
+        assert rxn.template is not None, 'isotope reaction {0} does not have a template attribute. Full details :\n\n{1}'.format(str(rxn),repr(rxn))
+
+    from rmgpy.reaction import _isomorphicSpeciesList
+
+    found_reactions = []
+    rxn_index = 0
+    while rxn_index < len(isotopeless_reactions):
+        rxn = isotopeless_reactions[rxn_index]
+        # find all reactions involving same reactants
+        rxns_w_same_reactants = [rxn]
+        rxn_index2 = rxn_index + 1
+        while rxn_index2 < len(isotopeless_reactions):
+            if isomorphic_species_lists(isotopeless_reactions[rxn_index].reactants,
+                                      isotopeless_reactions[rxn_index2].reactants,
+                                     ):
+                rxns_w_same_reactants.append(isotopeless_reactions[rxn_index2])
+                del isotopeless_reactions[rxn_index2]
+            else:
+                rxn_index2 += 1
+        ##### find all pairs of reacting isotoper species #####
+        # find the lists of reactants that have identical isotopomers
+        reactants = []
+        for reactant in rxn.reactants:
+            for iso_index, isotopomers in enumerate(isotopes):
+                if compare_isotopomers(reactant,isotopomers[0]):
+                    reactants.append(iso_index)
+                    break
+        # find pairs of all reactants to react together
+        reactant_pairs = []
+        if len(rxn.reactants) == 1:
+            reactant_pairs = [[spec] for spec in isotopes[reactants[0]]]
+        elif len(rxn.reactants) == 2:
+            for spec1 in isotopes[reactants[0]]:
+                for spec2 in isotopes[reactants[1]]:
+                    reactant_pairs.append([spec1, spec2])
+        else:
+            raise ValueError('Cannot process reactions with over 2 reactants')
+
+        # remove identical pairs
+        rxn_index3 = 0
+        while rxn_index3 < len(reactant_pairs):
+            rxn_index4 = rxn_index3 + 1
+            while rxn_index4 < len(reactant_pairs):
+                if isomorphic_species_lists(reactant_pairs[rxn_index3],
+                                          reactant_pairs[rxn_index4]):
+                    del reactant_pairs[rxn_index4]
+                else:
+                    rxn_index4 += 1
+            rxn_index3 += 1
+
+        # make reaction objects
+        for pair in reactant_pairs:
+            # copy species so they don't get modified
+            speciesTuple = tuple([spc.copy(deep=True) for spc in pair])
+            unfiltered_rxns = getDB('kinetics').generate_reactions_from_families(speciesTuple)
+            # remove reactions whose products don't match the original reactions
+            rxn_index5 = 0
+            while rxn_index5 < len(unfiltered_rxns):
+                for isotopeless_reaction in rxns_w_same_reactants:
+                    isotopeless_kinetics = isotopeless_reaction.kinetics
+                    isotopeless_degeneracy = isotopeless_reaction.degeneracy
+                    if compare_isotopomers(isotopeless_reaction, unfiltered_rxns[rxn_index5],eitherDirection = False)\
+                        and isotopeless_reaction.family == unfiltered_rxns[rxn_index5].family\
+                        and frozenset(isotopeless_reaction.template) == \
+                                     frozenset(unfiltered_rxns[rxn_index5].template):
+                        # apply kinetics to new reaction & modify for degeneracy
+                        unfiltered_rxns[rxn_index5].kinetics = deepcopy(isotopeless_kinetics)
+                        unfiltered_rxns[rxn_index5].kinetics.changeRate(unfiltered_rxns[rxn_index5].degeneracy / isotopeless_degeneracy)
+                        rxn_index5 += 1
+                        break
+                else: # did not find same prodcuts
+                    del unfiltered_rxns[rxn_index5]
+            found_reactions.extend(unfiltered_rxns)
+        rxn_index += 1
+    return found_reactions
+
+def generate_isotopomers(spc, N=1):
+    """
+    Generate all isotopomers of the parameter species by adding max. N carbon isotopes to the
+    atoms of the species.
+    """
+
+    mol = spc.molecule[0]
+    isotope = getElement(6, 13)
+
+    mols = []
+    add_isotope(0, N, mol, mols, isotope)
+
+    spcs = []
+    for isomol in mols:
+        isotopomer = Species(molecule=[isomol], thermo=deepcopy(spc.thermo), transportData=spc.transportData, reactive=spc.reactive)
+        isotopomer.generate_resonance_structures(keep_isomorphic=True)
+        spcs.append(isotopomer)
+
+    # do not retain identical species:
+    filtered = []
+    while spcs:
+        candidate = spcs.pop()
+        unique = True
+        for isotopomer in filtered:
+            if isotopomer.isIsomorphic(candidate):
+                unique = False
+                break
+        if unique: filtered.append(candidate)
+
+    if spc.thermo:
+        for isotopomer in filtered:
+            correct_entropy(isotopomer, spc)
+
+    return filtered
+
+def add_isotope(i, N, mol, mols, element):
+    """
+    Iterate over the atoms of the molecule, and changes the element object
+    of the atom by the provide parameter element object. Add the newly created
+    isotopomer to the list of Molecule objects. For each created isotopomer,
+    recursively call the method, until the maximum number of isotopes per molecule
+    (N) is reached.
+
+    """
+    if i == N: return
+    else:
+        atoms = filter(lambda at: at.symbol == element.symbol, mol.atoms)
+        for at in atoms:
+            if at.element == element: continue
+            else:
+                isotopomer = mol.copy(deep=True)
+                isotopomer.atoms[mol.atoms.index(at)].element = element
+                mols.append(isotopomer)
+                add_isotope(i+1, N, isotopomer, mols, element)
+
+def cluster(objList):
+    """
+    Creates subcollections of isotopomers/reactions that 
+    only differ in their isotopic labeling.
+
+    This method works for either species or reactions.
+
+    It is O(n^2) efficient
+    """
+
+    unclustered = copy(objList)
+
+    # [[list of Species objs]]
+    clusters = []
+
+    while unclustered:
+        candidate = unclustered.pop()
+        for cluster in clusters:
+            if compare_isotopomers(cluster[0],candidate):
+                cluster.append(candidate)
+                break
+        else:
+            clusters.append([candidate])
+
+    return clusters
+
+def remove_isotope(labeledObj, inplace = False):
+    """
+    Create a deep copy of the first molecule of the species object and replace
+    non-normal Element objects (of special isotopes) by the 
+    expected isotope.
+
+    If the boolean `inplace` is True, the method remove the isotopic atoms of 
+    the Species/Reaction
+    inplace and returns a list of atom objects & element pairs for adding back
+    to the oritinal object. This should significantly improve speed of this method.
+
+    If successful, the non-inplace parts should be removed
+    """
+
+    if isinstance(labeledObj,Species2):
+        if inplace:
+            modifiedAtoms = []
+            for mol in labeledObj.molecule:
+                for atom in mol.atoms:
+                    if atom.element.isotope != -1:
+                        modifiedAtoms.append((atom,atom.element))
+                        atom.element = getElement(atom.element.symbol)
+            return modifiedAtoms
+        else:
+            stripped = labeledObj.copy(deep=True)
+    
+            for atom in stripped.molecule[0].atoms:
+                if atom.element.isotope != -1:
+                    atom.element = getElement(atom.element.symbol)
+
+        # only do it for the first molecule, generate the other resonance isomers.
+            stripped.molecule = [stripped.molecule[0]]
+            stripped.generate_resonance_structures(keep_isomorphic=True)
+
+        return stripped
+
+    elif isinstance(labeledObj,Reaction):
+
+        if inplace:
+
+            atomList = []
+            for reactant in  labeledObj.reactants:
+                removed = remove_isotope(reactant,inplace)
+                if removed:
+                    atomList += removed
+            for product in labeledObj.products:
+                removed = remove_isotope(product,inplace)
+                if removed:
+                    atomList += removed
+
+            return atomList
+        else:
+            strippedRxn = labeledObj.copy()
+
+            strippedReactants = []
+            for reactant in  strippedRxn.reactants:
+                strippedReactants.append(remove_isotope(reactant,inplace))
+            strippedRxn.reactants = strippedReactants
+
+            strippedProducts = []
+            for product in  strippedRxn.products:
+                strippedProducts.append(remove_isotope(product,inplace))
+            strippedRxn.products = strippedProducts
+
+            return strippedRxn
+    elif isinstance(labeledObj,Molecule):
+        if inplace:
+            modifiedAtoms = []
+            for atom in labeledObj.atoms:
+                if atom.element.isotope != -1:
+                    modifiedAtoms.append((atom,atom.element))
+                    atom.element = getElement(atom.element.symbol)
+            return modifiedAtoms
+        else:
+            stripped = labeledObj.copy(deep=True)
+
+            for atom in stripped.atoms:
+                if atom.element.isotope != -1:
+                    atom.element = getElement(atom.element.symbol)
+
+            return stripped
+    else:
+        raise TypeError('Only Reaction, Species, and Molecule objects are supported')
+
+
+def redo_isotope(atomList):
+    """
+    This takes a list of zipped atoms with their isotopes removed, from 
+    and elements.
+    """
+    for atom, element in atomList:
+        atom.element = element
+
+def compare_isotopomers(obj1, obj2, eitherDirection = True):
+    """
+    This method takes two species or reaction objects and returns true if
+    they only differ in isotopic labeling, and false if they have other
+    differences.
+
+    The remove_isotope method can be slow, especially when comparing molecules
+    and reactions. This was due to many copying of objects.
+
+    This method avoid copying by storing the isotope and atom objects,
+    removing them, doing the comparison, and rewriting them when
+    finished the comparison.
+    """
+
+    atomlist = remove_isotope(obj1,inplace=True) + remove_isotope(obj2,inplace=True)
+    if isinstance(obj1,Reaction):
+        comparisonBool = obj1.isIsomorphic(obj2, eitherDirection)
+        if comparisonBool and isinstance(obj1, TemplateReaction):
+            # ensure families are the same
+            comparisonBool = obj1.family == obj2.family
+            if comparisonBool and not eitherDirection:
+                # make sure templates are identical if in the same direction
+                comparisonBool = frozenset(obj1.template) == frozenset(obj2.template)
+    elif isinstance(obj1,Species2):
+        comparisonBool = obj1.isIsomorphic(obj2)
+    else:
+        raise TypeError('Only Reaction and Speicies Objects are supported in compareIsotopomers')
+    redo_isotope(atomlist)
+    return comparisonBool
+
+def generate_RMG_model(inputFile, outputDirectory):
+    """
+    Generate the RMG-Py model NOT containing any non-normal isotopomers.
+
+    Returns created RMG object.
+    """
+    initializeLog(logging.INFO, os.path.join(outputDirectory, 'RMG.log'))
+    # generate mechanism:
+    rmg = RMG(inputFile = os.path.abspath(inputFile),
+            outputDirectory = os.path.abspath(outputDirectory)
+        )
+    rmg.execute()
+
+    return rmg
+
+def is_enriched(obj):
+    """
+    Returns True if the species or reaction object has any enriched isotopes.
+    """
+
+    if isinstance(obj,Species):
+        for atom in obj.molecule[0].atoms:
+            if atom.element.isotope != -1 and not np.allclose(atom.element.mass, getElement(atom.element.symbol).mass):
+                return True
+        return False
+    elif isinstance(obj,Reaction):
+        enriched = []
+        for spec in obj.reactants:
+            enriched.append(is_enriched(spec))
+        for spec in obj.products:
+            enriched.append(is_enriched(spec))
+        return any(enriched)
+    else:
+        raise TypeError('is_enriched only takes species and reaction objects. {} was sent'.format(str(type(obj))))
+
+def run(inputFile, outputDir, original=None, maximumIsotopicAtoms = 1,
+                            useOriginalReactions = False,
+                            kineticIsotopeEffect = None):
+    """
+    Accepts one input file with the RMG-Py model to generate.
+
+    Firstly, generates the RMG model for the first input file. Takes the core species of that mechanism
+    and generates all isotopomers of those core species. Next, generates all reactions between the
+    generated pool of isotopomers, and writes it to file. 
+    """
+    logging.info("isotope: Starting the RMG isotope generation method 'run'")
+    if not original:
+        logging.info("isotope: original model not found, generating new one in directory `rmg`")
+        logging.info("isotope: check `rmg/RMG.log` for the rest of the logging info.")
+
+        outputdirRMG = os.path.join(outputDir, 'rmg')
+        os.mkdir(outputdirRMG)
+
+        rmg = generate_RMG_model(inputFile, outputdirRMG)
+    else:
+        logging.info("isotope: original model being copied from previous RMG job in folder {}".format(original))
+        outputdirRMG = original
+        chemkinFile = os.path.join(outputdirRMG, 'chemkin', 'chem_annotated.inp')
+        dictFile = os.path.join(outputdirRMG, 'chemkin', 'species_dictionary.txt')
+        rmg = loadRMGJob(inputFile, chemkinFile, dictFile, generateImages=False, useChemkinNames=True)
+
+    logging.info("isotope: generating isotope model")
+    logging.info('Generating isotopomers for the core species in {}'.format(outputdirRMG))
+    isotopes = []
+
+    logging.info("isotope: adding all the new and old isotopomers")
+    for spc in rmg.reactionModel.core.species:
+        findCp0andCpInf(spc, spc.thermo)
+        isotopes.append([spc] + generate_isotopomers(spc, maximumIsotopicAtoms))
+    logging.info('isotope: number of isotopomers: {}'.format(sum([len(isotopomer) for isotopomer in isotopes if isotopomer])))
+
+    outputdirIso = os.path.join(outputDir, 'iso')
+    os.mkdir(outputdirIso)
+
+    logging.info('isotope: Generating RMG isotope model in {}'.format(outputdirIso))
+    generate_isotope_model(outputdirIso, rmg, isotopes, useOriginalReactions = useOriginalReactions, kineticIsotopeEffect = kineticIsotopeEffect)

--- a/rmgpy/tools/isotopesTest.py
+++ b/rmgpy/tools/isotopesTest.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import unittest
+import os
+import numpy as np
+
+from rmgpy.species import Species
+from rmgpy.molecule import Molecule
+from rmgpy.tools.isotopes import *
+from rmgpy import settings
+from rmgpy.reaction import Reaction
+from rmgpy.data.kinetics.family import TemplateReaction
+from rmgpy.kinetics.arrhenius import Arrhenius
+
+from rmgpy.data.rmg import RMGDatabase
+
+def setUpModule():
+    """A function that is run ONCE before all unit tests in this module."""
+    global database
+    database = RMGDatabase()
+    database.load(
+        path=os.path.join(settings['test_data.directory'], 'testing_database'),
+        kineticsFamilies=[
+            'H_Abstraction',
+        ],
+        testing=True,
+        depository=False,
+        solvation=False,
+    )
+    database.loadForbiddenStructures()
+
+    # Prepare the database by loading training reactions and averaging the rate rules
+    for family in database.kinetics.families.values():
+        family.addKineticsRulesFromTrainingSet(thermoDatabase=database.thermo)
+        family.fillKineticsRulesByAveragingUp(verbose=True)
+
+
+def tearDownModule():
+    """A function that is run ONCE after all unit tests in this module."""
+    from rmgpy.data import rmg
+    rmg.database = None
+
+
+class IsotopesTest(unittest.TestCase):
+
+    def testClusterWithSpecies(self):
+        """
+        Test that isotope partitioning algorithm work with Reaction Objects.
+        """
+
+        eth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        meth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+        """
+    )
+
+        spcList = [eth, ethi]
+
+        clusters = cluster(spcList)
+        self.assertEquals(len(clusters), 1)
+        self.assertEquals(len(clusters[0]), 2)
+
+        spcList = [meth, ethi]
+
+        clusters = cluster(spcList)
+        self.assertEquals(len(clusters), 2)
+        self.assertEquals(len(clusters[0]), 1)
+
+    def testClusterWithReactions(self):
+        """
+        Test that isotope partitioning algorithm works with Reaction objects
+        """
+
+        eth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        meth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+        """
+    )
+
+        rxn0 = Reaction(reactants=[ethi,ethi], products=[ethi,eth])
+        rxn1 = Reaction(reactants=[eth,ethi], products=[eth,eth])
+        rxn2 = Reaction(reactants=[ethi,meth], products=[meth,ethi])
+        rxn3 = Reaction(reactants=[eth,meth], products=[eth,meth])
+        rxn4 = Reaction(reactants=[meth], products=[meth])
+        rxn5 = Reaction(reactants=[ethi], products=[eth])
+        
+        
+        sameClusterList = [rxn0,rxn1]
+
+        clusters = cluster(sameClusterList)
+        self.assertEquals(len(clusters), 1)
+        self.assertEquals(len(clusters[0]), 2)
+        
+        sameClusterList = [rxn2,rxn3]
+
+        clusters = cluster(sameClusterList)
+        self.assertEquals(len(clusters), 1)
+        self.assertEquals(len(clusters[0]), 2)
+
+        multiClusterList = [rxn0, rxn1, rxn2, rxn3, rxn4, rxn5]
+
+        clusters = cluster(multiClusterList)
+        self.assertEquals(len(clusters), 4)
+        self.assertEquals(len(clusters[0]), 1)
+
+        
+    def testRemoveIsotopeForReactions(self):
+        """
+        Test that remove isotope algorithm works with Reaction objects.
+        """
+
+        eth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+        unlabeledRxn = Reaction(reactants=[eth], products = [eth])
+        labeledRxn = Reaction(reactants=[ethi], products = [ethi])
+        stripped = remove_isotope(labeledRxn)
+        
+        self.assertTrue(unlabeledRxn.isIsomorphic(stripped))
+
+    def testRemoveIsotopeForSpecies(self):
+        """
+        Test that remove isotope algorithm works with Species.
+        """
+
+        eth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        stripped = remove_isotope(ethi)
+
+        self.assertTrue(eth.isIsomorphic(stripped))
+
+    def testInplaceRemoveIsotopeForReactions(self):
+        """
+        Test that removeIsotope and redoIsotope works with reactions
+        """
+
+        eth = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """
+    )
+        unlabeledRxn = Reaction(reactants=[eth], products = [eth])
+        labeledRxn = Reaction(reactants=[ethi], products = [ethi])
+        storedLabeledRxn = labeledRxn.copy()
+        modifiedAtoms = remove_isotope(labeledRxn, inplace=True)
+
+        self.assertTrue(unlabeledRxn.isIsomorphic(labeledRxn))
+
+        redo_isotope(modifiedAtoms)
+
+        self.assertTrue(storedLabeledRxn.isIsomorphic(labeledRxn))
+
+    def testCompareIsotopomersWorksOnSpecies(self):
+        """
+        Test that compareIsotomers works on species objects
+        """
+        ethii = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """)
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """)
+        self.assertTrue(compare_isotopomers(ethii,ethi))
+
+    def testCompareIsotopomersDoesNotAlterSpecies(self):
+        """
+        Test that compareIsotomers works on species objects
+        """
+        ethii = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """)
+        ethi = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 i13 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """)
+        compare_isotopomers(ethii,ethi)
+        
+        # ensure species still have labels
+        for atom in ethii.molecule[0].atoms:
+            if atom.element.symbol == 'C':
+                self.assertEqual(atom.element.isotope, 13, 'compareIsotopomer removed the isotope of a species.')
+
+    def testCompareIsotopomersFailsOnSpecies(self):
+        """
+        Test that compareIsotomers fails on species objects
+        """
+        ethane = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+        """)
+        ethenei = Species().fromAdjacencyList(
+        """
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 i13 {1,D} {6,S} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+        """)
+        self.assertFalse(compare_isotopomers(ethane,ethenei))
+
+    def testCompareIsotopomersWorksOnReactions(self):
+        """
+        Test that compareIsotomers works on different reaction objects
+        """
+        h = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1 H u1 p0 c0
+        """)
+        h2 = Species().fromAdjacencyList(
+        """
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+        """)
+        propanei = Species().fromAdjacencyList(
+        """
+1  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3  C u0 p0 c0 i13 {2,S} {9,S} {10,S} {11,S}
+4  H u0 p0 c0 {1,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+        """)
+        propane = Species().fromAdjacencyList(
+        """
+1  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  H u0 p0 c0 {1,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+        """)
+        npropyli = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  C u1 p0 c0 i13 {2,S} {4,S} {5,S}
+4  H u0 p0 c0 {3,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+        """)
+        npropyl = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  C u1 p0 c0 {2,S} {4,S} {5,S}
+4  H u0 p0 c0 {3,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+        """)
+
+        reaction2 = TemplateReaction(reactants = [propanei,h],
+                            products = [npropyli,h2],
+                            family = 'H_Abstraction')
+        reaction3 = TemplateReaction(reactants = [propane,h],
+                            products = [h2,npropyl],
+                            family = 'H_Abstraction')
+        self.assertTrue(compare_isotopomers(reaction2,reaction3))
+        
+    def testCompareIsotopomersFailsOnReactions(self):
+        """
+        Test that compareIsotomers fails on different reaction objects
+        """
+        h = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1 H u1 p0 c0
+        """)
+        h2 = Species().fromAdjacencyList(
+        """
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+        """)
+        propanei = Species().fromAdjacencyList(
+        """
+1  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3  C u0 p0 c0 i13 {2,S} {9,S} {10,S} {11,S}
+4  H u0 p0 c0 {1,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+        """)
+        propane = Species().fromAdjacencyList(
+        """
+1  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  H u0 p0 c0 {1,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+        """)
+        npropyli = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  C u1 p0 c0 i13 {2,S} {4,S} {5,S}
+4  H u0 p0 c0 {3,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+        """)
+
+        reaction2 = TemplateReaction(reactants = [propanei,h],
+                            products = [npropyli,h2],
+                            family = 'H_Abstraction')
+        
+        magicReaction = TemplateReaction(reactants = [propane,h],
+                            products = [propanei,h],
+                            family = 'H_Abstraction')
+        self.assertFalse(compare_isotopomers(reaction2,magicReaction))
+
+    def testGenerateIsotopomers(self):
+        """
+        Test that the generation of isotopomers with N isotopes works.
+        """
+        from rmgpy.thermo.nasa import NASAPolynomial, NASA
+
+        spc = Species().fromSMILES('CC')
+
+        polynomial = NASAPolynomial(coeffs=[1.,1.,1.,1.,1.,1.,1.],
+                         Tmin=(200,'K'),Tmax=(1600,'K'),E0=(1.,'kJ/mol'),
+                         comment='made up thermo')
+        
+        spc.thermo = NASA(polynomials=[polynomial],Tmin=(200,'K'),
+                        Tmax=(1600,'K'),E0=(1.,'kJ/mol'),
+                        comment='made up thermo')
+
+        spcs = generate_isotopomers(spc, 0)
+        self.assertEquals(len(spcs), 0)
+
+        spcs = generate_isotopomers(spc)
+        self.assertEquals(len(spcs), 1)
+
+        spcs = generate_isotopomers(spc, 2)
+        self.assertEquals(len(spcs), 2)
+
+        spcs = generate_isotopomers(spc, 3)
+        self.assertEquals(len(spcs), 2)
+
+    def testIsEnriched(self):
+        """
+        ensures the Enriched method functions
+        """
+        npropyl = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  C u1 p0 c0 {2,S} {4,S} {5,S}
+4  H u0 p0 c0 {3,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+        """)
+        
+        npropyli = Species().fromAdjacencyList(
+        """
+multiplicity 2
+1  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  C u0 p0 c0 i13 {1,S} {3,S} {9,S} {10,S}
+3  C u1 p0 c0 {2,S} {4,S} {5,S}
+4  H u0 p0 c0 {3,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+        """)
+        
+        self.assertTrue(is_enriched(npropyli))
+        
+        self.assertFalse(is_enriched(npropyl))
+        
+        enrichedReaction = TemplateReaction(reactants = [npropyl],
+                            products = [npropyli],
+                            family = 'H_Abstraction')
+        self.assertTrue(is_enriched(enrichedReaction))
+               
+        bareReaction = TemplateReaction(reactants = [npropyl],
+                            products = [npropyl],
+                            family = 'H_Abstraction')
+                            
+        self.assertFalse(is_enriched(bareReaction))
+
+    def testGenerateIsotopeReactions(self):
+        """
+        shows that all isotope reactions are created with generateIsotopeReactions
+        """
+        methyl = Species().fromSMILES('[CH3]')
+        methyli = Species().fromAdjacencyList(
+            """
+    multiplicity 2
+    1 C u1 p0 c0 i13 {2,S} {3,S} {4,S}
+    2 H u0 p0 c0 {1,S}
+    3 H u0 p0 c0 {1,S}
+    4 H u0 p0 c0 {1,S}
+            """)
+        methane = Species().fromAdjacencyList(
+            """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+            """)
+        methanei = Species().fromAdjacencyList(
+            """
+1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+            """)
+        craigie = Species().fromAdjacencyList(
+            """
+multiplicity 3
+1 C u2 p0 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+            """)
+        craigiei = Species().fromAdjacencyList(
+            """
+multiplicity 3
+1 C u2 p0 c0 i13 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+            """)
+        reaction = TemplateReaction(reactants = [methyl,methyl],
+                                    products = [methane,craigie],
+                                    family = 'H_Abstraction',
+                                    template = ['Xrad_H', 'Y_rad'],
+                                    degeneracy = 3)
+        reaction.kinetics = Arrhenius(A=(1e5,'cm^3/(mol*s)'),Ea=(0,'J/mol'))
+        isotope_list = [[methyl,methyli],
+                        [methane,methanei],
+                        [craigie,craigiei]]
+        
+        new_reactions = generate_isotope_reactions([reaction], isotope_list)
+
+        self.assertEqual(len(new_reactions), 4)
+
+        degeneracies_found = set()
+        for rxn in new_reactions:
+            self.assertEqual(rxn.template, reaction.template)
+            degeneracies_found.add(rxn.degeneracy)
+            self.assertIsNotNone(rxn.kinetics,'kinetics not obtained for reaction {}.'.format(rxn))
+            self.assertAlmostEqual(reaction.kinetics.getRateCoefficient(298),
+                                   rxn.kinetics.getRateCoefficient(298) *\
+                                    reaction.degeneracy / rxn.degeneracy)
+
+        self.assertEqual(degeneracies_found, set([3]))

--- a/scripts/isotopes.py
+++ b/scripts/isotopes.py
@@ -35,6 +35,8 @@ def parseCommandLineArguments():
                         help='The maxuminum number of isotopes you allow in a specific molecule')
     parser.add_argument('--useOriginalReactions' , action='store_true', default=False,
                         help='Use reactions from the original rmgpy generated chem_annotated.inp file')
+    parser.add_argument('--kineticIsotopeEffect', type=str, nargs=1, default='',
+                        help='Type of kinetic isotope effects to use, currently only "simple" supported.')
     args = parser.parse_args()
     
     return args
@@ -49,11 +51,15 @@ def main():
     inputFile = args.input
     outputdir = os.path.abspath(args.output[0]) if args.output else os.path.abspath('.')
     original = os.path.abspath(args.original[0]) if args.original else None
-
+    kie = args.kineticIsotopeEffect[0] if args.kineticIsotopeEffect else None
+    supported_kie_methods = ['simple']
+    if kie not in supported_kie_methods and kie is not None:
+        raise InputError('The kie input, {0}, is not one of the currently supported methods, {1}'.format(kie,supported_kie_methods))
     initializeLog(logging.INFO, os.path.join(os.getcwd(), 'RMG.log'))
     run(inputFile, outputdir, original=original, 
         maximumIsotopicAtoms=maximumIsotopicAtoms,
-        useOriginalReactions=useOriginalReactions)
+        useOriginalReactions=useOriginalReactions,
+        kineticIsotopeEffect = kie)
 
 if __name__ == '__main__':
     main()

--- a/scripts/isotopes.py
+++ b/scripts/isotopes.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+This script accepts one input file (e.g. input.py) with the RMG-Py model to generate, 
+optional parameters `--original [folder of original rmg model] ` can allow using 
+a starting RMG model. A special path can be added  with the argument `--output` for the
+path to output the final files.
+"""
+
+import argparse
+import logging
+import os
+import os.path
+
+from rmgpy.rmg.main import initializeLog
+from rmgpy.tools.isotopes import run
+from rmgpy.exceptions import InputError
+################################################################################
+
+
+def parseCommandLineArguments():
+    """
+    Parse the command-line arguments being passed to RMG-Py. This uses the
+    :mod:`argparse` module, which ensures that the command-line arguments are
+    sensible, parses them, and returns them.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', help='RMG input file')
+    parser.add_argument('--output', type=str, nargs=1, default='',help='Output folder')
+    parser.add_argument('--original', type=str, nargs=1, default='', 
+                        help='Location of the isotopeless mechanism')
+    parser.add_argument('--maximumIsotopicAtoms', type=int, nargs=1, default=[1000000],
+                        help='The maxuminum number of isotopes you allow in a specific molecule')
+    parser.add_argument('--useOriginalReactions' , action='store_true', default=False,
+                        help='Use reactions from the original rmgpy generated chem_annotated.inp file')
+    args = parser.parse_args()
+    
+    return args
+
+def main():
+
+    args = parseCommandLineArguments()
+    if args.useOriginalReactions and not args.original:
+        raise InputError('Cannot use original reactions without a previously run RMG job')
+    maximumIsotopicAtoms = args.maximumIsotopicAtoms[0]
+    useOriginalReactions = args.useOriginalReactions
+    inputFile = args.input
+    outputdir = os.path.abspath(args.output[0]) if args.output else os.path.abspath('.')
+    original = os.path.abspath(args.original[0]) if args.original else None
+
+    initializeLog(logging.INFO, os.path.join(os.getcwd(), 'RMG.log'))
+    run(inputFile, outputdir, original=original, 
+        maximumIsotopicAtoms=maximumIsotopicAtoms,
+        useOriginalReactions=useOriginalReactions)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/isotopes.py
+++ b/scripts/isotopes.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-This script accepts one input file (e.g. input.py) with the RMG-Py model to generate, 
-optional parameters `--original [folder of original rmg model] ` can allow using 
+This script accepts one input file (e.g. input.py) with the RMG-Py model to generate,
+optional parameters `--original [folder of original rmg model] ` can allow using
 a starting RMG model. A special path can be added  with the argument `--output` for the
 path to output the final files.
 """
@@ -29,7 +29,7 @@ def parseCommandLineArguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('input', help='RMG input file')
     parser.add_argument('--output', type=str, nargs=1, default='',help='Output folder')
-    parser.add_argument('--original', type=str, nargs=1, default='', 
+    parser.add_argument('--original', type=str, nargs=1, default='',
                         help='Location of the isotopeless mechanism')
     parser.add_argument('--maximumIsotopicAtoms', type=int, nargs=1, default=[1000000],
                         help='The maxuminum number of isotopes you allow in a specific molecule')
@@ -38,7 +38,7 @@ def parseCommandLineArguments():
     parser.add_argument('--kineticIsotopeEffect', type=str, nargs=1, default='',
                         help='Type of kinetic isotope effects to use, currently only "simple" supported.')
     args = parser.parse_args()
-    
+
     return args
 
 def main():
@@ -56,7 +56,7 @@ def main():
     if kie not in supported_kie_methods and kie is not None:
         raise InputError('The kie input, {0}, is not one of the currently supported methods, {1}'.format(kie,supported_kie_methods))
     initializeLog(logging.INFO, os.path.join(os.getcwd(), 'RMG.log'))
-    run(inputFile, outputdir, original=original, 
+    run(inputFile, outputdir, original=original,
         maximumIsotopicAtoms=maximumIsotopicAtoms,
         useOriginalReactions=useOriginalReactions,
         kineticIsotopeEffect = kie)


### PR DESCRIPTION
This PR adds the ability for RMG to create isotopic mechanisms from previous RMG runs.

The file `rmgpy/tools/isotopes.py` contains pretty much all the methods for manipulating isotopes and creating the isotope mechanism. `rmgpy/tools/isotopeTest.py` tests all the methods in `isotopes.py` except for the main run function, and the post-analysis methods to ensure proper degeneracy and symmetry. 

The file `scripts/isotopes.py` allows users to interface the `isotopes.py` method in the terminal.

A page is added to the documentation to describe all the options for using RMG to create isotopic mechanisms. 

Since most of the methods have unittests, for testing I would recommend:

1. peruse the code and testing methods
2. take your favorite rmg mechanism output (which preferably does not use reaction libraries, though you could use them for an adventure). Make it a subdirectory called `rmg`. You should have the file `rmg/chemkin/chem_annotated.inp`. Then run 

`python $rmg/scripts/isotopes.py --original rmg --kineticIsotopeEffect simple --maximumIsotopicAtoms 1 --useOriginalReactions`

