### PR TITLE
Allow PDep reactions and non-template library reactions in PDep networks

### DIFF
--- a/documentation/source/users/rmg/database/modification.rst
+++ b/documentation/source/users/rmg/database/modification.rst
@@ -3,9 +3,9 @@
 *********************
 Database Modification
 *********************
-Note that the RMG-Py database is written in Python code where line indentions
+Note that the RMG-Py database is written in Python code where line indentations
 determine the scope. When modifying the database, be sure to preserve all 
-line indentions shown in the examples.
+line indentations shown in the examples.
 
 Modifying the Thermo Database
 =============================
@@ -81,6 +81,25 @@ To conform to RMG's format, simply copy and modify an existing library.
 
 At the top of the reactions file fill in the name and short (one line) and long descriptions.
 The name must be identical to the folder's name. Then list the kinetics entries, each with a unique index number.
+
+There are two flags relevant for pressure dependent library reactions that one should consider using:
+
+1. **elementary_high_p**: Should be set to ``True`` for *elementary* unimolecular reactions (with only one reactant
+and/or product) with a kinetics entry that has information about the high pressure kinetics, i.e., Troe or Lindemann,
+PDepArrhenius or Chebyshev that are defined up to at least 100 bar, or Arrhenius that represents the high pressure limit
+(i.e., not the measured rate at some low or medium experimental pressure). If set to ``True``, RMG will use the high pressure
+limit rate when constructing pressure-dependent networks. The kinetics entry of the original library reaction will only be
+updated if it is an Arrhenius type (will be replaced with either PDepArrhenius or Chebyshev, as specified in the
+pressureDependent block of the input file). If set to ``False`` (the default value), RMG will not use the high pressure
+limit rate in network exploration, and will not convert Arrhenius kinetics of library reactions that have no template
+(a corresponding reaction family) into a pressure-dependent form.
+
+2. **has_pdep_route**: If set to ``True`` and RMG discovers a pressure-dependent reaction with the same reactants and products,
+the latter *will* be considered in addition to the library reaction. This is useful for cases when more than one pathway connects
+the same reactants and products, and some of these pathways are well-skipping reactions. If set to ``False`` (the default value),
+similar network reactions will not be considered in the model generation.
+
+
 The following formats are accepted as kinetics entries:
 
 **Arrhenius** of the form :math:`k(T) = A \left( \frac{T}{T_0} \right)^n \exp \left( -\frac{E_\mathrm{a}}{RT} \right)`

--- a/documentation/source/users/rmg/database/modification.rst
+++ b/documentation/source/users/rmg/database/modification.rst
@@ -94,7 +94,7 @@ pressureDependent block of the input file). If set to ``False`` (the default val
 limit rate in network exploration, and will not convert Arrhenius kinetics of library reactions that have no template
 (a corresponding reaction family) into a pressure-dependent form.
 
-2. **has_pdep_route**: If set to ``True`` and RMG discovers a pressure-dependent reaction with the same reactants and products,
+2. **allow_pdep_route**: If set to ``True`` and RMG discovers a pressure-dependent reaction with the same reactants and products,
 the latter *will* be considered in addition to the library reaction. This is useful for cases when more than one pathway connects
 the same reactants and products, and some of these pathways are well-skipping reactions. If set to ``False`` (the default value),
 similar network reactions will not be considered in the model generation.

--- a/rmgpy/cantherm/pdep.py
+++ b/rmgpy/cantherm/pdep.py
@@ -633,7 +633,10 @@ class PressureDependenceJob(object):
                 if rxn.kinetics is not None:
                     if isinstance(rxn, LibraryReaction) and 'Reaction library:' not in rxn.kinetics.comment:
                         rxn.kinetics.comment += 'Reaction library: {0!r}'.format(rxn.library)
-                    f.write('    kinetics = {0!r},\n'.format(rxn.kinetics))
+                    if rxn.network_kinetics is not None:
+                        f.write('    kinetics = {0!r},\n'.format(rxn.network_kinetics))
+                    else:
+                        f.write('    kinetics = {0!r},\n'.format(rxn.kinetics))
                 if ts.tunneling is not None:
                     f.write('    tunneling = {0!r},\n'.format(ts.tunneling.__class__.__name__))
                 f.write(')\n\n')

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -72,7 +72,7 @@ def saveEntry(f, entry):
 
 
     #Entries for kinetic rules, libraries, training reactions
-    #and depositories will have an Reaction object for its item
+    #and depositories will have a Reaction object for its item
     if isinstance(entry.item, Reaction):
         #Write out additional data if depository or library
         #kinetic rules would have a Group object for its reactants instead of Species
@@ -83,6 +83,10 @@ def saveEntry(f, entry):
                 f.write('    duplicate = {0!r},\n'.format(entry.item.duplicate))
             if not entry.item.reversible:
                 f.write('    reversible = {0!r},\n'.format(entry.item.reversible))
+            if not entry.item.has_pdep_route:
+                f.write('    has_pdep_route = {0!r},\n'.format(entry.item.has_pdep_route))
+            if not entry.item.elementary_high_p:
+                f.write('    elementary_high_p = {0!r},\n'.format(entry.item.elementary_high_p))
     #Entries for groups with have a group or logicNode for its item
     elif isinstance(entry.item, Group):
         f.write('    group = \n')

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -83,9 +83,9 @@ def saveEntry(f, entry):
                 f.write('    duplicate = {0!r},\n'.format(entry.item.duplicate))
             if not entry.item.reversible:
                 f.write('    reversible = {0!r},\n'.format(entry.item.reversible))
-            if not entry.item.has_pdep_route:
-                f.write('    has_pdep_route = {0!r},\n'.format(entry.item.has_pdep_route))
-            if not entry.item.elementary_high_p:
+            if entry.item.allow_pdep_route:
+                f.write('    allow_pdep_route = {0!r},\n'.format(entry.item.allow_pdep_route))
+            if entry.item.elementary_high_p:
                 f.write('    elementary_high_p = {0!r},\n'.format(entry.item.elementary_high_p))
     #Entries for groups with have a group or logicNode for its item
     elif isinstance(entry.item, Group):

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -35,6 +35,7 @@ This module contains functionality for working with kinetics libraries.
 import os.path
 import logging
 import re
+import numpy as np
 try:
     from collections import OrderedDict
 except ImportError:
@@ -67,6 +68,7 @@ class LibraryReaction(Reaction):
                  products=None,
                  specificCollider=None,
                  kinetics=None,
+                 network_kinetics=None,
                  reversible=True,
                  transitionState=None,
                  duplicate=False,
@@ -83,6 +85,7 @@ class LibraryReaction(Reaction):
                           products=products,
                           specificCollider=specificCollider,
                           kinetics=kinetics,
+                          network_kinetics=network_kinetics,
                           reversible=reversible,
                           transitionState=transitionState,
                           duplicate=duplicate,
@@ -104,6 +107,7 @@ class LibraryReaction(Reaction):
                                   self.products,
                                   self.specificCollider,
                                   self.kinetics,
+                                  self.network_kinetics,
                                   self.reversible,
                                   self.transitionState,
                                   self.duplicate,

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -74,6 +74,7 @@ class LibraryReaction(Reaction):
                  pairs=None,
                  library=None,
                  has_pdep_route=False,
+                 elementary_high_p=False,
                  entry=None
                  ):
         Reaction.__init__(self,
@@ -87,7 +88,8 @@ class LibraryReaction(Reaction):
                           duplicate=duplicate,
                           degeneracy=degeneracy,
                           pairs=pairs,
-                          has_pdep_route=has_pdep_route
+                          has_pdep_route=has_pdep_route,
+                          elementary_high_p=elementary_high_p,
                           )
         self.library = library
         self.family = library
