### PR TITLE
Fix multi pdep arrhenius calculation

### DIFF
--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -762,25 +762,9 @@ cdef class MultiPDepArrhenius(PDepKineticsModel):
         if P == 0:
             raise ValueError('No pressure specified to pressure-dependent MultiPDepArrhenius.getRateCoefficient().')
         
-        Plist1 = self.arrhenius[0].pressures.value_si
-        for arrh in self.arrhenius[1:]:
-            Plist2 = arrh.pressures.value_si
-            assert Plist1.shape[0] == Plist2.shape[0]
-            for i in range(Plist1.shape[0]):
-                assert 0.99 < (Plist2[i] / Plist1[i]) < 1.01            
-        
-        klow = 0.0; khigh = 0.0
+        k = 0
         for arrh in self.arrhenius:
-            Plow, Phigh, arrh_low, arrh_high = arrh.getAdjacentExpressions(P)
-            klow += arrh_low.getRateCoefficient(T)
-            khigh += arrh_high.getRateCoefficient(T)
-            
-        if klow == khigh == 0.0: 
-            return 0.0
-        elif Plow == Phigh:
-            k = klow
-        else:
-            k = klow * 10**(log10(P/Plow)/log10(Phigh/Plow)*log10(khigh/klow))
+            k += arrh.getRateCoefficient(T,P)
         
         return k
 

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -110,6 +110,12 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             test.description = test_name
             self.compat_func_name = test_name
             yield test, library_name
+            
+            test = lambda x: self.kinetics_checkLibraryRatesCanBeEvaluated(library)
+            test_name = "Kinetics library {0}: check rates can be evaluated?".format(library_name)
+            test.description = test_name
+            self.compat_func_name = test_name
+            yield test, library_name
 
     def test_thermo(self):
         for group_name, group in self.database.thermo.groups.iteritems():
@@ -415,7 +421,14 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
                         continue
 
                     nose.tools.assert_false(speciesList[i].molecule[0].isIsomorphic(speciesList[j].molecule[0], initialMap), "Species {0} and species {1} in {2} database were found to be identical.".format(speciesList[i].label,speciesList[j].label,database.label))
-
+    
+    def kinetics_checkLibraryRatesCanBeEvaluated(self, library):
+        """
+        This test ensures that every library reaction has evaluable kinetics
+        """
+        for entry in library.entries.values():
+            entry.data.getRateCoefficient(1000.0,1.0)
+            
     def kinetics_checkReactantAndProductTemplate(self, family_name):
         """
         This test checks whether the reactant and product templates within a family are correctly defined.


### PR DESCRIPTION
This removes the requirement that PdepArrhenius objects in a MultiPdepArrhenius must have the same pressure lists by changing the getRateCoefficient function to evaluate each PdepArrhenius object independently.  Also adds a database test that checks that all library reactions can be evaluated.  