### PR TITLE
Save and parse Arkane species with all statmech properties using YAML format

### DIFF
--- a/arkane/__init__.py
+++ b/arkane/__init__.py
@@ -33,3 +33,4 @@ from arkane.statmech import StatMechJob
 from arkane.thermo import ThermoJob
 from arkane.kinetics import KineticsJob
 from arkane.pdep import PressureDependenceJob
+from arkane.common import ArkaneSpecies

--- a/arkane/commonTest.py
+++ b/arkane/commonTest.py
@@ -35,13 +35,17 @@ This script contains unit tests of the :mod:`arkane.common` module.
 import unittest
 import numpy
 import os
+import shutil
+import logging
 
 import rmgpy
 import rmgpy.constants as constants
 from rmgpy.species import Species, TransitionState
+from rmgpy.quantity import ScalarQuantity
+from rmgpy.thermo import NASA
 
-from arkane.common import get_element_mass
 from arkane import Arkane, input
+from arkane.common import ArkaneSpecies, get_element_mass
 from arkane.statmech import InputError, StatMechJob
 from arkane.input import jobList
 
@@ -268,6 +272,104 @@ class TestArkaneInput(unittest.TestCase):
         job.includeHinderedRotors = self.useHinderedRotors
         job.applyBondEnergyCorrections = self.useBondCorrections
         job.load()
+
+
+class TestStatmech(unittest.TestCase):
+    """
+    Contains unit tests of statmech.py
+    """
+    @classmethod
+    def setUp(self):
+        arkane = Arkane()
+        self.job_list = arkane.loadInputFile(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                                          'data', 'Benzyl', 'input.py'))
+
+    def test_gaussian_log_file_error(self):
+        """Test that the proper error is raised if gaussian geometry and frequency file paths are the same"""
+        job = self.job_list[-2]
+        self.assertTrue(isinstance(job, StatMechJob))
+        with self.assertRaises(InputError):
+            job.load()
+
+
+class TestArkaneSpecies(unittest.TestCase):
+    """
+    Contains YAML dump and load unit tests for :class:ArkaneSpecies
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run ONCE before all unit tests in this class.
+        """
+        cls.arkane = Arkane()
+        path = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)),
+                            'examples', 'arkane', 'species')
+        cls.dump_path = os.path.join(path, 'C2H6')
+        cls.dump_input_path = os.path.join(cls.dump_path, 'input.py')
+        cls.dump_output_file = os.path.join(cls.dump_path, 'output.py')
+        cls.dump_yaml_file = os.path.join(cls.dump_path, 'ArkaneSpecies', 'C2H6.yml')
+
+        cls.load_path = os.path.join(path, 'C2H6_from_yaml')
+        cls.load_input_path = os.path.join(cls.load_path, 'input.py')
+        cls.load_output_file = os.path.join(cls.load_path, 'output.py')
+
+        if os.path.exists(cls.dump_yaml_file):
+            logging.debug('removing existing yaml file {0} before running tests'.format(cls.dump_yaml_file))
+            os.remove(cls.dump_yaml_file)
+
+    def test_dump_yaml(self):
+        """
+        Test properly dumping the ArkaneSpecies object and respective sub-objects
+        """
+        jobList = self.arkane.loadInputFile(self.dump_input_path)
+        for job in jobList:
+            job.execute(outputFile=self.dump_output_file)
+        self.assertTrue(os.path.isfile(self.dump_yaml_file))
+
+    def test_load_yaml(self):
+        """
+        Test properly loading the ArkaneSpecies object and respective sub-objects
+        """
+        jobList = self.arkane.loadInputFile(self.load_input_path)
+        for job in jobList:
+            job.execute(outputFile=self.load_output_file)
+        arkane_spc = jobList[0].arkane_species
+        self.assertIsInstance(arkane_spc, ArkaneSpecies)  # checks make_object
+        self.assertIsInstance(arkane_spc.molecular_weight, ScalarQuantity)
+        self.assertIsInstance(arkane_spc.thermo, NASA)
+        self.assertNotEqual(arkane_spc.author, '')
+        self.assertEqual(arkane_spc.inchi, 'InChI=1S/C2H6/c1-2/h1-2H3')
+        self.assertEqual(arkane_spc.smiles, 'CC')
+        self.assertTrue('8 H u0 p0 c0 {2,S}' in arkane_spc.adjacency_list)
+        self.assertEqual(arkane_spc.label, 'C2H6')
+        self.assertEqual(arkane_spc.frequency_scale_factor, 0.99)  # checks float conversion
+        self.assertFalse(arkane_spc.use_bond_corrections)
+        self.assertAlmostEqual(arkane_spc.conformer.modes[2].frequencies.value_si[0], 818.91718, 4)  # HarmonicOsc.
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        A method that is run ONCE after all unit tests in this class.
+        """
+        path = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)),
+                            'examples', 'arkane', 'species')
+        cls.dump_path = os.path.join(path, 'C2H6')
+        cls.load_path = os.path.join(path, 'C2H6_from_yaml')
+        cls.extensions_to_delete = ['pdf', 'txt', 'inp', 'csv']
+        cls.files_to_delete = ['arkane.log', 'output.py']
+        cls.files_to_keep = ['C2H6.yml']
+        for path in [cls.dump_path, cls.load_path]:
+            for name in os.listdir(path):
+                item_path = os.path.join(path, name)
+                if os.path.isfile(item_path):
+                    extension = name.split('.')[-1]
+                    if name in cls.files_to_delete or\
+                            (extension in cls.extensions_to_delete and name not in cls.files_to_keep):
+                        os.remove(item_path)
+                else:
+                    # This is a sub-directory. remove.
+                    shutil.rmtree(item_path)
 
 
 class TestGetMass(unittest.TestCase):

--- a/arkane/main.py
+++ b/arkane/main.py
@@ -57,6 +57,7 @@ from arkane.statmech import StatMechJob
 from arkane.thermo import ThermoJob
 from arkane.pdep import PressureDependenceJob
 from arkane.explorer import ExplorerJob
+from arkane.common import is_pdep
 
 ################################################################################
 
@@ -264,7 +265,7 @@ class Arkane:
             if isinstance(job, ThermoJob):
                 job.execute(outputFile=outputFile, plot=self.plot)
             if isinstance(job, StatMechJob):
-                job.execute(outputFile=outputFile, plot=self.plot)
+                job.execute(outputFile=outputFile, plot=self.plot, pdep=is_pdep(self.jobList))
                 supporting_info.append(job.supporting_info)
 
         with open(chemkinFile, 'a') as f:

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -555,7 +555,7 @@ class StatMechJob(object):
             z = coordinates[i,2]
             f.write('#   {0} {1:9.4f} {2:9.4f} {3:9.4f}\n'.format(symbol_by_number[number[i]], x, y, z))
 
-        string = 'conformer(label={0!r}, E0={1!r}, modes={2!r}, spinMultiplicity={3:d}, opticalIsomers={4:d}'.format(
+        result = 'conformer(label={0!r}, E0={1!r}, modes={2!r}, spinMultiplicity={3:d}, opticalIsomers={4:d}'.format(
             self.species.label,
             conformer.E0,
             conformer.modes,
@@ -563,12 +563,10 @@ class StatMechJob(object):
             conformer.opticalIsomers,
         )
         try:
-            string += ', frequency={0!r}'.format(self.species.frequency)
+            result += ', frequency={0!r}'.format(self.species.frequency)
         except AttributeError: pass
-        string += ')'
-
-        f.write('{0}\n\n'.format(prettify(string)))
-
+        result += ')'
+        f.write('{0}\n\n'.format(prettify(result)))
         f.close()
 
     def plotHinderedRotor(self, angle, v_list, cosineRotor, fourierRotor, rotor, rotorIndex, directory):

--- a/arkane/thermo.py
+++ b/arkane/thermo.py
@@ -166,9 +166,9 @@ class ThermoJob(object):
             except ValueError:
                 logging.debug("Valid thermo for {0} is outside range for temperature {1}".format(species,T))
         f.write('#    =========== =========== =========== =========== ===========\n')
-        
-        string = 'thermo(label={0!r}, thermo={1!r})'.format(species.label, species.getThermoData())
-        f.write('{0}\n\n'.format(prettify(string)))
+
+        thermo_string = 'thermo(label={0!r}, thermo={1!r})'.format(species.label, species.getThermoData())
+        f.write('{0}\n\n'.format(prettify(thermo_string)))
         
         f.close()
         # write chemkin file
@@ -183,8 +183,8 @@ class ThermoJob(object):
                     elementCounts = {'C': 0, 'H': 0}
         else:
             elementCounts = {'C': 0, 'H': 0}
-        string = writeThermoEntry(species, elementCounts=elementCounts, verbose=True)
-        f.write('{0}\n'.format(string))
+        chemkin_thermo_string = writeThermoEntry(species, elementCounts=elementCounts, verbose=True)
+        f.write('{0}\n'.format(chemkin_thermo_string))
         f.close()
 
         # write species dictionary

--- a/arkane/thermo.py
+++ b/arkane/thermo.py
@@ -34,7 +34,7 @@ thermodynamics information for a single species.
 """
 
 import os.path
