### PR TITLE
Fix react flag usage in initial react step

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -614,7 +614,9 @@ class RMG(util.Subject):
             pass
         
         self.rmg_memories = []
-        
+
+        logging.info('Initialization complete. Starting model generation.\n')
+
         # Initiate first reaction discovery step after adding all core species
         for index, reactionSystem in enumerate(self.reactionSystems):
             # Initialize memory object to track conditions for ranged reactors
@@ -642,11 +644,14 @@ class RMG(util.Subject):
                     rxnSysBimolecularThreshold=reactionSystem.bimolecularThreshold,
                     rxnSysTrimolecularThreshold=reactionSystem.trimolecularThreshold,
                 )
+
+                logging.info('Generating initial reactions for reaction system {0}...'.format(index + 1))
             else:
                 # If we're not filtering reactions, then we only need to react
                 # the first reaction system since they share the same core
                 if index > 0:
                     continue
+                logging.info('Generating initial reactions...')
 
             # React core species to enlarge edge
             self.reactionModel.enlarge(reactEdge=True,
@@ -666,7 +671,7 @@ class RMG(util.Subject):
         if not np.isinf(self.modelSettingsList[0].toleranceThermoKeepSpeciesInEdge):
             self.reactionModel.thermoFilterDown(maximumEdgeSpecies=self.modelSettingsList[0].maximumEdgeSpecies)
         
-        logging.info('Completed initial enlarge edge step...')
+        logging.info('Completed initial enlarge edge step.\n')
         
         self.saveEverything()
         
@@ -683,7 +688,7 @@ class RMG(util.Subject):
 
             self.filterReactions = modelSettings.filterReactions
 
-            logging.info('Beginning model generation stage {0}\n\n'.format(q+1))
+            logging.info('Beginning model generation stage {0}...\n'.format(q+1))
             
             self.done = False
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -688,7 +688,8 @@ class CoreEdgeReactionModel:
         # Begin processing the new species and reactions
         
         # Generate kinetics of new reactions
-        logging.info('Generating kinetics for new reactions...')
+        if self.newReactionList:
+            logging.info('Generating kinetics for new reactions...')
         for reaction in self.newReactionList:
             # If the reaction already has kinetics (e.g. from a library),
             # assume the kinetics are satisfactory

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -304,7 +304,7 @@ cdef class ReactionSystem(DASx):
         cdef bool notInSurface
         cdef object obj
         
-        logging.info('initializing surface ...')
+        logging.debug('Initializing surface...')
         
         productIndices = self.productIndices
         reactantIndices = self.reactantIndices
@@ -354,7 +354,7 @@ cdef class ReactionSystem(DASx):
         surfaceSpecies = [coreSpecies[i] for i in surfaceSpeciesIndices]
         surfaceReactions = [coreReactions[i] for i in surfaceReactionIndices]
         
-        logging.info('surface initialization complete')
+        logging.debug('Surface initialization complete')
 
         return surfaceSpecies,surfaceReactions
         

--- a/rmgpy/tools/plot.py
+++ b/rmgpy/tools/plot.py
@@ -194,7 +194,7 @@ class GenericPlot(object):
         if self.title:
             plt.title(self.title)
             
-        ax.grid('on')
+        ax.grid(True)
         handles, labels = ax.get_legend_handles_labels()
         if labels:
             # Create a legend outside the plot and adjust width based off of longest legend label
@@ -291,7 +291,7 @@ class GenericPlot(object):
         if title:
             plt.title(title)
             
-        ax.grid('on')
+        ax.grid(True)
         handles, labels = ax.get_legend_handles_labels()
         if labels:
             # Create a legend outside the plot and adjust width based off of longest legend label


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
React flags were being reset in the initial react step if filterReactions was on and the user specified multiple reactors. As a result, no reactions would be generated in some cases.

### Description of Changes
Reorganized the initial react step to be more similar to the react sequence in the main loop. Specifically, we now loop through each reactor, update the react flags, and react the appropriate species. If filterReactions is off, then we break after the first reactor since they all share the same core species.

Also made a few minor changes to logging and fixed a deprecated matplotlib call. If the reviewers prefer, these can be moved to a separate PR.

### Testing
The particular case that brought this to our attention was a PDD model from @amarkpayne. That should be the main test to make sure the fix worked.

We also expect to see no changes in RMG-tests, though this bug was not caught last time either...

### Reviewer Tips
Read through the changes to check that they make sense. Take a look at RMG-tests. Run a separate job of interest if desired, especially to check the changes to logging.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
