### PR TITLE
Allow proper termination when maxNumSpcs is hit

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -826,15 +826,19 @@ class RMG(util.Subject):
                             self.reactionModel.thermoFilterDown(maximumEdgeSpecies=modelSettings.maximumEdgeSpecies)
                         
                         maxNumSpcsHit = len(self.reactionModel.core.species) >= modelSettings.maxNumSpecies
-                        
+
+                        self.saveEverything()
+
+                        if maxNumSpcsHit:  # breaks the nSims loop
+                            # self.done is still True, which will break the while loop
+                            break
+
                         if not reactorDone:
                             self.done = False
                         
-                        self.saveEverything()
-                        
-                        if maxNumSpcsHit: #breaks the while loop 
-                            break
-                    
+                    if maxNumSpcsHit:  # breaks the reactionSystems loop
+                        break
+
                 if not self.done: # There is something that needs exploring/enlarging
 
                     # If we reached our termination conditions, then try to prune


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG job was not terminating upon reaching maxNumSpecies.

### Description of Changes
Move break statement before `self.done` is set to False and add a second break statement for outer for loop.

### Testing
Run any example with maxNumSpecies set.
