### PR TITLE
Peroxide chemistry families

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2046,6 +2046,80 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[1],reaction.products[0]])
                 else:
                     error = True
+        elif self.label.lower() == 'baeyer-villiger_step1_cat':
+            # Hardcoding for Baeyer-Villiger_step1_cat: pair the two reactants
+            # with the Criegee intermediate and pair the catalyst with itself
+            assert len(reaction.reactants) == 3 and len(reaction.products) == 2
+            if reaction.reactants[0].containsLabeledAtom('*5'):
+                if reaction.products[0].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[1],reaction.products[0]])
+                    pairs.append([reaction.reactants[2],reaction.products[0]])
+                    pairs.append([reaction.reactants[0],reaction.products[1]])
+                elif reaction.products[1].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[1],reaction.products[1]])
+                    pairs.append([reaction.reactants[2], reaction.products[1]])
+                    pairs.append([reaction.reactants[0], reaction.products[0]])
+                else:
+                    error = True
+            elif reaction.reactants[1].containsLabeledAtom('*5'):
+                if reaction.products[0].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[0]])
+                    pairs.append([reaction.reactants[2], reaction.products[0]])
+                    pairs.append([reaction.reactants[1], reaction.products[1]])
+                elif reaction.products[1].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[1]])
+                    pairs.append([reaction.reactants[2], reaction.products[1]])
+                    pairs.append([reaction.reactants[1], reaction.products[0]])
+                else:
+                    error = True
+            elif reaction.reactants[2].containsLabeledAtom('*5'):
+                if reaction.products[0].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[0]])
+                    pairs.append([reaction.reactants[1], reaction.products[0]])
+                    pairs.append([reaction.reactants[2], reaction.products[1]])
+                elif reaction.products[1].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[1]])
+                    pairs.append([reaction.reactants[1], reaction.products[1]])
+                    pairs.append([reaction.reactants[2], reaction.products[0]])
+                else:
+                    error = True
+        elif self.label.lower() == 'baeyer-villiger_step2_cat':
+            # Hardcoding for Baeyer-Villiger_step2_cat: pair the Criegee
+            # intermediate with the two products and the catalyst with itself
+            assert len(reaction.reactants) == 2 and len(reaction.products) == 3
+            if reaction.products[0].containsLabeledAtom('*7'):
+                if reaction.reactants[0].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[1]])
+                    pairs.append([reaction.reactants[0], reaction.products[2]])
+                    pairs.append([reaction.reactants[1], reaction.products[0]])
+                elif reaction.reactants[1].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[1], reaction.products[1]])
+                    pairs.append([reaction.reactants[1], reaction.products[2]])
+                    pairs.append([reaction.reactants[0], reaction.products[0]])
+                else:
+                    error = True
+            elif reaction.products[1].containsLabeledAtom('*7'):
+                if reaction.reactants[0].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[0]])
+                    pairs.append([reaction.reactants[0], reaction.products[2]])
+                    pairs.append([reaction.reactants[1], reaction.products[1]])
+                elif reaction.reactants[1].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[1], reaction.products[0]])
+                    pairs.append([reaction.reactants[1], reaction.products[2]])
+                    pairs.append([reaction.reactants[0], reaction.products[1]])
+                else:
+                    error = True
+            elif reaction.products[2].containsLabeledAtom('*7'):
+                if reaction.reactants[0].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[0], reaction.products[0]])
+                    pairs.append([reaction.reactants[0], reaction.products[1]])
+                    pairs.append([reaction.reactants[1], reaction.products[2]])
+                elif reaction.reactants[1].containsLabeledAtom('*1'):
+                    pairs.append([reaction.reactants[1], reaction.products[0]])
+                    pairs.append([reaction.reactants[1], reaction.products[1]])
+                    pairs.append([reaction.reactants[0], reaction.products[2]])
+                else:
+                    error = True
         else:
             error = True
             

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1921,9 +1921,9 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[1],reaction.products[0]])
                 else:
                     error = True
