### PR TITLE
Chemkin flexibility

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1373,7 +1373,7 @@ def getSpeciesIdentifier(species):
     if species.index == -1:
         # No index present -- probably not in RMG job
         # In this case just return the label (if the right size)
-        if len(label) > 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#]+', label):
+        if len(label) > 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#=\[\]]+', label):
             if len(label) <= 10:
                 return label
             elif len(label) <= 15:
@@ -1394,7 +1394,7 @@ def getSpeciesIdentifier(species):
 
         # First try to use the label and index
         # The label can only contain alphanumeric characters, and -()*#_,
-        if len(label) > 0 and species.index >= 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#]+', label):
+        if len(label) > 0 and species.index >= 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#=\[\]]+', label):
             name = '{0}({1:d})'.format(label, species.index)
             if len(name) <= 10:
                 return name

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1559,7 +1559,9 @@ def writeReactionString(reaction, javaLibrary = False):
 def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = False, commented=False):
     """
     Return a string representation of the reaction as used in a Chemkin
-    file. Use verbose = True to turn on comments.  Use javaLibrary = True in order to 
+    file. Use `verbose = True` to turn on kinetics comments.
+    Use `commented = True` to comments out the entire reaction.
+    Use javaLibrary = True in order to
     generate a kinetics entry suitable for an RMG-Java kinetics library.  
     """
     string = ""

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -316,13 +316,14 @@ def _readKineticsReaction(line, speciesDict, Aunits, Eunits):
     
     # Split the reaction equation into reactants and products
     reversible = True
-    reactants, products = reaction.split('=')
-    if '<=>' in reaction:
-        reactants = reactants[:-1]
-        products = products[1:]
-    elif '=>' in reaction:
-        products = products[1:]
-        reversible = False
+    # to allow species to contain =, we should also check for <=>
+    try:
+        reactants, products = reaction.split('<=>')
+    except ValueError:
+        reactants, products = reaction.split('=')
+        if '=>' in reaction:
+            products = products[1:]
+            reversible = False
     specificCollider = None
     # search for a third body collider, e.g., '(+M)', '(+m)', or a specific species like '(+N2)', matching `(+anythingOtherThanEndingParenthesis)`:
     collider = re.search('\(\+[^\)]+\)',reactants)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG puts many more restrictions on chemkin output files than Chemkin actually does. It would be great to have more SMILES output.



### Description of Changes
This PR increases the flexibility of outputs to allow common SMILES characters like `=`, `[` and `]`, allowing RMG to output more smiles characters than before.

It fixes some of the parsing issues this creates.

### Testing
unittests run. travis tests. 

My biggest concern is character line limits in Chemkin reaction lines (currently 52 char) may be closer to being hit if RMG outputs `<=>` for reversible reactions instead of `=`. For third-body colliders this could cause an issue. 

Each species can maximally be 10 characters long. For bimolecular reactions this leads to 40 + ' <=> '(5 char) + 2' + '(6 char). This is 51 characters, which is still within the limit...though it doesn't include third body colliders, but these typically involve a unimolecular reaction, so it is probably not important...unless specific third body colliders with long names are able to be automatically generated. Since we're not planning on adding that functionality, we should be fine using `<=>` instead of `=`.

### Reviewer Tips
make sure the additions make sense and that 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
