### PR TITLE
Ranged Pruning

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -300,7 +300,7 @@ not make the algorithm non-deterministic.
     :align: center
     :height: 300px
 
-These variable condition reactors run a defined number of times (``nSimsTerm``) each reactor cycle. Use of these reactors tends to 
+These variable condition reactors run a defined number of times (``nSims``) each reactor cycle. Use of these reactors tends to 
 improve treatment of reaction conditions that otherwise would be between reactors and reduce the number of simulations needed by 
 focusing on reaction conditions at which the model terminates earlier.  An example with sensitivity analysis at a specified reaction condition 
 is available below::
@@ -308,7 +308,7 @@ is available below::
 	simpleReactor(
 		temperature=[(1000,'K'),(1500,'K')],
 		pressure=[(1.0,'bar'),(10.0,'bar')],
-		nSimsTerm=12,
+		nSims=12,
 		initialMoleFractions={
 		"ethane": [0.05,0.15],
 		"O2": 0.1,
@@ -326,17 +326,17 @@ is available below::
 		balanceSpecies = "N2",
 		)
 
-Note that increasing ``nSimsTerm`` improves convergence over the entire range, but convergence is only guaranteed at the 
-last set of ``nSimsTerm`` reaction conditions. Theoretically if ``nSimsTerm`` is set high enough the RMG model converges over the 
-entire interval.  Except at very small values for ``nSimsTerm`` the convergence achieved is usually as good or superior to 
+Note that increasing ``nSims`` improves convergence over the entire range, but convergence is only guaranteed at the 
+last set of ``nSims`` reaction conditions. Theoretically if ``nSims`` is set high enough the RMG model converges over the 
+entire interval.  Except at very small values for ``nSims`` the convergence achieved is usually as good or superior to 
 that achieved using the same number of evenly spaced fixed reactors.   
 
 If there is a particular reaction condition you expect to converge more slowly than the rest of the range 
 there is virtually no cost to using a single condition reactor (or a ranged reactor at a smaller range) at that condition 
-and a ranged reactor with a smaller value for nSimsTerm.  This is because the fixed reactor simulations will almost always
+and a ranged reactor with a smaller value for nSims.  This is because the fixed reactor simulations will almost always
 be useful and keep the overall RMG job from terminating while the ranged reactor samples the faster converging conditions.   
 
-What you should actually set ``nSimsTerm`` to is very system dependent.  The value you choose should be at least 2 + N 
+What you should actually set ``nSims`` to is very system dependent.  The value you choose should be at least 2 + N 
 where N is the number of dimensions the reactor spans (T=>N=1, T and P=>N=2, etc...).  There may be benefits to setting it as high
 as 2 + 5N.  The first should give you convergence over most of the interval that is almost always better than the same 
 number of fixed reactors.  The second should get you reasonably close to convergence over the entire range for N <= 2.  

--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -300,10 +300,9 @@ not make the algorithm non-deterministic.
     :align: center
     :height: 300px
 
-These variable condition reactors terminate after a defined number of 
-consecutive successfully terminating iterations (``nSimsTerm``). Use of these reactors tends to improve treatment of reaction 
-conditions that otherwise would be between reactors and reduce the number of simulations needed by focusing on reaction 
-conditions at which the model terminates earlier.  An example with sensitivity analysis at a specified reaction condition 
+These variable condition reactors run a defined number of times (``nSimsTerm``) each reactor cycle. Use of these reactors tends to 
+improve treatment of reaction conditions that otherwise would be between reactors and reduce the number of simulations needed by 
+focusing on reaction conditions at which the model terminates earlier.  An example with sensitivity analysis at a specified reaction condition 
 is available below::
 
 	simpleReactor(
@@ -333,9 +332,9 @@ entire interval.  Except at very small values for ``nSimsTerm`` the convergence 
 that achieved using the same number of evenly spaced fixed reactors.   
 
 If there is a particular reaction condition you expect to converge more slowly than the rest of the range 
-there is virually no cost to using a single condition reactor (or a ranged reactor at a smaller range) at that condition 
+there is virtually no cost to using a single condition reactor (or a ranged reactor at a smaller range) at that condition 
 and a ranged reactor with a smaller value for nSimsTerm.  This is because the fixed reactor simulations will almost always
-be useful and keep the overall RMG job from terminating when the ranged reactor samples the faster converging conditions.   
+be useful and keep the overall RMG job from terminating while the ranged reactor samples the faster converging conditions.   
 
 What you should actually set ``nSimsTerm`` to is very system dependent.  The value you choose should be at least 2 + N 
 where N is the number of dimensions the reactor spans (T=>N=1, T and P=>N=2, etc...).  There may be benefits to setting it as high

--- a/examples/rmg/SR_test/input.py
+++ b/examples/rmg/SR_test/input.py
@@ -31,7 +31,7 @@ species(
 simpleReactor(
     temperature=[(1000,'K'),(1500,'K')],
     pressure=[(1.0,'bar'),(10.0,'bar')],
-    nSimsTerm=12, 
+    nSims=12, 
     initialMoleFractions={
         "ethane": [0.05,0.15],
         "O2": 0.1,

--- a/examples/rmg/pruning_test/input.py
+++ b/examples/rmg/pruning_test/input.py
@@ -1,0 +1,69 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+species(
+    label='O2',
+    reactive=True,
+    structure=SMILES('[O][O]')
+)
+
+species(
+   label='N2',
+   reactive=False,
+   structure=SMILES('N#N'),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=[(1000,'K'),(1500,'K')],
+    pressure=[(1.0,'bar'),(10.0,'bar')],
+    nSimsTerm=3, 
+    initialMoleFractions={
+        "ethane": [0.05,0.15],
+        "O2": 0.1,
+        "N2": 0.9,
+    },
+    terminationConversion={
+        'ethane': 0.1,
+    },
+    terminationTime=(1e1,'s'),
+    balanceSpecies = "N2",
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.001,
+    toleranceMoveToCore=0.01,
+    toleranceInterruptSimulation=1e8,
+    maximumEdgeSpecies=20,
+    filterReactions=True,
+    minCoreSizeForPrune=5,
+    
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveEdgeSpecies=False,
+    saveSimulationProfiles=False,
+)

--- a/examples/rmg/pruning_test/input.py
+++ b/examples/rmg/pruning_test/input.py
@@ -31,7 +31,7 @@ species(
 simpleReactor(
     temperature=[(1000,'K'),(1500,'K')],
     pressure=[(1.0,'bar'),(10.0,'bar')],
-    nSimsTerm=3, 
+    nSims=3, 
     initialMoleFractions={
         "ethane": [0.05,0.15],
         "O2": 0.1,

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -134,7 +134,7 @@ def adjacencyList(string):
 def simpleReactor(temperature,
                   pressure,
                   initialMoleFractions,
-                  nSimsTerm=6,
+                  nSims=6,
                   terminationConversion=None,
                   terminationTime=None,
                   terminationRateRatio=None,
@@ -177,7 +177,7 @@ def simpleReactor(temperature,
         
         
     if not isinstance(temperature,list) and not isinstance(pressure,list) and all([not isinstance(x,list) for x in initialMoleFractions.values()]):
-        nSimsTerm=1
+        nSims=1
     
     termination = []
     if terminationConversion is not None:
@@ -210,7 +210,7 @@ def simpleReactor(temperature,
         sensConditions['P'] = Quantity(sensitivityPressure).value_si
 
     
-    system = SimpleReactor(T, P, initialMoleFractions, nSimsTerm, termination, sensitiveSpecies, sensitivityThreshold,sensConditions)
+    system = SimpleReactor(T, P, initialMoleFractions, nSims, termination, sensitiveSpecies, sensitivityThreshold,sensConditions)
     rmg.reactionSystems.append(system)
     
     assert balanceSpecies is None or isinstance(balanceSpecies,str), 'balanceSpecies should be the string corresponding to a single species'
@@ -231,7 +231,7 @@ def simpleReactor(temperature,
 def liquidReactor(temperature,
                   initialConcentrations,
                   terminationConversion=None,
-                  nSimsTerm = 4,
+                  nSims = 4,
                   terminationTime=None,
                   terminationRateRatio=None,
                   sensitivity=None,
@@ -261,7 +261,7 @@ def liquidReactor(temperature,
             initialConcentrations[spec] = [Quantity(conc[0]),Quantity(conc[1])]
             
     if not isinstance(temperature,list) and all([not isinstance(x,list) for x in initialConcentrations.itervalues()]):
-        nSimsTerm=1
+        nSims=1
         
     termination = []
     if terminationConversion is not None:
@@ -297,7 +297,7 @@ def liquidReactor(temperature,
         sensConditions = sensitivityConcentrations
         sensConditions['T'] = Quantity(sensitivityTemperature).value_si
         
-    system = LiquidReactor(T, initialConcentrations, nSimsTerm, termination, sensitiveSpecies, sensitivityThreshold, sensConditions, constantSpecies)
+    system = LiquidReactor(T, initialConcentrations, nSims, termination, sensitiveSpecies, sensitivityThreshold, sensConditions, constantSpecies)
     rmg.reactionSystems.append(system)
     
 def simulator(atol, rtol, sens_atol=1e-6, sens_rtol=1e-4):

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -826,14 +826,14 @@ class RMG(util.Subject):
                             self.reactionModel.thermoFilterDown(maximumEdgeSpecies=modelSettings.maximumEdgeSpecies)
                         
                         maxNumSpcsHit = len(self.reactionModel.core.species) >= modelSettings.maxNumSpecies
-    
-                        if maxNumSpcsHit: #breaks the while loop 
-                            break
                         
                         if not reactorDone:
                             self.done = False
                         
                         self.saveEverything()
+                        
+                        if maxNumSpcsHit: #breaks the while loop 
+                            break
                     
                 if not self.done: # There is something that needs exploring/enlarging
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -691,7 +691,7 @@ class RMG(util.Subject):
                     reactionSystem.prunableNetworks = prunableNetworks
                     reactionSystem.reset_max_edge_species_rate_ratios() 
                     
-                    for p in xrange(reactionSystem.nSimsTerm):
+                    for p in xrange(reactionSystem.nSims):
                         reactorDone = True
                         objectsToEnlarge = []
                         self.reactionSystem = reactionSystem

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -246,7 +246,6 @@ cdef class ReactionSystem(DASx):
         self.coreSpeciesRates = numpy.zeros((self.numCoreSpecies), numpy.float64)
         self.edgeSpeciesRates = numpy.zeros((self.numEdgeSpecies), numpy.float64)
         self.networkLeakRates = numpy.zeros((self.numPdepNetworks), numpy.float64)
-        self.maxEdgeSpeciesRateRatios = numpy.zeros((len(self.prunableSpecies)), numpy.float64)
         self.maxNetworkLeakRateRatios = numpy.zeros((len(self.prunableNetworks)), numpy.float64)
         self.sensitivityCoefficients = numpy.zeros((self.numCoreSpecies, self.numCoreReactions), numpy.float64)
         self.unimolecularThreshold = numpy.zeros((self.numCoreSpecies), bool)
@@ -262,6 +261,14 @@ cdef class ReactionSystem(DASx):
     def initialize_solver(self):
         DASx.initialize(self, self.t0, self.y0, self.dydt0, self.senpar, self.atol_array, self.rtol_array)
     
+    def reset_max_edge_species_rate_ratios(self):
+        """
+        This function sets maxEdgeSpeciesRateRatios back to zero
+        for pruning of ranged reactors it is important to avoid doing this
+        every initialization
+        """
+        self.maxEdgeSpeciesRateRatios = numpy.zeros((len(self.prunableSpecies)), numpy.float64)
+        
     def set_prunable_indices(self,edgeSpecies,pdepNetworks):
         cdef object spc
         cdef list temp

--- a/rmgpy/solver/liquid.pyx
+++ b/rmgpy/solver/liquid.pyx
@@ -59,11 +59,12 @@ cdef class LiquidReactor(ReactionSystem):
     cdef public list constSPCIndices
     cdef public dict initialConcentrations
     cdef public list Trange
-    cdef public int nSimsTerm
+    cdef public int nSims
     cdef public dict sensConditions
     
-    def __init__(self, T, initialConcentrations, nSimsTerm=None, termination=None, sensitiveSpecies=None,
-                 sensitivityThreshold=1e-3, sensConditions=None, constSPCNames=None):
+
+    def __init__(self, T, initialConcentrations, nSims=None, termination=None, sensitiveSpecies=None, sensitivityThreshold=1e-3, sensConditions=None, constSPCNames=None):
+        
         ReactionSystem.__init__(self, termination, sensitiveSpecies, sensitivityThreshold)
         
         if type(T) != list:
@@ -81,7 +82,7 @@ cdef class LiquidReactor(ReactionSystem):
         self.constSPCIndices=None
         self.constSPCNames = constSPCNames #store index of constant species 
         self.sensConditions = sensConditions
-        self.nSimsTerm = nSimsTerm
+        self.nSims = nSims
         
     def convertInitialKeysToSpeciesObjects(self, speciesDict):
         """

--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -106,9 +106,9 @@ cdef class SimpleReactor(ReactionSystem):
     
     cdef public list Trange
     cdef public list Prange
-    cdef public int nSimsTerm
+    cdef public int nSims
 
-    def __init__(self, T, P, initialMoleFractions, nSimsTerm=None, termination=None, sensitiveSpecies=None, sensitivityThreshold=1e-3,sensConditions=None):
+    def __init__(self, T, P, initialMoleFractions, nSims=None, termination=None, sensitiveSpecies=None, sensitivityThreshold=1e-3,sensConditions=None):
         ReactionSystem.__init__(self, termination, sensitiveSpecies, sensitivityThreshold)
         
         
@@ -134,14 +134,14 @@ cdef class SimpleReactor(ReactionSystem):
         self.pdepSpecificColliderKinetics = None
         self.specificColliderSpecies = None
         self.sensConditions = sensConditions
-        self.nSimsTerm = nSimsTerm
+        self.nSims = nSims
 
     def __reduce__(self):
         """
         A helper function used when pickling an object.
         """
         return (self.__class__, 
-            (self.T, self.P, self.initialMoleFractions, self.nSimsTerm, self.termination))
+            (self.T, self.P, self.initialMoleFractions, self.nSims, self.termination))
 
 
     def convertInitialKeysToSpeciesObjects(self, speciesDict):

--- a/rmgpy/solver/simpleTest.py
+++ b/rmgpy/solver/simpleTest.py
@@ -81,7 +81,7 @@ class SimpleReactorCheck(unittest.TestCase):
         edgeReactions = []
 
         T = 1000; P = 1.0e5
-        rxnSystem = SimpleReactor(T, P, initialMoleFractions={C2H5: 0.1, CH3: 0.1, CH4: 0.4, C2H6: 0.4}, nSimsTerm=1, termination=[])
+        rxnSystem = SimpleReactor(T, P, initialMoleFractions={C2H5: 0.1, CH3: 0.1, CH4: 0.4, C2H6: 0.4}, nSims=1, termination=[])
 
         rxnSystem.initializeModel(coreSpecies, coreReactions, edgeSpecies, edgeReactions)
 
@@ -146,7 +146,7 @@ class SimpleReactorCheck(unittest.TestCase):
             edgeSpecies = []
             coreReactions = [rxn]
             
-            rxnSystem0 = SimpleReactor(T,P,initialMoleFractions={CH4:0.2,CH3:0.1,C2H6:0.35,C2H5:0.15, H2:0.2},nSimsTerm=1,termination=[])
+            rxnSystem0 = SimpleReactor(T,P,initialMoleFractions={CH4:0.2,CH3:0.1,C2H6:0.35,C2H5:0.15, H2:0.2},nSims=1,termination=[])
             rxnSystem0.initializeModel(coreSpecies, coreReactions, edgeSpecies, edgeReactions)
             dydt0 = rxnSystem0.residual(0.0, rxnSystem0.y, numpy.zeros(rxnSystem0.y.shape))[0]
             numCoreSpecies = len(coreSpecies)
@@ -185,7 +185,7 @@ class SimpleReactorCheck(unittest.TestCase):
         edgeSpecies = []
         coreReactions = rxnList
         
-        rxnSystem0 = SimpleReactor(T,P,initialMoleFractions={CH4:0.2,CH3:0.1,C2H6:0.35,C2H5:0.15, H2:0.2},nSimsTerm=1,termination=[])
+        rxnSystem0 = SimpleReactor(T,P,initialMoleFractions={CH4:0.2,CH3:0.1,C2H6:0.35,C2H5:0.15, H2:0.2},nSims=1,termination=[])
         rxnSystem0.initializeModel(coreSpecies, coreReactions, edgeSpecies, edgeReactions)
         dfdt0 = rxnSystem0.residual(0.0, rxnSystem0.y, numpy.zeros(rxnSystem0.y.shape))[0]
         solver_dfdk = rxnSystem0.computeRateDerivative()
@@ -207,7 +207,7 @@ class SimpleReactorCheck(unittest.TestCase):
             rxnList[i].kinetics.A.value_si = rxnList[i].kinetics.A.value_si*(1+1e-3)               
             dk = rxnList[i].getRateCoefficient(T,P) - k0
 
-            rxnSystem = SimpleReactor(T,P,initialMoleFractions={CH4:0.2,CH3:0.1,C2H6:0.35,C2H5:0.15, H2:0.2},nSimsTerm=1,termination=[])
+            rxnSystem = SimpleReactor(T,P,initialMoleFractions={CH4:0.2,CH3:0.1,C2H6:0.35,C2H5:0.15, H2:0.2},nSims=1,termination=[])
             rxnSystem.initializeModel(coreSpecies, coreReactions, edgeSpecies, edgeReactions)
 
             dfdt = rxnSystem.residual(0.0, rxnSystem.y, numpy.zeros(rxnSystem.y.shape))[0]  
@@ -274,7 +274,7 @@ class SimpleReactorCheck(unittest.TestCase):
                         speciesDict['Ar']:4.0}
         
         # Initialize the model
-        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSimsTerm=1,termination=None)
+        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSims=1,termination=None)
         rxnSystem.initializeModel(speciesList, reactionList, [], [])
         
         # Advance to time = 0.1 s
@@ -303,7 +303,7 @@ class SimpleReactorCheck(unittest.TestCase):
                         speciesDict['CH3']:1}
         
         # Initialize the model
-        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSimsTerm=1,termination=None)
+        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSims=1,termination=None)
         rxnSystem.initializeModel(speciesList, reactionList, [], [])
         
         # Advance to time = 5 s
@@ -343,7 +343,7 @@ class SimpleReactorCheck(unittest.TestCase):
                         speciesDict['CH4']:0.001}
 
         # Initialize the model
-        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSimsTerm=1,termination=None)
+        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSims=1,termination=None)
         rxnSystem.initializeModel(speciesList, reactionList, [], [])
 
         # Advance to time = 0.1 s
@@ -372,7 +372,7 @@ class SimpleReactorCheck(unittest.TestCase):
                         speciesDict['CH4']:0.5}
 
         # Initialize the model
-        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSimsTerm=1,termination=None)
+        rxnSystem = SimpleReactor(T,P,initialMoleFractions=initialMoleFractions,nSims=1,termination=None)
         rxnSystem.initializeModel(speciesList, reactionList, [], [])
 
         # Advance to time = 5 s


### PR DESCRIPTION
This PR updates pruning to work properly with ranged reactors and solve #1386.  Instead of tracking how many times a ranged reactor is completed ranged reactors are simply run through nSimsTerm times each reactor cycle.  Furthermore, maxEdgeSpeciesRateRatios is now only reset for each reactor at the beginning of the reactor loop allowing ranged reactors to store the maxEdgeSpeciesRateRatios of all the runs they did that reactor cycle instead of just the last cycle.  This also solves the minimum number of iterations to pruning issues as the number of iterations is defined as the number of reactor cycles run.  I've also added an example for testing pruning and updated the documentation to reflect the changes to how ranged reactors operate.  