-        elif self.label.lower() in ['disproportionation', 'co_disproportionation']:
-            # Hardcoding for disproportionation and co_disproportionation: pair
-            # the reactant containing *1 with the product containing *1
+        elif self.label.lower() in ['disproportionation', 'co_disproportionation', 'korcek_step1_cat']:
+            # Hardcoding for disproportionation, co_disproportionation, korcek_step1_cat:
+            # pair the reactant containing *1 with the product containing *1
             assert len(reaction.reactants) == len(reaction.products) == 2
             if reaction.reactants[0].containsLabeledAtom('*1'):
                 if reaction.products[0].containsLabeledAtom('*1'):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1973,7 +1973,7 @@ class KineticsFamily(Database):
         as the reactants, return the reactant-product pairs to use when
         performing flux analysis.
         """
-        pairs = []; error = False
+        pairs = []
         if len(reaction.reactants) == 1 or len(reaction.products) == 1:
             # When there is only one reactant (or one product), it is paired 
             # with each of the products (reactants)
@@ -1991,8 +1991,6 @@ class KineticsFamily(Database):
                 elif reaction.products[1].containsLabeledAtom('*3'):
                     pairs.append([reaction.reactants[0],reaction.products[1]])
                     pairs.append([reaction.reactants[1],reaction.products[0]])
-                else:
-                    error = True
             elif reaction.reactants[1].containsLabeledAtom('*1'):
                 if reaction.products[1].containsLabeledAtom('*3'):
                     pairs.append([reaction.reactants[0],reaction.products[0]])
@@ -2000,8 +1998,6 @@ class KineticsFamily(Database):
                 elif reaction.products[0].containsLabeledAtom('*3'):
                     pairs.append([reaction.reactants[0],reaction.products[1]])
                     pairs.append([reaction.reactants[1],reaction.products[0]])
-                else:
-                    error = True
         elif self.label.lower() in ['disproportionation', 'co_disproportionation', 'korcek_step1_cat']:
             # Hardcoding for disproportionation, co_disproportionation, korcek_step1_cat:
             # pair the reactant containing *1 with the product containing *1
@@ -2013,8 +2009,6 @@ class KineticsFamily(Database):
                 elif reaction.products[1].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0],reaction.products[1]])
                     pairs.append([reaction.reactants[1],reaction.products[0]])
-                else:
-                    error = True
             elif reaction.reactants[1].containsLabeledAtom('*1'):
                 if reaction.products[1].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0],reaction.products[0]])
@@ -2022,8 +2016,6 @@ class KineticsFamily(Database):
                 elif reaction.products[0].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0],reaction.products[1]])
                     pairs.append([reaction.reactants[1],reaction.products[0]])
-                else:
-                    error = True
         elif self.label.lower() in ['substitution_o', 'substitutions']:
             # Hardcoding for Substitution_O: pair the reactant containing
             # *2 with the product containing *3 and vice versa
@@ -2035,8 +2027,6 @@ class KineticsFamily(Database):
                 elif reaction.products[1].containsLabeledAtom('*3'):
                     pairs.append([reaction.reactants[0],reaction.products[1]])
                     pairs.append([reaction.reactants[1],reaction.products[0]])
-                else:
-                    error = True
             elif reaction.reactants[1].containsLabeledAtom('*2'):
                 if reaction.products[1].containsLabeledAtom('*3'):
                     pairs.append([reaction.reactants[0],reaction.products[0]])
@@ -2044,8 +2034,6 @@ class KineticsFamily(Database):
                 elif reaction.products[0].containsLabeledAtom('*3'):
                     pairs.append([reaction.reactants[0],reaction.products[1]])
                     pairs.append([reaction.reactants[1],reaction.products[0]])
-                else:
-                    error = True
         elif self.label.lower() == 'baeyer-villiger_step1_cat':
             # Hardcoding for Baeyer-Villiger_step1_cat: pair the two reactants
             # with the Criegee intermediate and pair the catalyst with itself
@@ -2059,8 +2047,6 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[1],reaction.products[1]])
                     pairs.append([reaction.reactants[2], reaction.products[1]])
                     pairs.append([reaction.reactants[0], reaction.products[0]])
-                else:
-                    error = True
             elif reaction.reactants[1].containsLabeledAtom('*5'):
                 if reaction.products[0].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0], reaction.products[0]])
@@ -2070,8 +2056,6 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[0], reaction.products[1]])
                     pairs.append([reaction.reactants[2], reaction.products[1]])
                     pairs.append([reaction.reactants[1], reaction.products[0]])
-                else:
-                    error = True
             elif reaction.reactants[2].containsLabeledAtom('*5'):
                 if reaction.products[0].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0], reaction.products[0]])
@@ -2081,8 +2065,6 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[0], reaction.products[1]])
                     pairs.append([reaction.reactants[1], reaction.products[1]])
                     pairs.append([reaction.reactants[2], reaction.products[0]])
-                else:
-                    error = True
         elif self.label.lower() == 'baeyer-villiger_step2_cat':
             # Hardcoding for Baeyer-Villiger_step2_cat: pair the Criegee
             # intermediate with the two products and the catalyst with itself
@@ -2096,8 +2078,6 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[1], reaction.products[1]])
                     pairs.append([reaction.reactants[1], reaction.products[2]])
                     pairs.append([reaction.reactants[0], reaction.products[0]])
-                else:
-                    error = True
             elif reaction.products[1].containsLabeledAtom('*7'):
                 if reaction.reactants[0].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0], reaction.products[0]])
@@ -2107,8 +2087,6 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[1], reaction.products[0]])
                     pairs.append([reaction.reactants[1], reaction.products[2]])
                     pairs.append([reaction.reactants[0], reaction.products[1]])
-                else:
-                    error = True
             elif reaction.products[2].containsLabeledAtom('*7'):
                 if reaction.reactants[0].containsLabeledAtom('*1'):
                     pairs.append([reaction.reactants[0], reaction.products[0]])
@@ -2118,16 +2096,11 @@ class KineticsFamily(Database):
                     pairs.append([reaction.reactants[1], reaction.products[0]])
                     pairs.append([reaction.reactants[1], reaction.products[1]])
                     pairs.append([reaction.reactants[0], reaction.products[2]])
-                else:
-                    error = True
-        else:
-            error = True
-            
-        if error:
+
+        if not pairs:
             logging.debug('Preset mapping missing for determining reaction pairs for family {0!s}, falling back to Reaction.generatePairs'.format(self.label))
-            return []
-        else:
-            return pairs
+
+        return pairs
         
     def getReactionTemplate(self, reaction):
         """

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1203,7 +1203,65 @@ class KineticsFamily(Database):
                     identicalCenterCounter += 1
                     atom.label = '*' + str(identicalCenterCounter)
             if identicalCenterCounter != 2:
