### PR TITLE
Remove atoms parameter in Cantherm and allow user-defined atomic energies

### DIFF
--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -155,7 +155,7 @@ Allowed bond types for the ``bonds`` parameter are, e.g., ``'C-H'``, ``'C-C'``, 
 
 ``'O=S=O'`` is also allowed.
 
-The order of elements in the bond correction label is important and generally follows the order specified under "allowed atom symbols" above, i.e., ``'C=N'`` is correct while ``'N=C'`` is incorrect. Use ``-``/``=``/``#`` to denote a single/double/triple bond, respectively. For example, for formaldehyde we would write::
+The order of elements in the bond correction label is not important. Use ``-``/``=``/``#`` to denote a single/double/triple bond, respectively. For example, for formaldehyde we would write::
 
     bonds = {'C=O': 1, 'C-H': 2}
 

--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -67,9 +67,6 @@ Model Chemistry                                  AEC   BC   SOC
 ``'B-CCSD(T)-F12/cc-pVnZ-F12'``, *n = D,T,Q*      v         v
 ``'B-CCSD(T)-F12/cc-pCVnZ-F12'``, *n = D,T,Q*     v         v
 ``'B-CCSD(T)-F12/aug-cc-pVnZ-F12'``, *n = D,T,Q*  v         v
-``'DFT_G03_b3lyp'``                               v    v    v
-``'DFT_ks_b3lyp'``                                          v
-``'DFT_uks_b3lyp'``                                         v
 ``'G03_PBEPBE_6-311++g_d_p'``                     v         v
 ``'MP2_rmp2_pVnZ'``, *n = D,T,Q*                  v         v
 ``'FCI/cc-pVnZ'``, *n = D,T,Q*                    v         v

--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -39,7 +39,7 @@ which accepts a string describing the model chemistry.
 CanTherm uses this information to adjust the computed energies to the usual gas-phase reference
 states by applying atom, bond and spin-orbit coupling energy corrections. This is particularly
 important for ``thermo()`` calculations (see below). Note that the user must specify under the
-``species()`` function the type and number of atoms and bonds for CanTherm to apply these corrections.
+``species()`` function the type and number of bonds for CanTherm to apply these corrections.
 The example below specifies CBS-QB3 as the model chemistry::
 
     modelChemistry("CBS-QB3")
@@ -114,7 +114,6 @@ The species input file accepts the following parameters:
 ======================= =========================== ====================================
 Parameter               Required?                   Description
 ======================= =========================== ====================================
-``atoms``               yes                         Type and number of atoms in the species
 ``bonds``               optional                    Type and number of bonds in the species
 ``linear``              yes                         ``True`` if the molecule is linear, ``False`` if not
 ``externalSymmetry``    yes                         The external symmetry number for rotation
@@ -128,12 +127,11 @@ Parameter               Required?                   Description
 ``rotors``              optional                    A list of :class:`HinderedRotor()` and/or :class:`FreeRotor()` objects describing the hindered/free rotors
 ======================= =========================== ====================================
 
-The ``atom`` and ``bond`` parameters are used to apply atomization energy corrections (AEC), bond corrections (BC), and spin orbit corrections (SOC) for a given ``modelChemistry()`` (see `Model Chemistry`_).
+The types and number of atoms in the species are automatically inferred from the quantum chemistry output and are used
+to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry()``
+(see `Model Chemistry`_).
 
