### PR TITLE
Allow labeled atoms from generateReactions

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1572,7 +1572,7 @@ class KineticsFamily(Database):
         else:
             raise NotImplementedError("Not expecting template of type {}".format(type(struct)))
 
-    def generateReactions(self, reactants, products=None, prod_resonance=True):
+    def generateReactions(self, reactants, products=None, prod_resonance=True, unlabel_atoms=True):
         """
         Generate all reactions between the provided list of one, two, or three
         `reactants`, which should be either single :class:`Molecule` objects
@@ -1597,13 +1597,20 @@ class KineticsFamily(Database):
 
         # Forward direction (the direction in which kinetics is defined)
         reactionList.extend(
-            self.__generateReactions(reactants, products=products, forward=True, prod_resonance=prod_resonance))
+            self.__generateReactions(reactants, 
+            						 products=products, 
+            						 forward=True, 
+            						 prod_resonance=prod_resonance,
+            						 unlabel_atoms=unlabel_atoms))
 
         if not self.ownReverse and self.reversible:
             # Reverse direction (the direction in which kinetics is not defined)
             reactionList.extend(
-                self.__generateReactions(reactants, products=products, forward=False, prod_resonance=prod_resonance))
-
+                self.__generateReactions(reactants, 
+                						 products=products, 
+                						 forward=False, 
+                						 prod_resonance=prod_resonance,
+                						 unlabel_atoms=unlabel_atoms))
         return reactionList
 
     def addReverseAttribute(self, rxn, react_non_reactive=True):
@@ -1748,9 +1755,9 @@ class KineticsFamily(Database):
                                  'in reaction family {1}. Expected 1 reaction '
                                  'but generated {2}').format(reaction, self.label, len(reactions)))
         return reactions[0].degeneracy
-        
-    def __generateReactions(self, reactants, products=None, forward=True, prod_resonance=True,
-                            react_non_reactive=False):
+
+    def __generateReactions(self, reactants, products=None, forward=True, prod_resonance=True, unlabel_atoms=True,
+                                react_non_reactive=False):
         """
         Generate a list of all the possible reactions of this family between
         the list of `reactants`. The number of reactants provided must match
@@ -1962,8 +1969,9 @@ class KineticsFamily(Database):
             reaction.template = self.getReactionTemplateLabels(reaction)
 
             # Unlabel the atoms
-            for label, atom in reaction.labeledAtoms:
-                atom.label = ''
+            if unlabel_atoms:
+                for label, atom in reaction.labeledAtoms:
+                    atom.label = ''
             
             # We're done with the labeled atoms, so delete the attribute
             del reaction.labeledAtoms

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -773,15 +773,16 @@ class Molecule(Graph):
         """
         cython.declare(multiplicity=cython.int)
         multiplicity = self.multiplicity
-        try:
-            if multiplicity != self.getRadicalCount() + 1:
-                return 'Molecule(SMILES="{0}", multiplicity={1:d})'.format(self.toSMILES(), multiplicity)
-            return 'Molecule(SMILES="{0}")'.format(self.toSMILES())
-        except KeyError:
-            logging.warning('Could not generate SMILES for this molecule object.'+\
-                        ' Likely due to a keyerror when converting to RDKit'+\
-                        ' Here is molecules AdjList: {}'.format(self.toAdjacencyList()))
-            return 'Molecule().fromAdjacencyList"""{}"""'.format(self.toAdjacencyList())
+        if len(self.getLabeledAtoms())==0:
+            try:
+                if multiplicity != self.getRadicalCount() + 1:
+                    return 'Molecule(SMILES="{0}", multiplicity={1:d})'.format(self.toSMILES(), multiplicity)
+                return 'Molecule(SMILES="{0}")'.format(self.toSMILES())
+            except KeyError:
+                logging.warning('Could not generate SMILES for this molecule object.'+\
+                            ' Likely due to a keyerror when converting to RDKit'+\
+                            ' Here is molecules AdjList: {}'.format(self.toAdjacencyList()))
+        return 'Molecule().fromAdjacencyList("""{}""")'.format(self.toAdjacencyList())
 
     def __reduce__(self):
         """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Generate reactions automatically removes atom labels, which may not be desired in all applications. Previously, people would have to take the output reaction and re-add atom labels, taking over twice as much work

### Description of Changes
Added option to prevent removing labeled atoms in generateReactions. When this is used, the reactant molecule object is copied since the atom labels might be different for each reaction in the list of reactions returned from generateReactions.

This also makes the default __repr__ output to be the full adjacency list when there are labeled atoms in the molecule. This allows proper loading and unloading of molecule objects.

### Testing
unittests and will do server rmg-tests

### Reviewer Tips
ensure code is well written
<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
