### PR TITLE
Fix symmetry inconsistencies

### DIFF
--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -398,7 +398,45 @@ def calculateCyclicSymmetryNumber(molecule):
                     break
                 min_index += 1
                 max_index += -1
-
+            # check to make sure that the groups are identical on centers of flipping
+            if all_the_same:
+                ringed_atom_ids = [id(_atom) for _atom in ring]
+                if size % 2 == 0: # look at two atoms
+                    atom1 = ring[flipping_atom_index]
+                    atom2 = ring[flipping_atom_index + size/2]
+                    non_ring_bonded_atoms = [bonded_atom for bonded_atom in atom1.bonds.keys() + atom2.bonds.keys() if id(bonded_atom) not in ringed_atom_ids]
+                    if len(non_ring_bonded_atoms) < 3:
+                        pass # all_the_same still true
+                    elif len(non_ring_bonded_atoms) == 3:
+                        # at least one of these much be a match for flipping to happen
+                        identical = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1])
+                        identical2 = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[2])
+                        identical3 = vf2.feasible(non_ring_bonded_atoms[1],non_ring_bonded_atoms[2])
+                        if not (identical or identical2 or identical3):
+                            all_the_same = False
+                    elif len(non_ring_bonded_atoms) == 4:
+                        same_sides = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1]) and \
+                                     vf2.feasible(non_ring_bonded_atoms[2],non_ring_bonded_atoms[3])
+                        if not same_sides:
+                            atom0_matching = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[2]) or\
+                                             vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[3])
+                            atom1_matching = vf2.feasible(non_ring_bonded_atoms[1],non_ring_bonded_atoms[2]) or\
+                                             vf2.feasible(non_ring_bonded_atoms[1],non_ring_bonded_atoms[3])
+                            if not (atom0_matching and atom1_matching):
+                                all_the_same = False
+                else:
+                    atom = ring[flipping_atom_index]
+                    non_ring_bonded_atoms = [bonded_atom for bonded_atom in atom.bonds.keys() if id(bonded_atom) not in ringed_atom_ids]
+                    if len(non_ring_bonded_atoms) < 2:
+                        pass # all_the_same still true
+                    elif len(non_ring_bonded_atoms) == 2:
+                        identical = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1])
+                        if not identical:
+                            # flipping a tetrahedral will not work
+                            all_the_same = False
+                        else:
+                             # having 5+ bonnds is not modeled here
+                             pass
             # for even rings, check for flipping accross bonds too
             if not all_the_same and size % 2 == 0:
                 all_the_same = True

--- a/rmgpy/molecule/symmetryTest.py
+++ b/rmgpy/molecule/symmetryTest.py
@@ -494,7 +494,6 @@ multiplicity 3
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 6)
 
-    @work_in_progress
     def testTotalSymmetryNumberSpecialCyclic(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) from issue # 332
@@ -649,7 +648,68 @@ multiplicity 3
         Test the Molecule.calculateSymmetryNumber() on C1=C=C=1
         """
         self.assertEqual(Species().fromSMILES('C1=C=C=1').getSymmetryNumber(), 6)
+
+    def test_symmetry_number_S1_total(self):
+        """
+        Test the Molecule.calculateSymmetryNumber() on [CH]1CCC1CC1CC1
+        """
+        self.assertEqual(Species().fromSMILES('[CH]1CCC1CC1CC1').getSymmetryNumber(),1)
+
+    def testCyclicSymmetryNumberS1(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on [CH]1CCC1CC1CC1
+        """
+        molecule = Molecule().fromSMILES('[CH]1CCC1CC1CC1')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 1)
     
+    def testCyclicSymmetryNumberMethylCycloPropane(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on CC1CC1
+        """
+        molecule = Molecule().fromSMILES('CC1CC1')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 1)
+
+    def testCyclicSymmetryNumberMethylCycloPropene(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on C=C1CC1
+        """
+        molecule = Molecule().fromSMILES('C=C1CC1')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 2)
+
+
+    def testCyclicSymmetryNumberMethylCycloButene(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on C=C1CCC1
+        """
+        molecule = Molecule().fromSMILES('C=C1CCC1')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 2)
+
+    def testCyclicSymmetryNumberMethylCycloButane(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on CC1CCC1
+        """
+        molecule = Molecule().fromSMILES('CC1CCC1')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 1)
+
+    def testCyclicSymmetryNumberDiMethylCycloButane(self):
+        """
+        Test the Molecule.calculateCyclicSymmetryNumber() on CC1CC(C)C1
+        """
+        molecule = Molecule().fromSMILES('CC1CC(C)C1')
+        symmetryNumber = calculateCyclicSymmetryNumber(molecule)
+        self.assertEqual(symmetryNumber, 4)
+
+
+    def test_symmetry_number_dimethylcylcobutane_total(self):
+        """
+        Test the Molecule.calculateSymmetryNumber() on CC1CC(C)C1
+        """
+        self.assertEqual(Species().fromSMILES('CC1CC(C)C1').getSymmetryNumber(),36)
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, the cyclic symmetry algorithm assumed a cycle is planar,
and incorrectly identified some cyclic structures as symmetric
when they are flipped over. This commit looks at the groups attached
to the atom where flipping occurs and makes sure that it would not
result flipping the other groups attached to the ring before assigning
a symmetry value.

Thanks to Max for discussion.

This solves issue #332 and possibly part of #1327.