@@ -109,6 +111,7 @@ class LibraryReaction(Reaction):
                                   self.pairs,
                                   self.library,
                                   self.has_pdep_route,
+                                  self.elementary_high_p,
                                   self.entry
                                   ))
 
@@ -148,9 +151,10 @@ class KineticsLibrary(Database):
                 lib = lib[0].replace('Originally from reaction library: ','')
                 lib = lib.replace('\n','')
                 rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:],
-                 library=lib, specificCollider=entry.item.specificCollider, kinetics=entry.data, duplicate=entry.item.duplicate,
-                 reversible=entry.item.reversible
-                 )
+                                      library=lib, specificCollider=entry.item.specificCollider, kinetics=entry.data,
+                                      duplicate=entry.item.duplicate, reversible=entry.item.reversible,
+                                      has_pdep_route=entry.item.has_pdep_route,
+                                      elementary_high_p=entry.item.elementary_high_p)
             elif entry._longDesc and 'rate rule' in entry._longDesc: #template reaction
                 c = entry._longDesc.split('\n')
                 family_comments = [i for i in c if 'family: ' in i]
@@ -162,15 +166,15 @@ class KineticsLibrary(Database):
                 tstrings[0] = tstrings[0][1:]
                 tstrings[-1] = tstrings[-1][:-1]
                 rxn = TemplateReaction(reactants=entry.item.reactants[:], products=entry.item.products[:],
-                  specificCollider=entry.item.specificCollider, kinetics=entry.data, duplicate=entry.item.duplicate,
-                 reversible=entry.item.reversible,family=familyname,template=tstrings
-                 )
+                                       specificCollider=entry.item.specificCollider, kinetics=entry.data,
+                                       duplicate=entry.item.duplicate, reversible=entry.item.reversible,
+                                       family=familyname, template=tstrings)
             else:  # pdep or standard library reaction
                 rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:],
                                       library=self.label, specificCollider=entry.item.specificCollider,
                                       kinetics=entry.data, duplicate=entry.item.duplicate,
-                                      reversible=entry.item.reversible, has_pdep_route=entry.item.has_pdep_route
-                                      )
+                                      reversible=entry.item.reversible, has_pdep_route=entry.item.has_pdep_route,
+                                      elementary_high_p=entry.item.elementary_high_p)
             rxns.append(rxn)
         
         return rxns
@@ -393,6 +397,7 @@ class KineticsLibrary(Database):
                   shortDesc='',
                   longDesc='',
                   has_pdep_route=False,
+                  elementary_high_p=False,
                   ):
         
 #        reactants = [Species(label=reactant1.strip().splitlines()[0].strip(), molecule=[Molecule().fromAdjacencyList(reactant1)])]
@@ -405,7 +410,7 @@ class KineticsLibrary(Database):
 #        
         # Make a blank reaction
         rxn = Reaction(reactants=[], products=[], degeneracy=degeneracy, duplicate=duplicate, reversible=reversible,
-                       has_pdep_route=has_pdep_route)
+                       has_pdep_route=has_pdep_route, elementary_high_p=elementary_high_p)
 #        if not rxn.isBalanced():
 #            raise DatabaseError('Reaction {0} in kinetics library {1} was not balanced! Please reformulate.'.format(rxn, self.label))        
 #        label = str(rxn)

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -46,7 +46,7 @@ from rmgpy.data.base import DatabaseError, Database, Entry
 
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics import Arrhenius, ThirdBody, Lindemann, Troe, \
-                           PDepArrhenius, MultiArrhenius, MultiPDepArrhenius
+                           PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, Chebyshev
 from rmgpy.molecule import Molecule
 from rmgpy.species import Species
 from .common import saveEntry
