### PR TITLE
Remove reaction duplicate checking at model completion

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -811,19 +811,30 @@ class RMG(util.Subject):
         """
         Run checks on the RMG model
         """
-        #check that no two species in core or edge are isomorphic
-        for i,spc in enumerate(self.reactionModel.core.species):
+        logging.info('Performing final model checks...')
+
+        # Check that no two species in core or edge are isomorphic
+        for i, spc in enumerate(self.reactionModel.core.species):
             for j in xrange(i):
                 spc2 = self.reactionModel.core.species[j]
                 if spc.isIsomorphic(spc2):
-                    raise CoreError('Although the model has completed, species {0} is isomorphic to species {1} in the core.  Please open an issue on GitHub with the following output: \n{2}\n{3}'.format(spc.label,spc2.label,spc.toAdjacencyList(),spc2.toAdjacencyList()))
-        
-        for i,spc in enumerate(self.reactionModel.edge.species):
+                    raise CoreError(
+                        'Although the model has completed, species {0} is isomorphic to species {1} in the core. '
+                        'Please open an issue on GitHub with the following output:'
+                        '\n{2}\n{3}'.format(spc.label, spc2.label, spc.toAdjacencyList(), spc2.toAdjacencyList())
+                    )
+
+        for i, spc in enumerate(self.reactionModel.edge.species):
             for j in xrange(i):
                 spc2 = self.reactionModel.edge.species[j]
                 if spc.isIsomorphic(spc2):
-                    logging.warning('species {0} is isomorphic to species {1} in the edge.  Note this does not affect the generated model.  If you would like to report this to help make RMG better please open a GitHub issue with the following output: \n{2}\n{3}'.format(spc.label,spc2.label,spc.toAdjacencyList(),spc2.toAdjacencyList()))
-        
+                    logging.warning(
+                        'Species {0} is isomorphic to species {1} in the edge. This does not affect '
+                        'the generated model. If you would like to report this to help make RMG better '
+                        'please open a GitHub issue with the following output:'
+                        '\n{2}\n{3}'.format(spc.label, spc2.label, spc.toAdjacencyList(), spc2.toAdjacencyList())
+                    )
+
     def makeSeedMech(self,firstTime=False):
         """
         causes RMG to make a seed mechanism out of the current chem_annotated.inp and species_dictionary.txt

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -824,23 +824,6 @@ class RMG(util.Subject):
                 if spc.isIsomorphic(spc2):
                     logging.warning('species {0} is isomorphic to species {1} in the edge.  Note this does not affect the generated model.  If you would like to report this to help make RMG better please open a GitHub issue with the following output: \n{2}\n{3}'.format(spc.label,spc2.label,spc.toAdjacencyList(),spc2.toAdjacencyList()))
         
-        for i,rxn1 in enumerate(self.reactionModel.core.reactions):
-            for j in xrange(i):
-                rxn2 = self.reactionModel.core.reactions[j]
-                if not(rxn1.duplicate and rxn2.duplicate) and rxn1.isIsomorphic(rxn2):
-                    logging.warning('rxn {0} in the core has duplicate reactions that are unmarked these reactions may duplicate each other:'.format(str(rxn1)))
-                    logging.warning('index: {0}, \n rxn: {1!r}'.format(i,rxn1))
-                    logging.warning('index: {0}, \n rxn: {1!r}'.format(j,rxn2))
-                    
-        for i,rxn1 in enumerate(self.reactionModel.edge.reactions):
-            for j in xrange(i):
-                rxn2 = self.reactionModel.edge.reactions[j]
-                if not(rxn1.duplicate and rxn2.duplicate) and rxn1.isIsomorphic(rxn2):
-                    logging.warning('rxn {0} in the edge has duplicate reactions that are unmarked these reactions may duplicate each other:'.format(str(rxn1)))
-                    logging.warning('index: {0}, \n rxn: {1!r}'.format(i,rxn1))
-                    logging.warning('index: {0}, \n rxn: {1!r}'.format(j,rxn2))
-                    
-        
     def makeSeedMech(self,firstTime=False):
         """
         causes RMG to make a seed mechanism out of the current chem_annotated.inp and species_dictionary.txt


### PR DESCRIPTION
When a reaction duplicate warning is outputted, the entire reaction object gets print. This isn't informative, and could be frightening to users (~ 100 screens worth of output, see attached example when rxns are PDep)
[RMG_backup.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/1809491/RMG_backup.txt)
This small fix only outputs the reaction strings (in addition to indices).
