### PR TITLE
Fixed wrong parameter name in kinetics draw

### DIFF
--- a/rmgpy/cantherm/kinetics.py
+++ b/rmgpy/cantherm/kinetics.py
@@ -635,12 +635,12 @@ class KineticsDrawer:
         x2 -= wellSpacing / 2.0
         if abs(E0_TS - E0_reac) > 0.1 and abs(E0_TS - E0_prod) > 0.1:
             if len(self.reaction.reactants) == 2:
-                if reac < prod:
+                if E0_reac < E0_prod:
                     x0 = x1 + wellSpacing * 0.5
                 else:
                     x0 = x2 - wellSpacing * 0.5
             elif len(self.reaction.products) == 2:
-                if reac < prod:
+                if E0_reac < E0_prod:
                     x0 = x2 - wellSpacing * 0.5
                 else:
                     x0 = x1 + wellSpacing * 0.5


### PR DESCRIPTION
### Motivation or Problem
A variable name in Cantherm's kinetics draw is wrong

### Description of Changes
Corrected name

### Testing
Run the `examples/cantherm/networks/methoxy` example

### Reviewer Tips
Nothing in particular

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->