@@ -125,6 +125,67 @@ class LibraryReaction(Reaction):
         LibraryReaction this should be a KineticsLibrary object.
         """
         return self.library
+
+    def generate_high_p_limit_kinetics(self):
+        """
+        If the LibraryReactions represented by `self` has pressure dependent kinetics,
+        try extracting the high pressure limit rate from it.
+        Used for incorporating library reactions with pressure-dependent kinetics in PDep networks.
+        Only reactions flagged as `elementary_high_p=True` should be processed here.
+        If the kinetics is a :class:Lindemann or a :class:Troe, simply get the high pressure limit rate.
+        If the kinetics is a :class:PDepArrhenius or a :class:Chebyshev, generate a :class:Arrhenius kinetics entry
+        that represents the high pressure limit if Pmax >= 90 bar .
+        This high pressure limit Arrhenius kinetics is assigned to the reaction network_kinetics attribute.
+        If this method successfully generated the high pressure limit kinetics, return ``True``, otherwise ``False``.
+        """
+        logging.debug("Generating high pressure limit kinetics for {0}...".format(self))
+        if not self.isUnimolecular():
+            return False
+        if isinstance(self.kinetics, Arrhenius):
+            return self.elementary_high_p
+        if self.network_kinetics is not None:
+            return True
+        if self.elementary_high_p:
+            if isinstance(self.kinetics, (Lindemann, Troe)):
+                self.network_kinetics = self.kinetics.arrheniusHigh
+                self.network_kinetics.comment = self.kinetics.comment
+                self.network_kinetics.comment = "Kinetics taken from the arrheniusHigh attribute of a" \
+                    " Troe/Lindemann exprssion. Originally from reaction library {0}".format(self.library)
+                return True
+            if isinstance(self.kinetics, PDepArrhenius):
+                if self.kinetics.pressures.value_si[-1] >= 9000000:  # Pa units
+                    if isinstance(self.kinetics.arrhenius[-1], Arrhenius):
+                        self.network_kinetics = self.kinetics.arrhenius[-1]
+                        return True
+                    else:
+                        # This is probably MultiArrhenius entries inside a PDepArrhenius kinetics entry. Don't process
+                        return False
+            if isinstance(self.kinetics, Chebyshev):
+                if self.kinetics.Pmax.value_si >= 9000000:  # Pa units
+                    if len(self.reactants) == 1:
+                        kunits = 's^-1'
+                    elif len(self.reactants) == 2:
+                        kunits = 'm^3/(mol*s)'
+                    elif len(self.reactants) == 3:
+                        kunits = 'm^6/(mol^2*s)'
+                    else:
+                        kunits = ''
+                    t_step = (self.kinetics.Tmax.value_si - self.kinetics.Tmin.value_si) / 20
+                    t_list = np.arange(int(self.kinetics.Tmin.value_si), int(self.kinetics.Tmax.value_si), int(t_step))
+                    if t_list[-1] < int(self.kinetics.Tmax.value_si):
+                        t_list = np.insert(t_list,-1,[int(self.kinetics.Tmax.value_si)])
+                    k_list = []
+                    for t in t_list:
+                        k_list.append(self.kinetics.getRateCoefficient(t, self.kinetics.Pmax.value_si))
+                    k_list = np.array(k_list)
+                    self.network_kinetics = Arrhenius().fitToData(Tlist=t_list, klist=k_list, kunits=kunits)
+                    return True
+            logging.info("NOT processing reaction {0} in a pressure-dependent reaction network.\n"
+                         "Although it is marked with the `elementary_high_p=True` flag,"
+                         " it doesn't answer either of the following criteria:\n1. Has a Lindemann or Troe"
+                         " kinetics type; 2. Has a PDepArrhenius or Chebyshev kinetics type and has valid"
+                         " kinetics at P >= 100 bar.\n".format(self))
+        return False
 
 ################################################################################
 

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -75,7 +75,7 @@ class LibraryReaction(Reaction):
                  degeneracy=1,
                  pairs=None,
                  library=None,
-                 has_pdep_route=False,
+                 allow_pdep_route=False,
                  elementary_high_p=False,
                  entry=None
                  ):
@@ -91,7 +91,7 @@ class LibraryReaction(Reaction):
                           duplicate=duplicate,
                           degeneracy=degeneracy,
                           pairs=pairs,
-                          has_pdep_route=has_pdep_route,
+                          allow_pdep_route=allow_pdep_route,
                           elementary_high_p=elementary_high_p,
                           )
         self.library = library
@@ -114,7 +114,7 @@ class LibraryReaction(Reaction):
                                   self.degeneracy,
                                   self.pairs,
                                   self.library,
-                                  self.has_pdep_route,
+                                  self.allow_pdep_route,
                                   self.elementary_high_p,
                                   self.entry
                                   ))
@@ -218,7 +218,7 @@ class KineticsLibrary(Database):
                 rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:],
                                       library=lib, specificCollider=entry.item.specificCollider, kinetics=entry.data,
                                       duplicate=entry.item.duplicate, reversible=entry.item.reversible,
-                                      has_pdep_route=entry.item.has_pdep_route,
+                                      allow_pdep_route=entry.item.allow_pdep_route,
                                       elementary_high_p=entry.item.elementary_high_p)
             elif entry._longDesc and 'rate rule' in entry._longDesc: #template reaction
                 c = entry._longDesc.split('\n')
@@ -238,7 +238,7 @@ class KineticsLibrary(Database):
                 rxn = LibraryReaction(reactants=entry.item.reactants[:], products=entry.item.products[:],
                                       library=self.label, specificCollider=entry.item.specificCollider,
                                       kinetics=entry.data, duplicate=entry.item.duplicate,
-                                      reversible=entry.item.reversible, has_pdep_route=entry.item.has_pdep_route,
+                                      reversible=entry.item.reversible, allow_pdep_route=entry.item.allow_pdep_route,
                                       elementary_high_p=entry.item.elementary_high_p)
             rxns.append(rxn)
         
@@ -461,7 +461,7 @@ class KineticsLibrary(Database):
                   referenceType='',
                   shortDesc='',
                   longDesc='',
-                  has_pdep_route=False,
+                  allow_pdep_route=False,
                   elementary_high_p=False,
                   ):
         
@@ -475,7 +475,7 @@ class KineticsLibrary(Database):
 #        
         # Make a blank reaction
         rxn = Reaction(reactants=[], products=[], degeneracy=degeneracy, duplicate=duplicate, reversible=reversible,
-                       has_pdep_route=has_pdep_route, elementary_high_p=elementary_high_p)
+                       allow_pdep_route=allow_pdep_route, elementary_high_p=elementary_high_p)
 #        if not rxn.isBalanced():
 #            raise DatabaseError('Reaction {0} in kinetics library {1} was not balanced! Please reformulate.'.format(rxn, self.label))        
 #        label = str(rxn)

--- a/rmgpy/pdep/collision.pyx
+++ b/rmgpy/pdep/collision.pyx
@@ -31,7 +31,7 @@
 This module contains classes and functions for working with collision models.
 """
 
