### PR TITLE
Report OpenBabel version in check_dependencies

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -97,8 +97,9 @@ def check_dependencies():
                                   'Not found. Necessary for SMILES/InChI functionality for nitrogen compounds.')
         missing = True
     else:
+        version = openbabel.OBReleaseVersion()
         location = openbabel.__file__
-        print '{0:<30}{1}'.format('OpenBabel', location)
+        print '{0:<15}{1:<15}{2}'.format('OpenBabel', version, location)
 
     # Check for lpsolve
     try:


### PR DESCRIPTION
Came across #446 while reviewing stale branches and discovered how to retrieve OpenBabel's version number, which I couldn't figure out before. This adds adds version reporting to the check_dependencies function.

Confirmed to work on Linux. Perhaps Windows should be tried?