-import numpy.linalg
+import numpy as np
 import logging
 import string
 
@@ -95,8 +95,8 @@ class ThermoJob(object):
             logging.info("Thermo already generated for species {}. Skipping thermo generation.".format(species))
             return None
         
-        Tlist = numpy.arange(10.0, 3001.0, 10.0, numpy.float64)
-        Cplist = numpy.zeros_like(Tlist)
+        Tlist = np.arange(10.0, 3001.0, 10.0, np.float64)
+        Cplist = np.zeros_like(Tlist)
         H298 = 0.0
         S298 = 0.0
         conformer = self.species.conformer
@@ -208,15 +208,15 @@ class ThermoJob(object):
         except ImportError:
             return
         
-        Tlist = numpy.arange(10.0, 2501.0, 10.0)
-        Cplist = numpy.zeros_like(Tlist)
-        Cplist1 = numpy.zeros_like(Tlist)
-        Hlist = numpy.zeros_like(Tlist)
-        Hlist1 = numpy.zeros_like(Tlist)
-        Slist = numpy.zeros_like(Tlist)
-        Slist1 = numpy.zeros_like(Tlist)
-        Glist = numpy.zeros_like(Tlist)
-        Glist1 = numpy.zeros_like(Tlist)
+        Tlist = np.arange(10.0, 2501.0, 10.0)
+        Cplist = np.zeros_like(Tlist)
+        Cplist1 = np.zeros_like(Tlist)
+        Hlist = np.zeros_like(Tlist)
+        Hlist1 = np.zeros_like(Tlist)
+        Slist = np.zeros_like(Tlist)
+        Slist1 = np.zeros_like(Tlist)
+        Glist = np.zeros_like(Tlist)
+        Glist1 = np.zeros_like(Tlist)
         
         conformer = self.species.conformer
         thermo = self.species.getThermoData()

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -16,10 +16,13 @@ either single or double quotes.
 The following is a list of all the components of a Arkane input file for thermodynamics and high-pressure limit kinetics
 computations:
 
-=========================== ====================================================================
+=========================== ============================================================================================
 Component                   Description
-=========================== ====================================================================
-``modelChemistry``          Level of theory from quantum chemical calculations
+=========================== ============================================================================================
+``modelChemistry``          Level of theory from quantum chemical calculations, see ``Model Chemistry`` table below
+``levelOfTheory``           Level of theory, free text format (only used for archiving). Suggested format:
+                            ``energy_method/basis_set//geometry_method/basis_set, rotors at rotor_method/basis_set``
+``author``                  Author's name. Used when saving statistical mechanics properties as a .yml file.
 ``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
 ``useHinderedRotors``       ``True`` (by default) if hindered rotors are used, ``False`` if not
@@ -31,7 +34,7 @@ Component                   Description
 ``statmech``                Loads statistical mechanics parameters
 ``thermo``                  Performs a thermodynamics computation
 ``kinetics``                Performs a high-pressure limit kinetic computation