-import numpy
+import numpy, logging
 cimport cython
 
 cimport rmgpy.constants as constants
@@ -300,7 +300,7 @@ cdef class SingleExponentialDown:
         beta = (dEdown / (dEdown + Fe * R * T))**2 / Delta
     
         if beta > 1:
-            print('Warning: Collision efficiency {0:.3f} calculated at {1:g} K is greater than unity, so it will be set to unity.'.format(beta, T))
+            logging.debug('Collision efficiency {0:.3f} calculated at {1:g} K is greater than unity, so it will be set to unity.'.format(beta, T))
             beta = 1
         if beta < 0:
             raise CollisionError('Invalid collision efficiency {0:.3f} calculated at {1:g} K.'.format(beta, T))

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -219,7 +219,7 @@ class Network:
         
         self.calculateDensitiesOfStates()
         logging.debug('Finished initialization for network {0}.'.format(self.label))
-        logging.debug('The nework now has values of {0}'.format(repr(self)))
+        logging.debug('The network now has values of {0}'.format(repr(self)))
 
     def calculateRateCoefficients(self, Tlist, Plist, method, errorCheck=True):
         
@@ -290,7 +290,7 @@ class Network:
                                 K[t,p,:,:] = 0 * K[t,p,:,:]
                                 self.K = 0 * self.K
         logging.debug('Finished calculating rate coefficients for network {0}.'.format(self.label))
-        logging.debug('The nework now has values of {0}'.format(repr(self)))
+        logging.debug('The network now has values of {0}'.format(repr(self)))
         logging.debug('Master equation matrix found for network {0} is {1}'.format(self.label, K))
         return K
 
@@ -378,7 +378,7 @@ class Network:
             if temperatureChanged or pressureChanged:
                 self.calculateCollisionModel()
         logging.debug('Finished setting conditions for network {0}.'.format(self.label))
-        logging.debug('The nework now has values of {0}'.format(repr(self)))
+        logging.debug('The network now has values of {0}'.format(repr(self)))
 
     def __getEnergyGrains(self, Emin, Emax, grainSize=0.0, grainCount=0):
         """

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -787,7 +787,7 @@ class Network:
         current conditions using the modified strong collision method.
         """
         import rmgpy.pdep.msc as msc
-        logging.debug('Applying modified strong collision method at {0:g} K, {1:g} bar...'.format(self.T, self.P))
+        logging.debug('Applying modified strong collision method at {0:g} K, {1:g} Pa...'.format(self.T, self.P))
         self.K, self.p0 = msc.applyModifiedStrongCollisionMethod(self, efficiencyModel)
         return self.K, self.p0
     
@@ -797,7 +797,7 @@ class Network:
         current conditions using the reservoir state method.
         """
         import rmgpy.pdep.rs as rs
-        logging.debug('Applying reservoir state method at {0:g} K, {1:g} bar...'.format(self.T, self.P))
+        logging.debug('Applying reservoir state method at {0:g} K, {1:g} Pa...'.format(self.T, self.P))
         self.K, self.p0 = rs.applyReservoirStateMethod(self)
         return self.K, self.p0
     
@@ -810,7 +810,7 @@ class Network:
         reduced set of :math:`k(T,P)` values. 
         """
         import rmgpy.pdep.cse as cse
-        logging.debug('Applying chemically-significant eigenvalues method at {0:g} K, {1:g} bar...'.format(self.T, self.P))
+        logging.debug('Applying chemically-significant eigenvalues method at {0:g} K, {1:g} Pa...'.format(self.T, self.P))
         self.K, self.p0 = cse.applyChemicallySignificantEigenvaluesMethod(self, lumpingOrder)
         return self.K, self.p0
     

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -619,7 +619,8 @@ class Network:
                 kf_expected = rxn.calculateTSTRateCoefficient(T)
             else:
                 # ILT was used to compute k(E), so use high-P kinetics to compute k(T)
-                kf_expected = rxn.kinetics.getRateCoefficient(T)
+                kf_expected = rxn.kinetics.getRateCoefficient(T) if rxn.network_kinetics is None else\
+                    rxn.network_kinetics.getRateCoefficient(T)
             
             # Determine the expected value of the equilibrium constant (Kc)
             Keq_expected = self.eqRatios[prod] / self.eqRatios[reac] 

--- a/rmgpy/pdep/reaction.pyx
+++ b/rmgpy/pdep/reaction.pyx
@@ -119,11 +119,11 @@ def calculateMicrocanonicalRateCoefficient(reaction,
         # so let's use the less accurate inverse Laplace transform method
         logging.debug('Calculating microcanonical rate coefficient using ILT method for {0}...'.format(reaction))
         if reactantStatesKnown:
-            kinetics = reaction.kinetics
+            kinetics = reaction.kinetics if reaction.network_kinetics is None else reaction.network_kinetics
             kf = applyInverseLaplaceTransformMethod(reaction.transitionState, kinetics, Elist, Jlist, reacDensStates, T)
             forward = True
         elif productStatesKnown:
-            kinetics = reaction.generateReverseRateCoefficient()
+            kinetics = reaction.generateReverseRateCoefficient(network_kinetics=True)
             kr = applyInverseLaplaceTransformMethod(reaction.transitionState, kinetics, Elist, Jlist, prodDensStates, T)
             forward = False
         else:

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -50,6 +50,7 @@ cdef class Reaction:
     cdef public float _degeneracy
     cdef public list pairs
     cdef public bint has_pdep_route
+    cdef public bint elementary_high_p
     cdef public str comment
     cdef public dict k_effective_cache
     

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -46,6 +46,7 @@ cdef class Reaction:
     cdef public bint reversible
     cdef public TransitionState transitionState
     cdef public KineticsModel kinetics
+    cdef public Arrhenius network_kinetics
     cdef public bint duplicate
     cdef public float _degeneracy
     cdef public list pairs
@@ -92,7 +93,7 @@ cdef class Reaction:
 
     cpdef reverseThisArrheniusRate(self, Arrhenius kForward, str reverseUnits)
 
-    cpdef generateReverseRateCoefficient(self)
+    cpdef generateReverseRateCoefficient(self, bint network_kinetics=?)
 
     cpdef numpy.ndarray calculateTSTRateCoefficients(self, numpy.ndarray Tlist)
 

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -50,7 +50,7 @@ cdef class Reaction:
     cdef public bint duplicate
     cdef public float _degeneracy
     cdef public list pairs
-    cdef public bint has_pdep_route
+    cdef public bint allow_pdep_route
     cdef public bint elementary_high_p
     cdef public str comment
     cdef public dict k_effective_cache

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -80,6 +80,9 @@ class Reaction:
     `degeneracy`        :class:`double`             The reaction path degeneracy for the reaction
     `pairs`             ``list``                    Reactant-product pairings to use in converting reaction flux to species flux
     `has_pdep_route`    ``bool``                    ``True`` if the reaction has an additional PDep pathway, ``False`` if not (by default), used for LibraryReactions
+    `elementary_high_p` ``bool``                    If ``True``, pressure dependent kinetics will be generated (relevant only for unimolecular library reactions)
+                                                    If ``False`` (by default), this library reaction will not be explored.
+                                                    Only unimolecular library reactions with high pressure limit kinetics should be flagged (not if the kinetics were measured at some relatively low pressure)
     `comment`           ``str``                     A description of the reaction source (optional)
     =================== =========================== ============================
     
@@ -98,7 +101,8 @@ class Reaction:
                  degeneracy=1,
                  pairs=None,
                  has_pdep_route=False,
-                 comment=''
+                 elementary_high_p=False,
+                 comment='',
                  ):
         self.index = index
         self.label = label
