### PR TITLE
Add missing trimolecularThreshold

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -791,7 +791,9 @@ class RMG(util.Subject):
                                     except:
                                         self.updateReactionThresholdAndReactFlags(
                                             rxnSysUnimolecularThreshold = reactionSystem.unimolecularThreshold,
-                                            rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold, skipUpdate=True)
+                                            rxnSysBimolecularThreshold = reactionSystem.bimolecularThreshold,
+                                            rxnSysTrimolecularThreshold = reactionSystem.trimolecularThreshold,
+                                            skipUpdate=True)
                                         logging.warn('Reaction thresholds/flags for Reaction System {0} was not updated due to simulation failure'.format(index+1))
                                     else:
                                         self.updateReactionThresholdAndReactFlags(


### PR DESCRIPTION
One of the calls to `updateReactionThresholdAndReactFlags` in `main.py` was missing `trimolecularThreshold`. The call to that method was added on 5/19/18, whereas the trimolecular changes were written on 3/29/18. However, because #1338 was not merged until after the new call to the method was introduced, `trimolecularThreshold` was missing from that call. This PR fixes that.