### PR TITLE
Added a generate_N5dc_radical_resonance_structures resonance transition

### DIFF
--- a/rmgpy/molecule/pathfinder.pxd
+++ b/rmgpy/molecule/pathfinder.pxd
@@ -54,6 +54,8 @@ cpdef list find_lone_pair_radical_multiple_bond_delocalization_paths(Atom atom1)
 
 cpdef list find_N5ddc_N5tc_delocalization_paths(Atom atom1)
 
+cpdef list find_N5dc_radical_delocalization_paths(Atom atom1)
+
 cpdef list find_N5dc_delocalization_paths(Atom atom1)
 
 cpdef bint is_NOS_able_to_gain_lone_pair(Atom atom)

--- a/rmgpy/molecule/pathfinderTest.py
+++ b/rmgpy/molecule/pathfinderTest.py
@@ -493,12 +493,23 @@ class FindN5ddcN5tcDelocalizationPaths(unittest.TestCase):
         self.assertTrue(paths)
 
 
-class FindN5dDelocalizationPaths(unittest.TestCase):
+class FindN5dcRadicalDelocalizationPaths(unittest.TestCase):
     """
-    test the find_N5dc_delocalization_paths method
+    test the find_N5dc_radical_delocalization_paths method
     """
     def test_HNNOO(self):
         smiles = "N=[N+]([O])([O-])"
+        mol = Molecule().fromSMILES(smiles)
+        paths = find_N5dc_radical_delocalization_paths(mol.atoms[1])
+        self.assertTrue(paths)
+
+
+class FindN5dcDelocalizationPaths(unittest.TestCase):
+    """
+    test the find_N5dc_delocalization_paths method
+    """
+    def test_H2NNOO(self):
+        smiles = "N[N+]([O-])=O"
         mol = Molecule().fromSMILES(smiles)
         paths = find_N5dc_delocalization_paths(mol.atoms[1])
         self.assertTrue(paths)

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -46,6 +46,8 @@ cpdef list generate_lone_pair_radical_multiple_bond_resonance_structures(Molecul
 
 cpdef list generate_N5ddc_N5tc_resonance_structures(Molecule mol)
 
+cpdef list generate_N5dc_radical_resonance_structures(Molecule mol)
+
 cpdef list generate_N5dc_resonance_structures(Molecule mol)
 
 cpdef list generate_isomorphic_resonance_structures(Molecule mol, bint saturate_h=?)

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -184,8 +184,8 @@ class ResonanceTest(unittest.TestCase):
         self.assertEqual(mol_list[0].vertices[0].lonePairs + mol_list[0].vertices[1].lonePairs, 3)
         self.assertEqual(mol_list[1].vertices[0].lonePairs + mol_list[1].vertices[1].lonePairs, 4)
 
-    def testN5dc(self):
-        """Test the N5dc resonance transformation
+    def testN5dcRadical(self):
+        """Test the N5dc radical resonance transformation
 
         We should see N=[N+]([O])([O-]) <=> [NH-][N+]([O])=O
         Two isomorphic structures should be included in molList: N=[N+]([O])([O-]) <=> N=[N+]([O-])([O])"""
@@ -202,6 +202,19 @@ class ResonanceTest(unittest.TestCase):
                     negatively_charged_nitrogen += 1
         self.assertEquals(isomorphic_counter, 2)
         self.assertEquals(negatively_charged_nitrogen, 2)
+
+    def testN5dc(self):
+        """Test the N5dc resonance transformation
+
+        We should see N[N+]([O-])=O <=> N[N+](=O)[O-], which are isomorphic"""
+        mol = Molecule(SMILES="N[N+]([O-])=O")
+        mol_list = generate_resonance_structures(mol, keep_isomorphic=True)
+        self.assertEqual(len(mol_list), 2)
+        isomorphic_counter = 0
+        for mol1 in mol_list:
+            if mol1.isIsomorphic(mol):
+                isomorphic_counter += 1
+        self.assertEquals(isomorphic_counter, 2)
 
     def testStyryl1(self):
         """Test resonance structure generation for styryl, with radical on branch


### PR DESCRIPTION
### Motivation or Problem
We're currently not describing the resonance path of
[![image](https://user-images.githubusercontent.com/16158262/41948595-7a71cdfc-798b-11e8-8b9a-517a41c4393e.png) <-> ![image](https://user-images.githubusercontent.com/16158262/41948855-c240aec2-798c-11e8-9590-21b52383fb4e.png)]


This resembles to the transition mentioned in #1293, mainly since this is also probably only important for correct degeneracy determination.

### Description of Changes
Added resonance transition, pathfinder modifications, and tests

### Testing
Compare resonance structures for `N[N+]([O-])=O` on master and this branch

(Edit: One of the drawings in the resonance transition above was wrong, now fixed)