@@ -112,6 +116,7 @@ class Reaction:
         self.duplicate = duplicate
         self.pairs = pairs
         self.has_pdep_route = has_pdep_route
+        self.elementary_high_p = elementary_high_p
         self.comment = comment
         self.k_effective_cache = {}
 
@@ -132,7 +137,8 @@ class Reaction:
         if self.duplicate: string += 'duplicate={0}, '.format(self.duplicate)
         if self.degeneracy != 1: string += 'degeneracy={0:.1f}, '.format(self.degeneracy)
         if self.pairs is not None: string += 'pairs={0}, '.format(self.pairs)
-        if self.has_pdep_route: string += 'has_pdep_route={0}'.format(self.has_pdep_route)
+        if self.has_pdep_route: string += 'has_pdep_route={0}, '.format(self.has_pdep_route)
+        if self.elementary_high_p: string += 'elementary_high_p={0}, '.format(self.elementary_high_p)
         if self.comment != '': string += 'comment={0!r}, '.format(self.comment)
         string = string[:-2] + ')'
         return string
@@ -173,6 +179,7 @@ class Reaction:
                            self.degeneracy,
                            self.pairs,
                            self.has_pdep_route,
+                           self.elementary_high_p,
                            self.comment
                            ))
 
@@ -1063,6 +1070,7 @@ class Reaction:
         other.duplicate = self.duplicate
         other.pairs = deepcopy(self.pairs)
         other.has_pdep_route = self.has_pdep_route
+        other.elementary_high_p = self.elementary_high_p
         other.comment = deepcopy(self.comment)
         
         return other

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -80,7 +80,7 @@ class Reaction:
     `duplicate`         ``bool``                    ``True`` if the reaction is known to be a duplicate, ``False`` if not
     `degeneracy`        :class:`double`             The reaction path degeneracy for the reaction
     `pairs`             ``list``                    Reactant-product pairings to use in converting reaction flux to species flux
-    `has_pdep_route`    ``bool``                    ``True`` if the reaction has an additional PDep pathway, ``False`` if not (by default), used for LibraryReactions
+    `allow_pdep_route`  ``bool``                    ``True`` if the reaction has an additional PDep pathway, ``False`` if not (by default), used for LibraryReactions
     `elementary_high_p` ``bool``                    If ``True``, pressure dependent kinetics will be generated (relevant only for unimolecular library reactions)
                                                     If ``False`` (by default), this library reaction will not be explored.
                                                     Only unimolecular library reactions with high pressure limit kinetics should be flagged (not if the kinetics were measured at some relatively low pressure)
@@ -102,7 +102,7 @@ class Reaction:
                  duplicate=False,
                  degeneracy=1,
                  pairs=None,
-                 has_pdep_route=False,
+                 allow_pdep_route=False,
                  elementary_high_p=False,
                  comment='',
                  ):
@@ -118,7 +118,7 @@ class Reaction:
         self.transitionState = transitionState
         self.duplicate = duplicate
         self.pairs = pairs
-        self.has_pdep_route = has_pdep_route
+        self.allow_pdep_route = allow_pdep_route
         self.elementary_high_p = elementary_high_p
         self.comment = comment
         self.k_effective_cache = {}
@@ -141,7 +141,7 @@ class Reaction:
         if self.duplicate: string += 'duplicate={0}, '.format(self.duplicate)
         if self.degeneracy != 1: string += 'degeneracy={0:.1f}, '.format(self.degeneracy)
         if self.pairs is not None: string += 'pairs={0}, '.format(self.pairs)
-        if self.has_pdep_route: string += 'has_pdep_route={0}, '.format(self.has_pdep_route)
+        if self.allow_pdep_route: string += 'allow_pdep_route={0}, '.format(self.allow_pdep_route)
         if self.elementary_high_p: string += 'elementary_high_p={0}, '.format(self.elementary_high_p)
         if self.comment != '': string += 'comment={0!r}, '.format(self.comment)
         string = string[:-2] + ')'
@@ -183,7 +183,7 @@ class Reaction:
                            self.duplicate,
                            self.degeneracy,
                            self.pairs,
-                           self.has_pdep_route,
+                           self.allow_pdep_route,
                            self.elementary_high_p,
                            self.comment
                            ))
@@ -1091,7 +1091,7 @@ class Reaction:
         other.transitionState = deepcopy(self.transitionState)
         other.duplicate = self.duplicate
         other.pairs = deepcopy(self.pairs)
