### PR TITLE
Update rmgpy.display.display method

### DIFF
--- a/rmgpy/display.py
+++ b/rmgpy/display.py
@@ -34,18 +34,12 @@ the IPython --pylab mode, will render things inline in pretty SVG or PNG graphic
 If you are NOT running in IPython --pylab mode, it will do nothing.
 """
 
-def do_nothing(object):
-    pass
-    
 try:
-    import IPython
+    from IPython.core.interactiveshell import InteractiveShell
 except ImportError:
-    # Don't have IPython installed
-    display = do_nothing
+    def display(obj): pass
 else:
-    try:
-        displayer = IPython.core.display.display
-        display = lambda obj: displayer(obj, include='png')
-    except (NameError,AttributeError):
-        display = do_nothing #not runing in IPython --pylab mode.
-
+    if InteractiveShell.initialized():
+        from IPython.core.display import display
+    else:
+        def display(obj): pass


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This addresses #1360. The cause was an update to IPython where display defaults to print when not in an interactive shell.

### Description of Changes
Check for interactive shell using IPython method, and if not in interactive shell, set display to pass.

### Testing
Check that the species are no longer printed in the Travis build log.
