### PR TITLE
Subgraph isomorphism improvements

### DIFF
--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -153,6 +153,8 @@ cdef class Group(Graph):
 
     cpdef dict getLabeledAtoms(self)
 
+    cpdef dict get_element_count(self)
+
     cpdef fromAdjacencyList(self, str adjlist)
 
     cpdef toAdjacencyList(self, str label=?)

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -114,13 +114,7 @@ cdef class Group(Graph):
 
     # These read-only attribues act as a "fingerprint" for accelerating
     # subgraph isomorphism checks
-    cdef public short carbonCount
-    cdef public short nitrogenCount
-    cdef public short oxygenCount
-    cdef public short sulfurCount
-    cdef public short chlorineCount
-    cdef public short iodineCount
-    cdef public short siliconCount
+    cdef public dict elementCount
     cdef public short radicalCount
 
     cpdef addAtom(self, GroupAtom atom)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -869,6 +869,8 @@ class Group(Graph):
         Graph.__init__(self, atoms)
         self.props = props or {}
         self.multiplicity = multiplicity or []
+        self.elementCount = {}
+        self.radicalCount = -1
         self.update()
 
     def __reduce__(self):
@@ -1148,54 +1150,11 @@ class Group(Graph):
         Update the molecular fingerprint used to accelerate the subgraph
         isomorphism checks.
         """
-        cython.declare(atom=GroupAtom, atomType=AtomType)
-        cython.declare(carbon=AtomType, nitrogen=AtomType, oxygen=AtomType, sulfur=AtomType, chlorine=AtomType,
-                       iodine=AtomType, silicon=AtomType)
-        cython.declare(isCarbon=cython.bint, isNitrogen=cython.bint, isOxygen=cython.bint, isSulfur=cython.bint,
-                       isChlorine=cython.bint, isIodine=cython.bint, isSilicon=cython.bint, radical=cython.int)
+        cython.declare(atom=GroupAtom)
 
-        carbon   = atomTypes['C']
-        nitrogen = atomTypes['N']
-        oxygen   = atomTypes['O']
-        sulfur   = atomTypes['S']
-        chlorine = atomTypes['Cl']
-        iodine   = atomTypes['I']
-        silicon  = atomTypes['Si']
-        
-        self.carbonCount   = 0
-        self.nitrogenCount = 0
-        self.oxygenCount   = 0
-        self.sulfurCount   = 0
-        self.chlorineCount = 0
-        self.iodineCount   = 0
-        self.siliconCount  = 0
-        self.radicalCount  = 0
+        self.elementCount = self.get_element_count()
+        self.radicalCount = 0
         for atom in self.vertices:
-            if len(atom.atomType) == 1:
-                atomType   = atom.atomType[0]
-                isCarbon   = atomType.equivalent(carbon)
-                isNitrogen = atomType.equivalent(nitrogen)
-                isOxygen   = atomType.equivalent(oxygen)
-                isSulfur   = atomType.equivalent(sulfur)
-                isChlorine = atomType.equivalent(chlorine)
-                isIodine = atomType.equivalent(iodine)
-                isSilicon  = atomType.equivalent(silicon)
-                sum_is_atom = isCarbon + isNitrogen + isOxygen + isSulfur + isChlorine + isIodine + isSilicon
-                if sum_is_atom == 1:
-                    if isCarbon:
-                        self.carbonCount += 1
-                    elif isNitrogen:
-                        self.nitrogenCount += 1
-                    elif isOxygen:
-                        self.oxygenCount += 1
-                    elif isSulfur:
-                        self.sulfurCount += 1
-                    elif isChlorine:
-                        self.chlorineCount += 1
-                    elif isIodine:
-                        self.iodineCount += 1
-                    elif isSilicon:
-                        self.siliconCount += 1
             if len(atom.radicalElectrons) >= 1:
                 self.radicalCount += atom.radicalElectrons[0]
 

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1090,6 +1090,38 @@ class Group(Graph):
                     labeled[atom.label] = atom
         return labeled
 
+    def get_element_count(self):
+        """
+        Returns the element count for the molecule as a dictionary.
+        Wildcards are not counted as any particular element.
+        """
+        from rmgpy.molecule.atomtype import allElements
+
+        element_count = {}
+        for atom in self.atoms:
+            same = True
+            match = None
+            for atomtype in atom.atomType:
+                if match is None:
+                    # This is the first type in the list, so check all elements
+                    for element in allElements:
+                        if atomtype.isSpecificCaseOf(atomTypes[element]):
+                            match = element
+                            break
+                else:
+                    # We've already matched one atomtype, now confirm that the rest are the same
+                    if not atomtype.isSpecificCaseOf(atomTypes[match]):
+                        same = False
+                        break
+            # If match is None, then the group is not a specific case of any element
+            if match is not None and same:
+                if match in element_count:
+                    element_count[match] += 1
+                else:
+                    element_count[match] = 1
+
+        return element_count
+
     def fromAdjacencyList(self, adjlist):
         """
         Convert a string adjacency list `adjlist` to a molecular structure.

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -1375,6 +1375,18 @@ graph G {
         mergedGroup = backbone2.mergeGroups(end2)
         self.assertTrue(mergedGroup.isIdentical(desiredMerge2))
 
+    def test_get_element_count(self):
+        """Test that we can count elements properly."""
+        group = Group().fromAdjacencyList("""
+1 R!H u0 {2,S}
+2 [Cs,Cd,Ct,Cb] u0 {1,S} {3,S}
+3 [Cs,Cd,Ct,Cb,O2s,S2s] u0 {2,S} {4,S}
+4 N1s u0 {3,S}
+""")
+        expected = {'C': 1, 'N': 1}
+        result = group.get_element_count()
+        self.assertEqual(expected, result)
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -172,6 +172,8 @@ cdef class Molecule(Graph):
 
     cpdef dict getLabeledAtoms(self)
 
+    cpdef dict get_element_count(self)
+
     cpdef bint isIsomorphic(self, Graph other, dict initialMap=?) except -2
 
     cpdef list findIsomorphism(self, Graph other, dict initialMap=?)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1222,32 +1222,22 @@ class Molecule(Graph):
         if not isinstance(other, gr.Group):
             raise TypeError('Got a {0} object for parameter "other", when a Molecule object is required.'.format(other.__class__))
         group = other
-        
-        # Count the number of carbons, oxygens, and radicals in the molecule
-        carbonCount = 0; nitrogenCount = 0; oxygenCount = 0; sulfurCount = 0; radicalCount = 0
-        for atom in self.vertices:
-            if atom.element.symbol == 'C':
-                carbonCount += 1
-            elif atom.element.symbol == 'N':
-                nitrogenCount += 1
-            elif atom.element.symbol == 'O':
-                oxygenCount += 1
-            elif atom.element.symbol == 'S':
-                sulfurCount += 1
-            radicalCount += atom.radicalElectrons
-        
-        
+
+        # Check multiplicity
         if group.multiplicity:
             if self.multiplicity not in group.multiplicity: return False
-        # If the molecule has fewer of any of these things than the functional
-        # group does, then we know the subgraph isomorphism fails without
-        # needing to perform the full isomorphism check
-        if (radicalCount < group.radicalCount or
-            carbonCount < group.carbonCount or
-            nitrogenCount < group.nitrogenCount or
-            oxygenCount < group.oxygenCount or
-            sulfurCount < group.sulfurCount):
+
+        # Compare radical counts
+        if self.getRadicalCount() < group.radicalCount:
             return False
+
+        # Compare element counts
+        element_count = self.get_element_count()
+        for element, count in group.elementCount.iteritems():
+            if element not in element_count:
+                return False
+            elif element_count[element] < count:
+                return False
 
         # Do the isomorphism comparison
         result = Graph.isSubgraphIsomorphic(self, other, initialMap)
@@ -1272,31 +1262,23 @@ class Molecule(Graph):
         if not isinstance(other, gr.Group):
             raise TypeError('Got a {0} object for parameter "other", when a Group object is required.'.format(other.__class__))
         group = other
-                # Count the number of carbons, oxygens, and radicals in the molecule
-        carbonCount = 0; nitrogenCount = 0; oxygenCount = 0; sulfurCount = 0; radicalCount = 0
-        for atom in self.vertices:
-            if atom.element.symbol == 'C':
-                carbonCount += 1
-            elif atom.element.symbol == 'N':
-                nitrogenCount += 1
-            elif atom.element.symbol == 'O':
-                oxygenCount += 1
-            elif atom.element.symbol == 'S':
-                sulfurCount += 1
-            radicalCount += atom.radicalElectrons
-        
-        
+
+        # Check multiplicity
         if group.multiplicity:
             if self.multiplicity not in group.multiplicity: return []
-        # If the molecule has fewer of any of these things than the functional
-        # group does, then we know the subgraph isomorphism fails without
-        # needing to perform the full isomorphism check
-        if (radicalCount < group.radicalCount or
-            carbonCount < group.carbonCount or
-            nitrogenCount < group.nitrogenCount or
-            oxygenCount < group.oxygenCount or
-            sulfurCount < group.sulfurCount):
+
+        # Compare radical counts
+        if self.getRadicalCount() < group.radicalCount:
             return []
+
+        # Compare element counts
+        element_count = self.get_element_count()
+        for element, count in group.elementCount.iteritems():
+            if element not in element_count:
+                return []
+            elif element_count[element] < count:
+                return []
+
         # Do the isomorphism comparison
         result = Graph.findSubgraphIsomorphisms(self, other, initialMap)
         return result

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1138,6 +1138,22 @@ class Molecule(Graph):
                     labeled[atom.label] = atom
         return labeled
 
+    def get_element_count(self):
+        """
+        Returns the element count for the molecule as a dictionary.
+        """
+        element_count = {}
+        for atom in self.atoms:
+            symbol = atom.element.symbol
+            isotope = atom.element.isotope
+            key = symbol if isotope == -1 else (symbol, isotope)
+            if key in element_count:
+                element_count[key] += 1
+            else:
+                element_count[key] = 1
+
+        return element_count
+
     def isIsomorphic(self, other, initialMap=None):
         """
         Returns :data:`True` if two graphs are isomorphic and :data:`False`

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2206,6 +2206,23 @@ multiplicity 2
         test.update()
         self.assertTrue(expected.isIsomorphic(test))
 
+    def test_get_element_count(self):
+        """Test that we can count elements properly."""
+        mol1 = Molecule(SMILES='c1ccccc1')
+        expected1 = {'C': 6, 'H': 6}
+        result1 = mol1.get_element_count()
+        self.assertEqual(expected1, result1)
+
+        mol2 = Molecule(SMILES='CS(C)(=O)=O')
+        expected2 = {'C': 2, 'H': 6, 'O': 2, 'S': 1}
+        result2 = mol2.get_element_count()
+        self.assertEqual(expected2, result2)
+
+        mol3 = Molecule(SMILES='CCN')
+        expected3 = {'C': 2, 'H': 7, 'N': 1}
+        result3 = mol3.get_element_count()
+        self.assertEqual(expected3, result3)
+
 
 ################################################################################
 

--- a/rmgpy/molecule/util.py
+++ b/rmgpy/molecule/util.py
@@ -52,16 +52,7 @@ def retrieveElementCount(obj):
         return element_count
     
     elif isinstance(obj, Molecule):
-        for atom in obj.atoms:
-            symbol = atom.element.symbol
-            isotope = atom.element.isotope
-            key = symbol if isotope == -1 else (symbol, isotope)
-            if key in element_count:
-                updated_count = element_count[key] + 1
-                element_count[key] = updated_count 
-            else:
-                element_count[key] = 1
-        return element_count
+        return obj.get_element_count()
 
     else:
         raise Exception


### PR DESCRIPTION
Changes:
- Add `get_element_count` methods to both Molecule and Group. Both implementations are generic with no hard-coded elements.
- Replace element counting done during subgraph isomorphism with `get_element_count`.
- Add check for number of relevant cycles in subgraph isomorphism.

The following plot shows timings for subgraph isomorphism done using the timeit module. The individual values represent the mean of 10 repetitions of 100 calls.

![image](https://user-images.githubusercontent.com/10817103/37486268-646d3546-2864-11e8-8839-f8b3a1dbda92.png)

Main conclusions:
- The changes to elements do not have a statistically significant effect on time.
- isCyclic is worse in all aspects. Performing the isCyclic check for dodecane took longer than subgraph isomorphism alone.
- getRelevantCycles increases overhead but provides significant speedup in cases with many cycles

The methods tested were:
- master: current master
- elements: with element count changes in this PR
- isCyclic: with addition of isCyclic check
- getRelevantCycles: with addition of relevant cycle count check

The groups tested were:
- g1: strained_tetracyclic_1
- g2: strained_tricyclic_1
- g3: strained_tricyclic_2
- g4: strained_tricyclic_3

The molecules tested were:
- m1: CCCCCC
- m2: C1CCCCC1
- m3: CCCCCCCCCCCC
- m4: C1CCCC2C1CCC3CCCCC23

RMG-tests results to be posted...