### PR TITLE
"Edgeless"-RMG Part 1:  Moving Global Forbidden Structure Checking to Core Entrance

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1509,17 +1509,12 @@ class KineticsFamily(Database):
         Return ``True`` if the molecule is forbidden in this family, or
         ``False`` otherwise. 
         """
-        from rmgpy.data.rmg import getDB
-        
-        forbidden_structures = getDB('forbidden')
 
         # check family-specific forbidden structures 
         if self.forbidden is not None and self.forbidden.isMoleculeForbidden(molecule):
             return True
 
-        # check RMG globally forbidden structures
-        if forbidden_structures.isMoleculeForbidden(molecule):
-            return True
+
         return False
 
     def __createReaction(self, reactants, products, is_forward):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -53,6 +53,9 @@ from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 
 from rmgpy.kinetics import KineticsData, Arrhenius
+
+from rmgpy.data.rmg import getDB
+        
 import rmgpy.data.rmg
 from .react import reactAll
 
@@ -1052,6 +1055,34 @@ class CoreEdgeReactionModel:
 
         assert spec not in self.core.species, "Tried to add species {0} to core, but it's already there".format(spec.label)
 
+        forbidden_structures = getDB('forbidden')
+        
+        # check RMG globally forbidden structures
+        if forbidden_structures.isMoleculeForbidden(spec.molecule[0]):
+            
+            rxnList = []
+            if spec in self.edge.species:
+                self.core.species.append(spec)
+                # If species was in edge, remove it
+                logging.info("Species {0} was Forbidden and not added to Core...Removing from Edge.".format(spec))
+                self.edge.species.remove(spec)
+                # Search edge for reactions that now contain only core species;
+                # these belong in the model core and will be moved there
+                for rxn in self.edge.reactions:
+                    allCore = True
+                    for reactant in rxn.reactants:
+                        if reactant not in self.core.species: allCore = False
+                    for product in rxn.products:
+                        if product not in self.core.species: allCore = False
+                    if allCore: rxnList.append(rxn)
+                
+                self.core.species.remove(spec)
+                # Move any identified reactions to the core
+                for rxn in rxnList:
+                    self.edge.reactions.remove(rxn)
+                    logging.info("Removing Forbidden Reaction from Edge: {0}".format(rxn))
+                return []
+        
         # Add the species to the core
         self.core.species.append(spec)
         


### PR DESCRIPTION
This moves global forbidden structure checking from when species are created in the edge to when a species attempts to enter the core.  In a test constructing a dodecane combustion model this reduced time spent checking forbidden structures by 148x and overall runtime (in the react regime) by 4.5x without impacting the output model.  