-=========================== ====================================================================
+=========================== ============================================================================================
 
 Model Chemistry
 ===============
@@ -127,25 +130,30 @@ The frequency scale factor is automatically assigned according to the supplied `
 Species
 =======
 
-Each species of interest must be specified using a ``species()`` function, which can be input in two different ways,
+Each species of interest must be specified using a ``species()`` function, which can be input in three different ways,
 discussed in the separate subsections below:
 
 1. By pointing to the output files of quantum chemistry calculations, which Arkane will parse for the necessary
-molecular properties
-2. By directly entering the molecular properties
+molecular properties.
+2. By directly entering the molecular properties.
+3. By pointing to an appropriate YAML file.
 
-Within a single input file, both Option #1 and #2 may be used for different species.
+Within a single input file, any of the above options may be used for different species.
 
 Option #1: Automatically Parse Quantum Chemistry Calculation Output
 -------------------------------------------------------------------
 
 For this option, the ``species()`` function only requires two parameters, as in the example below::
 
-    species('C2H6', 'C2H6.py')
+    species('C2H6', 'C2H6.py',
+            structure = SMILES('CC'))
 
 The first parameter (``'C2H6'`` above) is the species label, which can be referenced later in the input file. The second
 parameter (``'C2H6.py'`` above) points to the location of another python file containing details of the species. This file
-will be referred to as the species input file.
+will be referred to as the species input file. The third parameter (``'structure = SMILES('CC')'`` above)
+gives the species structure (either SMILES, adjacencyList, or InChI could be used). The structure parameter isn't
+necessary for the calculation, however if it is not specified a .yml file representing an ArkaneSpecies will not be
+generated.
 
 The species input file accepts the following parameters:
 
@@ -542,16 +550,29 @@ Note that the format of the ``species()`` function above is identical to the ``c
 in ``output.py``. Therefore, the user could directly copy the ``conformer()`` output of an Arkane job to another Arkane
 input file, change the name of the function to ``species()`` (or ``transitionState()``, if appropriate, see next
 section) and run a new Arkane job in this manner. This can be useful if the user wants to easily switch a ``species()``
-function from  Option #1 (parsing  quantum chemistry calculation output) to Option #2 (directly enter molecular properties).
+function from `Option #1: Automatically Parse Quantum Chemistry Calculation Output`_ to
+`Option #2: Directly Enter Molecular Properties`_.
+
+Option #3: Automatically Parse YAML files
+-----------------------------------------
+Arkane automatically saves a .yml file representing an ArkaneSpecies in an ``ArkaneSpecies`` folder under the run
+directory with the statistical mechanics properties of a species along with additional useful metadata. This process is
+triggered whenever a ``thermo`` calculation is ran for a species with a specified structure. To automatically generate
+such file in the first place, a species has to be defined using one of the other options above. The generated .yml file
+could conveniently be used when referring to this species in subsequent Arkane jobs. We intend to create an online
+repository of Arkane .yml files, from which users would be able to pick the desired species calculated at an appropriate
+level of theory (if available), and directly use them for kinetic or pressure-dependent calculations. Once such
+repository becomes available, a full description will be added to these pages.
 
 Transition State
 ================
 
-Transition state(s) are only required when performimg kinetics computations.
+Transition state(s) are only required when performing kinetics computations.
 Each transition state of interest must be specified using a ``transitionState()``
-function, which is analogous to the ``species()`` function described above. Therefore, the ``transitionState()`` function
-may also be specified in two ways: `Option #1: Automatically Parse Quantum Chemistry Calculation Output`_ and
-`Option #2: Directly Enter Molecular Properties`_
+function, which is analogous to the ``species()`` function described above. Therefore, the ``transitionState()``
+function may also be specified in two ways: `Option #1: Automatically Parse Quantum Chemistry Calculation Output`_ and
+`Option #2: Directly Enter Molecular Properties`_. Note that currently a transitions state cannot be specified
+using a YAML file (Option #3).
 
 The following is an example of a typical ``transitionState()`` function using Option #1::
 

--- a/documentation/source/users/arkane/input_pdep.rst
+++ b/documentation/source/users/arkane/input_pdep.rst
@@ -21,10 +21,13 @@ either single or double quotes.
 
 The following is a list of all the components of a Arkane input file for pressure-dependent calculations:
 
-=========================== ================================================================
+=========================== ============================================================================================
 Component                   Description
-=========================== ================================================================
-``modelChemistry``          Level of theory from quantum chemical calculations
+=========================== ============================================================================================
+``modelChemistry``          Level of theory from quantum chemical calculations, see ``Model Chemistry`` table below
+``levelOfTheory``           Level of theory, free text format (only used for archiving). Suggested format:
+                            ``energy_method/basis_set//geometry_method/basis_set, rotors at rotor_method/basis_set``
+``author``                  Author's name. Used when saving statistical mechanics properties as a .yml file.
 ``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
 ``useHinderedRotors``       ``True`` if hindered rotors are used, ``False`` if not
@@ -38,7 +41,7 @@ Component                   Description
 ``statmech``                Loads statistical mechanics parameters
 ``thermo``                  Performs a thermodynamics computation
 ``kinetics``                Performs a high-pressure limit kinetic computation
-=========================== ================================================================
+=========================== ============================================================================================
 
 Note that many of the functions in the table above overlap with the functions available for
 `thermodynamics and high-pressure limit kinetics computations <input.html#syntax>`_. For most of these overlapping
@@ -90,19 +93,21 @@ and the bath gas(es). A species that appears in multiple bimolecular channels
 need only be specified with a single ``species()`` function.
 
 The input to the ``species()`` function for a pressure-dependent calculation is the same as for a
-`thermodynamic orhigh-pressure limit kinetics calculation <input.html#species>`_, with the addition of a few extra
-parameters needed to describe collisional energy transfer. There are two options for providing input to the
+`thermodynamic or high-pressure limit kinetics calculation <input.html#species>`_, with the addition of a few extra
+parameters needed to describe collisional energy transfer. There are three options for providing input to the
 ``species()`` function, which are described in the subsections below:
 
 1. By pointing to the output files of quantum chemistry calculations, which Arkane will parse for the necessary
-molecular properties
-2. By directly entering the molecular properties
+molecular properties.
+2. By directly entering the molecular properties.
+3. By pointing to an appropriate YAML file.
 
-Within a single input file, both Option #1 and #2 may be used.
+Within a single input file, any of the above options may be used (note that the YAML format is currently not supported
+for transition states).
 
-Regardless of which option is used to specify molecular properties (e.g., vibrational frequencies, rotational constants)
-in the ``species()`` function, the four parameters listed below (mostly relating to the collisional energy transfer
-model) are always specified in the same way.
+Unless Option #3 (pointing to a YAML file) is used to specify molecular properties (e.g., vibrational frequencies,
+rotational constants) in the ``species()`` function, the four parameters listed below (mostly relating to the
+collisional energy transfer model) are always specified in the same way:
 
 ======================= =================================== ====================================
 Parameter               Required?                           Description