-                raise KineticsError('Unable to change labels from "*" to "*1" and "*2" for reaction family {0}.'.format(label))
+                raise KineticsError(
+                    'Trying to apply recipe for reaction family {}: Only one occurrence of "*" found.'.format(label)
+                )
+        # Hardcoding of reaction family for peroxyl disproportionation
+        # '*1' and '*2' have to be changed to '*3' and '*4' for the second reactant
+        elif label == 'peroxyl_disproportionation' and forward:
+            identicalCenterCounter1 = identicalCenterCounter2 = 0
+            for atom in reactantStructure.atoms:
+                if atom.label == '*1':
+                    identicalCenterCounter1 += 1
+                    if identicalCenterCounter1 > 1:
+                        atom.label = '*3'
+                elif atom.label == '*2':
+                    identicalCenterCounter2 += 1
+                    if identicalCenterCounter2 > 1:
+                        atom.label = '*4'
+            msg = 'Trying to apply recipe for reaction family {}:'.format(label)
+            error = False
+            if identicalCenterCounter1 != 2:
+                msg += ' Only one occurrence of "*1" found.'
+                error = True
+            if identicalCenterCounter2 != 2:
+                msg += ' Only one occurrence of "*2" found.'
+                error = True
+            if error:
+                raise KineticsError(msg)
+        # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
+        # '*2' has to be changed to '*4' for the second reactant and '*1' has to be
+        # changed to '*6'. '*3' has to be changed to '*5' for the first reactant.
+        # '*5' and '*6' do no participate in the reaction but are required for
+        # relabeling in the reverse direction.
+        elif label == 'bimolec_hydroperoxide_decomposition' and forward:
+            identicalCenterCounter1 = identicalCenterCounter2 = identicalCenterCounter3 = 0
+            for atom in reactantStructure.atoms:
+                if atom.label == '*1':
+                    identicalCenterCounter1 += 1
+                    if identicalCenterCounter1 > 1:
+                        atom.label = '*6'
+                elif atom.label == '*2':
+                    identicalCenterCounter2 += 1
+                    if identicalCenterCounter2 > 1:
+                        atom.label = '*4'
+                elif atom.label == '*3':
+                    identicalCenterCounter3 += 1
+                    if identicalCenterCounter3 == 1:
+                        atom.label = '*5'
+            msg = 'Trying to apply recipe for reaction family {}:'.format(label)
+            error = False
+            if identicalCenterCounter1 != 2:
+                msg += ' Only one occurrence of "*1" found.'
+                error = True
+            if identicalCenterCounter2 != 2:
+                msg += ' Only one occurrence of "*2" found.'
+                error = True
+            if identicalCenterCounter3 != 2:
+                msg += ' Only one occurrence of "*3" found.'
+                error = True
+            if error:
+                raise KineticsError(msg)
 
         # Generate the product structure by applying the recipe
         if forward:
