### PR TITLE
Remove formulas with multiple structures from SMILES lookup dictionaries

### DIFF
--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -90,7 +90,6 @@ SMILES_LOOKUPS = {
 MOLECULE_LOOKUPS = {
     'N2': 'N#N',
     'CH4': 'C',
-    'CH2O': 'C=O',
     'H2O': 'O',
     'C2H6': 'CC',
     'H2': '[H][H]',
@@ -99,12 +98,10 @@ MOLECULE_LOOKUPS = {
     'Ar': '[Ar]',
     'He': '[He]',
     'CH4O': 'CO',
-    'CO2': 'O=C=O',
     'CO': '[C-]#[O+]',
     'O2': 'O=O',
     'C': '[C]',  # for this to be in the "molecule" list it must be singlet with 2 lone pairs
     'H2S': 'S',
-    'N2O': 'N#[N+][O-]',
     'NH3': 'N',
     'O3': '[O-][O+]=O',
     'Cl2': '[Cl][Cl]',
@@ -132,7 +129,6 @@ RADICAL_LOOKUPS = {
     'H2N': '[NH2]',
     'HN': '[NH]',
     'NO': '[N]=O',
-    'NO2': 'N(=O)[O]',
     'Cl': '[Cl]',
     'I': '[I]',
 }


### PR DESCRIPTION
### Motivation or Problem
@alongd just noticed in #735 that two nitrogen/oxygen molecules are not exported correctly as SMILES when using RMG. The issue is that both of those molecules correspond to the same chemical formula, which is only associated with a single SMILES in `RADICAL_LOOKUPS`, which is different from both of the structures.

### Description of Changes
In addition to `NO2`, I have removed other potentially offending formulas. For example, `CH2O` can correspond to both formaldehyde and hydroxymethylene. I also removed `CO2` and `N2O`, which probably have some kind of alternate cyclic structures, although someone may want to verify that.

### Other Comments
Why are these lookups needed? SMILES generation is very fast, so can we just get rid of all of them?