-Allowed atom symbols for the ``atoms`` parameter are
-``'C'``, ``'N'``, ``'O'``, ``'S'``, ``'P'``, and ``'H'``. For example, for formaldehyde we would write::
-
-    atoms = {'C': 1, 'O': 1, H': 2}
+The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry()``.
 
 Allowed bond types for the ``bonds`` parameter are, e.g., ``'C-H'``, ``'C-C'``, ``'C=C'``, ``'N-O'``, ``'C=S'``, ``'O=O'``, ``'C#N'``...
 
@@ -189,11 +187,6 @@ the ``species()`` function in the input file should look like the following exam
     species('C2H6', 'C2H6.py')
 
 and the species input file (``C2H6.py`` in the example above) should look like the following::
-
-    atoms = {
-    'C': 2,
-    'H': 6,
-    }
 
     bonds = {
         'C-C': 1,
@@ -299,11 +292,6 @@ puts a lower bound on the impact of that rotor on the species's overall partitio
 in between these two extremes.
 
 To summarize, the species input file with hindered/free rotors should look like the following example (different options for specifying the same ``rotors`` entry are commented out)::
-
-    atoms = {
-        'C': 2,
-        'H': 6,
-    }
 
     bonds = {
         'C-C': 1,

--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -22,6 +22,7 @@ Component                   Description
 ``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
 ``useHinderedRotors``       ``True`` if hindered rotors are used, ``False`` if not
+``useAtomCorrections``      ``True`` if atom corrections are used, ``False`` if not
 ``useBondCorrections``      ``True`` if bond corrections are used, ``False`` if not
 ``species``                 Contains parameters for non-transition states
 ``transitionState``         Contains parameters for transition state(s)
@@ -57,7 +58,7 @@ specified in the input file by providing a dictionary of these energies in the f
     }
 
 The table below shows which model chemistries have atomization energy corrections (AEC), bond
-corrections (BC), and spin orbit corrections (SOC). It also lists which atoms types are available
+corrections (BC), and spin orbit corrections (SOC). It also lists which elements are available
 for a given model chemistry.
 
 ================================================ ===== ==== ==== ====================
@@ -98,6 +99,12 @@ Notes:
 If a model chemistry other than the ones in the above table is used, then the user should supply
 the corresponding atomic energies (using ``atomEnergies``) to get meaningful results. Bond
 corrections would not be applied in this case.
+
+If a model chemistry or atomic energies are not available, then a kinetics job can still be run by
+setting ``useAtomCorrections`` to ``False``, in which case Cantherm will not raise an error for
+unknown elements. The user should be aware that the resulting energies and thermodynamic quantities
+in the output file will not be meaningful, but kinetics and equilibrium constants will still be
+correct.
 
 Frequency Scale Factor
 ======================
@@ -147,7 +154,8 @@ Parameter               Required?                   Description
 
 The types and number of atoms in the species are automatically inferred from the quantum chemistry output and are used
 to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry``
-(see `Model Chemistry`_).
+(see `Model Chemistry`_). If not interested in accurate thermodynamics (e.g., if only using ``kinetics()``), then
+atom corrections can be turned off by setting ``useAtomCorrections`` to ``False``.
 
 The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry``.
 

--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -87,7 +87,7 @@ Model Chemistry                                  AEC   BC   SOC  Supported Eleme
 ``'FCI/cc-pVnZ'``, *n = D,T,Q*                    v         v    C
 ``'BMK/cbsb7'``                                   v    v    v    H, C, N, O, P, S
 ``'BMK/6-311G(2d,d,p)'``                          v    v    v    H, C, N, O, P, S
-``'B3LYP/6-311+G(3df,2p)'``                            v
+``'B3LYP/6-311+G(3df,2p)'``                       v    v    v    H, C, N, O, P, S
 ``'B3LYP/6-31G**'``                               v    v         H, C, O, S
 ================================================ ===== ==== ==== ====================
 

--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -13,12 +13,13 @@ Each section is made up of one or more function calls, where parameters are
 specified as text strings, numbers, or objects. Text strings must be wrapped in
 either single or double quotes.
 
-The following is a list of all the functions of a CanTherm input file for thermodynamics and high-pressure limit kinetics computations:
+The following is a list of all the components of a CanTherm input file for thermodynamics and high-pressure limit kinetics computations:
 
 =========================== =========================================================
-Function                    Description
+Component                   Description
 =========================== =========================================================
 ``modelChemistry``          Level of theory from quantum chemical calculations
+``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
 ``useHinderedRotors``       ``True`` if hindered rotors are used, ``False`` if not
 ``useBondCorrections``      ``True`` if bond corrections are used, ``False`` if not
@@ -33,8 +34,8 @@ Function                    Description
 Model Chemistry
 ===============
 
-The first item in the input file should be a ``modelChemistry()`` function,
-which accepts a string describing the model chemistry.
+The first item in the input file should be a ``modelChemistry`` assignment
+with a string describing the model chemistry.
 
 CanTherm uses this information to adjust the computed energies to the usual gas-phase reference
 states by applying atom, bond and spin-orbit coupling energy corrections. This is particularly
@@ -42,49 +43,66 @@ important for ``thermo()`` calculations (see below). Note that the user must spe
 ``species()`` function the type and number of bonds for CanTherm to apply these corrections.
 The example below specifies CBS-QB3 as the model chemistry::
 
-    modelChemistry("CBS-QB3")
+    modelChemistry = "CBS-QB3"
 
-Currently, atomization energy corrections (AEC), bond corrections (BC), and spin orbit correction (SOC) are available for the following model chemistries:
+Alternatively, the atomic energies at the ``modelChemistry`` level of theory can be directly
+specified in the input file by providing a dictionary of these energies in the following format::
 
-================================================ ===== ==== ====
-Model Chemistry                                  AEC   BC   SOC     
-================================================ ===== ==== ====
-``'CBS-QB3'``                                     v    v    v
-``'G3'``                                          v         v
-``'M08SO/MG3S*'``                                 v         v
-``'M06-2X/cc-pVTZ'``                              v         v
-``'Klip_1'``                                      v         v
-``'Klip_2'`` *uses QCI(tz,qz) values*             v         v
-``'Klip_3'`` *uses QCI(dz,qz) values*             v         v
-``'Klip_2_cc'`` *uses CCSD(T)(tz,qz) values*      v         v
-``'CCSD-F12/cc-pVDZ-F12'``                        v         v
-``'CCSD(T)-F12/cc-pVDZ-F12_H-TZ'``                v         v
-``'CCSD(T)-F12/cc-pVDZ-F12_H-QZ'``                v         v
-``'CCSD(T)-F12/cc-pVnZ-F12'``, *n = D,T,Q*        v    v    v
-``'CCSD(T)-F12/cc-pVDZ-F12_noscale'``             v         v
-``'CCSD(T)-F12/cc-pCVnZ-F12'``, *n = D,T,Q*       v         v
-``'CCSD(T)-F12/aug-cc-pVnZ-F12'``, *n = D,T,Q*    v         v
-``'B-CCSD(T)-F12/cc-pVnZ-F12'``, *n = D,T,Q*      v         v
-``'B-CCSD(T)-F12/cc-pCVnZ-F12'``, *n = D,T,Q*     v         v
-``'B-CCSD(T)-F12/aug-cc-pVnZ-F12'``, *n = D,T,Q*  v         v
-``'G03_PBEPBE_6-311++g_d_p'``                     v         v
-``'MP2_rmp2_pVnZ'``, *n = D,T,Q*                  v         v
-``'FCI/cc-pVnZ'``, *n = D,T,Q*                    v         v
-``'BMK/cbsb7'``                                   v    v    v
-``'BMK/6-311G(2d,d,p)'``                          v    v    v
+    atomEnergies = {
+        'H': -0.499818,
+        'C': -37.78552,
+        'N': -54.520543,
+        'O': -74.987979,
+        'S': -397.658253,
+    }
+
+The table below shows which model chemistries have atomization energy corrections (AEC), bond
+corrections (BC), and spin orbit corrections (SOC). It also lists which atoms types are available
+for a given model chemistry.
+
+================================================ ===== ==== ==== ====================
+Model Chemistry                                  AEC   BC   SOC  Supported Elements
+================================================ ===== ==== ==== ====================
+``'CBS-QB3'``                                     v    v    v    H, C, N, O, P, S
+``'G3'``                                          v         v    H, C, N, O, P, S
+``'M08SO/MG3S*'``                                 v         v    H, C, N, O, P, S
+``'M06-2X/cc-pVTZ'``                              v         v    H, C, N, O, P, S
+``'Klip_1'``                                      v         v    H, C, N, O
+``'Klip_2'`` *uses QCI(tz,qz) values*             v         v    H, C, N, O
+``'Klip_3'`` *uses QCI(dz,qz) values*             v         v    H, C, N, O
+``'Klip_2_cc'`` *uses CCSD(T)(tz,qz) values*      v         v    H, C, O
+``'CCSD-F12/cc-pVDZ-F12'``                        v         v    H, C, N, O
+``'CCSD(T)-F12/cc-pVDZ-F12_H-TZ'``                v         v    H, C, N, O
+``'CCSD(T)-F12/cc-pVDZ-F12_H-QZ'``                v         v    H, C, N, O
+``'CCSD(T)-F12/cc-pVnZ-F12'``, *n = D,T,Q*        v    v    v    H, C, N, O, S
+``'CCSD(T)-F12/cc-pVDZ-F12_noscale'``             v         v    H, C, N, O
+``'CCSD(T)-F12/cc-pCVnZ-F12'``, *n = D,T,Q*       v         v    H, C, N, O
+``'CCSD(T)-F12/aug-cc-pVnZ'``, *n = D,T,Q*        v         v    H, C, N, O
+``'B-CCSD(T)-F12/cc-pVnZ-F12'``, *n = D,T,Q*      v         v    H, C, N, O, S
+``'B-CCSD(T)-F12/cc-pCVnZ-F12'``, *n = D,T,Q*     v         v    H, C, N, O
+``'B-CCSD(T)-F12/aug-cc-pVnZ'``, *n = D,T,Q*      v         v    H, C, N, O
+``'G03_PBEPBE_6-311++g_d_p'``                     v         v    H, C, N, O
+``'MP2_rmp2_pVnZ'``, *n = D,T,Q*                  v         v    H, C, N, O
+``'FCI/cc-pVnZ'``, *n = D,T,Q*                    v         v    C
+``'BMK/cbsb7'``                                   v    v    v    H, C, N, O, P, S
+``'BMK/6-311G(2d,d,p)'``                          v    v    v    H, C, N, O, P, S
 ``'B3LYP/6-311+G(3df,2p)'``                            v
-``'B3LYP/6-31G**'``                               v    v
-================================================ ===== ==== ====
+``'B3LYP/6-31G**'``                               v    v         H, C, O, S
+================================================ ===== ==== ==== ====================
 
 Notes:
 
-- In ``'M08SO/MG3S*'`` the grid size used in the [QChem] electronic structure calculation utilizes 75 radial points and 434 angular points. ``'DFT_G03_b3lyp'`` is a B3LYP calculation with a moderately large basis set.
+- In ``'M08SO/MG3S*'`` the grid size used in the [QChem] electronic structure calculation utilizes 75 radial points and 434 angular points.
 - Refer to paper by Goldsmith et al. (*Goldsmith, C. F.; Magoon, G. R.; Green, W. H., Database of Small Molecule Thermochemistry for Combustion. J. Phys. Chem. A 2012, 116, 9033-9057*) for definition of ``'Klip_2'`` (*QCI(tz,qz)*) and ``'Klip_3'`` (*QCI(dz,qz)*).
+
+If a model chemistry other than the ones in the above table is used, then the user should supply
+the corresponding atomic energies (using ``atomEnergies``) to get meaningful results. Bond
+corrections would not be applied in this case.
 
 Frequency Scale Factor
 ======================
 
-Frequency scale factors are empirically fit to experiment for different ``modelChemistry()``. Refer to NIST website for values (http://cccbdb.nist.gov/vibscalejust.asp).
+Frequency scale factors are empirically fit to experiment for different ``modelChemistry``. Refer to NIST website for values (http://cccbdb.nist.gov/vibscalejust.asp).
 For CBS-QB3, which is not included in the link above, ``frequencyScaleFactor = 0.99`` according to Montgomery et al. (*J. Chem. Phys. 1999, 110, 2822–2827*).
 
 Species
@@ -128,10 +146,10 @@ Parameter               Required?                   Description
 ======================= =========================== ====================================
 
 The types and number of atoms in the species are automatically inferred from the quantum chemistry output and are used
-to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry()``
+to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry``
 (see `Model Chemistry`_).
 
-The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry()``.
+The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry``.
 
 Allowed bond types for the ``bonds`` parameter are, e.g., ``'C-H'``, ``'C-C'``, ``'C=C'``, ``'N-O'``, ``'C=S'``, ``'O=O'``, ``'C#N'``...
 
@@ -155,7 +173,7 @@ For ethane, we would write::
 
     opticalIsomers = 1
 
-The ``energy`` parameter is a dictionary with entries for different ``modelChemistry()``. The entries can consist of either
+The ``energy`` parameter is a dictionary with entries for different ``modelChemistry``. The entries can consist of either
 floating point numbers corresponding to the 0 K atomization energy in Hartree (without zero-point energy correction), or
 they can specify the path to a quantum chemistry calculation output file that contains the species's energy. For example::
 
@@ -165,7 +183,7 @@ they can specify the path to a quantum chemistry calculation output file that co
     }
 
 In this example, the ``CBS-QB3`` energy is obtained from a Gaussian log file, while the ``Klip_2`` energy is specified directly.
-The energy used will depend on what ``modelChemistry()`` was specified in the input file. CanTherm can parse the energy from
+The energy used will depend on what ``modelChemistry`` was specified in the input file. CanTherm can parse the energy from
 a ``GaussianLog``, ``MolproLog`` or ``QchemLog``.
 
 The input to the remaining parameters, ``geometry``, ``frequencies`` and ``rotors``, will depend on if hindered/free rotors are included.

--- a/documentation/source/users/cantherm/input_pdep.rst
+++ b/documentation/source/users/cantherm/input_pdep.rst
@@ -28,6 +28,7 @@ Component                   Description
 ``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
 ``useHinderedRotors``       ``True`` if hindered rotors are used, ``False`` if not
+``useAtomCorrections``      ``True`` if atom corrections are used, ``False`` if not
 ``useBondCorrections``      ``True`` if bond corrections are used, ``False`` if not
 ``species``                 Contains parameters for non-transition states
 ``transitionState``         Contains parameters for transition state(s)
@@ -69,7 +70,7 @@ specified in the input file by providing a dictionary of these energies in the f
     }
 
 Whether or not atomization energy corrections (AEC), bond corrections (BC), and spin orbit
-corrections (SOC); and which atom types are available for a given model chemistry is described
+corrections (SOC); and which elements are available for a given model chemistry is described
 under `High-Pressure Limit: Model Chemistry <input.html#model-chemistry>`_
 
 Frequency Scale Factor
@@ -192,7 +193,8 @@ Parameter               Required?                   Description
 
 The types and number of atoms in the species are automatically inferred from the quantum chemistry output and are used
 to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry``
-(see `Model Chemistry`_).
+(see `Model Chemistry`_). If not interested in accurate thermodynamics (e.g., if only using ``kinetics()``), then
+atom corrections can be turned off by setting ``useAtomCorrections`` to ``False``.
 
 The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry``.
 

--- a/documentation/source/users/cantherm/input_pdep.rst
+++ b/documentation/source/users/cantherm/input_pdep.rst
@@ -19,12 +19,13 @@ Each section is made up of one or more function calls, where parameters are
 specified as text strings, numbers, or objects. Text strings must be wrapped in
 either single or double quotes.
 
-The following is a list of all the functions of a CanTherm input file for pressure-dependent calculations:
+The following is a list of all the components of a CanTherm input file for pressure-dependent calculations:
 
 =========================== ================================================================
-Function                    Description
+Component                   Description
 =========================== ================================================================
 ``modelChemistry``          Level of theory from quantum chemical calculations
+``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
 ``useHinderedRotors``       ``True`` if hindered rotors are used, ``False`` if not
 ``useBondCorrections``      ``True`` if bond corrections are used, ``False`` if not
@@ -45,8 +46,8 @@ Important differences are mentioned in the sections below.
 Model Chemistry
 ===============
 
-The first item in the input file should be a ``modelChemistry()`` function,
-which accepts a string describing the model chemistry.
+The first item in the input file should be a ``modelChemistry`` assignment
+with a string describing the model chemistry.
 
 CanTherm uses this information to adjust the computed energies to the usual gas-phase reference
 states by applying atom, bond and spin-orbit coupling energy corrections. This is particularly
@@ -54,15 +55,27 @@ important for ``thermo()`` calculations (see below). Note that the user must spe
 ``species()`` function the type and number of bonds for CanTherm to apply these corrections.
 The example below specifies CBS-QB3 as the model chemistry::
 
-    modelChemistry("CBS-QB3")
+    modelChemistry = "CBS-QB3"
 
-Currently, atomization energy corrections (AEC), bond corrections (BC), and spin orbit correction (SOC) are available for
-model chemistries as described under `High-Pressure Limit: Model Chemistry <input.html#model-chemistry>`_
+Alternatively, the atomic energies at the ``modelChemistry`` level of theory can be directly
+specified in the input file by providing a dictionary of these energies in the following format::
+
+    atomEnergies = {
+        'H': -0.499818,
+        'C': -37.78552,
+        'N': -54.520543,
+        'O': -74.987979,
+        'S': -397.658253,
+    }
+
+Whether or not atomization energy corrections (AEC), bond corrections (BC), and spin orbit
+corrections (SOC); and which atom types are available for a given model chemistry is described
+under `High-Pressure Limit: Model Chemistry <input.html#model-chemistry>`_
 
 Frequency Scale Factor
 ======================
 
-Frequency scale factors are empirically fit to experiment for different ``modelChemistry()``. Refer to NIST website for values (http://cccbdb.nist.gov/vibscalejust.asp).
+Frequency scale factors are empirically fit to experiment for different ``modelChemistry``. Refer to NIST website for values (http://cccbdb.nist.gov/vibscalejust.asp).
 For CBS-QB3, which is not included  in the link above, ``frequencyScaleFactor = 0.99`` according to Montgomery et al. (*J. Chem. Phys. 1999, 110, 2822–2827*).
 
 Species Parameters
@@ -178,10 +191,10 @@ Parameter               Required?                   Description
 ======================= =========================== ====================================
 
 The types and number of atoms in the species are automatically inferred from the quantum chemistry output and are used
-to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry()``
+to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry``
 (see `Model Chemistry`_).
 
-The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry()``.
+The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry``.
 
 Allowed bond types for the ``bonds`` parameter are, e.g., ``'C-H'``, ``'C-C'``, ``'C=C'``, ``'N-O'``, ``'C=S'``, ``'O=O'``, ``'C#N'``...
 
@@ -205,7 +218,7 @@ For acetylperoxy radical, we would write::
 
     opticalIsomers = 1
 
-The ``energy`` parameter is a dictionary with entries for different ``modelChemistry()``. The entries can consist of either
+The ``energy`` parameter is a dictionary with entries for different ``modelChemistry``. The entries can consist of either
 floating point numbers corresponding to the 0 K atomization energy in Hartree (without zero-point energy correction), or
 they can specify the path to a quantum chemistry calculation output file that contains the species's energy. For example::
 
@@ -215,7 +228,7 @@ they can specify the path to a quantum chemistry calculation output file that co
     }
 
 In this example, the ``CBS-QB3`` energy is obtained from a Gaussian log file, while the ``Klip_2`` energy is specified directly.
-The energy used will depend on what ``modelChemistry()`` was specified in the input file. CanTherm can parse the energy from
+The energy used will depend on what ``modelChemistry`` was specified in the input file. CanTherm can parse the energy from
 a ``GaussianLog``, ``MolproLog`` or ``QchemLog``.
 
 The input to the remaining parameters, ``geometry``, ``frequencies`` and ``rotors``, will depend on if hindered/free rotors are included.

--- a/documentation/source/users/cantherm/input_pdep.rst
+++ b/documentation/source/users/cantherm/input_pdep.rst
@@ -200,7 +200,7 @@ Allowed bond types for the ``bonds`` parameter are, e.g., ``'C-H'``, ``'C-C'``, 
 
 ``'O=S=O'`` is also allowed.
 
-The order of elements in for the bond correction is important and generally follows the order specified under "allowed atom symbols" above, i.e., ``'C=N'`` is correct while ``'N=C'`` is incorrect. Use ``-``/``=``/``#`` to denote a single/double/triple bond, respectively. For example, for acetylperoxy radical we would write::
+The order of elements in for the bond correction is not important. Use ``-``/``=``/``#`` to denote a single/double/triple bond, respectively. For example, for acetylperoxy radical we would write::
 
     bonds = {'C-C': 1, 'C=O': 1, 'C-O': 1, 'O-O': 1, 'C-H': 3}
 

--- a/documentation/source/users/cantherm/input_pdep.rst
+++ b/documentation/source/users/cantherm/input_pdep.rst
@@ -51,7 +51,7 @@ which accepts a string describing the model chemistry.
 CanTherm uses this information to adjust the computed energies to the usual gas-phase reference
 states by applying atom, bond and spin-orbit coupling energy corrections. This is particularly
 important for ``thermo()`` calculations (see below). Note that the user must specify under the
-``species()`` function the type and number of atoms and bonds for CanTherm to apply these corrections.
+``species()`` function the type and number of bonds for CanTherm to apply these corrections.
 The example below specifies CBS-QB3 as the model chemistry::
 
     modelChemistry("CBS-QB3")
@@ -164,7 +164,6 @@ The species input file accepts the following parameters:
 ======================= =========================== ====================================
 Parameter               Required?                   Description
 ======================= =========================== ====================================
-``atoms``               yes                         Type and number of atoms in the species
 ``bonds``               optional                    Type and number of bonds in the species
 ``linear``              yes                         ``True`` if the molecule is linear, ``False`` if not
 ``externalSymmetry``    yes                         The external symmetry number for rotation
@@ -178,12 +177,11 @@ Parameter               Required?                   Description
 ``rotors``              optional                    A list of :class:`HinderedRotor()` and/or :class:`FreeRotor()` objects describing the hindered/free rotors
 ======================= =========================== ====================================
 
-The ``atom`` and ``bond`` parameters are used to apply atomization energy corrections (AEC), bond corrections (BC), and spin orbit corrections (SOC) for a given ``modelChemistry()`` (see `Model Chemistry <input.html#model-chemistry>`_).
+The types and number of atoms in the species are automatically inferred from the quantum chemistry output and are used
+to apply atomization energy corrections (AEC) and spin orbit corrections (SOC) for a given ``modelChemistry()``
+(see `Model Chemistry`_).
 
-Allowed atom symbols for the ``atoms`` parameter are
-``'C'``, ``'N'``, ``'O'``, ``'S'``, ``'P'``, and ``'H'``. For example, for acetylperoxy radical we would write::
-
-    atoms = {'C': 2, 'O': 3, H': 3}
+The ``bond`` parameter is used to apply bond corrections (BC) for a given ``modelChemistry()``.
 
 Allowed bond types for the ``bonds`` parameter are, e.g., ``'C-H'``, ``'C-C'``, ``'C=C'``, ``'N-O'``, ``'C=S'``, ``'O=O'``, ``'C#N'``...
 
@@ -235,12 +233,6 @@ For example::
 
 In summary, in order to specify the molecular properties of a species by parsing the output of quantum chemistry calculations, without any hindered/free rotors,
 the species input file should look like the following (using acetylperoxy as an example)::
-
-    atoms = {
-    'C': 2,
-    'O': 3,
-    H': 3,
-    }
 
     bonds = {
     'C-C': 1,
@@ -349,12 +341,6 @@ puts a lower bound on the impact of that rotor on the species's overall partitio
 in between these two extremes.
 
 To summarize, the species input file with hindered/free rotors should look like the following example (different options for specifying the same ``rotors`` entry are commented out)::
-
-    atoms = {
-    'C': 2,
-    'O': 3,
-    'H': 3,
-    }
 
     bonds = {
     'C-C': 1,

--- a/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy.py
+++ b/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy.py
@@ -1,12 +1,5 @@
-
-#!/usr/bin/env python                                                                                                                          
+#!/usr/bin/env python
 # encoding: utf-8
-
-atoms = {
-    'C': 5,
-    'H': 11,
-    'O': 1
-}
 
 bonds = {}
 linear = False

--- a/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
+++ b/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python                                                                                                                          
 # encoding: utf-8
 
-atoms = {
-    'C': 5,
-    'H': 11,
-    'O': 1
-}
-
 bonds = {}
 linear = False
 

--- a/examples/cantherm/reactions/CH3OH+HCO/ch3oh.py
+++ b/examples/cantherm/reactions/CH3OH+HCO/ch3oh.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 1,
-    'H': 4,
-    'O': 1,
-}
-
 bonds = {
     'C-O': 1, 
     'C-H': 3,

--- a/examples/cantherm/reactions/CH3OH+HCO/hco.py
+++ b/examples/cantherm/reactions/CH3OH+HCO/hco.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 1,
-    'H': 1,
-    'O': 1,
-}
-
 bonds = {
     'C-O': 1, 
     'C-H': 1,

--- a/examples/cantherm/reactions/CH3OH+HCO/ts.py
+++ b/examples/cantherm/reactions/CH3OH+HCO/ts.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 2,
-    'H': 5,
-    'O': 2,
-}
-
 bonds = {}
 
 linear = False

--- a/examples/cantherm/reactions/H+C2H4=C2H5/TS.py
+++ b/examples/cantherm/reactions/H+C2H4=C2H5/TS.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 2,
-    'H': 5,
-}
-
 bonds = {}
 
 linear = False

--- a/examples/cantherm/species/Benzyl/benzyl.py
+++ b/examples/cantherm/species/Benzyl/benzyl.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 7,
-    'H': 7,
-}
-
 bonds = {
 	'C=C': 3,
     'C-C': 4, 

--- a/examples/cantherm/species/C2H4/ethene.py
+++ b/examples/cantherm/species/C2H4/ethene.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 2,
-    'H': 4,
-}
-
 bonds = {
     'C=C': 1, 
     'C-H': 4,

--- a/examples/cantherm/species/C2H5/ethyl.py
+++ b/examples/cantherm/species/C2H5/ethyl.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 2,
-    'H': 5,
-}
-
 bonds = {
     'C-C': 1, 
     'C-H': 5,

--- a/examples/cantherm/species/C2H6/C2H6.py
+++ b/examples/cantherm/species/C2H6/C2H6.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-atoms = {
-    'C': 2,
-    'H': 6,
-}
-
 bonds = {
     'C-C': 1,
     'C-H': 6,

--- a/examples/cantherm/species/H/H.py
+++ b/examples/cantherm/species/H/H.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'H': 1,
-}
-
 bonds = {}
 
 linear = False

--- a/examples/cantherm/species/Toulene/toluene_FreeRotor.py
+++ b/examples/cantherm/species/Toulene/toluene_FreeRotor.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 7,
-    'H': 8,
-}
-
 bonds = {
     'C-C': 4, 
     'C-H': 8,

--- a/examples/cantherm/species/Toulene/toluene_HinderedRotor.py
+++ b/examples/cantherm/species/Toulene/toluene_HinderedRotor.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-atoms = {
-    'C': 7,
-    'H': 8,
-}
-
 bonds = {
     'C-C': 4, 
     'C-H': 8,

--- a/rmgpy/cantherm/commonTest.py
+++ b/rmgpy/cantherm/commonTest.py
@@ -207,7 +207,7 @@ class testCanthermInput(unittest.TestCase):
     def setUp(self):
         """Preparation for all unit tests in this class."""
         self.directory = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)), 'examples', 'cantherm')
-        self.modelChemistry = "CBS-QB3"
+        self.modelChemistry = "cbs-qb3"
         self.frequencyScaleFactor = 0.99
         self.useHinderedRotors = False
         self.useBondCorrections = True

--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -388,6 +388,7 @@ def loadInputFile(path):
         logging.warning('No frequency scale factor specified in input file; assuming a value of unity.')
     frequencyScaleFactor = local_context.get('frequencyScaleFactor', 1.0)
     useHinderedRotors = local_context.get('useHinderedRotors', True)
+    useAtomCorrections = local_context.get('useAtomCorrections', True)
     useBondCorrections = local_context.get('useBondCorrections', False)
     atomEnergies = local_context.get('atomEnergies', None)
     
@@ -399,6 +400,7 @@ def loadInputFile(path):
             job.modelChemistry = modelChemistry
             job.frequencyScaleFactor = frequencyScaleFactor
             job.includeHinderedRotors = useHinderedRotors
+            job.applyAtomEnergyCorrections = useAtomCorrections
             job.applyBondEnergyCorrections = useBondCorrections
             job.atomEnergies = atomEnergies
     

--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -397,7 +397,7 @@ def loadInputFile(path):
     for job in jobList:
         if isinstance(job, StatMechJob):
             job.path = os.path.join(directory, job.path)
-            job.modelChemistry = modelChemistry
+            job.modelChemistry = modelChemistry.lower()
             job.frequencyScaleFactor = frequencyScaleFactor
             job.includeHinderedRotors = useHinderedRotors
             job.applyAtomEnergyCorrections = useAtomCorrections

--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -389,6 +389,7 @@ def loadInputFile(path):
     frequencyScaleFactor = local_context.get('frequencyScaleFactor', 1.0)
     useHinderedRotors = local_context.get('useHinderedRotors', True)
     useBondCorrections = local_context.get('useBondCorrections', False)
+    atomEnergies = local_context.get('atomEnergies', None)
     
     directory = os.path.dirname(path)
     
@@ -399,5 +400,6 @@ def loadInputFile(path):
             job.frequencyScaleFactor = frequencyScaleFactor
             job.includeHinderedRotors = useHinderedRotors
             job.applyBondEnergyCorrections = useBondCorrections
+            job.atomEnergies = atomEnergies
     
     return jobList

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -574,7 +574,6 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
     
     # We are assuming that SOC is included in the Bond Energy Corrections  
     elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
-#        atomEnergies = {'H':-0.499811124128, 'N':-54.526406291655, 'O':-74.995458316117, 'C':-37.788203485235}
         atomEnergies = {'H':-0.499811124128, 'N':-54.526406291655, 'O':-74.995458316117, 'C':-37.788203485235, 'S':-397.663040369707}
     elif modelChemistry == 'CCSD(T)-F12/cc-pVTZ-F12':
         atomEnergies = {'H':-0.499946213243, 'N':-54.53000909621, 'O':-75.004127673424, 'C':-37.789862146471, 'S':-397.675447487865}
@@ -615,13 +614,6 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
     elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVQZ':
         atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.528189769291 + SOC['N'], 'O':-75.001879610563+ SOC['O'], 'C':-37.788165047059+ SOC['C']}
 
-    elif modelChemistry == 'DFT_G03_b3lyp':
-        atomEnergies = {'H':-0.502256981529 + SOC['H'], 'N':-54.6007233648 + SOC['N'], 'O':-75.0898777574+ SOC['O'], 'C':-37.8572666349+ SOC['C']}
-    elif modelChemistry == 'DFT_ks_b3lyp':
-        atomEnergies = {'H':-0.49785866 + SOC['H'], 'N':-54.45608798 + SOC['N'], 'O':-74.93566254+ SOC['O'], 'C':-37.76119132+ SOC['C']}
-    elif modelChemistry == 'DFT_uks_b3lyp':
-        atomEnergies = {'H':-0.49785866 + SOC['H'], 'N':-54.45729113 + SOC['N'], 'O':-74.93566254+ SOC['O'], 'C':-37.76119132+ SOC['C']}
-
     elif modelChemistry == 'MP2_rmp2_pVDZ':
         atomEnergies = {'H':-0.49927840 + SOC['H'], 'N':-54.46141996 + SOC['N'], 'O':-74.89408254+ SOC['O'], 'C':-37.73792713+ SOC['C']}
     elif modelChemistry == 'MP2_rmp2_pVTZ':
@@ -639,7 +631,6 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
         atomEnergies = {'H':-0.499812273282 + SOC['H'], 'N':-54.5289567564 + SOC['N'], 'O':-75.0033596764+ SOC['O'], 'C':-37.7937388736+ SOC['C']}
 
     elif modelChemistry == 'FCI/cc-pVDZ':
-#        atomEnergies = {'C':-37.760717371923}
         atomEnergies = {'C':-37.789527+ SOC['C']}
     elif modelChemistry == 'FCI/cc-pVTZ':
         atomEnergies = {'C':-37.781266669684+ SOC['C']}
@@ -710,7 +701,7 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds):
             'N-H': -0.42, 'N=O': 1.11,  'N-N': -1.87, 'N=N': -1.58,'N-O': 0.35,  #Table 2: Ashcraft R (2007) J. Phys. Chem. B; DOI: 10.1021/jp073539t
             'N#N': -2.0,  'O=O': -0.2,  'H-H': 1.1,  # Unknown source
              }
