### PR TITLE
Prevent pruning of species exceeding flux tolerance

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -795,7 +795,8 @@ class RMG(util.Subject):
                     # If we reached our termination conditions, then try to prune
                     # species from the edge
                     if allTerminated and modelSettings.fluxToleranceKeepInEdge>0.0:
-                        self.reactionModel.prune(self.reactionSystems, modelSettings.fluxToleranceKeepInEdge, modelSettings.maximumEdgeSpecies, modelSettings.minSpeciesExistIterationsForPrune)
+                        logging.info('Attempting to prune...')
+                        self.reactionModel.prune(self.reactionSystems, modelSettings.fluxToleranceKeepInEdge, modelSettings.fluxToleranceMoveToCore, modelSettings.maximumEdgeSpecies, modelSettings.minSpeciesExistIterationsForPrune)
                         # Perform garbage collection after pruning
                         collected = gc.collect()
                         logging.info('Garbage collector: collected %d objects.' % (collected))

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1188,7 +1188,7 @@ class CoreEdgeReactionModel:
                     del(self.networkDict[source])
                 self.networkList.remove(network)
                     
-    def prune(self, reactionSystems, toleranceKeepInEdge, maximumEdgeSpecies, minSpeciesExistIterationsForPrune):
+    def prune(self, reactionSystems, toleranceKeepInEdge, toleranceMoveToCore, maximumEdgeSpecies, minSpeciesExistIterationsForPrune):
         """
         Remove species from the model edge based on the simulation results from
         the list of `reactionSystems`.
@@ -1245,8 +1245,12 @@ class CoreEdgeReactionModel:
                 pruneDueToRateCounter += 1
             # Keep removing species with the lowest rates until we are below the maximum edge species size
             elif numPrunableSpecies - len(speciesToPrune) > maximumEdgeSpecies:
-                logging.info('Pruning species {0} to make numEdgeSpecies smaller than maximumEdgeSpecies'.format(spec)) # repeated ~15 lines below
-                speciesToPrune.append((index, spec))
+                if maxEdgeSpeciesRateRatios[index] < toleranceMoveToCore:
+                    logging.info('Pruning species {0} to make numEdgeSpecies smaller than maximumEdgeSpecies'.format(spec))
+                    speciesToPrune.append((index, spec))
+                else:
+                    logging.warning('Attempted to prune a species that exceeded toleranceMoveToCore, pruning settings for this run are likely bad, either maximumEdgeSpecies needs to be set higher (~100000) or minSpeciesExistIterationsForPrune should be reduced (~2)')
+                    break
             else:
                 break
 


### PR DESCRIPTION
This prevents and adds a warning for when pruning attempts to prune species that exceed toleranceMoveToCore.
The warning informs the user that they should either increase maximumEdgeSpecies (~100000) or decrease
minSpeciesExistIterationsForPrune (~2).

Replaces #1138.  