@@ -171,7 +176,7 @@ exponential down parameters is the following paper:
 http://www.sciencedirect.com/science/article/pii/S1540748914001084#s0060
 
 The following subsections describe how the remaining molecular properties can be input to the ``species()`` function
-using either Option #1 or #2 mentioned above.
+using the above mentioned methods.
 
 Option #1: Automatically Parse Quantum Chemistry Calculation Output
 -------------------------------------------------------------------
@@ -573,7 +578,19 @@ Note that the format of the ``species()`` function above is identical to the ``c
 in ``output.py``. Therefore, the user could directly copy the ``conformer()`` output of an Arkane job to another Arkane
 input file, change the name of the function to ``species()`` (or ``transitionState()``, if appropriate, see next
 section) and run a new Arkane job in this manner. This can be useful if the user wants to easily switch a ``species()``
-function from  Option #1 (parsing  quantum chemistry calculation output) to Option #2 (directly enter molecular properties).
+function from `Option #1: Automatically Parse Quantum Chemistry Calculation Output`_ to
+`Option #2: Directly Enter Molecular Properties`_.
+
+Option #3: Automatically Parse YAML files
+-----------------------------------------
+Arkane automatically saves a .yml file representing an ArkaneSpecies in an ``ArkaneSpecies`` folder under the run
+directory with the statistical mechanics properties of a species along with additional useful metadata. This process is
+triggered whenever a ``thermo`` calculation is ran for a species with a specified structure. To automatically generate
+such file in the first place, a species has to be defined using one of the other options above. The generated .yml file
+could conveniently be used when referring to this species in subsequent Arkane jobs. We intend to create an online
+repository of Arkane .yml files, from which users would be able to pick the desired species calculated at an appropriate
+level of theory (if available), and directly use them for kinetic or pressure-dependent calculations. Once such
+repository becomes available, a full description will be added to these pages.
 
 Transition States
 =================
