### PR TITLE
Added sensitivity analysis to Cantherm

### DIFF
--- a/cantherm.py
+++ b/cantherm.py
@@ -47,7 +47,6 @@ for more information.
 """
 
 import os
-import os.path
 import logging
 
 from rmgpy.cantherm.main import *

--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -611,6 +611,20 @@ This is also acceptable::
 
     kinetics('H + C2H4 <=> C2H5')
 
+If a sensitivity analysis is desired, simply add the conditions at which to calculate sensitivity coefficients
+in the following format, e.g.::
+
+    kinetics(
+        label = 'HSOO <=> HOOS',
+        Tmin = (500,'K'), Tmax = (3000,'K'), Tcount = 15,
+        sensitivity_conditions = [(1000, 'K'), (2000, 'K')]
+    )
+
+The output of a sensitivity analysis is saved into a ``sensitivity`` folder in the output directory. A text file, named
+with the reaction label, delineates the semi-normalized sensitivity coefficients ``dln(r)/dE0`` in units of ``mol/J``
+at all requested conditions. A horizontal bar figure is automatically generated per reaction with subplots for both the
+forward and reverse direction at all conditions.
+
 Examples
 ========
 

--- a/documentation/source/users/cantherm/input_pdep.rst
+++ b/documentation/source/users/cantherm/input_pdep.rst
@@ -696,6 +696,7 @@ Parameter                                          Description
 ``Tmin``/``Tmax``/``Tcount`` **or** ``Tlist``      Define temperatures at which to compute (and output) :math:`k(T,P)`
 ``Pmin``/``Pmax``/``Pcount`` **or** ``Plist``      Define pressures at which to compute (and output) :math:`k(T,P)`
 ``maximumGrainSize`` **and** ``minimumGrainCount`` Defines fineness of energy grains used in master equation calculations.
+``sensitivity_conditions``                         Specifies the conditions at which to run a network sensitivity analysis.
 ================================================== ====================================================================================================================================================
 
 **Temperature and Pressure Ranges**
@@ -713,7 +714,8 @@ Determine the fineness of the energy grains to be used in the master equation ca
 the ``maximumGrainSize``, and the ``minimumGrainCount``.
 
 
-An example of the algorithm parameters function for the acetyl + O2 network is shown below. ::
+An example of the algorithm parameters function for the acetyl + O2 network is shown below.
+This example also includes the ``sensitivity_conditions`` attribute which invokes a sensitivity analysis calculation::
 
     pressureDependence(
         label='acetyl + O2',
@@ -730,7 +732,13 @@ An example of the algorithm parameters function for the acetyl + O2 network is s
         #interpolationModel = ('pdeparrhenius'),
         #activeKRotor = True, 
         activeJRotor = True,
+        sensitivity_conditions = [[(1000, 'K'), (1, 'bar')], [(1500, 'K'), (10, 'bar')]]
     )
+
+The output of a sensitivity analysis is saved into a ``sensitivity`` folder in the output directory. A text file, named
+with the network label, delineates the semi-normalized sensitivity coefficients ``dln(r)/dE0`` in units of ``mol/J``
+for all network reactions (both directions if reversible) at all requested conditions. Horizontal bar figures are
+automatically generated per network reaction, showing the semi-normalized sensitivity coefficients at all conditions.
 
 Thermodynamics Computations
 ===========================

--- a/examples/cantherm/networks/acetyl+O2/input.py
+++ b/examples/cantherm/networks/acetyl+O2/input.py
@@ -282,4 +282,5 @@ pressureDependence(
     #interpolationModel = ('pdeparrhenius'),
     #activeKRotor = True, 
     activeJRotor = True,
+    sensitivity_conditions = [[(1000, 'K'), (1, 'bar')], [(1500, 'K'), (10, 'bar')]]
 )

--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -47,7 +47,7 @@ from rmgpy.thermo.thermodata import ThermoData
 from rmgpy.thermo.nasa import NASAPolynomial, NASA
 from rmgpy.thermo.wilhoit import Wilhoit
 
-from rmgpy.kinetics.arrhenius import Arrhenius, ArrheniusEP, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius 
+from rmgpy.kinetics.arrhenius import Arrhenius, ArrheniusEP, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius
 from rmgpy.kinetics.chebyshev import Chebyshev
 from rmgpy.kinetics.falloff import ThirdBody, Lindemann, Troe
 from rmgpy.kinetics.kineticsdata import KineticsData, PDepKineticsData
@@ -266,13 +266,14 @@ def network(label, isomers=None, reactants=None, products=None, pathReactions=No
     )
     networkDict[label] = network
 
-def kinetics(label,Tmin=None, Tmax=None,Tlist=None, Tcount=0):
+def kinetics(label, Tmin=None, Tmax=None, Tlist=None, Tcount=0, sensitivity_conditions=None):
     global jobList, reactionDict
     try:
         rxn = reactionDict[label]
     except KeyError:
         raise ValueError('Unknown reaction label {0!r} for kinetics() job.'.format(label))
-    job = KineticsJob(reaction=rxn,Tmin=Tmin, Tmax=Tmax,Tcount = Tcount,Tlist=Tlist)
+    job = KineticsJob(reaction=rxn, Tmin=Tmin, Tmax=Tmax, Tcount=Tcount, Tlist=Tlist,
+                      sensitivity_conditions=sensitivity_conditions)
     jobList.append(job)
 
 def statmech(label):

--- a/rmgpy/cantherm/input.py
+++ b/rmgpy/cantherm/input.py
@@ -301,7 +301,8 @@ def pressureDependence(label,
                        Pmin=None, Pmax=None, Pcount=0, Plist=None,
                        maximumGrainSize=None, minimumGrainCount=0,
                        method=None, interpolationModel=None,
-                       activeKRotor=True, activeJRotor=True, rmgmode=False):
+                       activeKRotor=True, activeJRotor=True, rmgmode=False,
+                       sensitivity_conditions=None):
     global jobList, networkDict
     if isinstance(interpolationModel, str):
         interpolationModel = (interpolationModel,)
@@ -311,8 +312,7 @@ def pressureDependence(label,
         maximumGrainSize=maximumGrainSize, minimumGrainCount=minimumGrainCount,
         method=method, interpolationModel=interpolationModel,
         activeKRotor=activeKRotor, activeJRotor=activeJRotor,
-        rmgmode=rmgmode,
-    )
+        rmgmode=rmgmode, sensitivity_conditions=sensitivity_conditions)
     jobList.append(job)
 
 def SMILES(smiles):

--- a/rmgpy/cantherm/kinetics.py
+++ b/rmgpy/cantherm/kinetics.py
@@ -48,7 +48,7 @@ from rmgpy.molecule.draw import MoleculeDrawer, createNewSurface
 
 ################################################################################
 
-class KineticsJob:
+class KineticsJob(object):
     """
     A representation of a CanTherm kinetics job. This job is used to compute 
     and save the high-pressure-limit kinetics information for a single reaction.