-    elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'DFT_G03_b3lyp','B3LYP/6-311+G(3df,2p)','b3lyp/6-31G**']:
+    elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'B3LYP/6-311+G(3df,2p)', 'b3lyp/6-31G**']:
         bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
             'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44, 
             'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52, }    

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -257,6 +257,7 @@ class StatMechJob:
         except KeyError:
             raise InputError('Required attribute "energy" not found in species file {0!r}.'.format(path))
         if isinstance(energy, dict):
+            energy = {k.lower(): v for k, v in energy.items()}  # Make model chemistries lower-case
             try:
                 energy = energy[self.modelChemistry]
             except KeyError:
@@ -568,104 +569,105 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds,
 
         # Step 1: Reference all energies to a model chemistry-independent basis
         # by subtracting out that model chemistry's atomic energies
+        # All model chemistries here should be lower-case because the user input is changed to lower-case
         if atomEnergies is None:
             # Note: If your model chemistry does not include spin orbit coupling, you should add the corrections to the energies here
-            if modelChemistry == 'CBS-QB3':
+            if modelChemistry == 'cbs-qb3':
                 atomEnergies = {'H':-0.499818 + SOC['H'], 'N':-54.520543 + SOC['N'], 'O':-74.987624+ SOC['O'], 'C':-37.785385+ SOC['C'], 'P':-340.817186+ SOC['P'], 'S': -397.657360+ SOC['S']}
