### PR TITLE
Identifier fixes

### DIFF
--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -713,6 +713,9 @@ def toAdjacencyList(atoms, multiplicity, label=None, group=False, removeH=False,
     Convert a chemical graph defined by a list of `atoms` into a string
     adjacency list.
     """
+    if not atoms:
+        return ''
+
     if oldStyle:
         return toOldAdjacencyList(atoms, multiplicity, label, group, removeH)
     

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -509,6 +509,10 @@ def _write(mol, identifier_type, backend):
 
     Returns a string identifier of the requested type.
     """
+    # Check that the molecule is not empty
+    if not mol.atoms:
+        return ''
+
     for option in _get_backend_list(backend):
         if option == 'rdkit':
             try:

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -345,6 +345,8 @@ def _rdkit_translator(input_object, identifier_type, mol=None):
             raise ValueError('Identifier type {0} is not supported for reading using RDKit.'.format(identifier_type))
         if rdkitmol is None:
             raise ValueError("Could not interpret the identifier {0!r}".format(input_object))
+        if mol is None:
+            mol = mm.Molecule()
         output = fromRDKitMol(mol, rdkitmol)
     elif isinstance(input_object, mm.Molecule):
         # We are converting from a molecule to a string identifier

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -355,7 +355,7 @@ def _rdkit_translator(input_object, identifier_type, mol=None):
         if identifier_type == 'inchi':
             output = Chem.inchi.MolToInchi(rdkitmol, options='-SNon')
         elif identifier_type == 'inchikey':
-            inchi = toInChI(mol)
+            inchi = toInChI(input_object)
             output = Chem.inchi.InchiToInchiKey(inchi)
         elif identifier_type == 'sma':
             output = Chem.MolToSmarts(rdkitmol)

--- a/rmgpy/molecule/translatorTest.py
+++ b/rmgpy/molecule/translatorTest.py
@@ -406,6 +406,14 @@ multiplicity 2
         for inchi in inchi_list:
             self.assertEqual(inchi, expected_inchi)
 
+    def test_disconnected_molecule(self):
+        """Test that we can generate an InChI for a disconnected molecule."""
+        mol = Molecule().fromSMILES('CCCCO.C=O')
+
+        inchi = 'InChI=1S/C4H10O.CH2O/c1-2-3-4-5;1-2/h5H,2-4H2,1H3;1H2'
+
+        self.assertEqual(mol.toInChI(), inchi)
+
 
 class SMILESGenerationTest(unittest.TestCase):
     def compare(self, adjlist, smiles):

--- a/rmgpy/molecule/translatorTest.py
+++ b/rmgpy/molecule/translatorTest.py
@@ -44,6 +44,16 @@ from rmgpy.molecule.translator import *
 from rmgpy.species import Species
 
 
+class TranslatorTest(unittest.TestCase):
+
+    def test_empty_molecule(self):
+        """Test that we can safely return a blank identifier for an empty molecule."""
+        mol = Molecule()
+
+        self.assertEqual(mol.toSMILES(), '')
+        self.assertEqual(mol.toInChI(), '')
+
+
 class InChIGenerationTest(unittest.TestCase):
     def compare(self, adjlist, aug_inchi):
         spc = Species(molecule=[Molecule().fromAdjacencyList(adjlist)])

--- a/rmgpy/molecule/util.py
+++ b/rmgpy/molecule/util.py
@@ -48,7 +48,10 @@ def retrieveElementCount(obj):
                 element, count = match.groups()
                 if count is '':
                     count = 1
-                element_count[element] = int(count)
+                if element in element_count:
+                    element_count[element] += int(count)
+                else:
+                    element_count[element] = int(count)
         return element_count
     
     elif isinstance(obj, Molecule):

--- a/rmgpy/molecule/utilTest.py
+++ b/rmgpy/molecule/utilTest.py
@@ -33,6 +33,30 @@ from scipy.special import comb
 
 from .util import *
 
+
+class ElementCountTest(unittest.TestCase):
+
+    def test_inchi_count(self):
+        """Test element counting for InChI"""
+        inchi = 'InChI=1S/C4H10O/c1-2-3-4-5/h5H,2-4H2,1H3'
+
+        expected = {'C': 4, 'H': 10, 'O': 1}
+
+        count = retrieveElementCount(inchi)
+
+        self.assertEqual(count, expected)
+
+    def test_inchi_count_disconnected(self):
+        """Test element counting for InChI with disconnected molecule"""
+        inchi = 'InChI=1S/C4H10O.CH2O/c1-2-3-4-5;1-2/h5H,2-4H2,1H3;1H2'
+
+        expected = {'C': 5, 'H': 12, 'O': 2}
+
+        count = retrieveElementCount(inchi)
+
+        self.assertEqual(count, expected)
+
+
 class PartitionTest(unittest.TestCase):
 
     def test_singleton(self):


### PR DESCRIPTION
Very straightforward fixes related to identifier generation:
- If a molecule doesn't have atoms, then don't try generating an identifier.
- When counting elements based on InChI, add counts from multiple instances of the same element. This can occur with disconnected molecules (see unit test).