-        other.has_pdep_route = self.has_pdep_route
+        other.allow_pdep_route = self.allow_pdep_route
         other.elementary_high_p = self.elementary_high_p
         other.comment = deepcopy(self.comment)
         

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -610,9 +610,9 @@ class CoreEdgeReactionModel:
             for network in self.networkList:
                 network.updateConfigurations(self)
                 index = 0
+                isomers = [isomer.species[0] for isomer in network.isomers]
                 while index < len(self.core.species):
                     species = self.core.species[index]
-                    isomers = [isomer.species[0] for isomer in network.isomers]
                     if species in isomers and species not in network.explored:
                         network.explored.append(species)
                         continue

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -52,7 +52,7 @@ from rmgpy.data.kinetics.depository import DepositoryReaction
 from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 
-from rmgpy.kinetics import KineticsData
+from rmgpy.kinetics import KineticsData, Arrhenius
 import rmgpy.data.rmg
 from .react import reactAll
 
@@ -810,10 +810,10 @@ class CoreEdgeReactionModel:
             elif not (rxn.isIsomerization() or rxn.isDissociation() or rxn.isAssociation()):
                 # The reaction is not unimolecular in either direction, so it cannot be pressure-dependent
                 pdep = False
-            elif rxn.kinetics is not None and rxn.kinetics.isPressureDependent():
-                # The reaction already has pressure-dependent kinetics (e.g. from a reaction library)
-                pdep = False
-                
+            elif isinstance(rxn,LibraryReaction):
+                # Try generating the high pressure limit kinetics. If successful, set pdep to ``True``, and vice versa.
+                pdep = rxn.generate_high_p_limit_kinetics()
+
             # If pressure dependence is on, we only add reactions that are not unimolecular;
             # unimolecular reactions will be added after processing the associated networks
             if not pdep:
@@ -1429,7 +1429,16 @@ class CoreEdgeReactionModel:
                  reversible=rxn.reversible
                  )
             r, isNew = self.makeNewReaction(rxn) # updates self.newSpeciesList and self.newReactionlist
-            if not isNew: logging.info("This library reaction was not new: {0}".format(rxn))
+            if not isNew:
+                logging.info("This library reaction was not new: {0}".format(rxn))
+            elif self.pressureDependence and rxn.elementary_high_p and rxn.isUnimolecular()\
+                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius):
+                # This unimolecular library reaction is flagged as `elementary_high_p` and has Arrhenius type kinetics.
+                # We should calculate a pressure-dependent rate for it
+                if len(rxn.reactants) == 1:
+                    self.processNewReactions(newReactions=[rxn],newSpecies=rxn.reactants[0])
+                else:
+                    self.processNewReactions(newReactions=[rxn],newSpecies=rxn.products[0])
             
         # Perform species constraints and forbidden species checks
         
@@ -1509,7 +1518,16 @@ class CoreEdgeReactionModel:
                  reversible=rxn.reversible
                  )
             r, isNew = self.makeNewReaction(rxn) # updates self.newSpeciesList and self.newReactionlist
-            if not isNew: logging.info("This library reaction was not new: {0}".format(rxn))
+            if not isNew:
+                logging.info("This library reaction was not new: {0}".format(rxn))
+            elif self.pressureDependence and rxn.elementary_high_p and rxn.isUnimolecular()\
+                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius):
+                # This unimolecular library reaction is flagged as `elementary_high_p` and has Arrhenius type kinetics.
+                # We should calculate a pressure-dependent rate for it
+                if len(rxn.reactants) == 1:
+                    self.processNewReactions(newReactions=[rxn],newSpecies=rxn.reactants[0])
+                else:
+                    self.processNewReactions(newReactions=[rxn],newSpecies=rxn.products[0])
 
         # Perform species constraints and forbidden species checks
         for spec in self.newSpeciesList:
@@ -1534,7 +1552,10 @@ class CoreEdgeReactionModel:
             # Note that we haven't actually evaluated any fluxes at this point
             # Instead, we remove the comment below if the reaction is moved to
             # the core later in the mechanism generation