-            elif modelChemistry == 'M06-2X/cc-pVTZ':
+            elif modelChemistry == 'm06-2x/cc-pvtz':
                 atomEnergies = {'H':-0.498135 + SOC['H'], 'N':-54.586780 + SOC['N'], 'O':-75.064242+ SOC['O'], 'C':-37.842468+ SOC['C'], 'P':-341.246985+ SOC['P'], 'S': -398.101240+ SOC['S']}
-            elif modelChemistry == 'G3':
+            elif modelChemistry == 'g3':
                 atomEnergies = {'H':-0.5010030, 'N':-54.564343, 'O':-75.030991, 'C':-37.827717, 'P':-341.116432, 'S': -397.961110}
-            elif modelChemistry == 'M08SO/MG3S*': # * indicates that the grid size used in the [QChem] electronic
+            elif modelChemistry == 'm08so/mg3s*': # * indicates that the grid size used in the [QChem] electronic
                 #structure calculation utilized 75 radial points and 434 angular points
                 #(i.e,, this is specified in the $rem section of the [qchem] input file as: XC_GRID 000075000434)
                 atomEnergies = {'H':-0.5017321350 + SOC['H'], 'N':-54.5574039365 + SOC['N'], 'O':-75.0382931348+ SOC['O'], 'C':-37.8245648740+ SOC['C'], 'P':-341.2444299005+ SOC['P'], 'S':-398.0940312227+ SOC['S'] }
-            elif modelChemistry == 'Klip_1':
+            elif modelChemistry == 'klip_1':
                 atomEnergies = {'H':-0.50003976 + SOC['H'], 'N':-54.53383153 + SOC['N'], 'O':-75.00935474+ SOC['O'], 'C':-37.79266591+ SOC['C']}
-            elif modelChemistry == 'Klip_2':
+            elif modelChemistry == 'klip_2':
                 #Klip QCI(tz,qz)
                 atomEnergies = {'H':-0.50003976 + SOC['H'], 'N':-54.53169400 + SOC['N'], 'O':-75.00714902+ SOC['O'], 'C':-37.79060419+ SOC['C']}
-            elif modelChemistry == 'Klip_3':
+            elif modelChemistry == 'klip_3':
                 #Klip QCI(dz,tz)
                 atomEnergies = {'H':-0.50005578 + SOC['H'], 'N':-54.53128140 + SOC['N'], 'O':-75.00356581+ SOC['O'], 'C':-37.79025175+ SOC['C']}
 
-            elif modelChemistry == 'Klip_2_cc':
+            elif modelChemistry == 'klip_2_cc':
                 #Klip CCSD(T)(tz,qz)
                 atomEnergies = {'H':-0.50003976 + SOC['H'], 'O':-75.00681155+ SOC['O'], 'C':-37.79029443+ SOC['C']}
 
-            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_H-TZ':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pvdz-f12_h-tz':
                 atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.526406291655 + SOC['N'], 'O':-74.995458316117+ SOC['O'], 'C':-37.788203485235+ SOC['C']}
-            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_H-QZ':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pvdz-f12_h-qz':
                 atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.526406291655 + SOC['N'], 'O':-74.995458316117+ SOC['O'], 'C':-37.788203485235+ SOC['C']}
 
             # We are assuming that SOC is included in the Bond Energy Corrections
-            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pvdz-f12':
                 atomEnergies = {'H':-0.499811124128, 'N':-54.526406291655, 'O':-74.995458316117, 'C':-37.788203485235, 'S':-397.663040369707}
-            elif modelChemistry == 'CCSD(T)-F12/cc-pVTZ-F12':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pvtz-f12':
                 atomEnergies = {'H':-0.499946213243, 'N':-54.53000909621, 'O':-75.004127673424, 'C':-37.789862146471, 'S':-397.675447487865}
-            elif modelChemistry == 'CCSD(T)-F12/cc-pVQZ-F12':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pvqz-f12':
                 atomEnergies = {'H':-0.499994558325, 'N':-54.530515226371, 'O':-75.005600062003, 'C':-37.789961656228, 'S':-397.676719774973}
-            elif modelChemistry == 'CCSD(T)-F12/cc-pCVDZ-F12':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pcvdz-f12':
                 atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.582137180344 + SOC['N'], 'O':-75.053045547421 + SOC['O'], 'C':-37.840869118707+ SOC['C']}
-            elif modelChemistry == 'CCSD(T)-F12/cc-pCVTZ-F12':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pcvtz-f12':
                 atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.588545831900 + SOC['N'], 'O':-75.065995072347 + SOC['O'], 'C':-37.844662139972+ SOC['C']}
-            elif modelChemistry == 'CCSD(T)-F12/cc-pCVQZ-F12':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pcvqz-f12':
                 atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.589137594139+ SOC['N'], 'O':-75.067412234737+ SOC['O'], 'C':-37.844893820561+ SOC['C']}
 
-            elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVDZ':
+            elif modelChemistry == 'ccsd(t)-f12/aug-cc-pvdz':
                 atomEnergies = {'H':-0.499459066131 + SOC['H'], 'N':-54.524279516472 + SOC['N'], 'O':-74.992097308083+ SOC['O'], 'C':-37.786694171716+ SOC['C']}
-            elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVTZ':
+            elif modelChemistry == 'ccsd(t)-f12/aug-cc-pvtz':
                 atomEnergies = {'H':-0.499844820798 + SOC['H'], 'N':-54.527419359906 + SOC['N'], 'O':-75.000001429806+ SOC['O'], 'C':-37.788504810868+ SOC['C']}
-            elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVQZ':
+            elif modelChemistry == 'ccsd(t)-f12/aug-cc-pvqz':
                 atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.529569719016 + SOC['N'], 'O':-75.004026586610+ SOC['O'], 'C':-37.789387892348+ SOC['C']}
 
 
-            elif modelChemistry == 'B-CCSD(T)-F12/cc-pVDZ-F12':
+            elif modelChemistry == 'b-ccsd(t)-f12/cc-pvdz-f12':
                 atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.523269942190 + SOC['N'], 'O':-74.990725918500 + SOC['O'], 'C':-37.785409916465 + SOC['C'], 'S': -397.658155086033 + SOC['S']}
-            elif modelChemistry == 'B-CCSD(T)-F12/cc-pVTZ-F12':
+            elif modelChemistry == 'b-ccsd(t)-f12/cc-pvtz-f12':
                 atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.528135889213 + SOC['N'], 'O':-75.001094055506 + SOC['O'], 'C':-37.788233578503 + SOC['C'], 'S':-397.671745425929 + SOC['S']}
-            elif modelChemistry == 'B-CCSD(T)-F12/cc-pVQZ-F12':
+            elif modelChemistry == 'b-ccsd(t)-f12/cc-pvqz-f12':
                 atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.529425753163 + SOC['N'], 'O':-75.003820485005 + SOC['O'], 'C':-37.789006506290 + SOC['C'], 'S':-397.674145126931 + SOC['S']}
-            elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVDZ-F12':
+            elif modelChemistry == 'b-ccsd(t)-f12/cc-pcvdz-f12':
                 atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.578602780288 + SOC['N'], 'O':-75.048064317367+ SOC['O'], 'C':-37.837592033417+ SOC['C']}
-            elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVTZ-F12':
+            elif modelChemistry == 'b-ccsd(t)-f12/cc-pcvtz-f12':
                 atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.586402551258 + SOC['N'], 'O':-75.062767632757+ SOC['O'], 'C':-37.842729156944+ SOC['C']}
-            elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVQZ-F12':
+            elif modelChemistry == 'b-ccsd(t)-f12/cc-pcvqz-f12':
                 atomEnergies = {'H':-0.49999456 + SOC['H'], 'N':-54.587781507581 + SOC['N'], 'O':-75.065397706471+ SOC['O'], 'C':-37.843634971592+ SOC['C']}
 
-            elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVDZ':
+            elif modelChemistry == 'b-ccsd(t)-f12/aug-cc-pvdz':
                 atomEnergies = {'H':-0.499459066131 + SOC['H'], 'N':-54.520475581942 + SOC['N'], 'O':-74.986992215049+ SOC['O'], 'C':-37.783294495799+ SOC['C']}
-            elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVTZ':
+            elif modelChemistry == 'b-ccsd(t)-f12/aug-cc-pvtz':
                 atomEnergies = {'H':-0.499844820798 + SOC['H'], 'N':-54.524927371700 + SOC['N'], 'O':-74.996328829705+ SOC['O'], 'C':-37.786320700792+ SOC['C']}
-            elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVQZ':
+            elif modelChemistry == 'b-ccsd(t)-f12/aug-cc-pvqz':
                 atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.528189769291 + SOC['N'], 'O':-75.001879610563+ SOC['O'], 'C':-37.788165047059+ SOC['C']}
 
-            elif modelChemistry == 'MP2_rmp2_pVDZ':
+            elif modelChemistry == 'mp2_rmp2_pvdz':
                 atomEnergies = {'H':-0.49927840 + SOC['H'], 'N':-54.46141996 + SOC['N'], 'O':-74.89408254+ SOC['O'], 'C':-37.73792713+ SOC['C']}
-            elif modelChemistry == 'MP2_rmp2_pVTZ':
+            elif modelChemistry == 'mp2_rmp2_pvtz':
                 atomEnergies = {'H':-0.49980981 + SOC['H'], 'N':-54.49615972 + SOC['N'], 'O':-74.95506980+ SOC['O'], 'C':-37.75833104+ SOC['C']}
-            elif modelChemistry == 'MP2_rmp2_pVQZ':
+            elif modelChemistry == 'mp2_rmp2_pvqz':
                 atomEnergies = {'H':-0.49994557 + SOC['H'], 'N':-54.50715868 + SOC['N'], 'O':-74.97515364+ SOC['O'], 'C':-37.76533215+ SOC['C']}
 
-            elif modelChemistry == 'CCSD-F12/cc-pVDZ-F12':
+            elif modelChemistry == 'ccsd-f12/cc-pvdz-f12':
                 atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.524325513811 + SOC['N'], 'O':-74.992326577897+ SOC['O'], 'C':-37.786213495943+ SOC['C']}
 