@@ -1228,7 +1286,27 @@ class KineticsFamily(Database):
         # '*'
         if label == 'r_recombination' and not forward:
             for atom in productStructure.atoms:
-                if atom.label == '*1' or atom.label == '*2': atom.label = '*'
+                if atom.label == '*1' or atom.label == '*2':
+                    atom.label = '*'
+        # Hardcoding of reaction family for reverse of peroxyl disproportionation
+        # Labels '*3' and '*4' have to be changed back to '*1' and '*2'
+        elif label == 'peroxyl_disproportionation' and not forward:
+            for atom in productStructure.atoms:
+                if atom.label == '*3':
+                    atom.label = '*1'
+                elif atom.label == '*4':
+                    atom.label = '*2'
+        # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
+        # '*5' has to be changed back to '*3', '*6' has to be changed to '*1', and
+        # '*4' has to be changed to '*2'
+        elif label == 'bimolec_hydroperoxide_decomposition' and not forward:
+            for atom in productStructure.atoms:
+                if atom.label == '*5':
+                    atom.label = '*3'
+                elif atom.label == '*6':
+                    atom.label = '*1'
+                elif atom.label == '*4':
+                    atom.label = '*2'
 
         # If reaction family is its own reverse, relabel atoms
         # This allows comparison of the product species to forbidden

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1192,82 +1192,83 @@ class KineticsFamily(Database):
         for s in reactantStructures:
             reactantStructure = reactantStructure.merge(s.copy(deep=True))
 
-        # Hardcoding of reaction family for radical recombination (colligation)
-        # because the two reactants are identical, they have the same tags
-        # In this case, we must change the labels from '*' and '*' to '*1' and
-        # '*2'
-        if label == 'r_recombination' and forward:
-            identicalCenterCounter = 0
-            for atom in reactantStructure.atoms:
-                if atom.label == '*':
-                    identicalCenterCounter += 1
-                    atom.label = '*' + str(identicalCenterCounter)
-            if identicalCenterCounter != 2:
-                raise KineticsError(
-                    'Trying to apply recipe for reaction family {}: Only one occurrence of "*" found.'.format(label)
-                )
-        # Hardcoding of reaction family for peroxyl disproportionation
-        # '*1' and '*2' have to be changed to '*3' and '*4' for the second reactant
-        elif label == 'peroxyl_disproportionation' and forward:
-            identicalCenterCounter1 = identicalCenterCounter2 = 0
-            for atom in reactantStructure.atoms:
-                if atom.label == '*1':
-                    identicalCenterCounter1 += 1
-                    if identicalCenterCounter1 > 1:
-                        atom.label = '*3'
-                elif atom.label == '*2':
-                    identicalCenterCounter2 += 1
-                    if identicalCenterCounter2 > 1:
-                        atom.label = '*4'
-            msg = 'Trying to apply recipe for reaction family {}:'.format(label)
-            error = False
-            if identicalCenterCounter1 != 2:
-                msg += ' Only one occurrence of "*1" found.'
-                error = True
-            if identicalCenterCounter2 != 2:
-                msg += ' Only one occurrence of "*2" found.'
-                error = True
-            if error:
-                raise KineticsError(msg)
-        # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
-        # '*2' has to be changed to '*4' for the second reactant and '*1' has to be
-        # changed to '*6'. '*3' has to be changed to '*5' for the first reactant.
-        # '*5' and '*6' do no participate in the reaction but are required for
-        # relabeling in the reverse direction.
-        elif label == 'bimolec_hydroperoxide_decomposition' and forward:
-            identicalCenterCounter1 = identicalCenterCounter2 = identicalCenterCounter3 = 0
-            for atom in reactantStructure.atoms:
-                if atom.label == '*1':
-                    identicalCenterCounter1 += 1
-                    if identicalCenterCounter1 > 1:
-                        atom.label = '*6'
-                elif atom.label == '*2':
-                    identicalCenterCounter2 += 1
-                    if identicalCenterCounter2 > 1:
-                        atom.label = '*4'
-                elif atom.label == '*3':
-                    identicalCenterCounter3 += 1
-                    if identicalCenterCounter3 == 1:
-                        atom.label = '*5'
-            msg = 'Trying to apply recipe for reaction family {}:'.format(label)
-            error = False
-            if identicalCenterCounter1 != 2:
-                msg += ' Only one occurrence of "*1" found.'
-                error = True
-            if identicalCenterCounter2 != 2:
-                msg += ' Only one occurrence of "*2" found.'
-                error = True
-            if identicalCenterCounter3 != 2:
-                msg += ' Only one occurrence of "*3" found.'
-                error = True
-            if error:
-                raise KineticsError(msg)
-
-        # Generate the product structure by applying the recipe
         if forward:
+            # Hardcoding of reaction family for radical recombination (colligation)
+            # because the two reactants are identical, they have the same tags
+            # In this case, we must change the labels from '*' and '*' to '*1' and
+            # '*2'
+            if label == 'r_recombination':
+                identicalCenterCounter = 0
+                for atom in reactantStructure.atoms:
+                    if atom.label == '*':
+                        identicalCenterCounter += 1
+                        atom.label = '*' + str(identicalCenterCounter)
+                if identicalCenterCounter != 2:
+                    raise KineticsError(
+                        'Trying to apply recipe for reaction family {}: Only one occurrence of "*" found.'.format(label)
+                    )
+            # Hardcoding of reaction family for peroxyl disproportionation
+            # '*1' and '*2' have to be changed to '*3' and '*4' for the second reactant
+            elif label == 'peroxyl_disproportionation':
+                identicalCenterCounter1 = identicalCenterCounter2 = 0
+                for atom in reactantStructure.atoms:
+                    if atom.label == '*1':
+                        identicalCenterCounter1 += 1
+                        if identicalCenterCounter1 > 1:
+                            atom.label = '*3'
+                    elif atom.label == '*2':
+                        identicalCenterCounter2 += 1
+                        if identicalCenterCounter2 > 1:
+                            atom.label = '*4'
+                msg = 'Trying to apply recipe for reaction family {}:'.format(label)
+                error = False
+                if identicalCenterCounter1 != 2:
+                    msg += ' Only one occurrence of "*1" found.'
+                    error = True
+                if identicalCenterCounter2 != 2:
+                    msg += ' Only one occurrence of "*2" found.'
+                    error = True
+                if error:
+                    raise KineticsError(msg)
+            # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
+            # '*2' has to be changed to '*4' for the second reactant and '*1' has to be
+            # changed to '*6'. '*3' has to be changed to '*5' for the first reactant.
+            # '*5' and '*6' do no participate in the reaction but are required for
+            # relabeling in the reverse direction.
+            elif label == 'bimolec_hydroperoxide_decomposition':
+                identicalCenterCounter1 = identicalCenterCounter2 = identicalCenterCounter3 = 0
+                for atom in reactantStructure.atoms:
+                    if atom.label == '*1':
+                        identicalCenterCounter1 += 1
+                        if identicalCenterCounter1 > 1:
+                            atom.label = '*6'
+                    elif atom.label == '*2':
+                        identicalCenterCounter2 += 1
+                        if identicalCenterCounter2 > 1:
+                            atom.label = '*4'
+                    elif atom.label == '*3':
+                        identicalCenterCounter3 += 1
+                        if identicalCenterCounter3 == 1:
+                            atom.label = '*5'
+                msg = 'Trying to apply recipe for reaction family {}:'.format(label)
+                error = False
+                if identicalCenterCounter1 != 2:
+                    msg += ' Only one occurrence of "*1" found.'
+                    error = True
+                if identicalCenterCounter2 != 2:
+                    msg += ' Only one occurrence of "*2" found.'
+                    error = True
+                if identicalCenterCounter3 != 2:
+                    msg += ' Only one occurrence of "*3" found.'
+                    error = True
+                if error:
+                    raise KineticsError(msg)
+
+            # Generate the product structure by applying the recipe
             self.forwardRecipe.applyForward(reactantStructure, unique)
         else:
             self.reverseRecipe.applyForward(reactantStructure, unique)
+
         if not reactantStructure.props['validAromatic']:
             if isinstance(reactantStructure, Molecule):
                 # For molecules, kekulize the product to redistribute bonds appropriately
