### PR TITLE
Characteristic Rate Based Termination Criterion

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -214,9 +214,13 @@ Currently, RMG can only model constant temperature and pressure systems. Future 
 will allow for variable temperature and pressure. To define a reaction system we need to
 define the temperature, pressure and initial mole fractions of the reactant species. The
 initial mole fractions are defined using the label for the species in
-the species block. Every reaction system can have its termination criterion based on
-species conversion or termination time or both. When both termination criterion are specified
-the model generation will stop when either of the termination criterion is satisfied.
+the species block. Reaction system simulations terminate when one of the specified termination
+criteria are satisfied.  Termination can be specied to occur at a specific time, at a specific
+conversion of a given initial species or to occur at a given terminationRateRatio, which is the
+characteristic flux in the system at that time divided by the maximum characteristic flux observed so far
+in the system (measure of how much chemistry is happening at a moment relative to the main chemical process).  
+
+
 
 The following is an example of a simple reactor system::
 
@@ -232,6 +236,7 @@ The following is an example of a simple reactor system::
 			'CH4': 0.9,
 		},
 		terminationTime=(1e0,'s'),
+		terminationRateRatio=0.01,
 		sensitivity=['CH4','H2'],
 		sensitivityThreshold=0.001,
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -38,7 +38,7 @@ from rmgpy import settings
 
 from rmgpy.molecule import Molecule
 from rmgpy.quantity import Quantity
-from rmgpy.solver.base import TerminationTime, TerminationConversion
+from rmgpy.solver.base import TerminationTime, TerminationConversion, TerminationRateRatio
 from rmgpy.solver.simple import SimpleReactor
 from rmgpy.solver.liquid import LiquidReactor
 from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