-            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_noscale':
+            elif modelChemistry == 'ccsd(t)-f12/cc-pvdz-f12_noscale':
                 atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.526026290887 + SOC['N'], 'O':-74.994751897699+ SOC['O'], 'C':-37.787881871511+ SOC['C']}
 
-            elif modelChemistry == 'G03_PBEPBE_6-311++g_d_p':
+            elif modelChemistry == 'g03_pbepbe_6-311++g_d_p':
                 atomEnergies = {'H':-0.499812273282 + SOC['H'], 'N':-54.5289567564 + SOC['N'], 'O':-75.0033596764+ SOC['O'], 'C':-37.7937388736+ SOC['C']}
 
-            elif modelChemistry == 'FCI/cc-pVDZ':
+            elif modelChemistry == 'fci/cc-pvdz':
                 atomEnergies = {'C':-37.789527+ SOC['C']}
-            elif modelChemistry == 'FCI/cc-pVTZ':
+            elif modelChemistry == 'fci/cc-pvtz':
                 atomEnergies = {'C':-37.781266669684+ SOC['C']}
-            elif modelChemistry == 'FCI/cc-pVQZ':
+            elif modelChemistry == 'fci/cc-pvqz':
                 atomEnergies = {'C':-37.787052110598+ SOC['C']}
 
-            elif modelChemistry in ['BMK/cbsb7', 'BMK/6-311G(2d,d,p)']:
+            elif modelChemistry in ['bmk/cbsb7', 'bmk/6-311g(2d,d,p)']:
                 atomEnergies = {'H':-0.498618853119+ SOC['H'], 'N':-54.5697851544+ SOC['N'], 'O':-75.0515210278+ SOC['O'], 'C':-37.8287310027+ SOC['C'], 'P':-341.167615941+ SOC['P'], 'S': -398.001619915+ SOC['S']}
-            elif modelChemistry == 'b3lyp/6-31G**':
+            elif modelChemistry == 'b3lyp/6-31g**':
                 atomEnergies = {'H':-0.500426155, 'C':-37.850331697831, 'O':-75.0535872748806, 'S':-398.100820107242}
 
             else:
@@ -712,33 +714,33 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds,
         bondEnergies = {}
         # 'S-H', 'C-S', 'C=S', 'S-S', 'O-S', 'O=S', 'O=S=O' taken from http://hdl.handle.net/1721.1/98155 (both for
         # 'CCSD(T)-F12/cc-pVDZ-F12' and 'CCSD(T)-F12/cc-pVTZ-F12')
-        if modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
+        if modelChemistry == 'ccsd(t)-f12/cc-pvdz-f12':
             bondEnergies = { 'C-H': -0.46, 'C-C': -0.68, 'C=C': -1.90, 'C#C': -3.13,
                 'O-H': -0.51, 'C-O': -0.23, 'C=O': -0.69, 'O-O': -0.02, 'C-N': -0.67,
                 'C=N': -1.46, 'C#N': -2.79, 'N-O': 0.74, 'N_O': -0.23, 'N=O': -0.51,
                 'N-H': -0.69, 'N-N': -0.47, 'N=N': -1.54, 'N#N': -2.05, 'S-H': 0.87,
                 'C-S': 0.42, 'C=S': 0.51, 'S-S': 0.86, 'O-S': 0.23, 'O=S': -0.53,
                 'O=S=O': 1.95, }
-        elif modelChemistry == 'CCSD(T)-F12/cc-pVTZ-F12':
+        elif modelChemistry == 'ccsd(t)-f12/cc-pvtz-f12':
             bondEnergies = { 'C-H': -0.09, 'C-C': -0.27, 'C=C': -1.03, 'C#C': -1.79,
                 'O-H': -0.06, 'C-O': 0.14, 'C=O': -0.19, 'O-O': 0.16, 'C-N': -0.18,
                 'C=N': -0.41, 'C#N': -1.41, 'N-O': 0.87, 'N_O': -0.09, 'N=O': -0.23,
                 'N-H': -0.01, 'N-N': -0.21, 'N=N': -0.44, 'N#N': -0.76, 'S-H': 0.52,
                 'C-S': 0.13, 'C=S': -0.12, 'S-S': 0.30, 'O-S': 0.15, 'O=S': -2.61,
                 'O=S=O': 0.27, }
-        elif modelChemistry == 'CCSD(T)-F12/cc-pVQZ-F12':
+        elif modelChemistry == 'ccsd(t)-f12/cc-pvqz-f12':
             bondEnergies = { 'C-H': -0.08, 'C-C': -0.26, 'C=C': -1.01, 'C#C': -1.66,
                 'O-H':  0.07, 'C-O': 0.25, 'C=O': -0.03, 'O-O': 0.26, 'C-N': -0.20,
                 'C=N': -0.30, 'C#N': -1.33, 'N-O': 1.01, 'N_O': -0.03, 'N=O': -0.26,
                 'N-H':  0.06, 'N-N': -0.23, 'N=N': -0.37, 'N#N': -0.64,}
-        elif modelChemistry == 'CBS-QB3':
+        elif modelChemistry == 'cbs-qb3':
             bondEnergies = {
                 'C-C': -0.495,'C-H': -0.045,'C=C': -0.825,'C-O': 0.378,'C=O': 0.743,'O-H': -0.423,  #Table2: Paraskevas, PD (2013). Chemistry-A European J., DOI: 10.1002/chem.201301381
                 'C#C': -0.64, 'C#N': -0.89, 'C-S': 0.43,  'O=S': -0.78,'S-H': 0.0,  'C-N': -0.13, 'C-Cl': 1.29, 'C-F': 0.55,  # Table IX: Petersson GA (1998) J. of Chemical Physics, DOI: 10.1063/1.477794
                 'N-H': -0.42, 'N=O': 1.11,  'N-N': -1.87, 'N=N': -1.58,'N-O': 0.35,  #Table 2: Ashcraft R (2007) J. Phys. Chem. B; DOI: 10.1021/jp073539t
                 'N#N': -2.0,  'O=O': -0.2,  'H-H': 1.1,  # Unknown source
                  }
-        elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'B3LYP/6-311+G(3df,2p)', 'b3lyp/6-31G**']:
+        elif modelChemistry in ['b3lyp/cbsb7', 'b3lyp/6-311g(2d,d,p)', 'b3lyp/6-311+g(3df,2p)', 'b3lyp/6-31g**']:
             bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
                 'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44,
                 'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52, }

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -667,8 +667,10 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds,
 
             elif modelChemistry in ['bmk/cbsb7', 'bmk/6-311g(2d,d,p)']:
                 atomEnergies = {'H':-0.498618853119+ SOC['H'], 'N':-54.5697851544+ SOC['N'], 'O':-75.0515210278+ SOC['O'], 'C':-37.8287310027+ SOC['C'], 'P':-341.167615941+ SOC['P'], 'S': -398.001619915+ SOC['S']}
-            elif modelChemistry == 'b3lyp/6-31g**':
+            elif modelChemistry == 'b3lyp/6-31g**':  # Fitted to small molecules
                 atomEnergies = {'H':-0.500426155, 'C':-37.850331697831, 'O':-75.0535872748806, 'S':-398.100820107242}
+            elif modelChemistry == 'b3lyp/6-311+g(3df,2p)':  # Calculated atomic energies
+                atomEnergies = {'H':-0.502155915123 + SOC['H'], 'C':-37.8574709934 + SOC['C'], 'N':-54.6007233609 + SOC['N'], 'O':-75.0909131284 + SOC['O'], 'P':-341.281730319 + SOC['P'], 'S':-398.134489850 + SOC['S']}
 
             else:
                 raise Exception('Unknown model chemistry "{}".'.format(modelChemistry))

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -174,6 +174,7 @@ class StatMechJob:
         self.modelChemistry = ''
         self.frequencyScaleFactor = 1.0
         self.includeHinderedRotors = True
+        self.applyAtomEnergyCorrections = True
         self.applyBondEnergyCorrections = True
         self.atomEnergies = None
     
@@ -345,11 +346,15 @@ class StatMechJob:
             E0 = energyLog.loadEnergy(self.frequencyScaleFactor)
         else:
             E0 = E0 * constants.E_h * constants.Na         # Hartree/particle to J/mol
+        if not self.applyAtomEnergyCorrections:
+            logging.warning('Atom corrections are not being used. Do not trust energies and thermo.')
         E0 = applyEnergyCorrections(E0,
                                     self.modelChemistry,
                                     atoms,
-                                    bonds if self.applyBondEnergyCorrections else {},
-                                    atomEnergies=self.atomEnergies)
+                                    bonds,
+                                    atomEnergies=self.atomEnergies,
+                                    applyAtomEnergyCorrections=self.applyAtomEnergyCorrections,
+                                    applyBondEnergyCorrections=self.applyBondEnergyCorrections)
         ZPE = statmechLog.loadZeroPointEnergy() * self.frequencyScaleFactor
         
         # The E0_withZPE at this stage contains the ZPE
@@ -539,7 +544,8 @@ class StatMechJob:
 
 ################################################################################
 
-def applyEnergyCorrections(E0, modelChemistry, atoms, bonds, atomEnergies=None):
+def applyEnergyCorrections(E0, modelChemistry, atoms, bonds,
+                           atomEnergies=None, applyAtomEnergyCorrections=True, applyBondEnergyCorrections=False):
     """
     Given an energy `E0` in J/mol as read from the output of a quantum chemistry
     calculation at a given `modelChemistry`, adjust the energy such that it
@@ -554,190 +560,198 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds, atomEnergies=None):
     `bonds` is a dictionary associating bond types with the number
     of that bond in the molecule.
     """
-    
-    # Spin orbit correction (SOC) in Hartrees
-    # Values taken from ref 22 of http://dx.doi.org/10.1063/1.477794 and converted to hartrees
-    # Values in millihartree are also available (with fewer significant figures) from table VII of http://dx.doi.org/10.1063/1.473182 
-    SOC = {'H':0.0, 'N':0.0, 'O': -0.000355, 'C': -0.000135, 'S':  -0.000893, 'P': 0.0} 
-    
-    # Step 1: Reference all energies to a model chemistry-independent basis
-    # by subtracting out that model chemistry's atomic energies
-    if atomEnergies is None:
-        # Note: If your model chemistry does not include spin orbit coupling, you should add the corrections to the energies here
-        if modelChemistry == 'CBS-QB3':
-            atomEnergies = {'H':-0.499818 + SOC['H'], 'N':-54.520543 + SOC['N'], 'O':-74.987624+ SOC['O'], 'C':-37.785385+ SOC['C'], 'P':-340.817186+ SOC['P'], 'S': -397.657360+ SOC['S']}
-        elif modelChemistry == 'M06-2X/cc-pVTZ':
-            atomEnergies = {'H':-0.498135 + SOC['H'], 'N':-54.586780 + SOC['N'], 'O':-75.064242+ SOC['O'], 'C':-37.842468+ SOC['C'], 'P':-341.246985+ SOC['P'], 'S': -398.101240+ SOC['S']}
-        elif modelChemistry == 'G3':
-            atomEnergies = {'H':-0.5010030, 'N':-54.564343, 'O':-75.030991, 'C':-37.827717, 'P':-341.116432, 'S': -397.961110}
-        elif modelChemistry == 'M08SO/MG3S*': # * indicates that the grid size used in the [QChem] electronic
-            #structure calculation utilized 75 radial points and 434 angular points
-            #(i.e,, this is specified in the $rem section of the [qchem] input file as: XC_GRID 000075000434)
-            atomEnergies = {'H':-0.5017321350 + SOC['H'], 'N':-54.5574039365 + SOC['N'], 'O':-75.0382931348+ SOC['O'], 'C':-37.8245648740+ SOC['C'], 'P':-341.2444299005+ SOC['P'], 'S':-398.0940312227+ SOC['S'] }
-        elif modelChemistry == 'Klip_1':
-            atomEnergies = {'H':-0.50003976 + SOC['H'], 'N':-54.53383153 + SOC['N'], 'O':-75.00935474+ SOC['O'], 'C':-37.79266591+ SOC['C']}
-        elif modelChemistry == 'Klip_2':
-            #Klip QCI(tz,qz)
-            atomEnergies = {'H':-0.50003976 + SOC['H'], 'N':-54.53169400 + SOC['N'], 'O':-75.00714902+ SOC['O'], 'C':-37.79060419+ SOC['C']}
-        elif modelChemistry == 'Klip_3':
-            #Klip QCI(dz,tz)
-            atomEnergies = {'H':-0.50005578 + SOC['H'], 'N':-54.53128140 + SOC['N'], 'O':-75.00356581+ SOC['O'], 'C':-37.79025175+ SOC['C']}
+    if applyAtomEnergyCorrections:
+        # Spin orbit correction (SOC) in Hartrees
+        # Values taken from ref 22 of http://dx.doi.org/10.1063/1.477794 and converted to hartrees
+        # Values in millihartree are also available (with fewer significant figures) from table VII of http://dx.doi.org/10.1063/1.473182
+        SOC = {'H':0.0, 'N':0.0, 'O': -0.000355, 'C': -0.000135, 'S':  -0.000893, 'P': 0.0}
 
