### PR TITLE
Allow tri-rads in findAllDelocalizationPaths

### DIFF
--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -256,7 +256,7 @@ def findAllDelocalizationPaths(atom1):
     paths = []
     for atom2, bond12 in atom1.edges.items():
         # Vinyl bond must be capable of gaining an order
-        if (bond12.isSingle() or bond12.isDouble()) and (atom1.radicalElectrons == 1 or atom1.radicalElectrons == 2):
+        if (bond12.isSingle() or bond12.isDouble()) and (atom1.radicalElectrons in [1,2,3]):
             for atom3, bond23 in atom2.edges.items():
                 # Allyl bond must be capable of losing an order without breaking
                 if atom1 is not atom3 and (bond23.isDouble() or bond23.isTriple()):


### PR DESCRIPTION
We currently find the ally resonance transformation `[C..]=C[CH2.] --> [C...]C=C`, but we don't find the transformation in the reverse direction, creating a hysteresis (and duplicate species).
(dots above were added to explicitly denote radicals in the SMILES)

As a result, the following are currently different species if they are generated in the following order:
![image](https://user-images.githubusercontent.com/16158262/36491550-fe1a848c-16f8-11e8-839f-78ca7c65e2a4.png)
![image](https://user-images.githubusercontent.com/16158262/36491554-00b08016-16f9-11e8-871d-3f4711ff94b3.png)


No test was added now since this will also be implemented in a future lone pair resonance PR with appropriate testing for this case as well.