### PR TITLE
Adjust atom sorting algorithm for Molecules

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -212,11 +212,13 @@ class Atom(Vertex):
                     return False
             return True
     
-    def getDescriptor(self):
-        return self.number, self.getAtomConnectivityValue(), self.radicalElectrons, self.lonePairs, self.charge
-
-    def getAtomConnectivityValue(self):
-        return getVertexConnectivityValue(self)
+    def get_descriptor(self):
+        """
+        Return a tuple used for sorting atoms.
+        Currently uses atomic number, connectivity value,
+        radical electrons, lone pairs, and charge
+        """
+        return self.number, -getVertexConnectivityValue(self), self.radicalElectrons, self.lonePairs, self.charge
 
     def isSpecificCaseOf(self, other):
         """
@@ -879,7 +881,7 @@ class Molecule(Graph):
             if vertex.sortingLabel < 0:
                 self.updateConnectivityValues()
                 break
-        self.atoms.sort(key=lambda a: a.getDescriptor(), reverse=True)
+        self.atoms.sort(key=lambda a: a.get_descriptor(), reverse=True)
         for index, vertex in enumerate(self.vertices):
             vertex.sortingLabel = index
 

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -526,7 +526,6 @@ multiplicity 2
         self.assertTrue(result1[0].isIsomorphic(result2[0]))
         self.assertTrue(result1[0].isIsomorphic(result3[0]))
 
-    @work_in_progress
     def testBridgedAromatic(self):
         """Test that we can handle bridged aromatics.
 

--- a/rmgpy/molecule/translatorTest.py
+++ b/rmgpy/molecule/translatorTest.py
@@ -363,7 +363,7 @@ multiplicity 3
 11 H u0 p0 c0 {5,S}
         """
 
-        aug_inchi = 'InChI=1S/C5H6/c1-3-5-4-2/h1-3H2/u1,2/lp3,5'
+        aug_inchi = 'InChI=1S/C5H6/c1-3-5-4-2/h1-3H2/u1,2/lp4,5'
         self.compare(adjlist, aug_inchi)
 
     def test_aromatic_resonance_structures(self):


### PR DESCRIPTION
Use negative of connectivity value to prioritize atoms with high connectivity.

Also eliminate unnecessary `getAtomConnectivityValue` method.

This is a pretty minor fix which somewhat restores prior behavior. In 8abbee9a9856bfd3cbac9d74da8e3d6a856cbefc, I restored a previously implemented improvement to the atom sorting method. However, I failed to notice that `Molecule.sortAtoms()` method sorts in reverse, whereas the `Graph.sortVertices()` method sorts in the forward direction. Therefore, we need to take the negative of `getVertexConnectivityValue` to maintain the same result.