### PR TITLE
Automatically skip TCD tests if TCD is unavailable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,19 +75,12 @@ ifneq ($(OS),Windows_NT)
 endif
 	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 
-test-unittests:
+test test-unittests:
 ifneq ($(OS),Windows_NT)
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
 endif
 	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
-
-test test-unittests-non-auth:
-ifneq ($(OS),Windows_NT)
-	mkdir -p testing/coverage
-	rm -rf testing/coverage/*
-endif
-	nosetests --nocapture --nologcapture --all-modules -A 'not functional and not auth' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy
 
 test-functional:
 ifneq ($(OS),Windows_NT)

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -31,7 +31,6 @@
 import os
 import unittest
 from external.wip import work_in_progress
-from nose.plugins.attrib import attr
 
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase, database
@@ -1356,7 +1355,37 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
                             expected_saturated_ring_submol.multiplicity)
         self.assertTrue(saturated_ring_submol.isIsomorphic(expected_saturated_ring_submol))
 
-@attr('auth')
+
+def getTestingTCDAuthenticationInfo():
+
+    try:
+        host = os.environ['TCD_HOST']
+        port = int(os.environ['TCD_PORT'])
+        username = os.environ['TCD_USER']
+        password = os.environ['TCD_PW']
+    except KeyError:
+        print('Thermo Central Database Authentication Environment Variables Not Completely Set!')
+        return None, 0, None, None
+
+    return host, port, username, password
+
+
+def isTCDAvailable():
+    """Check if TCD is available."""
+    import platform
+    import subprocess
+
+    host = getTestingTCDAuthenticationInfo()[0]
+    if host is not None:
+        arg = '-n' if platform.system() == 'Windows' else '-c'
+        result = subprocess.call(['ping', arg, '1', host]) == 0
+    else:
+        result = False
+
+    return result
+
+
+@unittest.skipIf(not isTCDAvailable(), 'TCD unavailable, skipping unit tests.')
 class TestThermoCentralDatabaseInterface(unittest.TestCase):
     """
     Contains unit tests for methods of ThermoCentralDatabaseInterface
@@ -1588,19 +1617,6 @@ class TestThermoCentralDatabaseInterface(unittest.TestCase):
 
         # clean up the table
         results_table.delete_many({"aug_inchi": expected_aug_inchi})
-
-def getTestingTCDAuthenticationInfo():
-
-    try:
-        host = os.environ['TCD_HOST']
-        port = int(os.environ['TCD_PORT'])
-        username = os.environ['TCD_USER']
-        password = os.environ['TCD_PW']
-    except KeyError:
-        print('Thermo Central Database Authentication Environment Variables Not Completely Set!')
-        return 'None', 0, 'None', 'None'
-
-    return host, port, username, password
 
 ################################################################################
 


### PR DESCRIPTION
### Motivation or Problem
Travis build depends on the server hosting the TCD being online, which is not always true.

### Description of Changes
Add functions to automatically skip TCD tests if the host is not available (determined via pinging). Also skip the test if the proper environment variables are not defined. This eliminates the need for the 'auth' attribute for unit tests and the related make target can also be removed.

### Testing
Check that Travis passes.