--- a/rmgpy/cantherm/kinetics.py
+++ b/rmgpy/cantherm/kinetics.py
@@ -43,6 +43,7 @@ from rmgpy.kinetics.tunneling import Wigner, Eckart
 
 import rmgpy.quantity as quantity
 import rmgpy.constants as constants
+from rmgpy.molecule.draw import MoleculeDrawer, createNewSurface
 
 ################################################################################
 
@@ -127,6 +128,8 @@ class KineticsJob:
             self.save(outputFile)
             if plot:
                 self.plot(os.path.dirname(outputFile))
+        if outputFile is not None:
+            self.draw(os.path.dirname(outputFile))
         logging.debug('Finished kinetics job for reaction {0}.'.format(self.reaction))
         logging.debug(repr(self.reaction))
     
@@ -295,3 +298,426 @@ class KineticsJob:
         filename = 'plots/' + ''.join(c for c in reaction_str if c in valid_chars) + '.pdf'
         plt.savefig(os.path.join(outputDirectory, filename))
         plt.close()
+
+
+    def draw(self, outputDirectory, format='pdf'):
+        """
+        Generate a PDF drawing of the reaction.
+        This requires that Cairo and its Python wrapper be available; if not,
+        the drawing is not generated.
+
+        You may also generate different formats of drawings, by changing format to
+        one of the following: `pdf`, `svg`, `png`.
+        """
+
+        if not os.path.exists('paths'):
+            os.mkdir('paths')
+        valid_chars = "-_.()<=> %s%s" % (string.ascii_letters, string.digits)
+        reaction_str = '{0} {1} {2}'.format(
+            ' + '.join([reactant.label for reactant in self.reaction.reactants]),
+            '<=>', ' + '.join([product.label for product in self.reaction.products]))
+        filename = os.path.join('paths', ''.join(c for c in reaction_str if c in valid_chars) + '.pdf')
+        path = os.path.join(outputDirectory, filename)
+
+        KineticsDrawer().draw(self.reaction, format=format, path=path)
+
+
+class KineticsDrawer:
+    """
+    This class provides functionality for drawing the potential energy surface
+    for a high pressure limit reaction using the Cairo 2D graphics engine.
+    The most common use case is simply::
+
+        KineticsDrawer().draw(reaction, format='png', path='network.png')
+
+    where ``reaction`` is the :class:`Reaction` object to draw. You can also
+    pass a dict of options to the constructor to affect how the reaction is drawn.
+    """
+
+    def __init__(self, options=None):
+        self.options = {
+            'structures': True,
+            'fontFamily': 'sans',
+            'fontSizeNormal': 12,
+            'Eunits': 'kJ/mol',
+            'padding': 16,
+            'wellWidth': 64,
+            'wellSpacing': 64,
+            'Eslope': 1.5,
+            'TSwidth': 16,
+            'E0offset': 0.0,
+        }
+        if options: self.options.update(options)
+        self.clear()
+
+    def clear(self):
+        self.reaction = None
+        self.wells = None
+        self.left = 0.0
+        self.top = 0.0
+        self.right = 0.0
+        self.bottom = 0.0
+        self.surface = None
+        self.cr = None
+
+    def __getEnergyRange(self):
+        """
+        Return the minimum and maximum energy in J/mol on the potential energy surface.
+        """
+        E0min = min(self.wells[0].E0, self.wells[1].E0, self.reaction.transitionState.conformer.E0.value_si)
+        E0max = max(self.wells[0].E0, self.wells[1].E0, self.reaction.transitionState.conformer.E0.value_si)
+        return E0min, E0max
+
+    def __useStructureForLabel(self, configuration):
+        """
+        Return ``True`` if the configuration should use molecular structures
+        for its labels or ``False`` otherwise.
+        """
+
+        # Initialize with the current user option value
+        useStructures = self.options['structures']
+
+        # But don't use structures if one or more species in the configuration
+        # do not have structure data
+        for spec in configuration.species_list:
+            if spec.molecule is None or len(spec.molecule) == 0:
+                useStructures = False
+                break
+
+        return useStructures
+
+    def __getTextSize(self, text, padding=2, format='pdf'):
+        try:
+            import cairocffi as cairo
+        except ImportError:
+            import cairo
+
+        # Use dummy surface to determine text extents
+        surface = createNewSurface(format)
+        cr = cairo.Context(surface)
+        cr.set_font_size(self.options['fontSizeNormal'])
+        extents = cr.text_extents(text)
+        width = extents[2] + 2 * padding
+        height = extents[3] + 2 * padding
+        return [0, 0, width, height]
+
+    def __drawText(self, text, cr, x0, y0, padding=2):
+        cr.save()
+        cr.set_font_size(self.options['fontSizeNormal'])
+        extents = cr.text_extents(text)
+        cr.move_to(x0 - extents[0] - padding, y0 - extents[1] + padding)
+        cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+        cr.show_text(text)
+        cr.restore()
+        width = extents[2] + 2 * padding
+        height = extents[3] + 2 * padding
+        return [0, 0, width, height]
+
+    def __getLabelSize(self, configuration, format='pdf'):
+        width = 0
+        height = 0
+        boundingRects = []
+        if self.__useStructureForLabel(configuration):
+            for spec in configuration.species_list:
+                _, _, rect = MoleculeDrawer().draw(spec.molecule[0], format=format)
+                boundingRects.append(list(rect))
+        else:
+            for spec in configuration.species_list:
+                boundingRects.append(self.__getTextSize(spec.label, format=format))
+
+        plusRect = self.__getTextSize('+', format=format)
+
+        for rect in boundingRects:
+            if width < rect[2]: width = rect[2]
+            height += rect[3] + plusRect[3]
+        height -= plusRect[3]
+
+        return [0, 0, width, height]
+
+    def __drawLabel(self, configuration, cr, x0, y0, format='pdf'):
+
+        boundingRect = self.__getLabelSize(configuration, format=format)
+        padding = 2
+
+        useStructures = self.__useStructureForLabel(configuration)
+        y = y0
+        for i, spec in enumerate(configuration.species_list):
+            if i > 0:
+                rect = self.__getTextSize('+', padding=padding, format=format)
+                x = x0 - 0.5 * (rect[2] - boundingRect[2]) + 2 * padding
+                self.__drawText('+', cr, x, y)
+                y += rect[3]
+
+            if useStructures:
+                moleculeDrawer = MoleculeDrawer()
+                cr.save()
+                _, _, rect = moleculeDrawer.draw(spec.molecule[0], format=format)
+                cr.restore()
+                x = x0 - 0.5 * (rect[2] - boundingRect[2])
+                cr.save()
+                moleculeDrawer.render(cr, offset=(x, y))
+                cr.restore()
+                y += rect[3]
+            else:
+                rect = self.__getTextSize(spec.label, padding=padding, format=format)
+                x = x0 - 0.5 * (rect[2] - boundingRect[2]) + 2 * padding
+                self.__drawText(spec.label, cr, x, y)
+                y += rect[3]
+
+        return boundingRect
+
+    def draw(self, reaction, format, path=None):
+        """
+        Draw the potential energy surface for the given `network` as a Cairo
+        surface of the given `format`. If `path` is given, the surface is
+        saved to that location on disk.
+        """
+        try:
+            import cairocffi as cairo
+        except ImportError:
+            try:
+                import cairo
+            except ImportError:
+                logging.warning('Cairo not found; potential energy surface will not be drawn.')
+                return
+
+        self.reaction = reaction
+        self.wells = [Well(self.reaction.reactants), Well(self.reaction.products)]
+
+        # Generate the bounding rectangles for each configuration label
+        labelRects = []
+        for well in self.wells:
+            labelRects.append(self.__getLabelSize(well, format=format))
+
+        # Get energy range (use kJ/mol internally)
+        E0min, E0max = self.__getEnergyRange()
+        E0min *= 0.001
+        E0max *= 0.001
+
+        # Drawing parameters
+        padding = self.options['padding']
+        wellWidth = self.options['wellWidth']
+        wellSpacing = self.options['wellSpacing']
+        Eslope = self.options['Eslope']
+        TSwidth = self.options['TSwidth']
+
+        E0_offset = self.options['E0offset'] * 0.001
+
+        # Choose multiplier to convert energies to desired units (on figure only)
+        Eunits = self.options['Eunits']
+        try:
+            Emult = \
+            {'J/mol': 1.0, 'kJ/mol': 0.001, 'cal/mol': 1.0 / 4.184, 'kcal/mol': 1.0 / 4184., 'cm^-1': 1.0 / 11.962}[
+                Eunits]
+        except KeyError:
+            raise Exception('Invalid value "{0}" for Eunits parameter.'.format(Eunits))
+
+        # Determine height required for drawing
+        Eheight = self.__getTextSize('0.0', format=format)[3] + 6
+        y_E0 = (E0max - 0.0) * Eslope + padding + Eheight
+        height = (E0max - E0min) * Eslope + 2 * padding + Eheight + 6
+        for i in xrange(len(self.wells)):
+            if 0.001 * self.wells[i].E0 == E0min:
+                height += labelRects[i][3]
+                break
+
+        # Determine naive position of each well (one per column)
+        coordinates = numpy.zeros((len(self.wells), 2), numpy.float64)
+        x = padding
+        for i in xrange(len(self.wells)):
+            well = self.wells[i]
+            rect = labelRects[i]
+            thisWellWidth = max(wellWidth, rect[2])
+            E0 = 0.001 * well.E0
+            y = y_E0 - E0 * Eslope
+            coordinates[i] = [x + 0.5 * thisWellWidth, y]
+            x += thisWellWidth + wellSpacing
+        width = x + padding - wellSpacing
+
+        # Determine the rectangles taken up by each well
+        # We'll use this to merge columns safely so that wells don't overlap
+        wellRects = []
+        for i in range(len(self.wells)):
+            l, t, w, h = labelRects[i]
+            x, y = coordinates[i, :]
+            if w < wellWidth: w = wellWidth
+            t -= 6 + Eheight
+            h += 6 + Eheight
+            wellRects.append([l + x - 0.5 * w, t + y + 6, w, h])
+
+        # Squish columns together from the left where possible until an isomer is encountered
+        oldLeft = numpy.min(coordinates[:, 0])
+        Nleft = - 1
+        columns = []
+        for i in range(Nleft, -1, -1):
+            top = wellRects[i][1]
+            bottom = top + wellRects[i][3]
+            for column in columns:
+                for c in column:
+                    top0 = wellRects[c][1]
+                    bottom0 = top + wellRects[c][3]
+                    if (top >= top0 and top <= bottom0) or (top <= top0 and top0 <= bottom):
+                        # Can't put it in this column
+                        break
+                else:
+                    # Can put it in this column
+                    column.append(i)
+                    break
+            else:
+                # Needs a new column
+                columns.append([i])
+        for column in columns:
+            columnWidth = max([wellRects[c][2] for c in column])
+            x = coordinates[column[0] + 1, 0] - 0.5 * wellRects[column[0] + 1][2] - wellSpacing - 0.5 * columnWidth
+            for c in column:
+                delta = x - coordinates[c, 0]
+                wellRects[c][0] += delta
+                coordinates[c, 0] += delta
+        newLeft = numpy.min(coordinates[:, 0])
+        coordinates[:, 0] -= newLeft - oldLeft
+
+        # Squish columns together from the right where possible until an isomer is encountered
+        Nright = 3
+        columns = []
+        for i in range(Nright, len(self.wells)):
+            top = wellRects[i][1]
+            bottom = top + wellRects[i][3]
+            for column in columns:
+                for c in column:
+                    top0 = wellRects[c][1]
+                    bottom0 = top0 + wellRects[c][3]
+                    if (top >= top0 and top <= bottom0) or (top <= top0 and top0 <= bottom):
+                        # Can't put it in this column
+                        break
+                else:
+                    # Can put it in this column
+                    column.append(i)
+                    break
+            else:
+                # Needs a new column
+                columns.append([i])
+        for column in columns:
+            columnWidth = max([wellRects[c][2] for c in column])
+            x = coordinates[column[0] - 1, 0] + 0.5 * wellRects[column[0] - 1][2] + wellSpacing + 0.5 * columnWidth
+            for c in column:
+                delta = x - coordinates[c, 0]
+                wellRects[c][0] += delta
+                coordinates[c, 0] += delta
+
+        width = max([rect[2] + rect[0] for rect in wellRects]) - min([rect[0] for rect in wellRects]) + 2 * padding
+
+        # Draw to the final surface
+        surface = createNewSurface(format=format, target=path, width=width, height=height)
+        cr = cairo.Context(surface)
+
+        # Some global settings
+        cr.select_font_face("sans")
+        cr.set_font_size(self.options['fontSizeNormal'])
+
+        # Fill the background with white
+        cr.set_source_rgba(1.0, 1.0, 1.0, 1.0)
+        cr.paint()
+        self.__drawText('E0 ({0})'.format(Eunits), cr, 15, 10, padding=2)  # write units
+
+        # Draw reactions
+        E0_reac = self.wells[0].E0 * 0.001 - E0_offset
+        E0_prod = self.wells[1].E0 * 0.001 - E0_offset
+        E0_TS = self.reaction.transitionState.conformer.E0.value_si * 0.001 - E0_offset
+        x1, y1 = coordinates[0, :]
+        x2, y2 = coordinates[1, :]
+        x1 += wellSpacing / 2.0
+        x2 -= wellSpacing / 2.0
+        if abs(E0_TS - E0_reac) > 0.1 and abs(E0_TS - E0_prod) > 0.1:
+            if len(self.reaction.reactants) == 2:
+                if reac < prod:
+                    x0 = x1 + wellSpacing * 0.5
+                else:
+                    x0 = x2 - wellSpacing * 0.5
+            elif len(self.reaction.products) == 2:
+                if reac < prod:
+                    x0 = x2 - wellSpacing * 0.5
+                else:
+                    x0 = x1 + wellSpacing * 0.5
+            else:
+                x0 = 0.5 * (x1 + x2)
+            y0 = y_E0 - (E0_TS + E0_offset) * Eslope
+            width1 = (x0 - x1)
+            width2 = (x2 - x0)
+            # Draw horizontal line for TS
+            cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+            cr.set_line_width(2.0)
+            cr.move_to(x0 - TSwidth / 2.0, y0)
+            cr.line_to(x0 + TSwidth / 2.0, y0)
+            cr.stroke()
+            # Add background and text for energy
+            E0 = "{0:.1f}".format(E0_TS * 1000. * Emult)
+            extents = cr.text_extents(E0)
+            x = x0 - extents[2] / 2.0
+            y = y0 - 6.0
+            cr.rectangle(x + extents[0] - 2.0, y + extents[1] - 2.0, extents[2] + 4.0, extents[3] + 4.0)
+            cr.set_source_rgba(1.0, 1.0, 1.0, 0.75)
+            cr.fill()
+            cr.move_to(x, y)
+            cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+            cr.show_text(E0)
+            # Draw Bezier curve connecting reactants and products through TS
+            cr.set_source_rgba(0.0, 0.0, 0.0, 0.5)
+            cr.set_line_width(1.0)
+            cr.move_to(x1, y1)
+            cr.curve_to(x1 + width1 / 8.0, y1, x0 - width1 / 8.0 - TSwidth / 2.0, y0, x0 - TSwidth / 2.0, y0)
+            cr.move_to(x0 + TSwidth / 2.0, y0)
+            cr.curve_to(x0 + width2 / 8.0 + TSwidth / 2.0, y0, x2 - width2 / 8.0, y2, x2, y2)
+            cr.stroke()
+        else:
+            width = (x2 - x1)
+            # Draw Bezier curve connecting reactants and products through TS
+            cr.set_source_rgba(0.0, 0.0, 0.0, 0.5)
+            cr.set_line_width(1.0)
+            cr.move_to(x1, y1)
+            cr.curve_to(x1 + width / 4.0, y1, x2 - width / 4.0, y2, x2, y2)
+            cr.stroke()
+
+        # Draw wells (after path reactions so that they are on top)
+        for i, well in enumerate(self.wells):
+            x0, y0 = coordinates[i, :]
+            # Draw horizontal line for well
+            cr.set_line_width(4.0)
+            cr.move_to(x0 - wellWidth / 2.0, y0)
+            cr.line_to(x0 + wellWidth / 2.0, y0)
+            cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+            cr.stroke()
+            # Add background and text for energy
+            E0 = well.E0 * 0.001 - E0_offset
+            E0 = "{0:.1f}".format(E0 * 1000. * Emult)
+            extents = cr.text_extents(E0)
+            x = x0 - extents[2] / 2.0;
+            y = y0 - 6.0
+            cr.rectangle(x + extents[0] - 2.0, y + extents[1] - 2.0, extents[2] + 4.0, extents[3] + 4.0)
+            cr.set_source_rgba(1.0, 1.0, 1.0, 0.75)
+            cr.fill()
+            cr.move_to(x, y)
+            cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+            cr.show_text(E0)
+            # Draw background and text for label
+            x = x0 - 0.5 * labelRects[i][2]
+            y = y0 + 6
+            cr.rectangle(x, y, labelRects[i][2], labelRects[i][3])
+            cr.set_source_rgba(1.0, 1.0, 1.0, 0.75)
+            cr.fill()
+            self.__drawLabel(well, cr, x, y, format=format)
+
+        # Finish Cairo drawing
+        if format == 'png':
+            surface.write_to_png(path)
+        else:
+            surface.finish()
+
+class Well:
+    """
+    A helper class representing a "well" of species
+    `species_list` is a list of at least one entry
+    `E0 `is the sum of all species' E0 in that list
+    """
+    def __init__(self, species_list):
+        self.species_list = species_list
+        self.E0 = sum([species.conformer.E0.value_si for species in species_list])

