### PR TITLE
Minor: Corrected `r` notation into `k` in CanTherm's SA

### DIFF
--- a/documentation/source/users/cantherm/input.rst
+++ b/documentation/source/users/cantherm/input.rst
@@ -621,7 +621,7 @@ in the following format, e.g.::
     )
 
 The output of a sensitivity analysis is saved into a ``sensitivity`` folder in the output directory. A text file, named
-with the reaction label, delineates the semi-normalized sensitivity coefficients ``dln(r)/dE0`` in units of ``mol/J``
+with the reaction label, delineates the semi-normalized sensitivity coefficients ``dln(k)/dE0`` in units of ``mol/J``
 at all requested conditions. A horizontal bar figure is automatically generated per reaction with subplots for both the
 forward and reverse direction at all conditions.
 

--- a/documentation/source/users/cantherm/input_pdep.rst
+++ b/documentation/source/users/cantherm/input_pdep.rst
@@ -736,7 +736,7 @@ This example also includes the ``sensitivity_conditions`` attribute which invoke
     )
 
 The output of a sensitivity analysis is saved into a ``sensitivity`` folder in the output directory. A text file, named
-with the network label, delineates the semi-normalized sensitivity coefficients ``dln(r)/dE0`` in units of ``mol/J``
+with the network label, delineates the semi-normalized sensitivity coefficients ``dln(k)/dE0`` in units of ``mol/J``
 for all network reactions (both directions if reversible) at all requested conditions. Horizontal bar figures are
 automatically generated per network reaction, showing the semi-normalized sensitivity coefficients at all conditions.
 

--- a/rmgpy/cantherm/sensitivity.py
+++ b/rmgpy/cantherm/sensitivity.py
@@ -187,14 +187,14 @@ class KineticsSensitivity(object):
             ax[i][0].set_yticks(y_pos)
             ax[i][0].set_yticklabels(labels)
             ax[i][0].invert_yaxis()  # labels read top-to-bottom
-            ax[i][0].set_xlabel('dln(r)/dE0 (mol/J)')
+            ax[i][0].set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
             ax[i][0].set_title('Forward, {0}'.format(condition))
             ax[i][0].set_xlim([min_sa, max_sa])
             ax[i][1].barh(y_pos, r_values, align='center', color='blue')
             ax[i][1].set_yticks(y_pos)
             ax[i][1].set_yticklabels(labels)
             ax[i][1].invert_yaxis()  # labels read top-to-bottom
-            ax[i][1].set_xlabel('dln(r)/dE0 (mol/J)')
+            ax[i][1].set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
             ax[i][1].set_title('Reverse, {0}'.format(condition))
             ax[i][1].set_xlim([min_sa, max_sa])
             plt.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
@@ -365,7 +365,7 @@ class PDepSensitivity(object):
                 axis.set_yticks(y_pos)
                 axis.set_yticklabels(labels)
                 axis.invert_yaxis()  # labels read top-to-bottom
-                axis.set_xlabel('dln(r)/dE0 (mol/J)')
+                axis.set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
                 # axis.ticklabel_format('sci')
                 axis.set_title('{0}, {1}'.format(condition[0], condition[1]))
                 axis.set_xlim([min_sa, max_sa])


### PR DESCRIPTION
I made a terminology mistake in CanTherm's sensitivity analysis, fixed here.
While revisiting these lines, I also improved the style of the x axis label.