@@ -583,7 +600,8 @@ using a ``transitionState()`` function, however it has less parameters (``struct
 ``collisionModel`` and ``energyTransferModel`` aren't specified for a transition state). Like the ``species()``
 function, the ``transitionState()`` function may also be specified in two ways:
 `Option #1: Automatically Parse Quantum Chemistry Calculation Output`_ and
-`Option #2: Directly Enter Molecular Properties`_
+`Option #2: Directly Enter Molecular Properties`_.  Note that currently a transitions state cannot be specified
+using a CanthermSpecies file (Option #3).
 
 The following is an example of a typical ``transitionState()`` function using Option #1::
 

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -43,3 +43,4 @@ dependencies:
   - pymongo
   - mpmath
   - dde
+  - pyyaml

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -42,3 +42,4 @@ dependencies:
   - pymongo
   - mpmath
   - dde
+  - pyyaml

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -41,3 +41,4 @@ dependencies:
   - pymongo
   - mpmath
   - dde
+  - pyyaml

--- a/examples/arkane/species/C2H4/input.py
+++ b/examples/arkane/species/C2H4/input.py
@@ -5,7 +5,7 @@ modelChemistry = "CBS-QB3"
 useHinderedRotors = True
 useBondCorrections = False
 
-species('C2H4', 'ethene.py')
+species('C2H4', 'ethene.py',
+        structure=SMILES('C=C'))
 
-statmech('C2H4')
 thermo('C2H4', 'NASA')

--- a/examples/arkane/species/C2H6/input.py
+++ b/examples/arkane/species/C2H6/input.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+"""
+This input file generates a  .yml file in the ArkaneSpecies folder
+(If a `thermo()` function exists and the species `structure` is specified,
+a respective .yml file is automatically generated)
+"""
+
 modelChemistry = "CBS-QB3"
 useHinderedRotors = True
 useBondCorrections = False
+author = 'I.B. Modeling'
 
-species('C2H6', 'C2H6.py')
+species('C2H6', 'C2H6.py',
+        structure=SMILES('CC'))
 
-statmech('C2H6')
 thermo('C2H6', 'NASA')

--- a/examples/arkane/species/C2H6_from_yaml/C2H6.yml
+++ b/examples/arkane/species/C2H6_from_yaml/C2H6.yml
@@ -1,0 +1,124 @@
+RMG_version: 2.3.0
+adjacency_list: '1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+  2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+  3 H u0 p0 c0 {1,S}
+  4 H u0 p0 c0 {1,S}
+  5 H u0 p0 c0 {1,S}
+  6 H u0 p0 c0 {2,S}
+  7 H u0 p0 c0 {2,S}
+  8 H u0 p0 c0 {2,S}
+  '
+author: I.B. Modeling
+chemkin_thermo_string: 'C2H6                    H   6C   2          G    10.000  3000.000  650.75      1
+  -3.07955238E-01 2.45265786E-02-1.24126639E-05 3.07709642E-09-3.01448276E-13    2
+  -1.06954638E+04 2.26275649E+01 4.03054858E+00-2.14149353E-03 4.90589370E-05    3
+  -5.98988799E-08 2.38924897E-11-1.12601125E+04 3.56080023E+00                   4
+  '
+class: ArkaneSpecies
+conformer:
+  E0: {class: ScalarQuantity, units: kJ/mol, value: -93.62123301113816}
+  class: Conformer
+  coordinates:
+    class: ArrayQuantity
+    units: angstroms
+    value:
+    - [0.000754, 0.001193, 0.000552]
+    - [0.00074, 0.001171, 1.094138]
+    - [1.043766, 0.001171, -0.32820199999999994]
+    - [-0.447603, 0.9428949999999999, -0.328253]
+    - [-0.760142, -1.203896, -0.557483]
+    - [-0.760128, -1.203874, -1.6510689999999997]
+    - [-0.311785, -2.145598, -0.228678]
+    - [-1.8031539999999997, -1.203874, -0.22872899999999996]
+  mass:
+    class: ArrayQuantity
+    units: amu
+    value: [12.000000000000002, 1.00782503224, 1.00782503224, 1.00782503224, 12.000000000000002,
+      1.00782503224, 1.00782503224, 1.00782503224]
+  modes:
+  - class: IdealGasTranslation
+    mass: {class: ScalarQuantity, units: amu, value: 30.04695}
+    quantum: false
+  - class: NonlinearRotor
+    inertia:
+      class: ArrayQuantity
+      units: amu*angstrom^2
+      value: [6.270708119932641, 25.383187266376552, 25.383302007628593]
+    quantum: false
+    rotationalConstant:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [2.6883134617226574, 0.6641257804404529, 0.6641227783635939]
+    symmetry: 6
+  - class: HarmonicOscillator
+    frequencies:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [818.9171843883556, 819.4796692316016, 987.0988175534343, 1206.808923244572,
+        1207.057986037514, 1395.998196494915, 1411.35092097768, 1489.7775448627638,
+        1489.974610347119, 1492.4948979987632, 1492.6606309470462, 2995.3597074739528,
+        2996.062357040249, 3040.8343099905774, 3040.999590821795, 3065.8572777214767,
+        3066.0229860229088]
+    quantum: true
+  - barrier: {class: ScalarQuantity, units: kJ/mol, value: 11.271733995399375}
+    class: HinderedRotor
+    frequency: 301.9762155284581
+    inertia: {class: ScalarQuantity, units: amu*angstrom^2, value: 1.5676771438327364}
+    quantum: false
+    rotationalConstant: {class: ScalarQuantity, units: cm^-1, value: 10.753253065955985}
+    semiclassical: true
+    symmetry: 3
+  number:
+    class: ArrayQuantity
+    value: [6.0, 1.0, 1.0, 1.0, 6.0, 1.0, 1.0, 1.0]
+  opticalIsomers: 1
+  spinMultiplicity: 1
+datetime: 2018-12-26 22:07
+energy_transfer_model:
+  T0: {class: ScalarQuantity, units: K, value: 300.0}
+  alpha0: {class: ScalarQuantity, units: kJ/mol, value: 3.5886}
+  class: SingleExponentialDown
+  n: 0.85
+frequency_scale_factor: 0.99
+inchi: InChI=1S/C2H6/c1-2/h1-2H3
+inchi_key: OTMSDBZUPAUEDD-UHFFFAOYSA-N
+label: C2H6
+molecular_weight: {class: ScalarQuantity, units: amu, value: 30.069042884392132}
+smiles: CC
+thermo:
+  Cp0: {class: ScalarQuantity, units: J/(mol*K), value: 33.257888}
+  CpInf: {class: ScalarQuantity, units: J/(mol*K), value: 178.76114800000002}
+  E0: {class: ScalarQuantity, units: kJ/mol, value: -93.61605653117894}
+  Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+  Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+  class: NASA
+  polynomials:
+    polynomial1:
+      Tmax: {class: ScalarQuantity, units: K, value: 650.7459550802785}
+      Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+      class: NASAPolynomial
+      coeffs: [4.030548584805702, -0.0021414935306286226, 4.905893700989926e-05, -5.989887991833683e-08,
+        2.389248966826902e-11, -11260.112483833142, 3.560800228639454]
+    polynomial2:
+      Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+      Tmin: {class: ScalarQuantity, units: K, value: 650.7459550802785}
+      class: NASAPolynomial
+      coeffs: [-0.30795523835705524, 0.024526578551662518, -1.2412663932854692e-05,
+        3.077096424536947e-09, -3.014482760995944e-13, -10695.46377988354, 22.62756488263164]
+thermo_data:
+  Cp (cal/mol*K): {1000 K: '28.98', 1500 K: '34.60', 2000 K: '37.53', 2400 K: '38.94',
+    300 K: '12.68', 400 K: '15.50', 500 K: '18.34', 600 K: '21.00', 800 K: '25.48'}
+  H298: -19.53 kcal/mol
+  S298: 54.81 cal/mol*K
+use_bond_corrections: false
+use_hindered_rotors: true
+xyz: '8
+  C2H6
+  C 7.54e-14 1.193e-13 5.52e-14
+  H 7.4e-14 1.171e-13 1.094138e-10
+  H 1.043766e-10 1.171e-13 -3.28202e-11
+  H -4.47603e-11 9.42895e-11 -3.28253e-11
+  C -7.60142e-11 -1.203896e-10 -5.57483e-11
+  H -7.60128e-11 -1.203874e-10 -1.651069e-10
+  H -3.11785e-11 -2.145598e-10 -2.28678e-11
+  H -1.803154e-10 -1.203874e-10 -2.28729e-11'

--- a/examples/arkane/species/C2H6_from_yaml/input.py
+++ b/examples/arkane/species/C2H6_from_yaml/input.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+This example loads all species data from the C2H6.yml file in this folder.
+The C2H4 and C2H6 examples demonstare how to generate such .yml files.
+"""
+
+modelChemistry = "CBS-QB3"
+useHinderedRotors = True
+useBondCorrections = False
+
+species('C2H6', 'C2H6.yml')
+
+thermo('C2H6', 'NASA')

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -70,7 +70,7 @@ cdef Vertex _getEdgeVertex1(Edge edge)
 
 cdef Vertex _getEdgeVertex2(Edge edge)
 
-cdef class Graph:
+cdef class Graph(object):
 
     cdef public list vertices
     

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -205,7 +205,7 @@ cdef  Vertex _getEdgeVertex1(Edge edge):
 cdef Vertex _getEdgeVertex2(Edge edge):
     return edge.vertex2
 
-cdef class Graph:
+cdef class Graph(object):
     """
     A graph data type. The vertices of the graph are stored in a list
     `vertices`; this provides a consistent traversal order. A single edge can

--- a/rmgpy/pdep/collision.pxd
+++ b/rmgpy/pdep/collision.pxd
@@ -27,12 +27,13 @@
 
 cimport numpy
 
+from rmgpy.rmgobject cimport RMGObject
 from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 
 
 ################################################################################
 
-cdef class SingleExponentialDown:
+cdef class SingleExponentialDown(RMGObject):
 
     cdef public ScalarQuantity _alpha0, _T0
     cdef public double n

--- a/rmgpy/pdep/collision.pyx
+++ b/rmgpy/pdep/collision.pyx
@@ -41,7 +41,7 @@ from rmgpy.exceptions import CollisionError
 
 ################################################################################
 
-cdef class SingleExponentialDown:
+cdef class SingleExponentialDown(RMGObject):
     """
     A representation of a single exponential down model of collisional energy
     transfer. The attributes are:
@@ -94,12 +94,13 @@ cdef class SingleExponentialDown:
         def __get__(self):
             return self._alpha0
         def __set__(self, value):
-            try:
-                self._alpha0 = quantity.Frequency(value)
-                self._alpha0.value_si *= constants.h * constants.c * 100. * constants.Na
-                self._alpha0.units = 'kJ/mol'
-            except quantity.QuantityError:
-                self._alpha0 = quantity.Energy(value)
+            if value is not None:
+                try:
+                    self._alpha0 = quantity.Frequency(value)
+                    self._alpha0.value_si *= constants.h * constants.c * 100. * constants.Na
+                    self._alpha0.units = 'kJ/mol'
+                except quantity.QuantityError:
+                    self._alpha0 = quantity.Energy(value)
 
     property T0:
         """The reference temperature."""

--- a/rmgpy/quantity.pxd
+++ b/rmgpy/quantity.pxd
@@ -46,7 +46,11 @@ cdef class ScalarQuantity(Units):
     cdef public double value_si
     cdef        str _uncertaintyType
     cdef public double uncertainty_si
-    
+
+    cpdef dict as_dict(self)
+
+    cpdef make_object(self, dict data, dict class_dict)
+
     cpdef str getUncertaintyType(self)
     cpdef     setUncertaintyType(self, str v)
     
@@ -63,6 +67,10 @@ cdef class ArrayQuantity(Units):
     cdef public numpy.ndarray value_si
     cdef public str _uncertaintyType
     cdef public numpy.ndarray uncertainty_si
+
+    cpdef dict as_dict(self)
+
+    cpdef make_object(self, dict data, dict class_dict)
 
     cpdef str getUncertaintyType(self)
     cpdef     setUncertaintyType(self, str v)

--- a/rmgpy/rmgobject.pxd
+++ b/rmgpy/rmgobject.pxd
@@ -1,0 +1,33 @@
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2018 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+
+cdef class RMGObject(object):
+
+    cpdef dict as_dict(self)
+
+    cpdef make_object(self, dict data, dict class_dict)

--- a/rmgpy/rmgobject.pyx
+++ b/rmgpy/rmgobject.pyx
@@ -1,0 +1,111 @@
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import logging
+import numpy as np
+
+################################################################################
+
+
+cdef class RMGObject(object):
+    """
+    This class provides a general `as_dict` method to help with yml file construction.
+    Used as a parent class for other classes in RMG to inherit from.
+    """
+    def __init__(self):
+        pass
+
+    cpdef dict as_dict(self):
+        """
+        A helper function for dumping objects as dictionaries for YAML files
+        """
+        cdef dict output_dict
+        cdef list all_attributes
+        cdef str attr
+
+        output_dict = dict()
+        output_dict['class'] = self.__class__.__name__
+        all_attributes = [attr for attr in dir(self) if not attr.startswith('_')]
+        for attr in all_attributes:
+            val = getattr(self, attr)
+            if val is not None and not callable(val) and val != '':
+                output_dict[attr] = val
+        for key, val in output_dict.iteritems():
+            if isinstance(val, list) and isinstance(val[0], RMGObject):
+                output_dict[key] = [v.as_dict() for v in val]
+            elif not isinstance(val, (int, float, str, dict)):
+                if isinstance(val, np.ndarray):
+                    output_dict[key] = val.tolist()
+                else:
+                    # this is an object, call as_dict() again
+                    output_dict[key] = val.as_dict()
+        return output_dict
+
+    cpdef make_object(self, dict data, dict class_dict):
+        """
+        A helper function for constructing objects from a dictionary (used when loading YAML files)
+        """
+        for key, val in data.iteritems():
+            if isinstance(val, dict) and 'class' in val:
+                # Call make_object to make another object within the parent object
+                class_name = val['class']
+                del val['class']
+                try:
+                    class_to_make = class_dict[class_name]
+                except KeyError:
+                    raise KeyError("Class {0} must be provided in the 'class_dict' parameter "
+                                   "to make the object.".format(class_name))
+                obj = class_to_make()
+                obj.make_object(val, class_dict)
+                logging.debug("made object {0}".format(class_name))
+                data[key] = obj
+            elif isinstance(val, list) and isinstance(val[0], dict) and 'class' in val[0]:
+                # Call make_object to make a list of objects within the parent object (as in Conformer.Modes)
+                data[key] = list()
+                for entry in val:
+                    class_name = entry['class']
+                    del entry['class']
+                    try:
+                        class_to_make = class_dict[class_name]
+                    except KeyError:
+                        raise KeyError("Class {0} must be provided in the 'class_dict' parameter "
+                                       "to make the object.".format(class_name))
+                    obj = class_to_make()
+                    if class_name in ['LinearRotor', 'NonlinearRotor', 'KRotor', 'SphericalTopRotor', 'HinderedRotor',
+                                      'FreeRotor'] and 'rotationalConstant' in entry and 'inertia' in entry:
+                            # Either `rotationalConstant` or `inertia` should be specified for a rotor.
+                            # Here both are specified, so we delete `inertia`.
+                            del entry['inertia']
+                    obj.make_object(entry, class_dict)
+                    logging.debug("made object {0}".format(class_name))
+                    data[key].append(obj)
+            elif isinstance(val, str):
+                try:
+                    float(val)
+                except ValueError:
+                    pass
+        self.__init__(**data)

--- a/rmgpy/statmech/conformer.pxd
+++ b/rmgpy/statmech/conformer.pxd
@@ -27,11 +27,12 @@
 
 cimport numpy
 
+from rmgpy.rmgobject cimport RMGObject
 from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 
 ################################################################################
 
-cdef class Conformer:
+cdef class Conformer(RMGObject):
 
     cdef public ScalarQuantity _E0
     cdef public list modes

--- a/rmgpy/statmech/conformer.pyx
+++ b/rmgpy/statmech/conformer.pyx
@@ -34,22 +34,21 @@ of freedom.
 """
 
 import numpy
+import logging
 import cython
 
 from libc.math cimport log, exp, sqrt
 
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
-
 from rmgpy.statmech.translation cimport *
 from rmgpy.statmech.rotation cimport *
 from rmgpy.statmech.vibration cimport *
 from rmgpy.statmech.torsion cimport *
-import logging
 from rmgpy.exceptions import StatmechError
 ################################################################################
 
-cdef class Conformer:
+cdef class Conformer(RMGObject):
     """
     A representation of an individual molecular conformation. The attributes 
     are:

--- a/rmgpy/statmech/mode.pxd
+++ b/rmgpy/statmech/mode.pxd
@@ -27,7 +27,9 @@
 
 cimport numpy
 
-cdef class Mode:
+from rmgpy.rmgobject cimport RMGObject
+
+cdef class Mode(RMGObject):
 
     cdef public bint quantum
 

--- a/rmgpy/statmech/mode.pyx
+++ b/rmgpy/statmech/mode.pyx
@@ -34,7 +34,7 @@ degrees of freedom.
 
 ################################################################################
 
-cdef class Mode:
+cdef class Mode(RMGObject):
     """
     A base class for representing molecular degrees of freedom. The attributes
     are:

--- a/rmgpy/statmech/rotation.pyx
+++ b/rmgpy/statmech/rotation.pyx
@@ -125,6 +125,7 @@ cdef class LinearRotor(Rotation):
             self.rotationalConstant = rotationalConstant
         else:
             self.inertia = inertia
+        self.quantum = quantum
 
     def __repr__(self):
         """
@@ -296,6 +297,7 @@ cdef class NonlinearRotor(Rotation):
             self.rotationalConstant = rotationalConstant
         else:
             self.inertia = inertia
+        self.quantum = quantum
 
     def __repr__(self):
         """
@@ -473,6 +475,7 @@ cdef class KRotor(Rotation):
             self.rotationalConstant = rotationalConstant
         else:
             self.inertia = inertia
+        self.quantum = quantum
 
     def __repr__(self):
         """
@@ -645,6 +648,7 @@ cdef class SphericalTopRotor(Rotation):
             self.rotationalConstant = rotationalConstant
         else:
             self.inertia = inertia
+        self.quantum = quantum
 
     def __repr__(self):
         """

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -112,7 +112,8 @@ cdef class HinderedRotor(Torsion):
     independently.
     """
     
-    def __init__(self, inertia=None, symmetry=1, barrier=None, fourier=None, rotationalConstant=None, quantum=False, semiclassical=True):
+    def __init__(self, inertia=None, symmetry=1, barrier=None, fourier=None, rotationalConstant=None, quantum=False,
+                 semiclassical=True, frequency=None):
         Torsion.__init__(self, symmetry, quantum)
         if inertia is not None and rotationalConstant is not None:
             raise ValueError('Only one of moment of inertia and rotational constant can be specified.')
@@ -123,6 +124,8 @@ cdef class HinderedRotor(Torsion):
         self.barrier = barrier
         self.fourier = fourier
         self.semiclassical = False if quantum else semiclassical
+        self.quantum = quantum
+        self.frequency = frequency if frequency is not None else 0.0
         
     def __repr__(self):
         """

--- a/rmgpy/statmech/vibration.pyx
+++ b/rmgpy/statmech/vibration.pyx
@@ -87,6 +87,7 @@ cdef class HarmonicOscillator(Vibration):
     def __init__(self, frequencies=None, quantum=True):
         Vibration.__init__(self, quantum)
         self.frequencies = quantity.Frequency(frequencies)
+        self.quantum = quantum
 
     def __repr__(self):
         """

--- a/rmgpy/thermo/nasa.pxd
+++ b/rmgpy/thermo/nasa.pxd
@@ -59,6 +59,10 @@ cdef class NASA(HeatCapacityModel):
     
     cpdef NASAPolynomial selectPolynomial(self, double T)
 
+    cpdef dict as_dict(self)
+
+    cpdef make_object(self, dict data, dict class_dict)
+
     cpdef double getHeatCapacity(self, double T) except -1000000000
 
     cpdef double getEnthalpy(self, double T) except 1000000000

--- a/rmgpy/thermo/wilhoit.pxd
+++ b/rmgpy/thermo/wilhoit.pxd
@@ -38,6 +38,10 @@ cdef class Wilhoit(HeatCapacityModel):
     
     cdef public ScalarQuantity _B, _H0, _S0
     cdef public double a0, a1, a2, a3
+
+    cpdef dict as_dict(self)
+
+    cpdef make_object(self, dict data, dict class_dict)
     
     cpdef double getHeatCapacity(self, double T) except -1000000000
 

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -57,7 +57,6 @@ cdef class Wilhoit(HeatCapacityModel):
     `Tmax`          The maximum temperature in K at which the model is valid, or zero if unknown or undefined
     `comment`       Information about the model (e.g. its source)
     =============== ============================================================
-    
     """
 
     def __init__(self, Cp0=None, CpInf=None, a0=0.0, a1=0.0, a2=0.0, a3=0.0, H0=None, S0=None, B=None, Tmin=None, Tmax=None, label='', comment=''):
@@ -89,6 +88,57 @@ cdef class Wilhoit(HeatCapacityModel):
         A helper function used when pickling a Wilhoit object.
         """
         return (Wilhoit, (self.Cp0, self.CpInf, self.a0, self.a1, self.a2, self.a3, self.H0, self.S0, self.B, self.Tmin, self.Tmax, self.label, self.comment))
+
+    cpdef dict as_dict(self):
+        """
+        A helper function for YAML parsing
+        """
+        output_dict = dict()
+        output_dict['class'] = self.__class__.__name__
+        if self.Tmin is not None:
+            output_dict['Tmin'] = self.Tmin.as_dict()
+        if self.Tmax is not None:
+            output_dict['Tmax'] = self.Tmax.as_dict()
+        if self.E0 is not None:
+            output_dict['E0'] = self.E0.as_dict()
+        if self.Cp0 is not None:
+            output_dict['Cp0'] = self.Cp0.as_dict()
+        if self.CpInf is not None:
+            output_dict['CpInf'] = self.CpInf.as_dict()
+        if self.label != '':
+            output_dict['label'] = self.label
+        if self.comment != '':
+            output_dict['comment'] = self.comment
+        output_dict['B'] = self.B.as_dict()
+        output_dict['E0'] = self.E0.as_dict()
+        output_dict['H0'] = self.H0.as_dict()
+        output_dict['S0'] = self.S0.as_dict()
+        output_dict['a0'] = self.a0
+        output_dict['a1'] = self.a1
+        output_dict['a2'] = self.a2
+        output_dict['a3'] = self.a3
+        return output_dict
+
+    cpdef make_object(self, dict data, dict class_dict):
+        """
+        A helper function for YAML parsing
+        """
+        try:
+            data['Tmin'] = quantity.ScalarQuantity().make_object(data['Tmin'], class_dict)
+            data['Tmax'] = quantity.ScalarQuantity().make_object(data['Tmax'], class_dict)
+        except KeyError:
+            pass
+        data['B'] = quantity.ScalarQuantity().make_object(data['B'], class_dict)
+        data['Cp0'] = quantity.ScalarQuantity().make_object(data['Cp0'], class_dict)
+        data['CpInf'] = quantity.ScalarQuantity().make_object(data['CpInf'], class_dict)
+        data['H0'] = quantity.ScalarQuantity().make_object(data['H0'], class_dict)
+        data['S0'] = quantity.ScalarQuantity().make_object(data['S0'], class_dict)
+        data['a0'] = float(data['a0'])
+        data['a1'] = float(data['a1'])
+        data['a2'] = float(data['a2'])
+        data['a3'] = float(data['a3'])
+        del data['E0']
+        self.__init__(**data)
 
     property B:
         """The Wilhoit scaled temperature coefficient."""

--- a/rmgpy/transport.py
+++ b/rmgpy/transport.py
@@ -32,12 +32,15 @@
 This module contains the TransportData class for storing transport properties.
 """
 
+import numpy
+
+from rmgpy.rmgobject import RMGObject
 from rmgpy import quantity
 from rmgpy.quantity import DipoleMoment, Energy, Length, Volume
 import rmgpy.constants as constants
-import numpy
 
-class TransportData:
+
+class TransportData(RMGObject):
     """
     A set of transport properties.
     
@@ -55,7 +58,8 @@ class TransportData:
     
     """
 
-    def __init__(self, shapeIndex=None, epsilon=None, sigma=None, dipoleMoment=None, polarizability=None, rotrelaxcollnum=None, comment = ''):
+    def __init__(self, shapeIndex=None, epsilon=None, sigma=None, dipoleMoment=None, polarizability=None,
+                 rotrelaxcollnum=None, comment = ''):
         self.shapeIndex = shapeIndex
         try:
             self.epsilon = Energy(epsilon)
@@ -69,7 +73,6 @@ class TransportData:
         self.rotrelaxcollnum = rotrelaxcollnum
         self.comment = comment
 
-    
     def __repr__(self):
         """
         Return a string representation that can be used to reconstruct the
@@ -129,8 +132,7 @@ class TransportData:
         import cantera as ct
         
         ctTransport = ct.GasTransportData()
-        
-        
+
         if self.shapeIndex == 0:
             geometry = 'atom'
         elif self.shapeIndex == 1:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ Cython.Compiler.Options.annotate = True
 
 def getMainExtensionModules():
     return [
+        # RMG
+        Extension('rmgpy.rmgobject', ['rmgpy/rmgobject.pyx']),
         # Kinetics
         Extension('rmgpy.kinetics.arrhenius', ['rmgpy/kinetics/arrhenius.pyx']),
         Extension('rmgpy.kinetics.chebyshev', ['rmgpy/kinetics/chebyshev.pyx']),
@@ -124,6 +126,8 @@ def getSolverExtensionModules():
 
 def getArkaneExtensionModules():
     return [
+        # RMG
+        Extension('rmgpy.rmgobject', ['rmgpy/rmgobject.pyx']),
         # Kinetics
         Extension('rmgpy.kinetics.arrhenius', ['rmgpy/kinetics/arrhenius.pyx']),
         Extension('rmgpy.kinetics.chebyshev', ['rmgpy/kinetics/chebyshev.pyx']),


### PR DESCRIPTION
We'd like to be able to conveniently use previously calculated statmech data in Arkane (prev. Cantherm). The purpose is to have an online repository of such files, from which users can pick the desired species at the appropriate level of theory (if available). This PR sets the ground by allowing Arkane to save and parse such files.