--- a/rmgpy/cantherm/pdepTest.py
+++ b/rmgpy/cantherm/pdepTest.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import os
+import unittest
+import shutil
+import logging
+from nose.plugins.attrib import attr
+from rmgpy.cantherm.main import CanTherm
+from rmgpy import settings
+from rmgpy.chemkin import readReactionsBlock
+from rmgpy.species import Species
+from rmgpy.kinetics.chebyshev import Chebyshev
+
+################################################################################
+
+
+@attr('functional')
+class CanthermTest(unittest.TestCase):
+    """
+    Contains unit tests for the sensitivity module in Cantherm
+    """
+
+    @classmethod
+    def setUp(self):
+        """A function that is run ONCE before all unit tests in this class."""
+        self.directory = os.path.join(settings['test_data.directory'], 'Cantherm', 'tst1', '')
+        self.input_file = os.path.join(self.directory, 'pdep_sa.py')
+
+        # clean working folder from all previous test output
+        dirs = [d for d in os.listdir(self.directory) if not os.path.isfile(os.path.join(self.directory, d))]
+        for d in dirs:
+            shutil.rmtree(os.path.join(settings['test_data.directory'], 'Cantherm', 'tst1', d, ''))
+        files = [f for f in os.listdir(self.directory) if os.path.isfile(os.path.join(self.directory, f))]
+        for f in files:
+            if not 'pdep_sa' in f:
+                os.remove(os.path.join(settings['test_data.directory'], 'Cantherm', 'tst1', f))
+
+    def testPDepJob(self):
+        """
+        A general test for a PDep job in Cantherm
+        """
+        self.tst1 = CanTherm()
+        self.tst1.inputFile = self.input_file
+        self.tst1.outputDirectory = self.directory
+        self.tst1.verbose = logging.WARN
+        self.tst1.plot = False
+        self.tst1.jobList = []
+        self.tst1.jobList = self.tst1.loadInputFile(self.tst1.inputFile)
+        self.tst1.execute()
+
+        job = self.tst1.jobList[0]
+        self.assertEquals(job.Tmin.value_si, 300.0)
+        self.assertEquals(job.minimumGrainCount, 100)
+        self.assertFalse(job.rmgmode)
+        self.assertTrue(job.activeJRotor)
+        self.assertEquals(job.network.pathReactions[0].label,'acetylperoxy <=> hydroperoxylvinoxy')
+        self.assertAlmostEquals(job.network.pathReactions[0].transitionState.tunneling.E0_TS.value_si,-24267.2)
+        self.assertAlmostEquals(job.network.pathReactions[0].transitionState.tunneling.frequency.value_si,-1679.04)
+        self.assertEquals(len(job.network.netReactions[0].reactants[0].conformer.modes), 6)
+        # self.assertEquals(self.tst1.frequencyScaleFactor, 0.947)
+
+        # test that a network pdf was generated
+        files = [f for f in os.listdir(self.directory) if os.path.isfile(os.path.join(self.directory, f))]
+        self.assertTrue(any(f == 'network.pdf' for f in files))
+
+        # Test the generated network reaction
+        dictionary = {'hydroperoxylvinoxy': Species().fromSMILES('[CH2]C(=O)OO'),
+        'acetylperoxy': Species().fromSMILES('CC(=O)O[O]')}
+        with open(os.path.join(self.directory, 'chem.inp'), 'r') as chem:
+            reaction_list = readReactionsBlock(chem, dictionary)
+        rxn = reaction_list[0]
+        self.assertIsInstance(rxn.kinetics, Chebyshev)
+        self.assertAlmostEquals(rxn.kinetics.getRateCoefficient(1000.0, 1.0), 88.879056605)
+
+        files = [f for f in os.listdir(os.path.join(self.directory, 'sensitivity', ''))
+                 if os.path.isfile(os.path.join(self.directory, 'sensitivity', f))]
+        self.assertTrue(any('hydroperoxylvinoxy.pdf' in f for f in files))
+
+        with open(os.path.join(self.directory, 'sensitivity', 'network1.txt'), 'r') as f:
+            lines = f.readlines()
+            for line in lines:
+                if '1000.0' in line:
+                    break
+        sa_coeff = line.split()[-2]
+        self.assertEquals(float(sa_coeff), -8.24e-6)
+
+    @classmethod
+    def tearDown(self):
+        """A function that is run ONCE after all unit tests in this class."""
+        self.directory = os.path.join(settings['test_data.directory'], 'Cantherm', 'tst1', '')
+        self.input_file = os.path.join(self.directory, 'pdep_sa.py')
+
+        # clean working folder from all previous test output
+        dirs = [d for d in os.listdir(self.directory) if not os.path.isfile(os.path.join(self.directory, d))]
+        for d in dirs:
+            shutil.rmtree(os.path.join(settings['test_data.directory'], 'Cantherm', 'tst1', d, ''))
+        files = [f for f in os.listdir(self.directory) if os.path.isfile(os.path.join(self.directory, f))]
+        for f in files:
+            if not 'pdep_sa' in f:
+                os.remove(os.path.join(settings['test_data.directory'], 'Cantherm', 'tst1', f))