@@ -1279,34 +1280,35 @@ class KineticsFamily(Database):
                 return []
         productStructure = reactantStructure
 
-        # Hardcoding of reaction family for reverse of radical recombination
-        # (Unimolecular homolysis)
-        # Because the two products are identical, they should the same tags
-        # In this case, we must change the labels from '*1' and '*2' to '*' and
-        # '*'
-        if label == 'r_recombination' and not forward:
-            for atom in productStructure.atoms:
-                if atom.label == '*1' or atom.label == '*2':
-                    atom.label = '*'
-        # Hardcoding of reaction family for reverse of peroxyl disproportionation
-        # Labels '*3' and '*4' have to be changed back to '*1' and '*2'
-        elif label == 'peroxyl_disproportionation' and not forward:
-            for atom in productStructure.atoms:
-                if atom.label == '*3':
-                    atom.label = '*1'
-                elif atom.label == '*4':
-                    atom.label = '*2'
-        # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
-        # '*5' has to be changed back to '*3', '*6' has to be changed to '*1', and
-        # '*4' has to be changed to '*2'
-        elif label == 'bimolec_hydroperoxide_decomposition' and not forward:
-            for atom in productStructure.atoms:
-                if atom.label == '*5':
-                    atom.label = '*3'
-                elif atom.label == '*6':
-                    atom.label = '*1'
-                elif atom.label == '*4':
-                    atom.label = '*2'
+        if not forward:
+            # Hardcoding of reaction family for reverse of radical recombination
+            # (Unimolecular homolysis)
+            # Because the two products are identical, they should the same tags
+            # In this case, we must change the labels from '*1' and '*2' to '*' and
+            # '*'
+            if label == 'r_recombination':
+                for atom in productStructure.atoms:
+                    if atom.label == '*1' or atom.label == '*2':
+                        atom.label = '*'
+            # Hardcoding of reaction family for reverse of peroxyl disproportionation
+            # Labels '*3' and '*4' have to be changed back to '*1' and '*2'
+            elif label == 'peroxyl_disproportionation':
+                for atom in productStructure.atoms:
+                    if atom.label == '*3':
+                        atom.label = '*1'
+                    elif atom.label == '*4':
+                        atom.label = '*2'
+            # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
+            # '*5' has to be changed back to '*3', '*6' has to be changed to '*1', and
+            # '*4' has to be changed to '*2'
+            elif label == 'bimolec_hydroperoxide_decomposition':
+                for atom in productStructure.atoms:
+                    if atom.label == '*5':
+                        atom.label = '*3'
+                    elif atom.label == '*6':
+                        atom.label = '*1'
+                    elif atom.label == '*4':
+                        atom.label = '*2'
 
         # If reaction family is its own reverse, relabel atoms
         # This allows comparison of the product species to forbidden
@@ -1320,7 +1322,6 @@ class KineticsFamily(Database):
                 if atom.label != '':
                     atomLabels[atom.label] = atom
 
-            label = self.label.lower()
             if label == 'h_abstraction':
                 # '*2' is the H that migrates
                 # it moves from '*1' to '*3'
@@ -1372,8 +1373,10 @@ class KineticsFamily(Database):
                 atomLabels['*2'].label = '*3'
                 atomLabels['*3'].label = '*2'
 
-        if not forward: template = self.reverseTemplate
-        else:           template = self.forwardTemplate
+        if not forward:
+            template = self.reverseTemplate
+        else:
+            template = self.forwardTemplate
 
         # Split product structure into multiple species if necessary
         productStructures = productStructure.split()

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -147,7 +147,9 @@ class KineticsGroups(Database):
 
         # Get fresh templates (with duplicate nodes back in)
         forwardTemplate = self.top[:]
-        if self.label.lower().startswith('r_recombination'):
+        if (self.label.lower().startswith('r_recombination')
+            or self.label.lower().startswith('peroxyl_disproportionation')
+            or self.label.lower().startswith('bimolec_hydroperoxide_decomposition')):
             forwardTemplate.append(forwardTemplate[0])
 
         # Check that we were able to match the template.


### PR DESCRIPTION
Should be merged together with ReactionMechanismGenerator/RMG-database#262.

Hard-codes flux pairs for new `Korcek_step1_cat` and Baeyer-Villiger families. Also makes sure that the groups in `Bimolec_Hydroperoxide_Decomposition` and `Peroxyl_Disproportionation` are relabeled correctly, because these families all involve identical trees for both reactants.