### PR TITLE
Extend saveTrainingReactions to take list input

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -115,7 +115,7 @@ def saveEntry(f, entry):
         f.write('    kinetics = None,\n')
             
     # Write reference
-    if entry.reference is not None:
+    if entry.reference is not None and entry.reference != '':
         reference = entry.reference.toPrettyRepr()
         lines = reference.splitlines()
         f.write('    reference = {0}\n'.format(lines[0]))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -743,7 +743,7 @@ class KineticsFamily(Database):
         """
         return saveEntry(f, entry)
     
-    def saveTrainingReactions(self, reactions, reference=None, referenceType='', shortDesc='', rank=3):
+    def saveTrainingReactions(self, reactions, reference='', referenceType='', shortDesc='', rank=3):
         """
         This function takes a list of reactions appends it to the training reactions file.  It ignores the existence of
         duplicate reactions.  
@@ -754,6 +754,15 @@ class KineticsFamily(Database):
         For each entry, the long description is imported from the kinetics comment. 
         """ 
         from rmgpy import settings
+        
+        if not isinstance(reference,list):
+            reference = [reference]*len(reactions)
+        if not isinstance(referenceType,list):
+            referenceType = [referenceType]*len(reactions)
+        if not isinstance(shortDesc,list):
+            shortDesc = [shortDesc]*len(reactions)
+        if not isinstance(rank,list):
+            rank = [rank]*len(reactions)
 
         training_path = os.path.join(settings['database.directory'], 'kinetics', 'families', \
             self.label, 'training')
@@ -822,11 +831,11 @@ class KineticsFamily(Database):
                 label = str(reaction),
                 item = reaction,
                 data = reaction.kinetics,
-                reference = reference,
-                referenceType = referenceType,
-                shortDesc = unicode(shortDesc),
+                reference = reference[i],
+                referenceType = referenceType[i],
+                shortDesc = unicode(shortDesc[i]),
                 longDesc = unicode(longDesc),
-                rank = rank,
+                rank = rank[i],
                 )
             
             self.saveEntry(training_file, entry)


### PR DESCRIPTION
This PR includes some improvements to the saveTrainingReaction function that were useful in converting the rules in the database to training reactions.  Note this is not interdependent with the rules to training reactions pull request itself, although it was used to run the script used to create that PR.  