--- a/rmgpy/cantherm/sensitivity.py
+++ b/rmgpy/cantherm/sensitivity.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This module contains classes for sensitivity analysis
+of kinetics and pressure-dependent jobs.
+"""
+
+import os
+import logging
+import string
+import numpy as np
+import rmgpy.quantity as quantity
+
+################################################################################
+
+
+class KineticsSensitivity(object):
+    """
+    The :class:`KineticsSensitivity` class represents an instance of a sensitivity analysis job
+    performed for a KineticsJob. The attributes are:
+
+    =================== ================================================================================================
+    Attribute           Description
+    =================== ================================================================================================
+    `conditions`        A list of the conditions at which the sensitivity coefficients are calculated
+    `job`               The KineticsJob object
+    `f_rates`           A list of forward rates from `job` at the respective `conditions` in the appropriate units
+    `r_rates`           A list of reverse rates from `job` at the respective `conditions` in the appropriate units
+    `f_sa_rates`        A dictionary with Species as keys and each value is a list of forward rates from `job` at the
+                        respective `conditions` in the appropriate units after perturbing the corresponding Species' E0
+    `r_sa_rates`        Same as `f_sa_rates`, only for the reverse direction
+    `f_sa_coefficients` A dictionary with Species keys and sensitivity coefficients in the forward direction as values
+    `r_sa_coefficients` A dictionary with Species keys and sensitivity coefficients in the reverse direction as values
+    =================== ================================================================================================
+    """
+
+    def __init__(self, job, output_directory):
+        self.job = job
+        self.output_directory = output_directory
+        self.conditions = self.job.sensitivity_conditions
+        self.f_rates = [self.job.reaction.kinetics.getRateCoefficient(condition.value_si)
+                        for condition in self.conditions]
+        kr = self.job.reaction.generateReverseRateCoefficient()
+        self.r_rates = [kr.getRateCoefficient(condition.value_si) for condition in self.conditions]
+        self.f_sa_rates = {}
+        self.r_sa_rates = {}
+        self.f_sa_coefficients = {}
+        self.r_sa_coefficients = {}
+        self.perturbation = quantity.Quantity(1, 'kcal/mol')
+        self.execute()
+
+    def execute(self):
+        """
+        Execute the sensitivity analysis for a :class:KineticsJob: object
+        """
+        for species in [self.job.reaction.reactants[0], self.job.reaction.products[0],
+                        self.job.reaction.transitionState]:
+            self.perturb(species)
+            self.job.execute(outputFile=None, plot=False)  # run the perturbed job
+            self.f_sa_rates[species] = [self.job.reaction.kinetics.getRateCoefficient(condition.value_si)
+                                        for condition in self.conditions]
+            kr = self.job.reaction.generateReverseRateCoefficient()
+            self.r_sa_rates[species] = [kr.getRateCoefficient(condition.value_si)
+                                        for condition in self.conditions]
+            self.unperturb(species)
+            # Calculate the sensitivity coefficients according to dln(r) / dln(E0) = (E0 * dr) / (r * dE0)
+            self.f_sa_coefficients[species] = [(self.f_sa_rates[species][i] - self.f_rates[i]) /
+                                               (self.perturbation.value_si * self.f_rates[i])
+                                               for i in xrange(len(self.conditions))]
+            self.r_sa_coefficients[species] = [(self.r_sa_rates[species][i] - self.r_rates[i]) /
+                                               (self.perturbation.value_si * self.r_rates[i])
+                                               for i in xrange(len(self.conditions))]
+        self.save()
+        self.plot()
+
+    def perturb(self, species):
+        species.conformer.E0.value_si += self.perturbation.value_si
+
+    def unperturb(self, species):
+        species.conformer.E0.value_si -= self.perturbation.value_si  # restore E0 to its original value
+
+    def save(self):
+        if not os.path.exists('sensitivity'):
+            os.mkdir('sensitivity')
+        valid_chars = "-_.()<=> %s%s" % (string.ascii_letters, string.digits)
+        reaction_str = '{0} {1} {2}'.format(
+            ' + '.join([reactant.label for reactant in self.job.reaction.reactants]),
+            '<=>', ' + '.join([product.label for product in self.job.reaction.products]))
+        filename = os.path.join('sensitivity', ''.join(c for c in reaction_str if c in valid_chars) + '.txt')
+        path = os.path.join(self.output_directory, filename)
+        with open(path, 'w') as sa_f:
+            sa_f.write("Sensitivity analysis for reaction {0}\n\n"
+                       "The semi-normalized sensitivity coefficients are calculated as dln(r)/dE0\n"
+                       "by perturbing E0 of each well or TS by {1}, and are given in `mol/J` units.\n\n\n".format(
+                reaction_str, self.perturbation))
+            reactants_label = ' + '.join([reactant.label for reactant in self.job.reaction.reactants])
+            ts_label = self.job.reaction.transitionState.label
+            products_label = ' + '.join([reactant.label for reactant in self.job.reaction.products])
+            max_label = max(len(reactants_label), len(products_label), len(ts_label), 10)
+            sa_f.write('========================={0}=============================================\n'
+                       '| Direction | Well or TS {1}| Temperature (K) | Sensitivity coefficient |\n'
+                       '|-----------+------------{2}+-----------------+-------------------------|\n'.format(
+                       '='*(max_label-10), ' '*(max_label-10), '-'*(max_label-10)))
+            for i, condition in enumerate(self.conditions):
+                sa_f.write('| Forward   | {0} {1}| {2:6.1f}          | {3:+1.2e}               |\n'.format(
+                    reactants_label, ' '*(max_label - len(reactants_label)), condition.value_si,
+                    self.f_sa_coefficients[self.job.reaction.reactants[0]][i]))
+            for i, condition in enumerate(self.conditions):
+                sa_f.write('| Forward   | {0} {1}| {2:6.1f}          | {3:+1.2e}               |\n'.format(
+                    products_label, ' '*(max_label - len(products_label)), condition.value_si,
+                    self.f_sa_coefficients[self.job.reaction.products[0]][i]))
+            for i, condition in enumerate(self.conditions):
+                sa_f.write('| Forward   | {0} {1}| {2:6.1f}          | {3:+1.2e}               |\n'.format(
+                    ts_label, ' '*(max_label - len(ts_label)), condition.value_si,
+                    self.f_sa_coefficients[self.job.reaction.transitionState][i]))
+            sa_f.write('|-----------+------------{0}+-----------------+-------------------------|\n'.format(
+                '-'*(max_label-10)))
+            for i, condition in enumerate(self.conditions):
+                sa_f.write('| Reverse   | {0} {1}| {2:6.1f}          | {3:+1.2e}               |\n'.format(
+                    reactants_label, ' '*(max_label - len(reactants_label)), condition.value_si,
+                    self.r_sa_coefficients[self.job.reaction.reactants[0]][i]))
+            for i, condition in enumerate(self.conditions):
+                sa_f.write('| Reverse   | {0} {1}| {2:6.1f}          | {3:+1.2e}               |\n'.format(
+                    products_label, ' '*(max_label - len(products_label)), condition.value_si,
+                    self.r_sa_coefficients[self.job.reaction.products[0]][i]))
+            for i, condition in enumerate(self.conditions):
+                sa_f.write('| Reverse   | {0} {1}| {2:6.1f}          | {3:+1.2e}               |\n'.format(
+                    ts_label, ' '*(max_label - len(ts_label)), condition.value_si,
+                    self.r_sa_coefficients[self.job.reaction.transitionState][i]))
+            sa_f.write('========================={0}=============================================\n'.format(
+                       '='*(max_label-10)))
+
+    def plot(self):
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            return
+
+        reactants_label = ' + '.join([reactant.label for reactant in self.job.reaction.reactants])
+        ts_label = self.job.reaction.transitionState.label
+        products_label = ' + '.join([reactant.label for reactant in self.job.reaction.products])
+
+        plt.rcdefaults()
+        _, ax = plt.subplots(nrows=len(self.conditions), ncols=2, tight_layout=True)
+        labels = [reactants_label, ts_label, products_label]
+        min_sa = min(min(min(self.f_sa_coefficients.itervalues())), min(min(self.r_sa_coefficients.itervalues())))
+        max_sa = max(max(max(self.f_sa_coefficients.itervalues())), max(max(self.r_sa_coefficients.itervalues())))
+        for i, condition in enumerate(self.conditions):
+            f_values = [self.f_sa_coefficients[self.job.reaction.reactants[0]][i],
+                        self.f_sa_coefficients[self.job.reaction.transitionState][i],
+                        self.f_sa_coefficients[self.job.reaction.products[0]][i]]
+            r_values = [self.r_sa_coefficients[self.job.reaction.reactants[0]][i],
+                        self.r_sa_coefficients[self.job.reaction.transitionState][i],
+                        self.r_sa_coefficients[self.job.reaction.products[0]][i]]
+            y_pos = np.arange(3)
+            ax[i][0].barh(y_pos, f_values, align='center', color='green')
+            ax[i][0].set_yticks(y_pos)
+            ax[i][0].set_yticklabels(labels)
+            ax[i][0].invert_yaxis()  # labels read top-to-bottom
+            ax[i][0].set_xlabel('dln(r)/dE0 (mol/J)')
+            ax[i][0].set_title('Forward, {0}'.format(condition))
+            ax[i][0].set_xlim([min_sa, max_sa])
+            ax[i][1].barh(y_pos, r_values, align='center', color='blue')
+            ax[i][1].set_yticks(y_pos)
+            ax[i][1].set_yticklabels(labels)
+            ax[i][1].invert_yaxis()  # labels read top-to-bottom
+            ax[i][1].set_xlabel('dln(r)/dE0 (mol/J)')
+            ax[i][1].set_title('Reverse, {0}'.format(condition))
+            ax[i][1].set_xlim([min_sa, max_sa])
+            plt.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
+
+        if not os.path.exists('sensitivity'):
+            os.mkdir('sensitivity')
+        valid_chars = "-_.()<=> %s%s" % (string.ascii_letters, string.digits)
+        reaction_str = '{0} {1} {2}'.format(
+            ' + '.join([reactant.label for reactant in self.job.reaction.reactants]),
+            '<=>', ' + '.join([product.label for product in self.job.reaction.products]))
+        filename = os.path.join('sensitivity', ''.join(c for c in reaction_str if c in valid_chars) + '.pdf')
+        path = os.path.join(self.output_directory, filename)
+        plt.savefig(path)
+        plt.close()

--- a/rmgpy/cantherm/sensitivity.py
+++ b/rmgpy/cantherm/sensitivity.py
@@ -38,6 +38,8 @@ import logging
 import string
 import numpy as np
 import rmgpy.quantity as quantity
+from rmgpy.species import TransitionState
+from rmgpy.pdep import Configuration
 
 ################################################################################
 
@@ -207,3 +209,173 @@ class KineticsSensitivity(object):
         path = os.path.join(self.output_directory, filename)
         plt.savefig(path)
         plt.close()
+
+
+class PDepSensitivity(object):
+    """
+    The :class:`Sensitivity` class represents an instance of a sensitivity analysis job
+    performed for a PressureDependenceJob. The attributes are:
+
+    =================== ================================================================================================
+    Attribute           Description
+    =================== ================================================================================================
+    `conditions`        A list of the conditions (each entry is a list of one T and one P quantities) at which the
+                        sensitivity coefficients are calculated
+    `job`               The PressureDependenceJob object
+    `rates`             A dictionary with netReactions as keys. Values are lists of forward rates from `job` for the
+                        respective path reaction at the respective `conditions` in the appropriate units
+    `sa_rates`          A dictionary with string representations of netReactions as keys. Values are dictionaries with
+                        Wells or TransitionStates as keys and each value is a list of forward rates from `job` at the
+                        respective `conditions` after perturbing the corresponding well or TS's E0
+    `sa_coefficients`   A dictionary with similar structure as `sa_rates`, containing the sensitivity coefficients
+                        in the forward direction
+    =================== ================================================================================================
+    """
+
+    def __init__(self, job, output_directory, perturbation):
+        self.job = job
+        self.output_directory = output_directory
+        self.conditions = self.job.sensitivity_conditions
+        self.rates = {}
+        for rxn in self.job.network.netReactions:
+            self.rates[str(rxn)] = []
+            for condition in self.conditions:
+                self.rates[str(rxn)].append(rxn.kinetics.getRateCoefficient(condition[0].value_si,
+                                                                            condition[1].value_si))
+        self.sa_rates = {}
+        self.sa_coefficients = {}
+        for rxn in self.job.network.netReactions:
+            self.sa_rates[str(rxn)] = {}
+            self.sa_coefficients[str(rxn)] = {}
+        self.perturbation = quantity.Quantity(perturbation, 'kcal/mol')
+        self.execute()
+
+    def execute(self):
+        """
+        Execute the sensitivity analysis for a :class:PressureDependenceJob: object
+        """
+        wells = []
+        wells.extend(self.job.network.reactants)
+        wells.extend(self.job.network.isomers)
+        wells.extend(self.job.network.products)
+        transition_states = []
+        for rxn in self.job.network.pathReactions:
+            # if rxn.transitionState is not None:
+            transition_states.append(rxn.transitionState)
+
+        for entry in wells + transition_states:
+            if entry in wells:
+                logging.info("\n\nPerturbing well '{0}' by {1}:".format(entry, self.perturbation))
+            else:
+                logging.info("\n\nPerturbing TS '{0}' by {1}:".format(entry.label, self.perturbation))
+            self.perturb(entry)
+            self.job.execute(outputFile=None, plot=False, print_summary=False)  # run the perturbed job
+            self.unperturb(entry)
+            for rxn in self.job.network.netReactions:
+                self.sa_rates[str(rxn)][entry] = [rxn.kinetics.getRateCoefficient(
+                    condition[0].value_si, condition[1].value_si) for condition in self.conditions]
+                self.sa_coefficients[str(rxn)][entry] = [((self.sa_rates[str(rxn)][entry][i]
+                                                           - self.rates[str(rxn)][i])) /
+                                                         (self.perturbation.value_si * self.rates[str(rxn)][i])
+                                                         for i in xrange(len(self.conditions))]
+        self.save(wells, transition_states)
+        self.plot(wells, transition_states)
+
+    def perturb(self, entry, unperturb=False):
+        """
+        Perturb E0 of `entry` which could be either a :class:TransitionState or a :class:Configuration
+        In the latter case, only the first species in the Configuration.species list is perturbed.
+        The perturbation is done by addition of the energy amount in self.perturbation.
+        If unperturb is `False`, the perturbation is addition of the energy amount in self.perturbation.
+        If unperturb is `False`, this is done by subtracting.
+        """
+        perturbation = self.perturbation.value_si
+        if unperturb:
+            perturbation *= -1
+        if isinstance(entry, TransitionState):
+            entry.conformer.E0 = quantity.Energy(entry.conformer.E0.value_si + perturbation, 'J/mol')
+        elif isinstance(entry, Configuration):
+            entry.species[0].conformer.E0 = quantity.Energy(entry.species[0].conformer.E0.value_si + perturbation,
+                                                            'J/mol')
+
+    def unperturb(self, entry):
+        self.perturb(entry, unperturb=True)
+
+    def save(self, wells, transition_states):
+        if not os.path.exists(os.path.join(self.output_directory, 'sensitivity', '')):
+            os.mkdir(os.path.join(self.output_directory, 'sensitivity', ''))
+        valid_chars = "-_.()<=>+ %s%s" % (string.ascii_letters, string.digits)
+        network_str = self.job.network.label
+        filename = os.path.join('sensitivity', ''.join(c for c in network_str if c in valid_chars) + '.txt')
+        path = os.path.join(self.output_directory, filename)
+        with open(path, 'w') as sa_f:
+            sa_f.write("Sensitivity analysis for network {0}\n\n"
+                       "The semi-normalized sensitivity coefficients are calculated as dln(r)/dE0\n"
+                       "by perturbing E0 of each well or TS by {1},\n and are given in `mol/J` units.\n\n\n".format(
+                network_str, self.perturbation))
+            for rxn in self.job.network.netReactions:
+                reactants_label = ' + '.join([reactant.label for reactant in rxn.reactants])
+                products_label = ' + '.join([reactant.label for reactant in rxn.products])
+                reaction_str = '{0} {1} {2}'.format(reactants_label, '<=>', products_label)
+                sa_f.write('  Sensitivity of network reaction '+reaction_str+' :'+'\n')
+                max_label = 40
+                sa_f.write('========================={0}==================================================\n'
+                           '| Well or TS {1}| Temperature (K) | Pressure (bar) | Sensitivity coefficient |\n'
+                           '|------------{2}+-----------------+----------------+-------------------------|\n'.format(
+                           '='*(max_label-10), ' '*(max_label-10), '-'*(max_label-10)))
+                for entry in wells + transition_states:
+                    if isinstance(entry, TransitionState):
+                        entry_label = '(TS) ' + entry.label
+                    elif isinstance(entry, Configuration):
+                        entry_label = ' + '.join([species.label for species in entry.species])
+                    entry_label += ' '*(max_label - len(entry_label))
+                    for i, condition in enumerate(self.conditions):
+                        sa_f.write('| {0} | {1:6.1f}          | {2:8.2f}       | {3:+1.2e}               |\n'.format(
+                            entry_label, condition[0].value_si, condition[1].value_si * 1e-5,
+                            self.sa_coefficients[str(rxn)][entry][i]))
+                sa_f.write('========================={0}==================================================\n\n\n'.format(
+                           '='*(max_label-10)))
+
+    def plot(self, wells, transition_states):
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            return
+
+        for rxn in self.job.network.netReactions:
+            plt.rcdefaults()
+            _, ax = plt.subplots(nrows=len(self.conditions), ncols=1, tight_layout=True)
+            labels = [str(entry) for entry in wells]
+            labels.extend(ts.label for ts in transition_states)
+            max_sa = min_sa = self.sa_coefficients[str(rxn)][wells[0]][0]
+            for conformer_sa in self.sa_coefficients[str(rxn)].itervalues():
+                for sa_condition in conformer_sa:
+                    if min_sa > sa_condition:
+                        min_sa = sa_condition
+                    if max_sa < sa_condition:
+                        max_sa = sa_condition
+            colors = ['b','g','r','c','m','y','k']
+            for i, condition in enumerate(self.conditions):
+                values = [self.sa_coefficients[str(rxn)][conf][i] for conf in wells + transition_states]
+                y_pos = np.arange(len(labels))
+                if len(self.conditions) > 1:
+                    axis = ax[i]
+                else: axis = ax
+                axis.barh(y_pos, values, align='center', color=colors[i % len(colors)])
+                axis.set_yticks(y_pos)
+                axis.set_yticklabels(labels)
+                axis.invert_yaxis()  # labels read top-to-bottom
+                axis.set_xlabel('dln(r)/dE0 (mol/J)')
+                # axis.ticklabel_format('sci')
+                axis.set_title('{0}, {1}'.format(condition[0], condition[1]))
+                axis.set_xlim([min_sa, max_sa])
+                axis.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
+
+            if not os.path.exists('sensitivity'):
+                os.mkdir('sensitivity')
+            valid_chars = "-_.()<=>+ %s%s" % (string.ascii_letters, string.digits)
+            reaction_str = str(rxn)
+            filename = os.path.join('sensitivity', ''.join(c for c in reaction_str if c in valid_chars) + '.pdf')
+            path = os.path.join(self.output_directory, filename)
+            plt.savefig(path)
+            plt.close()

--- a/rmgpy/cantherm/thermo.py
+++ b/rmgpy/cantherm/thermo.py
@@ -57,7 +57,7 @@ from rmgpy.molecule.util import retrieveElementCount
 
 ################################################################################
 
-class ThermoJob:
+class ThermoJob(object):
     """
     A representation of a CanTherm thermodynamics job. This job is used to
     compute and save the thermodynamics information for a single species.

