### PR TITLE
Fix network __repr__ method

### DIFF
--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -121,23 +121,23 @@ class Network:
     def __repr__(self):
         string = 'Network('
         if self.label != '': string += 'label="{0}", '.format(self.label)
-        if self.isomers: string += 'isomers="{0!r}", '.format(self.isomers)
-        if self.reactants: string += 'reactants="{0!r}", '.format(self.reactants)
-        if self.products: string += 'products="{0!r}", '.format(self.products)
-        if self.pathReactions: string += 'pathReactions="{0!r}", '.format(self.pathReactions)
-        if self.bathGas: string += 'bathGas="{0!r}", '.format(self.bathGas)
-        if self.netReactions: string += 'netReactions="{0!r}", '.format(self.netReactions)
+        if self.isomers is not None: string += 'isomers="{0!r}", '.format(self.isomers)
+        if self.reactants is not None: string += 'reactants="{0!r}", '.format(self.reactants)
+        if self.products is not None: string += 'products="{0!r}", '.format(self.products)
+        if self.pathReactions is not None: string += 'pathReactions="{0!r}", '.format(self.pathReactions)
+        if self.bathGas is not None: string += 'bathGas="{0!r}", '.format(self.bathGas)
+        if self.netReactions is not None: string += 'netReactions="{0!r}", '.format(self.netReactions)
         if self.T != 0.0: string += 'T="{0}", '.format(self.T)
         if self.P != 0.0: string += 'P="{0}", '.format(self.P)
-        if self.Elist: string += 'Elist="{0}", '.format(self.Elist)
-        if self.Jlist: string += 'Jlist="{0}", '.format(self.Jlist)
+        if self.Elist is not None: string += 'Elist="{0}", '.format(self.Elist)
+        if self.Jlist is not None: string += 'Jlist="{0}", '.format(self.Jlist)
         if self.Ngrains != 0: string += 'Ngrains="{0}", '.format(self.Ngrains)
         if self.NJ != 0: string += 'NJ="{0}", '.format(self.NJ)
         string += 'activeKRotor="{0}", '.format(self.activeKRotor)
         string += 'activeJRotor="{0}", '.format(self.activeJRotor)
         if self.grainSize != 0.0: string += 'grainSize="{0}", '.format(self.grainSize)
         if self.grainCount != 0: string += 'grainCount="{0}", '.format(self.grainCount)
-        if self.E0: string += 'E0="{0}", '.format(self.E0)
+        if self.E0 is not None: string += 'E0="{0}", '.format(self.E0)
         string += ')'
         return string
 


### PR DESCRIPTION
The __repr__ method throws an error when comparing the truth value
of a list. This commit adds more specific comparison to prevent an
error in the __repr__ method.

This fixes issue #1300.

I ran `make eg5` with no errors on this 