### PR TITLE
Adjust threshold for zero energy in applyInverseLaplaceTransformMethod

### DIFF
--- a/rmgpy/pdep/reaction.pyx
+++ b/rmgpy/pdep/reaction.pyx
@@ -309,7 +309,7 @@ def applyInverseLaplaceTransformMethod(transitionState,
             phi0 = numpy.zeros(Ngrains, numpy.float64)
             for r in range(Ngrains):
                 E = Elist[r] - Elist[0] - Ea
-                if E > 0:
+                if E > 1:
                     phi0[r] = (E/R)**(n-1.0)
             phi0 = phi0 * (dE / R) / scipy.special.gamma(n)
             # Evaluate the convolution


### PR DESCRIPTION
To prevent small values from blowing up in the subsequent calculation of `phi0`.

This has been shown to fix some cases of `InvalidMicrocanonicalRateError`, by @jimchu10 and @mjohnson541. The effect on previously converged pdep jobs has also been shown to be minimal.