### PR TITLE
Add deprecation warnings before v2.2

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -35,6 +35,7 @@ import shutil
 import math
 import re
 import logging
+import warnings
 import textwrap
 import os.path
 import numpy
@@ -1198,6 +1199,9 @@ def readReactionsBlock(f, speciesDict, readComments = True):
 
         elif len(tokens) > 0 and tokens[0].lower() == 'unit:':
             # RMG-Java kinetics library file
+            warnings.warn("The RMG-Java kinetic library files are"
+                          " no longer supported and may be"
+                          " removed in version 2.3.", DeprecationWarning)
             found = True
             while 'reactions:' not in line.lower():
                 line = f.readline()
@@ -1296,6 +1300,8 @@ def readReactionsBlock(f, speciesDict, readComments = True):
         commentsList.pop(-1)
     elif kineticsList[0] == '' and commentsList[0] == '':
         # True for Chemkin files generated from RMG-Java
+        warnings.warn("RMG-Java loading is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         kineticsList.pop(0)
         commentsList.pop(0)
     else:
@@ -1333,6 +1339,8 @@ def saveHTMLFile(path, readComments = True):
     """
     Save an output HTML file from the contents of a RMG-Java output folder
     """
+    warnings.warn("RMG-Java loading is no longer supported and may be"
+                  " removed in version 2.3.", DeprecationWarning)
     from rmgpy.rmg.model import CoreEdgeReactionModel
     from rmgpy.rmg.output import saveOutputHTML
     chemkinPath= os.path.join(path, 'chemkin', 'chem.inp')
@@ -1504,6 +1512,8 @@ def writeReactionString(reaction, javaLibrary = False):
                                     " reaction {0}".format(reaction.label)
 
     if javaLibrary:
+        warnings.warn("Writing RMG-Java format is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         thirdBody = ''
         if kinetics.isPressureDependent():
             if (isinstance(kinetics, _kinetics.ThirdBody) and
@@ -1670,6 +1680,8 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
         string += '{0:<9.3e} {1:<9.3f} {2:<9.3f}'.format(1, 0, 0)
         
     if javaLibrary:
+        warnings.warn("RMG-Java libraries are no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # Assume uncertainties are zero (when parsing from chemkin), may need to adapt later
         string += '{0:<9.1f} {1:<9.1f} {2:<9.1f}'.format(0, 0, 0)
 
@@ -1939,6 +1951,8 @@ def saveJavaKineticsLibrary(path, species, reactions):
     and reactions.txt given a list of reactions, with species.txt containing the
     RMG-Java formatted dictionary.
     """
+    warnings.warn("Java kinetics libararies are no longer supported and may be"\
+            "removed in version 2.3.", DeprecationWarning)
     # Check for duplicate
     markDuplicateReactions(reactions)
     

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -150,57 +150,6 @@ def saveEntry(f, entry):
     f.write(')\n\n')
 
 
-def filter_reactions(reactants, products, reactionList):
-    """
-    Remove any reactions from the given `reactionList` whose reactants do
-    not involve all the given `reactants` or whose products do not involve 
-    all the given `products`. This method checks both forward and reverse
-    directions, and only filters out reactions that don't match either.
-    
-    reactants and products can be either molecule or species objects
-    """
-    warnings.warn("The filter_reactions method is no longer used and may be removed in a future version.", DeprecationWarning)
-    
-    # Convert from molecules to species and generate resonance isomers.
-    ensure_species(reactants, resonance=True)
-    ensure_species(products, resonance=True)
-
-    reactions = reactionList[:]
-    
-    for reaction in reactionList:
-        # Forward direction
-        reactants0 = [r for r in reaction.reactants]
-        for reactant in reactants:
-            for reactant0 in reactants0:
-                if reactant.isIsomorphic(reactant0):
-                    reactants0.remove(reactant0)
-                    break
-        products0 = [p for p in reaction.products]
-        for product in products:
-            for product0 in products0:
-                if product.isIsomorphic(product0):
-                    products0.remove(product0)
-                    break
-        forward = not (len(reactants0) != 0 or len(products0) != 0)
-        # Reverse direction
-        reactants0 = [r for r in reaction.products]
-        for reactant in reactants:
-            for reactant0 in reactants0:
-                if reactant.isIsomorphic(reactant0):
-                    reactants0.remove(reactant0)
-                    break
-        products0 = [p for p in reaction.reactants]
-        for product in products:
-            for product0 in products0:
-                if product.isIsomorphic(product0):
-                    products0.remove(product0)
-                    break
-        reverse = not (len(reactants0) != 0 or len(products0) != 0)
-        if not forward and not reverse:
-            reactions.remove(reaction)
-    return reactions
-
-
 def ensure_species(input_list, resonance=False, keep_isomorphic=False):
     """
     The input list of :class:`Species` or :class:`Molecule` objects is modified

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2250,6 +2250,8 @@ class KineticsFamily(Database):
         
         Returns just the kinetics, or None.
         """
+        warnings.warn("Group additivity is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # Start with the generic kinetics of the top-level nodes
         kinetics = None
         root = self.getRootTemplate()

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -35,6 +35,7 @@ This module contains functionality for working with kinetics families.
 import os.path
 import numpy as np
 import logging
+import warnings
 import codecs
 from copy import deepcopy
 from collections import OrderedDict
@@ -438,6 +439,8 @@ class KineticsFamily(Database):
         Load an old-style RMG kinetics group additivity database from the
         location `path`.
         """
+        warnings.warn("The old kinetics databases are no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         self.label = os.path.basename(path)
         self.name = self.label
 
@@ -504,7 +507,8 @@ class KineticsFamily(Database):
         """
         Load an old-style RMG reaction family template from the location `path`.
         """
-
+        warnings.warn("The old kinetics databases are no longer supported and"
+                      " may be removed in version 2.3.", DeprecationWarning)
         self.forwardTemplate = Reaction(reactants=[], products=[])
         self.forwardRecipe = ReactionRecipe()
         self.ownReverse = False
@@ -546,6 +550,8 @@ class KineticsFamily(Database):
         """
         Save the old RMG kinetics groups to the given `path` on disk.
         """
+        warnings.warn("The old kinetics databases are no longer supported and"
+                      " may be removed in version 2.3.", DeprecationWarning)
         if not os.path.exists(path): os.mkdir(path)
         
         self.groups.saveOldDictionary(os.path.join(path, 'dictionary.txt'))
@@ -563,6 +569,8 @@ class KineticsFamily(Database):
         """
         Save an old-style RMG reaction family template from the location `path`.
         """
+        warnings.warn("The old kinetics databases are no longer supported and"
+                      " may be removed in version 2.3.", DeprecationWarning)
         ftemp = open(path, 'w')
         
         # Write the template

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -34,6 +34,7 @@ groups, including support for using group additivity to estimate rate
 coefficients.
 """
 import logging
+import warnings
 import math
 import numpy
 from copy import deepcopy
@@ -185,7 +186,8 @@ class KineticsGroups(Database):
         
         Returns just the kinetics.
         """
-
+        warnings.warn("Group additivity is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # Start with the generic kinetics of the top-level nodes
         # Make a copy so we don't modify the original
         kinetics = deepcopy(referenceKinetics)
@@ -310,7 +312,8 @@ class KineticsGroups(Database):
         changed significantly since the last time they were fitted, or ``False``
         otherwise.
         """
-        
+        warnings.warn("Group additivity is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # keep track of previous values so we can detect if they change
         old_entries = dict()
         for label,entry in self.entries.items():

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -37,7 +37,7 @@ import numpy
 from rmgpy import settings
 from rmgpy.chemkin import loadChemkinFile
 from rmgpy.data.base import Entry, DatabaseError, ForbiddenStructures
-from rmgpy.data.kinetics.common import saveEntry, filter_reactions, find_degenerate_reactions, ensure_independent_atom_ids
+from rmgpy.data.kinetics.common import saveEntry, find_degenerate_reactions, ensure_independent_atom_ids
 from rmgpy.data.kinetics.database import KineticsDatabase
 from rmgpy.data.kinetics.family import TemplateReaction
 from rmgpy.data.rmg import RMGDatabase
@@ -694,45 +694,6 @@ class TestKinetics(unittest.TestCase):
             os.path.join(settings['test_data.directory'], 'parsing_data', 'chem_annotated.inp'),
             os.path.join(settings['test_data.directory'], 'parsing_data', 'species_dictionary.txt')
         )
-        
-    def test_filter_reactions(self):
-        """
-        tests that filter reactions removes reactions that are missing
-        any reactants or products
-        """
-        
-        reactions=self.reactions
-        
-        reactants = []
-        products = []
-        for x in reactions:
-            reactants += x.reactants
-            products += x.products
-        
-        lrset = set(reactants[6:])
-        mlrset = {reactants[i].molecule[0] for i in range(6,len(reactants))}
-        
-        reactants = set(reactants)
-        products = set(products)
-        mreactants = {i.molecule[0] for i in reactants}
-        mproducts = {i.molecule[0] for i in products}
-
-        newmreactants = list(mreactants-mlrset)
-        newmproducts = list(mproducts-mlrset)
-
-        out = filter_reactions(newmreactants, newmproducts, reactions)
-            
-        rset = list(set(reactions) - set(out))
-
-        msets = [set(i.reactants+i.products) for i in rset]
-        
-        for i, iset in enumerate(msets): #test that all the reactions we removed are missing a reactant or a product
-            self.assertTrue(iset & lrset != set(),msg='reaction {0} removed improperly'.format(rset[i]))
-        
-        outsets = [set(i.reactants+i.products) for i in out]
-            
-        for i, iset in enumerate(outsets): #test that all the reactions left in aren't missing any reactants or products
-            self.assertTrue(iset & lrset == set(),msg='reaction {0} left in improperly, should have removed in based on presence of {1}'.format(out[i],iset & lrset))
 
     def test_react_molecules(self):
         """

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -33,7 +33,7 @@ This module contains functionality for working with kinetics "rate rules",
 which provide rate coefficient parameters for various combinations of 
 functional groups.
 """
-
+import warnings
 import os.path
 import re
 import codecs
@@ -109,7 +109,8 @@ class KineticsRules(Database):
         Process a list of parameters `data` as read from an old-style RMG
         thermo database, returning the corresponding kinetics object.
         """
-        
+        warnings.warn("The old kinetics databases are no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # The names of all of the RMG reaction families that are bimolecular
         BIMOLECULAR_KINETICS_FAMILIES = [
             'H_Abstraction',
@@ -214,6 +215,8 @@ class KineticsRules(Database):
         """
         Load a set of old rate rules for kinetics groups into this depository.
         """
+        warnings.warn("The old kinetics databases are no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # Parse the old library
         entries = self.parseOldLibrary(os.path.join(path, 'rateLibrary.txt'), numParameters=10, numLabels=numLabels)
         
@@ -249,6 +252,8 @@ class KineticsRules(Database):
         kinetics groups. This function assumes that the groups have already
         been loaded.
         """
+        warnings.warn("The old kinetics databases are no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         index = 'General' #mops up comments before the first rate ID
         
         re_underline = re.compile('^\-+')
@@ -303,7 +308,8 @@ class KineticsRules(Database):
         """
         Save a set of old rate rules for kinetics groups from this depository.
         """
-        
+        warnings.warn("The old kinetics databases are no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # This is hardcoding of reaction families!
         label = os.path.split(self.label)[-2]
         reactionOrder = groups.groups.numReactants

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -33,6 +33,7 @@ This module contains functionality for reading from and writing to the
 adjacency list format used by Reaction Mechanism Generator (RMG).
 """
 import logging
+import warnings
 import re
 from .molecule import Atom, Bond, getAtomType
 from .group import GroupAtom, GroupBond
@@ -929,6 +930,8 @@ def toOldAdjacencyList(atoms, multiplicity=None, label=None, group=False, remove
     Convert a chemical graph defined by a list of `atoms` into a string old-style 
     adjacency list that can be used in RMG-Java.  Currently not working for groups.
     """
+    warnings.warn("The old adjacency lists are no longer supported and may be"
+                  " removed in version 2.3.", DeprecationWarning)
     adjlist = ''
     
     if group:

--- a/rmgpy/molecule/inchi.py
+++ b/rmgpy/molecule/inchi.py
@@ -390,8 +390,8 @@ def _generate_minimum_resonance_isomer(mol):
         metric_cand=list,
     )
 
-    warnings.warn("The _generate_minimum_resonance_isomer method is no longer used and may be removed in a future"
-                  " version.", DeprecationWarning)
+    warnings.warn("The _generate_minimum_resonance_isomer method is no longer used"
+                    " and may be removed in RMG version 2.3.", DeprecationWarning)
 
     candidates = resonance.generate_isomorphic_resonance_structures(mol, saturate_h=True)
 

--- a/rmgpy/restart.py
+++ b/rmgpy/restart.py
@@ -33,7 +33,7 @@ import os.path
 import logging
 import cPickle
 import time
-
+import warnings
 def save(rmg):
     # Save the restart file if desired
     if rmg.saveRestartPeriod or rmg.done:
@@ -51,7 +51,8 @@ def saveRestartFile(path, rmg, delay=0):
     the restart file is not at least that old, the save is aborted. (Use the
     default value of 0 to force the restart file to be saved.)
     """
-    
+    warnings.warn("The saveRestartFile is no longer supported and may be"
+                  " removed in version 2.3.", DeprecationWarning)
     # Saving of a restart file is very slow (likely due to all the Quantity objects)
     # Therefore, to save it less frequently, don't bother if the restart file is less than an hour old
     if os.path.exists(path) and time.time() - os.path.getmtime(path) < delay:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -29,6 +29,7 @@
 ###############################################################################
 
 import logging
+import warnings
 import quantities
 import os
 import numpy
@@ -764,6 +765,8 @@ def saveInputFile(path, rmg):
     f.write('options(\n')
     f.write('    units = "{0}",\n'.format(rmg.units))
     if rmg.saveRestartPeriod:
+        warnings.warn("The option saveRestartPeriod is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         f.write('    saveRestartPeriod = ({0},"{1}"),\n'.format(rmg.saveRestartPeriod.getValue(), rmg.saveRestartPeriod.units))
     else:
         f.write('    saveRestartPeriod = None,\n')

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -36,6 +36,7 @@ Generator (RMG).
 import os.path
 import sys
 import logging
+import warnings
 import time
 import shutil
 import numpy
@@ -1447,7 +1448,8 @@ class RMG(util.Subject):
         Load an RMG-Java job from the input file located at `inputFile`, or
         from the `inputFile` attribute if not given as a parameter.
         """
-        
+        warnings.warn("The RMG-Java input is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         # NOTE: This function is currently incomplete!
         # It only loads a subset of the available information.
     
@@ -1599,6 +1601,8 @@ class RMG(util.Subject):
         Read a meaningful line from an RMG-Java condition file object `f`,
         returning the line with any comments removed.
         """
+        warnings.warn("The RMG-Java input is no longer supported and may be"
+                      " removed in version 2.3.", DeprecationWarning)
         line = f.readline()
         if line != '':
             line = line.strip()

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -569,6 +569,8 @@ class RMG(util.Subject):
             self.attach(OutputHTMLWriter(self.outputDirectory))
 
         if self.saveRestartPeriod:
+            warnings.warn("The option saveRestartPeriod is no longer supported and may be"
+                          " removed in version 2.3.", DeprecationWarning)
             self.attach(RestartWriter()) 
 
         if self.quantumMechanics:

--- a/rmgpy/tools/fluxdiagram.py
+++ b/rmgpy/tools/fluxdiagram.py
@@ -39,7 +39,7 @@ import re
 import math
 import numpy
 import pydot
-
+import warnings
 from rmgpy.solver.base import TerminationTime, TerminationConversion
 from rmgpy.solver.liquid import LiquidReactor
 from rmgpy.kinetics.diffusionLimited import diffusionLimiter
@@ -532,6 +532,9 @@ def createFluxDiagram(inputFile, chemkinFile, speciesDict, savePath=None, specie
     a speciesDict txt file, plus an optional chemkinOutput file.
     """
 
+    if java==True:
+        warnings.warn("RMG-Java loading is no longer supported and may be"\
+            "removed in version 2.3.", DeprecationWarning)
     if speciesPath is None:
         speciesPath = os.path.join(os.path.dirname(inputFile), 'species')
         generateImages = True

--- a/rmgpy/tools/loader.py
+++ b/rmgpy/tools/loader.py
@@ -34,7 +34,7 @@ This module contains functions for load existing RMG simulations
 by reading in files.
 """
 import os.path
-
+import warnings
 from rmgpy.chemkin import loadChemkinFile
 from rmgpy.solver.liquid import LiquidReactor
 from rmgpy.solver.base import TerminationConversion
@@ -44,6 +44,8 @@ def loadRMGJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=Tru
 
     if useJava:
         # The argument is an RMG-Java input file
+        warnings.warn("The RMG-Java input is no longer supported and may be"\
+            "removed in version 2.3.", DeprecationWarning)
         rmg = loadRMGJavaJob(inputFile, chemkinFile, speciesDict, generateImages,
                              useChemkinNames=useChemkinNames, checkDuplicates=checkDuplicates)
         
@@ -132,6 +134,8 @@ def loadRMGJavaJob(inputFile, chemkinFile=None, speciesDict=None, generateImages
     """
     Load the results of an RMG-Java job generated from the given `inputFile`.
     """
+    warnings.warn("The RMG-Java input is no longer supported and may be"\
+            "removed in version 2.3.", DeprecationWarning)
     from rmgpy.rmg.main import RMG
     from rmgpy.molecule import Molecule
     


### PR DESCRIPTION

### Motivation or Problem
methods missing deprecation messages

### Description of Changes
added deprecation messages to:

* save restart period
* RMG-Java reading/writing
* old adjacency lists 
* group additivity
* rxn.label

removed method with 8 month old deprecation warning, `filter_reactions`.

### Testing
I have not tested this branch yet. Will see what travis tests say.

### Reviewer Tips

