### PR TITLE
Fix networkIndices for "edge networks"

### DIFF
--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -480,7 +480,13 @@ cdef class ReactionSystem(DASx):
         for j, network in enumerate(pdepNetworks):
             self.networkLeakCoefficients[j] = network.getLeakCoefficient(self.T.value_si, self.P.value_si)
             for l, spec in enumerate(network.source):
-                i = self.get_species_index(spec)
+                try:
+                    i = self.get_species_index(spec)
+                except KeyError:
+                    # spec is probably in the edge, hence is not a key in the speciesIndex dictionary.
+                    # Sicne networkIndices is only used to identify the number of reactants, set the
+                    # corresponding value to be different than `-1`.
+                    i = -2
                 self.networkIndices[j,l] = i
    
     @cython.boundscheck(False)                               


### PR DESCRIPTION
### Motivation or Problem
When a high-p limit rate from a library reaction is converted into a pressure dependent rate upon library loading, a network is created with its source species in the edge. Since the `speciesIndex` dictionary only contains core species, a KeyError is raised.

### Description of Changes
This fix captures such cases and assigns an index value of `0` to the respective matrix entry. The only usage of `networkIndices` (the matrix in which relevant `speciesIndex` are saved) is in [residual()](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/solver/simple.pyx#L489) under simple.pyx and liquid.pyx, where these values are compared to `-1` to derive the number of reactants.

### Testing
Run the input file of the [long Nitrogen test](https://github.com/ReactionMechanismGenerator/RMG-tests/blob/new_tests/tests/rmg_long/Nitrogen/input.py) on both master and this branch (fails on master after about 2 mins)