### PR TITLE
Duplicate fixes

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1591,6 +1591,14 @@ class CoreEdgeReactionModel:
                 # Don't add to the edge library reactions that were already processed
                 self.addReactionToEdge(rxn)
 
+        if self.saveEdgeSpecies:
+            from rmgpy.chemkin import markDuplicateReaction
+            newEdgeReactions = self.edge.reactions[numOldEdgeReactions:]
+            checkedReactions = self.core.reactions + self.edge.reactions[:numOldEdgeReactions]
+            for rxn in newEdgeReactions:
+                markDuplicateReaction(rxn, checkedReactions)
+                checkedReactions.append(rxn)
+
         self.printEnlargeSummary(
             newCoreSpecies=[],
             newCoreReactions=[],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
We were not properly marking duplicates for reaction libraries in the edge and irreversible reactions.

### Description of Changes
Add duplicate checking when loading reaction libraries and update `markDuplicateReactions` to account for irreversible reactions.

### Testing
Check that the edge mechanism from the new sulfur test in RMG-tests can be loaded in Chemkin.

It would probably also be good to check RMG-tests to see if this has any noticeable effect on performance.