--- a/rmgpy/test_data/Cantherm/tst1/pdep_sa.py
+++ b/rmgpy/test_data/Cantherm/tst1/pdep_sa.py
@@ -1,0 +1,99 @@
+title = 'acetyl + oxygen PDep sensitivity analysis test'
+
+modelChemistry = "CCSD(T)-F12/cc-pVTZ-F12"
+
+species(
+    label = 'acetylperoxy',
+    structure = SMILES('CC(=O)O[O]'),
+    E0 = (-34.6,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([54.2977,104.836,156.05],"amu*angstrom^2"), symmetry=1),
+        HarmonicOscillator(frequencies=([319.695,500.474,536.674,543.894,727.156,973.365,1037.77,1119.72,1181.55,1391.11,1449.53,1454.72,1870.51,3037.12,3096.93,3136.39],"cm^-1")),
+        HinderedRotor(inertia=(7.38359,"amu*angstrom^2"), symmetry=1, fourier=([[-1.95191,-11.8215,0.740041,-0.049118,-0.464522],[0.000227764,0.00410782,-0.000805364,-0.000548218,-0.000266277]],"kJ/mol")),
+        HinderedRotor(inertia=(2.94723,"amu*angstrom^2"), symmetry=3, fourier=([[0.130647,0.0401507,-2.54582,-0.0436065,-0.120982],[-0.000701659,-0.000989654,0.00783349,-0.00140978,-0.00145843]],"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    molecularWeight = (75.04,"g/mol"),
+    collisionModel = TransportData(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
+    energyTransferModel = SingleExponentialDown(
+        alpha0 = (0.5718,'kcal/mol'),
+        T0 = (300,'K'),
+        n = 0.85,
+    ),
+)
+
+species(
+    label = 'hydroperoxylvinoxy',
+    structure = SMILES('[CH2]C(=O)OO'),
+    E0 = (-32.4,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([44.8034,110.225,155.029],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([318.758,420.907,666.223,675.962,752.824,864.66,998.471,1019.54,1236.21,1437.91,1485.74,1687.9,3145.44,3262.88,3434.34],"cm^-1")),
+        HinderedRotor(inertia=(1.68464,"u*angstrom**2"), symmetry=2, fourier=([[0.359649,-16.1155,-0.593311,1.72918,0.256314],[-7.42981e-06,-0.000238057,3.29276e-05,-6.62608e-05,8.8443e-05]],"kJ/mol")),
+        HinderedRotor(inertia=(8.50433,"u*angstrom**2"), symmetry=1, fourier=([[-7.53504,-23.4471,-3.3974,-0.940593,-0.313674],[-4.58248,-2.47177,0.550012,1.03771,0.844226]],"kJ/mol")),
+        HinderedRotor(inertia=(0.803309,"u*angstrom**2"), symmetry=1, fourier=([[-8.65946,-3.97888,-1.13469,-0.402197,-0.145101],[4.41884e-05,4.83249e-05,1.30275e-05,-1.31353e-05,-6.66878e-06]],"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    molecularWeight = (75.04,"g/mol"),
+    collisionModel = TransportData(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
+    energyTransferModel = SingleExponentialDown(
+        alpha0 = (0.5718,'kcal/mol'),
+        T0 = (300,'K'),
+        n = 0.85,
+    ),
+)
+
+species(
+    label='nitrogen',
+    structure=SMILES('N#N'),
+    molecularWeight=(28.04, "g/mol"),
+    collisionModel=TransportData(sigma=(3.70, 'angstrom'), epsilon=(94.9, 'K')),
+)
+
+transitionState(
+    label = 'ts1',
+    E0 = (-5.8,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([49.3418,103.697,149.682],"u*angstrom**2"), symmetry=1, quantum=False),
+        HarmonicOscillator(frequencies=([148.551,306.791,484.573,536.709,599.366,675.538,832.594,918.413,1022.28,1031.45,1101.01,1130.05,1401.51,1701.26,1844.17,3078.6,3163.07],"cm^-1"), quantum=True),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    frequency = (-1679.04,'cm^-1'),
+)
+
+reaction(
+    label = 'acetylperoxy <=> hydroperoxylvinoxy',
+    reactants = ['acetylperoxy'],
+    products = ['hydroperoxylvinoxy'],
+    transitionState = 'ts1',
+    tunneling = 'Eckart',
+)
+
+network(
+    label = 'network1',
+    isomers = [
+        'acetylperoxy',
+        'hydroperoxylvinoxy',
+    ],
+    bathGas = {
+        'nitrogen': 1.0,
+    }
+)
+
+pressureDependence(
+    'network1',
+    Tmin=(300.0,'K'), Tmax=(2000.0,'K'), Tcount=8,
+    Pmin=(0.1,'bar'), Pmax=(10,'bar'), Pcount=5,
+    maximumGrainSize = (5.0,'kcal/mol'),
+    minimumGrainCount = 100,
+    method = 'modified strong collision',
+    interpolationModel = ('chebyshev', 6, 4),
+    activeJRotor = True,
+    sensitivity_conditions = [(1000, 'K'), (1, 'bar')]
+)


### PR DESCRIPTION
Now users can run a Cantherm job (`KineticsJob` or `PressureDependenceJob`) and see to which wells or transitions states the calculated rates are most sensitive to (and hopefully later improve them).
The output of the SA is saved into a `sensitivity` folder in the output directory with a text file tabulating all normalized sensitivity coefficients per reaction (in both direction if the network reaction is reversible), and figures visualizing the sensitivity coefficients per network reaction at all conditions defined for the sensitivity analysis.

Test, example, and some documentation also added.