### PR TITLE
Handle invalid vector errors gracefully in clar optimization

### DIFF
--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -1007,11 +1007,14 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
         for constraint in constraints:
             try:
                 lpsolve('add_constraint', lp, constraint[0], '<=', constraint[1])
-            except:
-                logging.error('Unable to add constraint: {0} <= {1}'.format(constraint[0], constraint[1]))
-                logging.error('Cannot complete Clar optimization for {0}.'.format(str(mol)))
-                logging.error(mol.toAdjacencyList())
-                raise
+            except Exception as e:
+                logging.debug('Unable to add constraint: {0} <= {1}'.format(constraint[0], constraint[1]))
+                logging.debug(mol.toAdjacencyList())
+                if str(e) == 'invalid vector.':
+                    raise ILPSolutionError('Unable to add constraint, likely due to '
+                                           'inconsistent aromatic ring perception.')
+                else:
+                    raise e
 
     status = lpsolve('solve', lp)
     objVal, solution = lpsolve('get_solution', lp)[0:2]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
For certain polycyclics, getAromaticRings can give inconsistent results from call to call, as a result of some non-deterministic behavior in RDKit. If the number of aromatic rings changes, then the size of the matrix will change and previously generated constraint vectors will be the wrong size. Since this does not occur very often and occurs mostly with odd polycyclics, it seems more efficient to catch this error and continue instead of ending the RMG run.

After this is merged, I will remove the polycyclic global forbidden structures from RMG-database.

### Description of Changes
Instead of raising the error, raise an ILPSolutionError which will be caught by `generate_clar_structures`, allowing the job to continue.

### Testing
Example molecules which would break previously: `[c]1cc2CC=C3c1cc23`, `Cc1c[c]c2C3=C=Cc2c13`. Running `generate_resonance_structures` repeatedly will eventually generate the error. The behavior is non-deterministic, which is also why I haven't added a unit test.