-        elif modelChemistry == 'Klip_2_cc':
-            #Klip CCSD(T)(tz,qz)
-            atomEnergies = {'H':-0.50003976 + SOC['H'], 'O':-75.00681155+ SOC['O'], 'C':-37.79029443+ SOC['C']}
+        # Step 1: Reference all energies to a model chemistry-independent basis
+        # by subtracting out that model chemistry's atomic energies
+        if atomEnergies is None:
+            # Note: If your model chemistry does not include spin orbit coupling, you should add the corrections to the energies here
+            if modelChemistry == 'CBS-QB3':
+                atomEnergies = {'H':-0.499818 + SOC['H'], 'N':-54.520543 + SOC['N'], 'O':-74.987624+ SOC['O'], 'C':-37.785385+ SOC['C'], 'P':-340.817186+ SOC['P'], 'S': -397.657360+ SOC['S']}
+            elif modelChemistry == 'M06-2X/cc-pVTZ':
+                atomEnergies = {'H':-0.498135 + SOC['H'], 'N':-54.586780 + SOC['N'], 'O':-75.064242+ SOC['O'], 'C':-37.842468+ SOC['C'], 'P':-341.246985+ SOC['P'], 'S': -398.101240+ SOC['S']}
+            elif modelChemistry == 'G3':
+                atomEnergies = {'H':-0.5010030, 'N':-54.564343, 'O':-75.030991, 'C':-37.827717, 'P':-341.116432, 'S': -397.961110}
+            elif modelChemistry == 'M08SO/MG3S*': # * indicates that the grid size used in the [QChem] electronic
+                #structure calculation utilized 75 radial points and 434 angular points
+                #(i.e,, this is specified in the $rem section of the [qchem] input file as: XC_GRID 000075000434)
+                atomEnergies = {'H':-0.5017321350 + SOC['H'], 'N':-54.5574039365 + SOC['N'], 'O':-75.0382931348+ SOC['O'], 'C':-37.8245648740+ SOC['C'], 'P':-341.2444299005+ SOC['P'], 'S':-398.0940312227+ SOC['S'] }
+            elif modelChemistry == 'Klip_1':
+                atomEnergies = {'H':-0.50003976 + SOC['H'], 'N':-54.53383153 + SOC['N'], 'O':-75.00935474+ SOC['O'], 'C':-37.79266591+ SOC['C']}
+            elif modelChemistry == 'Klip_2':
+                #Klip QCI(tz,qz)
+                atomEnergies = {'H':-0.50003976 + SOC['H'], 'N':-54.53169400 + SOC['N'], 'O':-75.00714902+ SOC['O'], 'C':-37.79060419+ SOC['C']}
+            elif modelChemistry == 'Klip_3':
+                #Klip QCI(dz,tz)
+                atomEnergies = {'H':-0.50005578 + SOC['H'], 'N':-54.53128140 + SOC['N'], 'O':-75.00356581+ SOC['O'], 'C':-37.79025175+ SOC['C']}
 
-        elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_H-TZ':
-            atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.526406291655 + SOC['N'], 'O':-74.995458316117+ SOC['O'], 'C':-37.788203485235+ SOC['C']}
-        elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_H-QZ':
-            atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.526406291655 + SOC['N'], 'O':-74.995458316117+ SOC['O'], 'C':-37.788203485235+ SOC['C']}
+            elif modelChemistry == 'Klip_2_cc':
+                #Klip CCSD(T)(tz,qz)
+                atomEnergies = {'H':-0.50003976 + SOC['H'], 'O':-75.00681155+ SOC['O'], 'C':-37.79029443+ SOC['C']}
 
-        # We are assuming that SOC is included in the Bond Energy Corrections
-        elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
-            atomEnergies = {'H':-0.499811124128, 'N':-54.526406291655, 'O':-74.995458316117, 'C':-37.788203485235, 'S':-397.663040369707}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_H-TZ':
+                atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.526406291655 + SOC['N'], 'O':-74.995458316117+ SOC['O'], 'C':-37.788203485235+ SOC['C']}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_H-QZ':
+                atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.526406291655 + SOC['N'], 'O':-74.995458316117+ SOC['O'], 'C':-37.788203485235+ SOC['C']}
+
+            # We are assuming that SOC is included in the Bond Energy Corrections
+            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
+                atomEnergies = {'H':-0.499811124128, 'N':-54.526406291655, 'O':-74.995458316117, 'C':-37.788203485235, 'S':-397.663040369707}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pVTZ-F12':
+                atomEnergies = {'H':-0.499946213243, 'N':-54.53000909621, 'O':-75.004127673424, 'C':-37.789862146471, 'S':-397.675447487865}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pVQZ-F12':
+                atomEnergies = {'H':-0.499994558325, 'N':-54.530515226371, 'O':-75.005600062003, 'C':-37.789961656228, 'S':-397.676719774973}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pCVDZ-F12':
+                atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.582137180344 + SOC['N'], 'O':-75.053045547421 + SOC['O'], 'C':-37.840869118707+ SOC['C']}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pCVTZ-F12':
+                atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.588545831900 + SOC['N'], 'O':-75.065995072347 + SOC['O'], 'C':-37.844662139972+ SOC['C']}
+            elif modelChemistry == 'CCSD(T)-F12/cc-pCVQZ-F12':
+                atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.589137594139+ SOC['N'], 'O':-75.067412234737+ SOC['O'], 'C':-37.844893820561+ SOC['C']}
+
+            elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVDZ':
+                atomEnergies = {'H':-0.499459066131 + SOC['H'], 'N':-54.524279516472 + SOC['N'], 'O':-74.992097308083+ SOC['O'], 'C':-37.786694171716+ SOC['C']}
+            elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVTZ':
+                atomEnergies = {'H':-0.499844820798 + SOC['H'], 'N':-54.527419359906 + SOC['N'], 'O':-75.000001429806+ SOC['O'], 'C':-37.788504810868+ SOC['C']}
+            elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVQZ':
+                atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.529569719016 + SOC['N'], 'O':-75.004026586610+ SOC['O'], 'C':-37.789387892348+ SOC['C']}
+
+
+            elif modelChemistry == 'B-CCSD(T)-F12/cc-pVDZ-F12':
+                atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.523269942190 + SOC['N'], 'O':-74.990725918500 + SOC['O'], 'C':-37.785409916465 + SOC['C'], 'S': -397.658155086033 + SOC['S']}
+            elif modelChemistry == 'B-CCSD(T)-F12/cc-pVTZ-F12':
+                atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.528135889213 + SOC['N'], 'O':-75.001094055506 + SOC['O'], 'C':-37.788233578503 + SOC['C'], 'S':-397.671745425929 + SOC['S']}
+            elif modelChemistry == 'B-CCSD(T)-F12/cc-pVQZ-F12':
+                atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.529425753163 + SOC['N'], 'O':-75.003820485005 + SOC['O'], 'C':-37.789006506290 + SOC['C'], 'S':-397.674145126931 + SOC['S']}
+            elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVDZ-F12':
+                atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.578602780288 + SOC['N'], 'O':-75.048064317367+ SOC['O'], 'C':-37.837592033417+ SOC['C']}
+            elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVTZ-F12':
+                atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.586402551258 + SOC['N'], 'O':-75.062767632757+ SOC['O'], 'C':-37.842729156944+ SOC['C']}
+            elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVQZ-F12':
+                atomEnergies = {'H':-0.49999456 + SOC['H'], 'N':-54.587781507581 + SOC['N'], 'O':-75.065397706471+ SOC['O'], 'C':-37.843634971592+ SOC['C']}
+
+            elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVDZ':
+                atomEnergies = {'H':-0.499459066131 + SOC['H'], 'N':-54.520475581942 + SOC['N'], 'O':-74.986992215049+ SOC['O'], 'C':-37.783294495799+ SOC['C']}
+            elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVTZ':
+                atomEnergies = {'H':-0.499844820798 + SOC['H'], 'N':-54.524927371700 + SOC['N'], 'O':-74.996328829705+ SOC['O'], 'C':-37.786320700792+ SOC['C']}
+            elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVQZ':
+                atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.528189769291 + SOC['N'], 'O':-75.001879610563+ SOC['O'], 'C':-37.788165047059+ SOC['C']}
+
+            elif modelChemistry == 'MP2_rmp2_pVDZ':
+                atomEnergies = {'H':-0.49927840 + SOC['H'], 'N':-54.46141996 + SOC['N'], 'O':-74.89408254+ SOC['O'], 'C':-37.73792713+ SOC['C']}
+            elif modelChemistry == 'MP2_rmp2_pVTZ':
+                atomEnergies = {'H':-0.49980981 + SOC['H'], 'N':-54.49615972 + SOC['N'], 'O':-74.95506980+ SOC['O'], 'C':-37.75833104+ SOC['C']}
+            elif modelChemistry == 'MP2_rmp2_pVQZ':
+                atomEnergies = {'H':-0.49994557 + SOC['H'], 'N':-54.50715868 + SOC['N'], 'O':-74.97515364+ SOC['O'], 'C':-37.76533215+ SOC['C']}
+
+            elif modelChemistry == 'CCSD-F12/cc-pVDZ-F12':
+                atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.524325513811 + SOC['N'], 'O':-74.992326577897+ SOC['O'], 'C':-37.786213495943+ SOC['C']}
+
+            elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_noscale':
+                atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.526026290887 + SOC['N'], 'O':-74.994751897699+ SOC['O'], 'C':-37.787881871511+ SOC['C']}
+
+            elif modelChemistry == 'G03_PBEPBE_6-311++g_d_p':
+                atomEnergies = {'H':-0.499812273282 + SOC['H'], 'N':-54.5289567564 + SOC['N'], 'O':-75.0033596764+ SOC['O'], 'C':-37.7937388736+ SOC['C']}
+
+            elif modelChemistry == 'FCI/cc-pVDZ':
+                atomEnergies = {'C':-37.789527+ SOC['C']}
+            elif modelChemistry == 'FCI/cc-pVTZ':
+                atomEnergies = {'C':-37.781266669684+ SOC['C']}
+            elif modelChemistry == 'FCI/cc-pVQZ':
+                atomEnergies = {'C':-37.787052110598+ SOC['C']}
+
+            elif modelChemistry in ['BMK/cbsb7', 'BMK/6-311G(2d,d,p)']:
+                atomEnergies = {'H':-0.498618853119+ SOC['H'], 'N':-54.5697851544+ SOC['N'], 'O':-75.0515210278+ SOC['O'], 'C':-37.8287310027+ SOC['C'], 'P':-341.167615941+ SOC['P'], 'S': -398.001619915+ SOC['S']}
+            elif modelChemistry == 'b3lyp/6-31G**':
+                atomEnergies = {'H':-0.500426155, 'C':-37.850331697831, 'O':-75.0535872748806, 'S':-398.100820107242}
+
+            else:
+                raise Exception('Unknown model chemistry "{}".'.format(modelChemistry))
+
+        for symbol, count in atoms.items():
+            if symbol in atomEnergies:
+                E0 -= count * atomEnergies[symbol] * 4.35974394e-18 * constants.Na
+            else:
+                raise Exception(
+                    'Unknown element "{}". Turn off atom corrections if only running a kinetics jobs '
+                    'or supply a dictionary of atom energies.'.format(symbol)
+                )
+
+        # Step 2: Atom energy corrections to reach gas-phase reference state
+        # Experimental enthalpy of formation at 0 K
+        # See Gaussian thermo whitepaper at http://www.gaussian.com/g_whitepap/thermo.htm)
+        # Note: these values are relatively old and some improvement may be possible by using newer values, particularly for carbon
+        # However, care should be taken to ensure that they are compatible with the BAC values (if BACs are used)
+        # The enthalpies listed here should correspond to the allowed elements in atom_num_dict
+        atomHf = {'H': 51.63,
+                  'Li': 37.69, 'Be': 76.48, 'B': 136.2, 'C': 169.98, 'N': 112.53, 'O': 58.99, 'F': 18.47,
+                  'Na': 25.69, 'Mg': 34.87, 'Al': 78.23, 'Si': 106.6, 'P': 75.42, 'S': 65.66, 'Cl': 28.59}
+        # Thermal contribution to enthalpy Hss(298 K) - Hss(0 K) reported by Gaussian thermo whitepaper
+        # This will be subtracted from the corresponding value in atomHf to produce an enthalpy used in calculating the enthalpy of formation at 298 K
+        atomThermal = {'H': 1.01,
+                       'Li': 1.1, 'Be': 0.46, 'B': 0.29, 'C': 0.25, 'N': 1.04, 'O': 1.04, 'F': 1.05,
+                       'Na': 1.54, 'Mg': 1.19, 'Al': 1.08, 'Si': 0.76, 'P': 1.28, 'S': 1.05, 'Cl': 1.1}
+        # Total energy correction used to reach gas-phase reference state
+        # Note: Spin orbit coupling no longer included in these energies, since some model chemistries include it automatically
+        atomEnthalpyCorrections = {element: atomHf[element] - atomThermal[element] for element in atomHf}
+        for symbol, count in atoms.items():
+            if symbol in atomEnthalpyCorrections:
+                E0 += count * atomEnthalpyCorrections[symbol] * 4184.
+            else:
+                raise Exception('Element "{}" is not supported.'.format(symbol))
+
+    if applyBondEnergyCorrections:
+        # Step 3: Bond energy corrections
+        #The order of elements in the bond correction label is important and should follow the order specified below:
+        #'C', 'N', 'O', 'S', 'P', and 'H'
+        #Use ``-``/``=``/``#`` to denote a single/double/triple bond, respectively.
+        # For example, ``'C=N'`` is correct while ``'N=C'`` is incorrect
+        bondEnergies = {}
+        # 'S-H', 'C-S', 'C=S', 'S-S', 'O-S', 'O=S', 'O=S=O' taken from http://hdl.handle.net/1721.1/98155 (both for
+        # 'CCSD(T)-F12/cc-pVDZ-F12' and 'CCSD(T)-F12/cc-pVTZ-F12')
+        if modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
+            bondEnergies = { 'C-H': -0.46, 'C-C': -0.68, 'C=C': -1.90, 'C#C': -3.13,
+                'O-H': -0.51, 'C-O': -0.23, 'C=O': -0.69, 'O-O': -0.02, 'C-N': -0.67,
+                'C=N': -1.46, 'C#N': -2.79, 'N-O': 0.74, 'N_O': -0.23, 'N=O': -0.51,
+                'N-H': -0.69, 'N-N': -0.47, 'N=N': -1.54, 'N#N': -2.05, 'S-H': 0.87,
+                'C-S': 0.42, 'C=S': 0.51, 'S-S': 0.86, 'O-S': 0.23, 'O=S': -0.53,
+                'O=S=O': 1.95, }
         elif modelChemistry == 'CCSD(T)-F12/cc-pVTZ-F12':
