### PR TITLE
Fix critical filterReactions bug

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -626,7 +626,6 @@ class RMG(util.Subject):
                     rtol=self.simulatorSettingsList[0].rtol,
                     filterReactions=True,
                     conditions = self.rmg_memories[index].get_cond(),
-                    trimolecular = self.trimolecular,
                 )
 
                 self.updateReactionThresholdAndReactFlags(


### PR DESCRIPTION
During the final restructuring of #1338, a `trimolecular` attribute was introduced for the `ReactionSystem` class and the `trimolecular` argument was removed from the `initializeModel` method of that class. The `execute` method in `main.py` was still using the `trimolecular` argument even though it had been removed. This PR fixes the error in #1403.