-            self.addReactionToEdge(rxn)
+            if not (self.pressureDependence and rxn.elementary_high_p and rxn.isUnimolecular()
+                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius)):
+                # Don't add to the edge library reactions that were already processed
+                self.addReactionToEdge(rxn)
 
         self.printEnlargeSummary(
             newCoreSpecies=[],

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -594,7 +594,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         for rxn in reactionModel.core.reactions:
                             if isinstance(rxn, LibraryReaction) \
                                     and rxn.isIsomorphic(netReaction, eitherDirection=True) \
-                                    and not rxn.has_pdep_route:  # if this reaction is flagged as having an additional PDep pathway, do add the network reaction
+                                    and not rxn.has_pdep_route and not rxn.elementary_high_p:
                                 logging.info('Network reaction {0} matched an existing core reaction {1}'
                                     ' from the {2} library, and was not added to the model'.format(
                                     str(netReaction), str(rxn), rxn.library))
@@ -606,7 +606,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         for rxn in reactionModel.edge.reactions:
                             if isinstance(rxn, LibraryReaction) \
                                     and rxn.isIsomorphic(netReaction, eitherDirection=True) \
-                                    and not rxn.has_pdep_route:  # if this reaction is flagged as having an additional PDep pathway, do add the network reaction
+                                    and not rxn.has_pdep_route and not rxn.elementary_high_p:
                                 logging.info('Network reaction {0} matched an existing edge reaction {1}'
                                     ' from the {2} library, and was not added to the model'.format(
                                     str(netReaction), str(rxn), rxn.library))

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -387,8 +387,6 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         the current `reactionModel` because some decisions on sorting are made
         based on which species are in the model core. 
         """
-
-        isomers = []
         reactants = []
         products = []
         
@@ -486,7 +484,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
         for rxn in self.pathReactions:
             if rxn.kinetics is None and rxn.reverse.kinetics is None:
                 raise PressureDependenceError('Path reaction {0} with no high-pressure-limit kinetics encountered in PDepNetwork #{1:d}.'.format(rxn, self.index))
-            elif rxn.kinetics is not None and rxn.kinetics.isPressureDependent():
+            elif rxn.kinetics is not None and rxn.kinetics.isPressureDependent() and rxn.network_kinetics is None:
                 raise PressureDependenceError('Pressure-dependent kinetics encountered for path reaction {0} in PDepNetwork #{1:d}.'.format(rxn, self.index))
         
         # Do nothing if the network is already valid
@@ -536,13 +534,15 @@ class PDepNetwork(rmgpy.pdep.network.Network):
             elif isinstance(rxn.kinetics, MultiArrhenius):
                 logging.info('Converting multiple kinetics to a single Arrhenius expression for reaction {rxn}'.format(rxn=rxn))
                 rxn.kinetics = rxn.kinetics.toArrhenius(Tmin=Tmin, Tmax=Tmax)
-            elif not isinstance(rxn.kinetics, Arrhenius):
-                raise Exception('Path reaction "{0}" in PDepNetwork #{1:d} has invalid kinetics type "{2!s}".'.format(rxn, self.index, rxn.kinetics.__class__))
+            elif not isinstance(rxn.kinetics, Arrhenius) and rxn.network_kinetics is None:
+                raise Exception('Path reaction "{0}" in PDepNetwork #{1:d} has invalid kinetics type "{2!s}".'.format(
+                        rxn,self.index,rxn.kinetics.__class__))
             rxn.fixBarrierHeight(forcePositive=True)
-            E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.kinetics.Ea.value_si
-            rxn.transitionState = rmgpy.species.TransitionState(
-                conformer = Conformer(E0=(E0*0.001,"kJ/mol")),
-            )
+            if rxn.network_kinetics is None:
+                E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.kinetics.Ea.value_si
+            else:
+                E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.network_kinetics.Ea.value_si
+            rxn.transitionState = rmgpy.species.TransitionState(conformer=Conformer(E0=(E0 * 0.001, "kJ/mol")))
 
         # Set collision model
         bathGas = [spec for spec in reactionModel.core.species if not spec.reactive]
@@ -634,17 +634,23 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         # k(T,P) values potentially contain both direct and
                         # well-skipping contributions, and therefore could be
                         # significantly larger than the direct k(T) value
-                        # (This can also happen for association/dissocation
+                        # (This can also happen for association/dissociation
                         # reactions, but the effect is generally not too large)
                         continue
                     if pathReaction.reactants == netReaction.reactants and pathReaction.products == netReaction.products:
-                        kinf = pathReaction.kinetics.getRateCoefficient(Tlist[t])
+                        if pathReaction.network_kinetics is not None:
+                            kinf = pathReaction.network_kinetics.getRateCoefficient(Tlist[t])
+                        else:
+                            kinf = pathReaction.kinetics.getRateCoefficient(Tlist[t])
                         if K[t,p,i,j] > 2 * kinf: # To allow for a small discretization error
                             logging.warning('k(T,P) for net reaction {0} exceeds high-P k(T) by {1:g} at {2:g} K, {3:g} bar'.format(netReaction, K[t,p,i,j] / kinf, Tlist[t], Plist[p]/1e5))
                             logging.info('    k(T,P) = {0:9.2e}    k(T) = {1:9.2e}'.format(K[t,p,i,j], kinf))
                         break
                     elif pathReaction.products == netReaction.reactants and pathReaction.reactants == netReaction.products:
-                        kinf = pathReaction.kinetics.getRateCoefficient(Tlist[t]) / pathReaction.getEquilibriumConstant(Tlist[t])
+                        if pathReaction.network_kinetics is not None:
+                            kinf = pathReaction.network_kinetics.getRateCoefficient(Tlist[t]) / pathReaction.getEquilibriumConstant(Tlist[t])
+                        else:
+                            kinf = pathReaction.kinetics.getRateCoefficient(Tlist[t]) / pathReaction.getEquilibriumConstant(Tlist[t])
                         if K[t,p,i,j] > 2 * kinf: # To allow for a small discretization error
                             logging.warning('k(T,P) for net reaction {0} exceeds high-P k(T) by {1:g} at {2:g} K, {3:g} bar'.format(netReaction, K[t,p,i,j] / kinf, Tlist[t], Plist[p]/1e5))           
                             logging.info('    k(T,P) = {0:9.2e}    k(T) = {1:9.2e}'.format(K[t,p,i,j], kinf))

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -57,6 +57,7 @@ class PDepReaction(rmgpy.reaction.Reaction):
                  specificCollider=None,
                  network=None,
                  kinetics=None,
+                 network_kinetics=None,
                  reversible=True,
                  transitionState=None,
                  duplicate=False,
@@ -64,17 +65,18 @@ class PDepReaction(rmgpy.reaction.Reaction):
                  pairs=None
                  ):
         rmgpy.reaction.Reaction.__init__(self,
-                                         index,
-                                         label,
-                                         reactants,
-                                         products,
-                                         specificCollider,
-                                         kinetics,
-                                         reversible,
-                                         transitionState,
-                                         duplicate,
-                                         degeneracy,
-                                         pairs
+                                         index=index,
+                                         label=label,
+                                         reactants=reactants,
+                                         products=products,
+                                         specificCollider=specificCollider,
+                                         kinetics=kinetics,
+                                         network_kinetics=network_kinetics,
+                                         reversible=reversible,
+                                         transitionState=transitionState,
+                                         duplicate=duplicate,
+                                         degeneracy=degeneracy,
+                                         pairs=pairs
                                          )
         self.network = network
 

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -594,7 +594,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         for rxn in reactionModel.core.reactions:
                             if isinstance(rxn, LibraryReaction) \
                                     and rxn.isIsomorphic(netReaction, eitherDirection=True) \
-                                    and not rxn.has_pdep_route and not rxn.elementary_high_p:
+                                    and not rxn.allow_pdep_route and not rxn.elementary_high_p:
                                 logging.info('Network reaction {0} matched an existing core reaction {1}'
                                     ' from the {2} library, and was not added to the model'.format(
                                     str(netReaction), str(rxn), rxn.library))
@@ -606,7 +606,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         for rxn in reactionModel.edge.reactions:
                             if isinstance(rxn, LibraryReaction) \
                                     and rxn.isIsomorphic(netReaction, eitherDirection=True) \
-                                    and not rxn.has_pdep_route and not rxn.elementary_high_p:
+                                    and not rxn.allow_pdep_route and not rxn.elementary_high_p:
                                 logging.info('Network reaction {0} matched an existing edge reaction {1}'
                                     ' from the {2} library, and was not added to the model'.format(
                                     str(netReaction), str(rxn), rxn.library))

--- a/rmgpy/test_data/testing_database/kinetics/libraries/lib_net/dictionary.txt
+++ b/rmgpy/test_data/testing_database/kinetics/libraries/lib_net/dictionary.txt
@@ -1,0 +1,110 @@
+CH3
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+CO[O]
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 O u1 p2 c0 {2,S}
+
+H2
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+H
+multiplicity 2
+1 H u1 p0 c0
+
+ethane
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+
+CH4
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+[O]O
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+C=C
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+
+O2
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+C[CH2]
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+
+CO
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+
+OH
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+CO2
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 O u0 p2 c0 {2,D}
+
+C2H2
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
+C3H5
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,D}
+2 H u0 p0 c0 {1,S}
+3 C u0 p0 c0 {1,D} {4,S} {5,S}
+4 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {4,S}
+
+CH2
+multiplicity 3
+1 C u2 p0 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+O
+multiplicity 3
+1 O u2 p2 c0

--- a/rmgpy/test_data/testing_database/kinetics/libraries/lib_net/reactions.py
+++ b/rmgpy/test_data/testing_database/kinetics/libraries/lib_net/reactions.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "lib_net"
+shortDesc = u""
+longDesc = u"""
+This is a fake library for testing PDep networks exploration of library reactions
+"""
+
+entry(
+    index = 1,
+    label = "CH3 + CH3 <=> ethane",
+    degeneracy = 1.0,
+    elementary_high_p = True,
+    kinetics = Chebyshev(
+        coeffs = [
+            [12.8791, 0.560009, -0.115177, 0.0105093],
+            [-1.04561, 0.857712, -0.116582, -0.0134747],
+            [-0.599769, 0.449793, 0.0096248, -0.0271013],
+            [-0.314421, 0.177204, 0.0458462, -0.0107188],
+            [-0.155503, 0.0517415, 0.0323201, 0.00343069],
+            [-0.0727158, 0.00622718, 0.0138549, 0.00630263],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.001, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+)
+
+entry(
+    index = 2,
+    label = "H + CH3 <=> CH4",
+    degeneracy = 1.0,
+    elementary_high_p = True,
+    kinetics = Arrhenius(
+        A = (2.94005e-11, 'm^3/(mol*s)'),
+        n = 5.135,
+        Ea = (33.0118, 'kJ/mol'),
+        T0 = (1, 'K')),
+)
+
+entry(
+    index = 3,
+    label = "O2 + H2 <=> H + [O]O",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(
+        A = (2.9e+14, 'cm^3/(mol*s)', '*|/', 5),
+        n = 0,
+        Ea = (236.982, 'kJ/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (800, 'K'),
+    ),
+)
+
+entry(
+    index = 4,
+    label = "CO + OH <=> CO2 + H",
+    degeneracy = 1,
+    kinetics = PDepArrhenius(
+        pressures = ([0.01315, 0.1315, 1.315, 13.158, 131.58], 'atm'),
+        arrhenius = [
+            Arrhenius(A=(210000, 'cm^3/(mol*s)'), n=1.9, Ea=(-1064, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(250000, 'cm^3/(mol*s)'), n=1.88, Ea=(-1043, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(870000, 'cm^3/(mol*s)'), n=1.73, Ea=(-685, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(6.8e+06, 'cm^3/(mol*s)'), n=1.48, Ea=(48, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(2.3e+07, 'cm^3/(mol*s)'), n=1.35, Ea=(974, 'cal/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc = u"""The chemkin file reaction is CO + OH <=> CO2 + H""",
+)
+
+entry(
+    index = 5,
+    label = "C2H2 + CH3 <=> C3H5",
+    degeneracy = 1,
+    elementary_high_p = True,
+    kinetics = PDepArrhenius(
+        pressures = ([1, 2, 5], 'atm'),
+        arrhenius = [
+            Arrhenius(A=(4.99e+22, 'cm^3/(mol*s)'), n=-4.39, Ea = (18850, 'cal/mol'), T0 = (1, 'K')),
+            Arrhenius(A=(6e+23, 'cm^3/(mol*s)'), n=-4.6, Ea=(19571, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(7.31e+25, 'cm^3/(mol*s)'), n=-5.06, Ea=(21150, 'cal/mol'), T0 = (1, 'K')),
+        ],
+    ),
+)
+
+entry(
+    index = 6,
+    label = "H + CH2 <=> CH3",
+    degeneracy = 1,
+    elementary_high_p = True,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(6e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (1.04e+26, 'cm^6/(mol^2*s)'),
+            n = -2.76,
+            Ea = (1600, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.562,
+        T3 = (91, 'K'),
+        T1 = (5836, 'K'),
+        T2 = (8552, 'K'),
+        efficiencies = {'C': 2, 'O=C=O': 2, 'CC': 3, 'O': 6, '[H][H]': 2, '[C]=O': 1.5, '[Ar]': 0.7},
+    ),
+)
+
+entry(
+    index = 7,
+    label = "O + CO <=> CO2",
+    degeneracy = 1,
+    elementary_high_p = True,
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(1.8e+10, 'cm^3/(mol*s)'), n=0, Ea=(2385, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (6.02e+14, 'cm^6/(mol^2*s)'),
+            n = 0,
+            Ea = (3000, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'C': 2, 'O=C=O': 3.5, 'CC': 3, 'O': 6, '[H][H]': 2, '[O][O]': 6, '[C]=O': 1.5, '[Ar]': 0.5},
+    ),
+)


### PR DESCRIPTION
This PR allows PDep networks to use kinetics from a LibraryReaction in two cases:
1. When a unimolecular library reaction does not correspond to any kinetics family (but is flagged as `elementary`)
2. When a unimolecular library reaction has PDep kinetics, in which case a high pressure limit rate is generated and saved as a new attribute of the Reaction. This rate is then used in the network.

A test was added for the high pressure limit kinetic generation. This PR involved relatively modest changed to pdep.py, so direct pdep tests were currently not added.