### PR TITLE
Integrate MCNN (Molecular Convolutional Neural Network) thermo estimator with RMG

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -42,4 +42,4 @@ dependencies:
   - muq
   - pymongo
   - mpmath
-  
+  - dde

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -41,4 +41,4 @@ dependencies:
   # - muq
   - pymongo
   - mpmath
-  
+  - dde

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -40,3 +40,4 @@ dependencies:
   # - muq
   - pymongo
   - mpmath
+  - dde

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -257,3 +257,18 @@ generatedSpeciesConstraints(
 #     # If the amount of radicals is more than this, RMG will use hydrogen bond incrementation method
 #     maxRadicalNumber=0,
 # )
+
+# optional block allows thermo to be estimated through ML estimator
+# mlEstimator(
+#     thermo=True,
+#     # Name of folder containing ML architecture and parameters in database
+#     name='main',
+#     # Limits on heavy atom numbers
+#     minHeavyAtoms=1,
+#     maxHeavyAtoms=None,
+#     # If the estimated uncertainty of the thermo prediction is greater than
+#     # any of these values, then don't use the ML estimate
+#     H298UncertaintyCutoff=(3.0, 'kcal/mol'),
+#     S298UncertaintyCutoff=(2.0, 'cal/(mol*K)'),
+#     CpUncertaintyCutoff=(2.0, 'cal/(mol*K)')
+# )

--- a/examples/rmg/minimal_ml/RMG.sh
+++ b/examples/rmg/minimal_ml/RMG.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Make sure your PYTHONPATH includes the necessary paths to run RMG-Py 
+# Uncomment the following lines if your PYTHONPATH is not stored in 
+# your .bashrc file already. Be sure to modify the paths to the locations
+# of your code as necessary.
+
+# export PYTHONPATH=$PYTHONPATH:$HOME/RMG-Py/
+# export PYTHONPATH=$PYTHONPATH:$HOME/RMG-database/
+# export PYTHONPATH=$PYTHONPATH:$HOME/PyDAS/
+# export PYTHONPATH=$PYTHONPATH:$HOME/PyDQED/
+
+# In order for the solvers to work properly, be sure to compile the PyDAS and PyDQED codes
+# prior to running RMG.  Also be sure to compile RMG.  Sometimes with large code changes,
+# you must first 'make clean' to removed old compiled files and recompile with the 'make'
+# command.
+
+# Run RMG on the input.py file.
+export KERAS_BACKEND=theano
+python ../../../rmg.py input.py

--- a/examples/rmg/minimal_ml/input.py
+++ b/examples/rmg/minimal_ml/input.py
@@ -1,0 +1,55 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+mlEstimator(
+    thermo=True,
+    minHeavyAtoms=4,
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    maximumEdgeSpecies=100000,
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=True,
+)

--- a/meta.yaml
+++ b/meta.yaml
@@ -68,6 +68,7 @@ requirements:
     - scoop
     - symmetry
     - xlwt
+    - dde
 
 test:
   source_files:

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -48,6 +48,7 @@ from rmgpy.thermo import NASAPolynomial, NASA, ThermoData, Wilhoit
 from rmgpy.molecule import Molecule, Bond, Group
 import rmgpy.molecule
 from rmgpy.species import Species
+from rmgpy.ml.estimator import MLEstimator
 
 #: This dictionary is used to add multiplicity to species label
 _multiplicity_labels = {1:'S',2:'D',3:'T',4:'Q',5:'V',}
@@ -1102,17 +1103,15 @@ class ThermoDatabase(object):
         Return the thermodynamic parameters for a given :class:`Species`
         object `species`. This function first searches the loaded libraries
         in order, returning the first match found, before falling back to
-        estimation via group additivity.
+        estimation via machine learning and then group additivity.
         
-        The method corrects for symmetry when the molecule uses HBI or 
-        group additivity. Libraries and direct QM calculations are already
-        corrected.
+        The method corrects for symmetry when the molecule uses machine
+        learning or group additivity. Libraries and direct QM calculations
+        are already corrected.
         
         Returns: ThermoData
         """
         from rmgpy.rmg.input import getInput
-        
-        thermo0 = None
         
         thermo0 = self.getThermoDataFromLibraries(species)
         
@@ -1127,6 +1126,12 @@ class ThermoDatabase(object):
         except Exception:
             logging.debug('Quantum Mechanics DB could not be found.')
             quantumMechanics = None
+
+        try:
+            ml_estimator, ml_settings = getInput('MLEstimator')
+        except Exception:
+            logging.debug('ML estimator could not be found.')
+            ml_estimator, ml_settings = None, None
             
         if quantumMechanics:
             original_molecule = species.molecule[0]
@@ -1177,7 +1182,7 @@ class ThermoDatabase(object):
                     thermo0 = quantumMechanics.getThermoData(original_molecule) # returns None if it fails
                 
         if thermo0 is None:
-            # Use group additivity methods to determine thermo for molecule (or if QM fails completely)
+            # First try finding stable species in libraries and using HBI
             for mol in species.molecule:
                 if mol.reactive:
                     original_molecule = mol
@@ -1219,17 +1224,29 @@ class ThermoDatabase(object):
                     species.molecule = newMolList
                     thermo0 = thermo[0][2]
 
-                else:
-                    # Did not find any saturated values in the thermo libraries, so try group additivity instead
-                    thermo0 = self.getThermoDataFromGroups(species)
+            if thermo0 is None:
+                # If we still don't have thermo, use ML to estimate it, but
+                # only if the molecule is made up of H, C, N, and O atoms and
+                # is not a singlet carbene. Also check ML settings.
+                if (ml_estimator is not None
+                        and all(a.element.number in {1, 6, 7, 8} for a in species.molecule[0].atoms)
+                        and species.molecule[0].getSingletCarbeneCount() == 0):
 
-            else:
-                # Saturated molecule, estimate it via groups since we've already checked libraries much earlier
+                    nheavy = sum(1 for atom in species.molecule[0].atoms if atom.isNonHydrogen())
+                    min_heavy = ml_settings['min_heavy_atoms'] or 0
+                    max_heavy = ml_settings['max_heavy_atoms'] or numpy.inf
+                    
+                    if min_heavy <= nheavy <= max_heavy:
+                        thermo0 = self.get_thermo_data_from_ml(species,
+                                                               ml_estimator,
+                                                               ml_settings['uncertainty_cutoffs'])
+
+            if thermo0 is None:
+                # And lastly, resort back to group additivity to determine thermo for molecule
                 thermo0 = self.getThermoDataFromGroups(species)
-                
-            # update entropy by symmetry correction
-            thermo0.S298.value_si -= constants.R * math.log(species.getSymmetryNumber())
 
+            # Update entropy by symmetry correction (not included in trained ML model)
+            thermo0.S298.value_si -= constants.R * math.log(species.getSymmetryNumber())
 
         # Make sure to calculate Cp0 and CpInf if it wasn't done already
         findCp0andCpInf(species, thermo0)
@@ -1404,6 +1421,44 @@ class ThermoDatabase(object):
         findCp0andCpInf(species, thermoData)
         return thermoData
 
+    def get_thermo_data_from_ml(self, species, ml_estimator, ml_uncertainty_cutoffs):
+        """
+        Return the set of thermodynamic parameters corresponding to a
+        given :class:`Species` object `species` by estimation using the
+        ML estimator. Also compare the estimated uncertainties to the
+        user-defined cutoffs. If any of the uncertainties are larger
+        than their corresponding cutoffs, return None.
+
+        For HBI, the resonance isomer with the lowest H298 is used and
+        the resonance isomers in species are sorted in ascending order.
+
+        The entropy is not corrected for the symmetry of the molecule.
+        This should be done later by the calling function.
+        """
+        if species.molecule[0].isRadical():
+            thermo = [self.estimateRadicalThermoViaHBI(mol, ml_estimator.get_thermo_data) for mol in species.molecule]
+            H298 = numpy.array([tdata.H298 for tdata in thermo])
+            indices = H298.argsort()
+            species.molecule = [species.molecule[ind] for ind in indices]
+            thermo0 = thermo[indices[0]]
+        else:
+            thermo0 = ml_estimator.get_thermo_data_for_species(species)
+
+        # The keys for this dictionary should match the keys in
+        # `RMG.ml_uncertainty_cutoffs`. Use a temperature-weighted
+        # average to estimate uncertainty for Cp.
+        uncertainties = dict(
+            H298=thermo0.H298.uncertainty_si,
+            S298=thermo0.S298.uncertainty_si,
+            Cp=numpy.average(thermo0.Cpdata.uncertainty_si, weights=thermo0.Tdata.value_si)
+        )
+
+        if any(uncertainties[p] > ml_uncertainty_cutoffs[p].value_si for p in ml_uncertainty_cutoffs):
+            return None
+        else:
+            return thermo0
+
+
     def prioritizeThermo(self, species, thermoDataList):
         """
         Use some metrics to reorder a list of thermo data from best to worst.
@@ -1435,7 +1490,7 @@ class ThermoDatabase(object):
             indices = [0]
         return indices
 
-    def estimateRadicalThermoViaHBI(self, molecule, stableThermoEstimator ):
+    def estimateRadicalThermoViaHBI(self, molecule, stableThermoEstimator):
         """
         Estimate the thermodynamics of a radical by saturating it,
         applying the provided stableThermoEstimator method on the saturated species,
@@ -1470,8 +1525,8 @@ class ThermoDatabase(object):
         if not isinstance(thermoData_sat, ThermoData):
             thermoData_sat = thermoData_sat.toThermoData()
         
-        
-        if not stableThermoEstimator == self.computeGroupAdditivityThermo:
+        if not (stableThermoEstimator == self.computeGroupAdditivityThermo
+                or isinstance(stableThermoEstimator.__self__, MLEstimator)):
             #remove the symmetry contribution to the entropy of the saturated molecule
             ##assumes that the thermo data comes from QMTP or from a thermolibrary
             thermoData_sat.S298.value_si += constants.R * math.log(saturatedStruct.getSymmetryNumber())

--- a/rmgpy/ml/__init__.py
+++ b/rmgpy/ml/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################

--- a/rmgpy/ml/estimator.py
+++ b/rmgpy/ml/estimator.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import os
+import numpy as np
+
+from dde.predictor import Predictor
+
+from rmgpy.thermo import ThermoData
+
+
+class MLEstimator():
+
+    """
+    A machine learning based estimator for thermochemistry prediction.
+
+    The attributes are:
+
+    ==================== ======================= =======================
+    Attribute            Type                    Description
+    ==================== ======================= =======================
+    `hf298_estimator`    :class:`Predictor`      Hf298 estimator
+    `hf298_uncertainty`  ``bool``                Hf298 uncertainty flag
+    `s298_estimator`     :class:`Predictor`      S298 estimator
+    `s298_uncertainty`   ``bool``                S298 uncertainty flag
+    `cp_estimator`       :class:`Predictor`      Cp estimator
+    `cp_uncertainty`     ``bool``                Cp uncertainty flag
+    ==================== ======================= =======================
+
+    """
+
+    def __init__(self, hf298_path, s298_path, cp_path):
+        self.hf298_estimator, self.hf298_uncertainty = load_estimator(hf298_path)
+        self.s298_estimator, self.s298_uncertainty = load_estimator(s298_path)
+        self.cp_estimator, self.cp_uncertainty = load_estimator(cp_path)
+
+    def get_thermo_data(self, molecule):
+        """
+        Return thermodynamic parameters corresponding to a given
+        :class:`Molecule` object `molecule`. Also set the
+        uncertainties estimated by the ML model if available.
+
+        Returns: ThermoData
+        """
+
+        # These should correspond to the temperatures that the ML model was
+        # trained on for Cp.
+        temps = [300.0, 400.0, 500.0, 600.0, 800.0, 1000.0, 1500.0]
+
+        hf298 = self.hf298_estimator.predict(molecule=molecule, sigma=self.hf298_uncertainty)
+        s298 = self.s298_estimator.predict(molecule=molecule, sigma=self.s298_uncertainty)
+        cp = self.cp_estimator.predict(molecule=molecule, sigma=self.cp_uncertainty)
+
+        # If uncertainty is available for the ML model, a tuple of predicted
+        # value and estimated uncertainty is returned. An uncertainty of None
+        # gets set to a valua of 0 by :class:`Quantity`.
+        hf298, hf298u = hf298 if isinstance(hf298, tuple) else (hf298, None)
+        s298, s298u = s298 if isinstance(s298, tuple) else (s298, None)
+        cp, cpu = cp if isinstance(cp, tuple) else (cp, None)
+
+        cp = [np.float64(cp_i) for cp_i in cp]
+        if cpu is not None:
+            cpu = [np.float64(cpu_i) for cpu_i in cpu]
+
+        cp0 = molecule.calculateCp0()
+        cpinf = molecule.calculateCpInf()
+        thermo = ThermoData(
+            Tdata=(temps, 'K'),
+            Cpdata=(cp, 'cal/(mol*K)', cpu),
+            H298=(hf298, 'kcal/mol', hf298u),
+            S298=(s298, 'cal/(mol*K)', s298u),
+            Cp0=(cp0, 'J/(mol*K)'),
+            CpInf=(cpinf, 'J/(mol*K)'),
+            Tmin=(300.0, 'K'),
+            Tmax=(2000.0, 'K'),
+            comment='ML Estimation'
+        )
+
+        return thermo
+
+    def get_thermo_data_for_species(self, species):
+        """
+        Return the set of thermodynamic parameters corresponding to a
+        given :class:`Species` object `species`.
+
+        The current ML estimator treats each resonance isomer
+        identically, i.e., any of the resonance isomers can be chosen.
+
+        Returns: ThermoData
+        """
+        return self.get_thermo_data(species.molecule[0])
+
+
+def load_estimator(model_path):
+    estimator = Predictor()
+
+    input_file = os.path.join(model_path, 'predictor_input.py')
+    weights_file = os.path.join(model_path, 'full_train.h5')
+    model_file = os.path.join(model_path, 'full_train.json')
+    mean_and_std_file = os.path.join(model_path, 'full_train_mean_std.npz')
+
+    estimator.load_input(input_file)
+    if os.path.exists(model_file):
+        estimator.load_architecture(model_file)
+        uncertainty = True
+    else:
+        uncertainty = False
+    mean_and_std_file = mean_and_std_file if os.path.exists(mean_and_std_file) else None
+    estimator.load_parameters(param_path=weights_file, mean_and_std_path=mean_and_std_file)
+
+    return estimator, uncertainty

--- a/rmgpy/ml/estimator_test.py
+++ b/rmgpy/ml/estimator_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import os
+import unittest
+
+from rmgpy import settings
+from rmgpy.molecule import Molecule
+from rmgpy.ml.estimator import MLEstimator
+
+
+class TestMLEstimator(unittest.TestCase):
+    """
+    Contains unit tests for rmgpy.ml.estimator
+    """
+
+    def setUp(self):
+        """
+        Set up the MLEstimator class. This method is run once before all
+        other unit tests.
+        """
+        models_path = os.path.join(settings['database.directory'], 'thermo', 'ml', 'main')
+        Hf298_path = os.path.join(models_path, 'H298')
+        S298_path = os.path.join(models_path, 'S298')
+        Cp_path = os.path.join(models_path, 'Cp')
+        self.ml_estimator = MLEstimator(Hf298_path, S298_path, Cp_path)
+
+    def test_get_thermo_data(self):
+        """
+        Test that we can make a prediction using MLEstimator.
+        """
+        mol = Molecule().fromSMILES('C1C2C1C2')
+        thermo = self.ml_estimator.get_thermo_data(mol)
+
+        self.assertTrue(thermo.comment.startswith('ML Estimation'))
+        self.assertAlmostEqual(thermo.Cp0.value_si, 33.3, 1)
+        self.assertAlmostEqual(thermo.CpInf.value_si, 232.8, 1)
+        self.assertEqual(len(thermo.Cpdata.value_si), 7)
+        self.assertGreater(thermo.S298.uncertainty_si, 0.01)

--- a/rmgpy/rmg/inputTest.py
+++ b/rmgpy/rmg/inputTest.py
@@ -90,6 +90,25 @@ class TestInputDatabase(unittest.TestCase):
         self.assertIsInstance(rmg.reactionLibraries[0], tuple)
         self.assertTrue(rmg.reactionLibraries[0][1])
 
+class TestInputMLEstimator(unittest.TestCase):
+    """
+    Contains unit tests rmgpy.rmg.input.mlEstimator
+    """
+    def tearDown(self):
+        # remove the reactionLibraries value
+        global rmg
+        rmg.ml_estimator = None
+
+    def testMLEstimator(self):
+        """
+        Test that we can input.
+        """
+        from rmgpy.ml.estimator import MLEstimator
+        global rmg
+        # add database properties to RMG
+        inp.mlEstimator(thermo=True)
+        self.assertIsInstance(rmg.ml_estimator, MLEstimator)
+        self.assertIsInstance(rmg.ml_settings, dict)
 
 class TestInputThemoCentralDatabase(unittest.TestCase):
     """

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -130,6 +130,8 @@ class RMG(util.Subject):
     `trimolecularProductReversible`     ``True`` (default) to allow families with trimolecular products to react in the reverse direction, ``False`` otherwise
     `pressureDependence`                Whether to process unimolecular (pressure-dependent) reaction networks
     `quantumMechanics`                  Whether to apply quantum mechanical calculations instead of group additivity to certain molecular types.
+    `ml_estimator`                      To use thermo estimation with machine learning
+    `ml_settings`                       Settings for ML estimation
     `wallTime`                          The maximum amount of CPU time in the form DD:HH:MM:SS to expend on this job; used to stop gracefully so we can still get profiling information
     `kineticsdatastore`                 ``True`` if storing details of each kinetic database entry in text file, ``False`` otherwise
     ----------------------------------- ------------------------------------------------
@@ -200,6 +202,8 @@ class RMG(util.Subject):
         self.trimolecularProductReversible = None
         self.pressureDependence = None
         self.quantumMechanics = None
+        self.ml_estimator = None
+        self.ml_settings = None
         self.speciesConstraints = {}
         self.wallTime = '00:00:00:00'
         self.initializationTime = 0


### PR DESCRIPTION
This PR is an alternative version of PR https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1251.

Instead of adding all the CNN modules (data processing, model building, training, testing, loading parameters, and prediction) into RMG, we made a separate package of all these machine learning modules, called [DataDrivenEstimator](https://github.com/KEHANG/DataDrivenEstimator) (package short name: **`dde`**, key module: **`cnn_framework`**) and appended it to RMG's dependency list.

Thus this PR is very light, with only a handful of commits, including

- use **`cnn_framework`** to create a new thermo estimator: **`MCNNEstimator`**.

- load **`MCNNEstimator`** from RMG input file via **`mcnnEstimator()`**,

- an example **`minimal_mcnn`** to show the input file with **`MCNNEstimator`** turned on,

- currently **`MCNNEstimator`** will only be used when user specifically turn it on via input file, and
estimate thermo for **saturated non-aromatic polycyclics** as a starting point, as we discussed in the related RMG subgroup meeting. So user could opt out (the default option), and a developer can increase its responsibility in the future whenever he/she sees it fits. A performance dashboard mentioned later can guide such decision.

- latest weights files are placed in `rmgpy/mcnn/pretrained_models`. In the future, users are allowed to replace them with better weights trained via [DataDrivenEstimator](https://github.com/KEHANG/DataDrivenEstimator).

A brief introduction to [DataDrivenEstimator](https://github.com/KEHANG/DataDrivenEstimator). 
- we design **`DataDrivenEstimator`** in a way so that it contains current and future machine learning estimators developed by the team. Currently it only has MCNN thermo estimator, later it may have MCNN kinetic estimator, transfer learning feature, uncertainty etc.
- the MCNN thermo estimator currently supports resonance-isomer-free input; without bond order or atom-type features it also gets reasonably good prediction. 

Current status of package [DataDrivenEstimator](https://github.com/KEHANG/DataDrivenEstimator):

- thermo prediction performance dashboards can be found for [Hf298](http://kehangsblog.com/thermo_predictor/overall_performance/Hf298/), [S298](http://kehangsblog.com/thermo_predictor/overall_performance/S298/) and [Cp](http://kehangsblog.com/thermo_predictor/overall_performance/Cp/)

- the binary package of [DataDrivenEstimator v1.0.0](https://anaconda.org/RMG/dde) has been uploaded to RMG channel with Linux and Mac versions.

- The package is currently under my github account. After my graduation, it might be more convenient to transfer it over to `ReactionMechanismGenerator` organization.
