### PR TITLE
Fix cantherm examples

### DIFF
--- a/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy.py
+++ b/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy.py
@@ -8,7 +8,7 @@ externalSymmetry = 1
 
 spinMultiplicity = 2
 
-opticalIsomers = 1
+opticalIsomers = 2
 
 energy = {
     'M08SO': QchemLog('dimetpropoxy.out'),    

--- a/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
+++ b/examples/cantherm/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
@@ -8,7 +8,7 @@ externalSymmetry = 1
 
 spinMultiplicity = 2
 
-opticalIsomers = 1
+opticalIsomers = 2
 
 energy = {
     'M08SO': QchemLog('dimetpropoxy_betasci.out'),    


### PR DESCRIPTION
This PR fixes two issues @cgrambow and I identified in the Cantherm examples and I've set them to the values @cgrambow thinks they should be.  The symmetry of the methyl rotors in the Toulene example have been fixed from 6 to 3 and the number of opticalIsomers in the 23dimethylpropoxy example have been changed from 1 to 2 to reflect the presence of a chiral carbon.  