### PR TITLE
Clear vertex mapping after isomorphism

### DIFF
--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -424,7 +424,6 @@ class TestThermoAccuracy(unittest.TestCase):
                 self.assertAlmostEqual(Cp, thermoData.getHeatCapacity(T) / 4.184, places=1,
                                        msg="Cp{3} error for {0}. Expected {1} but calculated {2}.".format(smiles, Cp, thermoData.getHeatCapacity(T) / 4.184, T))
 
-    @work_in_progress
     def testSymmetryNumberGeneration(self):
         """
         Test we generate symmetry numbers correctly.

--- a/rmgpy/molecule/vf2.pyx
+++ b/rmgpy/molecule/vf2.pyx
@@ -166,6 +166,14 @@ cdef class VF2:
             graph1.restore_vertex_order()
             graph2.restore_vertex_order()
 
+        # We're done, so clear the mappings to prevent downstream effects
+        for vertex1 in graph1.vertices:
+            vertex1.mapping = None
+            vertex1.terminal = False
+        for vertex2 in graph2.vertices:
+            vertex2.mapping = None
+            vertex2.terminal = False
+
     cdef bint match(self, int callDepth) except -2:
         """
         Recursively search for pairs of vertices to match, until all vertices

--- a/rmgpy/molecule/vf2Test.py
+++ b/rmgpy/molecule/vf2Test.py
@@ -81,6 +81,15 @@ class TestVF2(unittest.TestCase):
                     self.assertTrue(self.vf2.feasible(atom1, atom2))
                 else: # different connectivity values should return false
                     self.assertFalse(self.vf2.feasible(atom1, atom2))
+
+    def test_clear_mapping(self):
+        """Test that vertex mapping is cleared after isomorphism."""
+        self.vf2.isIsomorphic(self.mol, self.mol2, None)
+
+        for atom in self.mol.atoms:
+            self.assertIsNone(atom.mapping)
+            self.assertFalse(atom.terminal)
+
 ################################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation or Problem
Fixes #1344. Previously, the mapping attribute was causing the symmetry algorithm to return unexpected results. This actually affects normal jobs, since the symmetry number is generally determined at the end of thermo estimation, following many calls to isomorphism. As a result, the symmetry corrections were sometimes incorrect.

### Description of Changes
At the end of `vf2.isomorphism`, clear the `Vertex.mapping`  and `Vertex.terminal` attributes. These are used solely be the vf2 algorithm, so there is no need for them to persist.

### Testing
Check that the examples in #1344 now work as expected. Thermo estimates are expected to be different in RMG-tests, but should be limited to entropy values.