-            atomEnergies = {'H':-0.499946213243, 'N':-54.53000909621, 'O':-75.004127673424, 'C':-37.789862146471, 'S':-397.675447487865}
+            bondEnergies = { 'C-H': -0.09, 'C-C': -0.27, 'C=C': -1.03, 'C#C': -1.79,
+                'O-H': -0.06, 'C-O': 0.14, 'C=O': -0.19, 'O-O': 0.16, 'C-N': -0.18,
+                'C=N': -0.41, 'C#N': -1.41, 'N-O': 0.87, 'N_O': -0.09, 'N=O': -0.23,
+                'N-H': -0.01, 'N-N': -0.21, 'N=N': -0.44, 'N#N': -0.76, 'S-H': 0.52,
+                'C-S': 0.13, 'C=S': -0.12, 'S-S': 0.30, 'O-S': 0.15, 'O=S': -2.61,
+                'O=S=O': 0.27, }
         elif modelChemistry == 'CCSD(T)-F12/cc-pVQZ-F12':
-            atomEnergies = {'H':-0.499994558325, 'N':-54.530515226371, 'O':-75.005600062003, 'C':-37.789961656228, 'S':-397.676719774973}
-        elif modelChemistry == 'CCSD(T)-F12/cc-pCVDZ-F12':
-            atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.582137180344 + SOC['N'], 'O':-75.053045547421 + SOC['O'], 'C':-37.840869118707+ SOC['C']}
-        elif modelChemistry == 'CCSD(T)-F12/cc-pCVTZ-F12':
-            atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.588545831900 + SOC['N'], 'O':-75.065995072347 + SOC['O'], 'C':-37.844662139972+ SOC['C']}
-        elif modelChemistry == 'CCSD(T)-F12/cc-pCVQZ-F12':
-            atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.589137594139+ SOC['N'], 'O':-75.067412234737+ SOC['O'], 'C':-37.844893820561+ SOC['C']}
-
-        elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVDZ':
-            atomEnergies = {'H':-0.499459066131 + SOC['H'], 'N':-54.524279516472 + SOC['N'], 'O':-74.992097308083+ SOC['O'], 'C':-37.786694171716+ SOC['C']}
-        elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVTZ':
-            atomEnergies = {'H':-0.499844820798 + SOC['H'], 'N':-54.527419359906 + SOC['N'], 'O':-75.000001429806+ SOC['O'], 'C':-37.788504810868+ SOC['C']}
-        elif modelChemistry == 'CCSD(T)-F12/aug-cc-pVQZ':
-            atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.529569719016 + SOC['N'], 'O':-75.004026586610+ SOC['O'], 'C':-37.789387892348+ SOC['C']}
-
-
-        elif modelChemistry == 'B-CCSD(T)-F12/cc-pVDZ-F12':
-            atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.523269942190 + SOC['N'], 'O':-74.990725918500 + SOC['O'], 'C':-37.785409916465 + SOC['C'], 'S': -397.658155086033 + SOC['S']}
-        elif modelChemistry == 'B-CCSD(T)-F12/cc-pVTZ-F12':
-            atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.528135889213 + SOC['N'], 'O':-75.001094055506 + SOC['O'], 'C':-37.788233578503 + SOC['C'], 'S':-397.671745425929 + SOC['S']}
-        elif modelChemistry == 'B-CCSD(T)-F12/cc-pVQZ-F12':
-            atomEnergies = {'H':-0.499994558325 + SOC['H'], 'N':-54.529425753163 + SOC['N'], 'O':-75.003820485005 + SOC['O'], 'C':-37.789006506290 + SOC['C'], 'S':-397.674145126931 + SOC['S']}
-        elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVDZ-F12':
-            atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.578602780288 + SOC['N'], 'O':-75.048064317367+ SOC['O'], 'C':-37.837592033417+ SOC['C']}
-        elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVTZ-F12':
-            atomEnergies = {'H':-0.499946213243 + SOC['H'], 'N':-54.586402551258 + SOC['N'], 'O':-75.062767632757+ SOC['O'], 'C':-37.842729156944+ SOC['C']}
-        elif modelChemistry == 'B-CCSD(T)-F12/cc-pCVQZ-F12':
-            atomEnergies = {'H':-0.49999456 + SOC['H'], 'N':-54.587781507581 + SOC['N'], 'O':-75.065397706471+ SOC['O'], 'C':-37.843634971592+ SOC['C']}
-
-        elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVDZ':
-            atomEnergies = {'H':-0.499459066131 + SOC['H'], 'N':-54.520475581942 + SOC['N'], 'O':-74.986992215049+ SOC['O'], 'C':-37.783294495799+ SOC['C']}
-        elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVTZ':
-            atomEnergies = {'H':-0.499844820798 + SOC['H'], 'N':-54.524927371700 + SOC['N'], 'O':-74.996328829705+ SOC['O'], 'C':-37.786320700792+ SOC['C']}
-        elif modelChemistry == 'B-CCSD(T)-F12/aug-cc-pVQZ':
-            atomEnergies = {'H':-0.499949526073 + SOC['H'], 'N':-54.528189769291 + SOC['N'], 'O':-75.001879610563+ SOC['O'], 'C':-37.788165047059+ SOC['C']}
-
-        elif modelChemistry == 'MP2_rmp2_pVDZ':
-            atomEnergies = {'H':-0.49927840 + SOC['H'], 'N':-54.46141996 + SOC['N'], 'O':-74.89408254+ SOC['O'], 'C':-37.73792713+ SOC['C']}
-        elif modelChemistry == 'MP2_rmp2_pVTZ':
-            atomEnergies = {'H':-0.49980981 + SOC['H'], 'N':-54.49615972 + SOC['N'], 'O':-74.95506980+ SOC['O'], 'C':-37.75833104+ SOC['C']}
-        elif modelChemistry == 'MP2_rmp2_pVQZ':
-            atomEnergies = {'H':-0.49994557 + SOC['H'], 'N':-54.50715868 + SOC['N'], 'O':-74.97515364+ SOC['O'], 'C':-37.76533215+ SOC['C']}
-
-        elif modelChemistry == 'CCSD-F12/cc-pVDZ-F12':
-            atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.524325513811 + SOC['N'], 'O':-74.992326577897+ SOC['O'], 'C':-37.786213495943+ SOC['C']}
-
-        elif modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12_noscale':
-            atomEnergies = {'H':-0.499811124128 + SOC['H'], 'N':-54.526026290887 + SOC['N'], 'O':-74.994751897699+ SOC['O'], 'C':-37.787881871511+ SOC['C']}
-
-        elif modelChemistry == 'G03_PBEPBE_6-311++g_d_p':
-            atomEnergies = {'H':-0.499812273282 + SOC['H'], 'N':-54.5289567564 + SOC['N'], 'O':-75.0033596764+ SOC['O'], 'C':-37.7937388736+ SOC['C']}
-
-        elif modelChemistry == 'FCI/cc-pVDZ':
-            atomEnergies = {'C':-37.789527+ SOC['C']}
-        elif modelChemistry == 'FCI/cc-pVTZ':
-            atomEnergies = {'C':-37.781266669684+ SOC['C']}
-        elif modelChemistry == 'FCI/cc-pVQZ':
-            atomEnergies = {'C':-37.787052110598+ SOC['C']}
-
-        elif modelChemistry in ['BMK/cbsb7', 'BMK/6-311G(2d,d,p)']:
-            atomEnergies = {'H':-0.498618853119+ SOC['H'], 'N':-54.5697851544+ SOC['N'], 'O':-75.0515210278+ SOC['O'], 'C':-37.8287310027+ SOC['C'], 'P':-341.167615941+ SOC['P'], 'S': -398.001619915+ SOC['S']}
-        elif modelChemistry == 'b3lyp/6-31G**':
-            atomEnergies = {'H':-0.500426155, 'C':-37.850331697831, 'O':-75.0535872748806, 'S':-398.100820107242}
-
+            bondEnergies = { 'C-H': -0.08, 'C-C': -0.26, 'C=C': -1.01, 'C#C': -1.66,
+                'O-H':  0.07, 'C-O': 0.25, 'C=O': -0.03, 'O-O': 0.26, 'C-N': -0.20,
+                'C=N': -0.30, 'C#N': -1.33, 'N-O': 1.01, 'N_O': -0.03, 'N=O': -0.26,
+                'N-H':  0.06, 'N-N': -0.23, 'N=N': -0.37, 'N#N': -0.64,}
+        elif modelChemistry == 'CBS-QB3':
+            bondEnergies = {
+                'C-C': -0.495,'C-H': -0.045,'C=C': -0.825,'C-O': 0.378,'C=O': 0.743,'O-H': -0.423,  #Table2: Paraskevas, PD (2013). Chemistry-A European J., DOI: 10.1002/chem.201301381
+                'C#C': -0.64, 'C#N': -0.89, 'C-S': 0.43,  'O=S': -0.78,'S-H': 0.0,  'C-N': -0.13, 'C-Cl': 1.29, 'C-F': 0.55,  # Table IX: Petersson GA (1998) J. of Chemical Physics, DOI: 10.1063/1.477794
+                'N-H': -0.42, 'N=O': 1.11,  'N-N': -1.87, 'N=N': -1.58,'N-O': 0.35,  #Table 2: Ashcraft R (2007) J. Phys. Chem. B; DOI: 10.1021/jp073539t
+                'N#N': -2.0,  'O=O': -0.2,  'H-H': 1.1,  # Unknown source
+                 }
+        elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'B3LYP/6-311+G(3df,2p)', 'b3lyp/6-31G**']:
+            bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
+                'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44,
+                'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52, }
         else:
-            logging.warning('Unknown model chemistry "{0}"; not applying energy corrections.'.format(modelChemistry))
-            return E0
+            logging.warning('No bond energy correction found for model chemistry: {0}'.format(modelChemistry))
 
-    for symbol, count in atoms.items():
-        if symbol in atomEnergies: E0 -= count * atomEnergies[symbol] * 4.35974394e-18 * constants.Na
-        else:
-            logging.warning('Ignored unknown atom type "{0}".'.format(symbol))
-    
-    # Step 2: Atom energy corrections to reach gas-phase reference state
-    # Experimental enthalpy of formation at 0 K 
-    # See Gaussian thermo whitepaper at http://www.gaussian.com/g_whitepap/thermo.htm)
-    # Note: these values are relatively old and some improvement may be possible by using newer values, particularly for carbon
-    # However, care should be taken to ensure that they are compatible with the BAC values (if BACs are used)
-    atomHf = {'H': 51.63,
-              'Li': 37.69, 'Be': 76.48, 'B': 136.2, 'C': 169.98, 'N': 112.53, 'O': 58.99, 'F': 18.47,
-              'Na': 25.69, 'Mg': 34.87, 'Al': 78.23, 'Si': 106.6, 'P': 75.42, 'S': 65.66, 'Cl': 28.59}
-    # Thermal contribution to enthalpy Hss(298 K) - Hss(0 K) reported by Gaussian thermo whitepaper
-    # This will be subtracted from the corresponding value in atomHf to produce an enthalpy used in calculating the enthalpy of formation at 298 K
-    atomThermal = {'H': 1.01,
-                   'Li': 1.1, 'Be': 0.46, 'B': 0.29, 'C': 0.25, 'N': 1.04, 'O': 1.04, 'F': 1.05,
-                   'Na': 1.54, 'Mg': 1.19, 'Al': 1.08, 'Si': 0.76, 'P': 1.28, 'S': 1.05, 'Cl': 1.1}
-    # Total energy correction used to reach gas-phase reference state
-    # Note: Spin orbit coupling no longer included in these energies, since some model chemistries include it automatically
-    atomEnergies = {}
-    for element in atomHf:
-        atomEnergies[element] = atomHf[element] - atomThermal[element]
-    for symbol, count in atoms.items():
-        if symbol in atomEnergies: E0 += count * atomEnergies[symbol] * 4184.
-    
-    # Step 3: Bond energy corrections
-    #The order of elements in the bond correction label is important and should follow the order specified below:
-    #'C', 'N', 'O', 'S', 'P', and 'H'
-    #Use ``-``/``=``/``#`` to denote a single/double/triple bond, respectively.
-    # For example, ``'C=N'`` is correct while ``'N=C'`` is incorrect
-    bondEnergies = {}
-    # 'S-H', 'C-S', 'C=S', 'S-S', 'O-S', 'O=S', 'O=S=O' taken from http://hdl.handle.net/1721.1/98155 (both for
-    # 'CCSD(T)-F12/cc-pVDZ-F12' and 'CCSD(T)-F12/cc-pVTZ-F12')
-    if modelChemistry == 'CCSD(T)-F12/cc-pVDZ-F12':
-        bondEnergies = { 'C-H': -0.46, 'C-C': -0.68, 'C=C': -1.90, 'C#C': -3.13,
-            'O-H': -0.51, 'C-O': -0.23, 'C=O': -0.69, 'O-O': -0.02, 'C-N': -0.67,
-            'C=N': -1.46, 'C#N': -2.79, 'N-O': 0.74, 'N_O': -0.23, 'N=O': -0.51,
-            'N-H': -0.69, 'N-N': -0.47, 'N=N': -1.54, 'N#N': -2.05, 'S-H': 0.87,
-            'C-S': 0.42, 'C=S': 0.51, 'S-S': 0.86, 'O-S': 0.23, 'O=S': -0.53,
-            'O=S=O': 1.95, }
-    elif modelChemistry == 'CCSD(T)-F12/cc-pVTZ-F12':
-        bondEnergies = { 'C-H': -0.09, 'C-C': -0.27, 'C=C': -1.03, 'C#C': -1.79,
-            'O-H': -0.06, 'C-O': 0.14, 'C=O': -0.19, 'O-O': 0.16, 'C-N': -0.18,
-            'C=N': -0.41, 'C#N': -1.41, 'N-O': 0.87, 'N_O': -0.09, 'N=O': -0.23,
-            'N-H': -0.01, 'N-N': -0.21, 'N=N': -0.44, 'N#N': -0.76, 'S-H': 0.52,
-            'C-S': 0.13, 'C=S': -0.12, 'S-S': 0.30, 'O-S': 0.15, 'O=S': -2.61,
-            'O=S=O': 0.27, }
-    elif modelChemistry == 'CCSD(T)-F12/cc-pVQZ-F12':
-        bondEnergies = { 'C-H': -0.08, 'C-C': -0.26, 'C=C': -1.01, 'C#C': -1.66,
-            'O-H':  0.07, 'C-O': 0.25, 'C=O': -0.03, 'O-O': 0.26, 'C-N': -0.20,
-            'C=N': -0.30, 'C#N': -1.33, 'N-O': 1.01, 'N_O': -0.03, 'N=O': -0.26,
-            'N-H':  0.06, 'N-N': -0.23, 'N=N': -0.37, 'N#N': -0.64,}
-    elif modelChemistry == 'CBS-QB3': 
-        bondEnergies = { 
-            'C-C': -0.495,'C-H': -0.045,'C=C': -0.825,'C-O': 0.378,'C=O': 0.743,'O-H': -0.423,  #Table2: Paraskevas, PD (2013). Chemistry-A European J., DOI: 10.1002/chem.201301381
-            'C#C': -0.64, 'C#N': -0.89, 'C-S': 0.43,  'O=S': -0.78,'S-H': 0.0,  'C-N': -0.13, 'C-Cl': 1.29, 'C-F': 0.55,  # Table IX: Petersson GA (1998) J. of Chemical Physics, DOI: 10.1063/1.477794
-            'N-H': -0.42, 'N=O': 1.11,  'N-N': -1.87, 'N=N': -1.58,'N-O': 0.35,  #Table 2: Ashcraft R (2007) J. Phys. Chem. B; DOI: 10.1021/jp073539t
-            'N#N': -2.0,  'O=O': -0.2,  'H-H': 1.1,  # Unknown source
-             }
-    elif modelChemistry in ['B3LYP/cbsb7', 'B3LYP/6-311G(2d,d,p)', 'B3LYP/6-311+G(3df,2p)', 'b3lyp/6-31G**']:
-        bondEnergies = { 'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
-            'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44, 
-            'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52, }    
-    else:
-        logging.warning('No bond energy correction found for model chemistry: {0}'.format(modelChemistry))
-
-    for symbol, count in bonds.items():
-        if symbol in bondEnergies: E0 += count * bondEnergies[symbol] * 4184.
-        elif symbol[::-1] in bondEnergies: E0 += count * bondEnergies[symbol[::-1]] * 4184.
-        else:
-            logging.warning('Ignored unknown bond type {0!r}.'.format(symbol))
+        for symbol, count in bonds.items():
+            if symbol in bondEnergies:
+                E0 += count * bondEnergies[symbol] * 4184.
+            elif symbol[::-1] in bondEnergies:
+                E0 += count * bondEnergies[symbol[::-1]] * 4184.
+            else:
+                logging.warning('Ignored unknown bond type {0!r}.'.format(symbol))
     
     return E0
 

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -676,10 +676,14 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds, atomEnergies=None):
     # See Gaussian thermo whitepaper at http://www.gaussian.com/g_whitepap/thermo.htm)
     # Note: these values are relatively old and some improvement may be possible by using newer values, particularly for carbon
     # However, care should be taken to ensure that they are compatible with the BAC values (if BACs are used)
-    atomHf = {'H': 51.63 , 'N': 112.53 ,'O': 58.99 ,'C': 169.98, 'S': 65.66 }
+    atomHf = {'H': 51.63,
+              'Li': 37.69, 'Be': 76.48, 'B': 136.2, 'C': 169.98, 'N': 112.53, 'O': 58.99, 'F': 18.47,
+              'Na': 25.69, 'Mg': 34.87, 'Al': 78.23, 'Si': 106.6, 'P': 75.42, 'S': 65.66, 'Cl': 28.59}
     # Thermal contribution to enthalpy Hss(298 K) - Hss(0 K) reported by Gaussian thermo whitepaper
     # This will be subtracted from the corresponding value in atomHf to produce an enthalpy used in calculating the enthalpy of formation at 298 K
-    atomThermal = {'H': 1.01 , 'N': 1.04, 'O': 1.04 ,'C': 0.25, 'S': 1.05 }
+    atomThermal = {'H': 1.01,
+                   'Li': 1.1, 'Be': 0.46, 'B': 0.29, 'C': 0.25, 'N': 1.04, 'O': 1.04, 'F': 1.05,
+                   'Na': 1.54, 'Mg': 1.19, 'Al': 1.08, 'Si': 0.76, 'P': 1.28, 'S': 1.05, 'Cl': 1.1}
     # Total energy correction used to reach gas-phase reference state
     # Note: Spin orbit coupling no longer included in these energies, since some model chemistries include it automatically
     atomEnergies = {}

--- a/rmgpy/cantherm/statmech.py
+++ b/rmgpy/cantherm/statmech.py
@@ -735,6 +735,7 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds, atomEnergies=None):
 
     for symbol, count in bonds.items():
         if symbol in bondEnergies: E0 += count * bondEnergies[symbol] * 4184.
+        elif symbol[::-1] in bondEnergies: E0 += count * bondEnergies[symbol[::-1]] * 4184.
         else:
             logging.warning('Ignored unknown bond type {0!r}.'.format(symbol))
     


### PR DESCRIPTION
When parsing quantum chemistry output in a Cantherm calculation, there is no reason for the user to specify the types and numbers of atoms, because the information can be obtained from the output files. In fact, mistyping atoms will lead to incorrect thermochemistry and rates, which is avoided in this PR.

This PR also increases the flexibility of Cantherm calculations by allowing the user to supply a dictionary of atomic energies, which means that we are no longer restricted by the hard-coded model chemistries in `rmgpy/cantherm/statmech.py`.

Lastly, another issue in #1315 and #742 is addressed by removing model chemistries that do not specify which basis set was used for the atomic energy calculations. This is a relatively drastic measure, but it should ensure that users do not accidentally end up with completely wrong results.