### PR TITLE
Minor changes to forbidden structure loading and checking

### DIFF
--- a/documentation/source/users/rmg/database/introduction.rst
+++ b/documentation/source/users/rmg/database/introduction.rst
@@ -218,12 +218,12 @@ or products that are forbidden.  These groups are stored in in the file located 
 
 To ban certain specific pathways in the kinetics 
 families, a `forbidden` group must be created, like the following group
-in the ``intra_H_migration`` family ::
+in the ``intra_H_migration`` family: ::
 
     forbidden(
         label = "bridged56_1254",
-    group =
-    """""""
+        group =
+    """
     1 *1 C 1 {2,S} {6,S}
     2 *4 C 0 {1,S} {3,S} {7,S}
     3    C 0 {2,S} {4,S}
@@ -234,9 +234,9 @@ in the ``intra_H_migration`` family ::
     8 *3 H 0 {4,S}
     """,
         shortDesc = u"""""",
-        longDesc = 
+        longDesc =
     u"""
-    
+
     """,
     )
 
@@ -244,6 +244,42 @@ Forbidden groups should be placed inside the groups.py file located inside the
 specific kinetics family's folder ``RMG-database/input/kinetics/family_name/`` 
 alongside normal group entries. The starred atoms in the forbidden group
 ban the specified reaction recipe from occurring in matched products and reactants.
+
+In addition for forbidding groups, there is the option of forbidding specific
+molecules or species. Forbidding a molecule will prevent that exact structure
+from being generated, while forbidding a species will prevent any of its resonance
+structures from being generated. To specify a forbidden molecule or species, simply
+replace the ``group`` keyword with ``molecule`` or ``species``: ::
+
+    # This forbids a molecule
+    forbidden(
+        label = "C_quintet",
+        molecule =
+    """
+    multiplicity 5
+    1 C u4 p0
+    """,
+        shortDesc = u"""""",
+        longDesc =
+    u"""
+
+    """,
+    )
+
+    # This forbids a species
+    forbidden(
+        label = "C_quintet",
+        species =
+    """
+    multiplicity 5
+    1 C u4 p0
+    """,
+        shortDesc = u"""""",
+        longDesc =
+    u"""
+
+    """,
+    )
 
 Hierarchical Trees
 ------------------

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -1280,10 +1280,7 @@ class ForbiddenStructures(Database):
                     return True
             
         # Until we have more thermodynamic data of molecular ions we will forbid them
-        molecule_charge = 0
-        for atom in molecule.atoms:
-            molecule_charge += atom.charge
-        if molecule_charge != 0:
+        if molecule.getNetCharge() != 0:
             return True
         
         return False

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -1287,7 +1287,7 @@ class ForbiddenStructures(Database):
                     if molecule.isMappingValid(entry.item, initialMap) and molecule.isSubgraphIsomorphic(entry.item, initialMap):
                         return True
             else:
-                raise NotImplementedError
+                raise NotImplementedError('Checking is only implemented for forbidden Groups, Molecule, and Species.')
             
         # Until we have more thermodynamic data of molecular ions we will forbid them
         if molecule.getNetCharge() != 0:

--- a/rmgpy/data/baseTest.py
+++ b/rmgpy/data/baseTest.py
@@ -32,8 +32,8 @@ import os
 import unittest
 from external.wip import work_in_progress
 
-from rmgpy.data.base import Entry, Database
-from rmgpy.molecule import Group
+from rmgpy.data.base import Entry, Database, ForbiddenStructures
+from rmgpy.molecule import Group, Molecule
 
 ################################################################################
 
@@ -116,6 +116,103 @@ class TestBaseDatabase(unittest.TestCase):
         self.assertTrue(self.database.matchNodeToNode(entry1,entry1))
         self.assertFalse(self.database.matchNodeToNode(entry1,entry2))
 
+
+class TestForbiddenStructures(unittest.TestCase):
+
+    def setUp(self):
+        self.database = ForbiddenStructures()
+
+    def test_forbidden_group(self):
+        """Test that we can load and check a forbidden group."""
+        test = """
+1 C u2 p0 {2,D}
+2 C u0 {1,D}
+"""
+        self.database.loadEntry(
+            label='test',
+            group=test,
+        )
+
+        molecule = Molecule().fromAdjacencyList("""
+multiplicity 3
+1 C u2 p0 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+""")
+
+        self.assertTrue(self.database.isMoleculeForbidden(molecule))
+
+    def test_forbidden_molecule(self):
+        """Test that we can load and check a forbidden molecule."""
+        test = """
+1 C u4 p0 c0
+"""
+        self.database.loadEntry(
+            label='test',
+            molecule=test,
+        )
+
+        molecule = Molecule().fromAdjacencyList("""
+1 C u4 p0 c0
+""")
+
+        self.assertTrue(self.database.isMoleculeForbidden(molecule))
+
+    def test_forbidden_species(self):
+        """Test that we can load and check a forbidden species.
+
+        This is a hypothetical test, we don't actually forbid benzene."""
+        test = """
+1  C u0 p0 c0 {2,D} {6,S} {7,S}
+2  C u0 p0 c0 {1,D} {3,S} {8,S}
+3  C u0 p0 c0 {2,S} {4,D} {9,S}
+4  C u0 p0 c0 {3,D} {5,S} {10,S}
+5  C u0 p0 c0 {4,S} {6,D} {11,S}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+"""
+        self.database.loadEntry(
+            label='test',
+            species=test,
+        )
+
+        molecule1 = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,D} {6,S} {7,S}
+2  C u0 p0 c0 {1,D} {3,S} {8,S}
+3  C u0 p0 c0 {2,S} {4,D} {9,S}
+4  C u0 p0 c0 {3,D} {5,S} {10,S}
+5  C u0 p0 c0 {4,S} {6,D} {11,S}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""")
+        molecule2 = Molecule().fromAdjacencyList("""
+1  C u0 p0 c0 {2,B} {6,B} {7,S}
+2  C u0 p0 c0 {1,B} {3,B} {8,S}
+3  C u0 p0 c0 {2,B} {4,B} {9,S}
+4  C u0 p0 c0 {3,B} {5,B} {10,S}
+5  C u0 p0 c0 {4,B} {6,B} {11,S}
+6  C u0 p0 c0 {1,B} {5,B} {12,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""")
+
+        self.assertTrue(self.database.isMoleculeForbidden(molecule1))
+        self.assertTrue(self.database.isMoleculeForbidden(molecule2))
 
 
 ################################################################################


### PR DESCRIPTION
This fixes the capability to specify a molecule as a forbidden structure and adds the capability to specify a species as a forbidden structure.

The benefit of these over groups is that they can use normal isomorphism, which allows comparison of molecular formulas. In the future, they could also be changed to an InChI comparison to completely eliminate the need for isomorphism.