@@ -137,6 +137,7 @@ def simpleReactor(temperature,
                   nSimsTerm=6,
                   terminationConversion=None,
                   terminationTime=None,
+                  terminationRateRatio=None,
                   balanceSpecies=None,
                   sensitivity=None,
                   sensitivityThreshold=1e-3,
@@ -184,6 +185,8 @@ def simpleReactor(temperature,
             termination.append(TerminationConversion(speciesDict[spec], conv))
     if terminationTime is not None:
         termination.append(TerminationTime(Quantity(terminationTime)))
+    if terminationRateRatio is not None:
+        termination.append(TerminationRateRatio(terminationRateRatio))
     if len(termination) == 0:
         raise InputError('No termination conditions specified for reaction system #{0}.'.format(len(rmg.reactionSystems)+2))
     
@@ -230,6 +233,7 @@ def liquidReactor(temperature,
                   terminationConversion=None,
                   nSimsTerm = 4,
                   terminationTime=None,
+                  terminationRateRatio=None,
                   sensitivity=None,
                   sensitivityThreshold=1e-3,
                   sensitivityTemperature=None,
@@ -265,6 +269,8 @@ def liquidReactor(temperature,
             termination.append(TerminationConversion(speciesDict[spec], conv))
     if terminationTime is not None:
         termination.append(TerminationTime(Quantity(terminationTime)))
+    if terminationRateRatio is not None:
+        termination.append(TerminationRateRatio(terminationRateRatio))
     if len(termination) == 0:
         raise InputError('No termination conditions specified for reaction system #{0}.'.format(len(rmg.reactionSystems)+2))
     

--- a/rmgpy/rmg/test_data/mainTest/input.py
+++ b/rmgpy/rmg/test_data/mainTest/input.py
@@ -29,6 +29,7 @@ simpleReactor(
         'ethane': 0.000000000001,
     },
     terminationTime=(1e6,'s'),
+    terminationRateRatio=0.01,
     balanceSpecies='N2',
 )
 
@@ -42,6 +43,7 @@ liquidReactor(
         'ethane': 0.000000000001,
     },
     terminationTime=(1e6,'s'),
+    terminationRateRatio=0.01,
 )
 
 liquidReactor(    
@@ -54,6 +56,7 @@ liquidReactor(
     	'ethane': 0.000000000001,
     },
     terminationTime=(1e6,'s'),
+    terminationRateRatio=0.01,
 )
 
 simulator(

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -1236,3 +1236,15 @@ class TerminationConversion:
     def __init__(self, spec=None, conv=0.0):
         self.species = spec
         self.conversion = conv
+        
+class TerminationRateRatio:
+    """
+    Represent a fraction of the maximum characteristic rate of the simulation
+    at which the simulation should be terminated.  This class has one attribute
+    the ratio between the current and maximum characteristic rates at which
+    to terminate
+    """
+    
+    def __init__(self, ratio=0.01):
+        self.ratio = ratio
+        

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -569,7 +569,7 @@ cdef class ReactionSystem(DASx):
         cdef numpy.ndarray[numpy.float64_t,ndim=1] surfaceSpeciesProduction, surfaceSpeciesConsumption
         cdef numpy.ndarray[numpy.float64_t,ndim=1] surfaceTotalDivAccumNums, surfaceSpeciesRateRatios
         cdef numpy.ndarray[numpy.float64_t, ndim=1] forwardRateCoefficients, coreSpeciesConcentrations
-        cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal
+        cdef double  prevTime, totalMoles, c, volume, RTP, unimolecularThresholdVal, bimolecularThresholdVal, maxCharRate
         cdef bool useDynamicsTemp, firstTime, useDynamics, terminateAtMaxObjects, schanged
         cdef numpy.ndarray[numpy.float64_t, ndim=1] edgeReactionRates
         cdef double reactionRate, production, consumption
@@ -645,7 +645,8 @@ cdef class ReactionSystem(DASx):
         maxNetworkRate = 0.0
         iteration = 0
         conversion = 0.0
-
+        maxCharRate = 0.0
+        
         maxEdgeSpeciesRateRatios = self.maxEdgeSpeciesRateRatios
         maxNetworkLeakRateRatios = self.maxNetworkLeakRateRatios
         forwardRateCoefficients = self.kf
@@ -749,6 +750,9 @@ cdef class ReactionSystem(DASx):
             # Get the characteristic flux
             charRate = sqrt(numpy.sum(self.coreSpeciesRates * self.coreSpeciesRates))
             
+            if charRate > maxCharRate:
+                maxCharRate = charRate
+                
             coreSpeciesRates = numpy.abs(self.coreSpeciesRates)
             edgeReactionRates = self.edgeReactionRates
             coreSpeciesConsumptionRates = self.coreSpeciesConsumptionRates

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -1065,7 +1065,12 @@ cdef class ReactionSystem(DASx):
                         logging.info('At time {0:10.4e} s, reached target termination conversion: {1:f} of {2}'.format(self.t,term.conversion,term.species))
                         self.logConversions(speciesIndex, y0)
                         break
-
+                elif isinstance(term, TerminationRateRatio):
+                    if maxCharRate != 0.0 and charRate/maxCharRate < term.ratio:
+                        terminated = True
+                        logging.info('At time {0:10.4e} s, reached target termination RateRatio: {1}'.format(self.t,charRate/maxCharRate))
+                        self.logConversions(speciesIndex, y0)
+                        
             # Increment destination step time if necessary
             if self.t >= 0.9999 * stepTime:
                 stepTime *= 10.0


### PR DESCRIPTION
Until now RMG has had two termination criteria:  time and conversion.  The fundamental problem with these criteria is that before we run RMG we don't know what the right value is for them.  We don't know how long the chemistry takes.  We don't know if the chemistry continues after conversion of the reactants to something else.  We don't even know if a specified conversion can even be reached.  

This creates issues, terminating using only time can cause you to simulate past where the chemistry is really happening at points where the characteristic rate is very small, which can cause RMG to add undesirable species.  Terminating using conversion will terminate much earlier than desired if the reactant breaks down faster than the downstream chemistry and will never terminate if the specified termination conversion is unachievable.  

This PR specifies a criterion that terminates the run exactly when the chemistry stops rather than relying on user guesses for times and conversions.  The criterion is the characteristic rate at a given time divided by the maximum characteristic rate so far observed in the run.  When this ratio drops below the specified value (a fraction of the maximum characteristic rate) the run terminates.  This termination criterion has none of the issues with time or conversion based termination and is theoretically robust to any chemical system.  