### PR TITLE
Allow Resurrection from Failed Filter Simulations

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -723,7 +723,8 @@ class RMG(util.Subject):
                             # Run a raw simulation to get updated reaction system threshold values
                             # Run with the same conditions as with pruning off
                             if not resurrected:
-                                reactionSystem.simulate(
+                                try:
+                                    reactionSystem.simulate(
                                         coreSpecies = self.reactionModel.core.species,
                                         coreReactions = self.reactionModel.core.reactions,
                                         edgeSpecies = [],
@@ -735,9 +736,16 @@ class RMG(util.Subject):
                                         simulatorSettings = simulatorSettings,
                                         conditions = self.rmg_memories[index].get_cond()
                                     )
-                                self.updateReactionThresholdAndReactFlags(
+                                except:
+                                    self.updateReactionThresholdAndReactFlags(
+                                        rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
+                                        rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold, skipUpdate=True)
+                                    logging.warn('Reaction thresholds/flags for Reaction System {0} was not updated due to simulation failure'.format(index+1))
+                                else:
+                                    self.updateReactionThresholdAndReactFlags(
                                         rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
                                         rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold)
+                                    
                             else:
                                 self.updateReactionThresholdAndReactFlags(
                                         rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,


### PR DESCRIPTION
This adds a try except that allows model runs to continue after failed filter simulations.  I believe this caused #1367 and #1258.  It worked as expected on the example in #1367.  However, its worth noting that nothing is reacted until a regular or a filter simulation succeeds and changes the react flags.  In the example in #1367 the run doesn't recover which results in the resurrection process consuming species from the edge until the edge is empty and then crashing.  