### PR TITLE
Correct library name parsing in Chemkin readReactionComments()

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -609,7 +609,7 @@ def readReactionComments(reaction, comments, read = True):
             )
             
         elif 'Library reaction:' in line or 'Seed mechanism:' in line:
-            label = str(tokens[-1])
+            label = str(tokens[2])
             reaction = LibraryReaction(
                 index = reaction.index,
                 reactants = reaction.reactants, 
@@ -619,7 +619,7 @@ def readReactionComments(reaction, comments, read = True):
                 reversible = reaction.reversible,
                 duplicate = reaction.duplicate,
                 library = label,
-            )   
+            )
             
         elif 'PDep reaction:' in line:
             networkIndex = int(tokens[-1][1:])


### PR DESCRIPTION
Currently, due to incorrect library name parsing of Chemkin files, the H2S test crashes with:
```
  File "rmgpy/chemkin.pyx", line 907, in rmgpy.chemkin.loadChemkinFile
  File "rmgpy/chemkin.pyx", line 960, in rmgpy.chemkin._process_duplicate_reactions
rmgpy.exceptions.ChemkinError: Identical reactions HSS(56) + H(3) <=> SH(21) + SH(21)
and HSS(56) + H(3) <=> SH(21) + SH(21) taken from different libraries:
Sulfur/GlarborgH2S, 3239-3247
```
for the duplicate reaction:
```
! Reaction index: Chemkin #55; RMG #252
! Library reaction: Sulfur/GlarborgH2S
HSS(35)+H(3)=SH(21)+SH(21)                          9.700000e+07 1.620     -1.030   
DUPLICATE
! Reaction index: Chemkin #56; RMG #252
! Library reaction: Sulfur/GlarborgH2S
! Sendt K Jazbec M Haynes BS PCI 29:2439-2446 2002
! CR Zhou K Sendt BS Haynes J. Phys. Chem. A 2009, 112, 3239-3247
HSS(35)+H(3)=SH(21)+SH(21)                          1.600000e+18 -0.983    0.261    
DUPLICATE
```
This commit addresses that.

Here's a Chemkin file for the reviewer:
[chem_annotated_tmp.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/2069311/chem_annotated_tmp.txt)
[species_dictionary.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/2069312/species_dictionary.txt)

This is an easy review. Can anyone take a look?