### PR TITLE
Added atomEnergy corrections for wB97X-D-aVTD chemistry

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -721,6 +721,8 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds,
                 atomEnergies = {'H':-0.500426155, 'C':-37.850331697831, 'O':-75.0535872748806, 'S':-398.100820107242}
             elif modelChemistry == 'b3lyp/6-311+g(3df,2p)':  # Calculated atomic energies
                 atomEnergies = {'H':-0.502155915123 + SOC['H'], 'C':-37.8574709934 + SOC['C'], 'N':-54.6007233609 + SOC['N'], 'O':-75.0909131284 + SOC['O'], 'P':-341.281730319 + SOC['P'], 'S':-398.134489850 + SOC['S']}
+            elif modelChemistry == 'wb97x-d/aug-cc-pvtz':
+                atomEnergies = {'H':-0.502803+ SOC['H'], 'N':-54.585652+ SOC['N'], 'O':-75.068286+ SOC['O'], 'C':-37.842014+ SOC['C']}
 
             elif modelChemistry == 'MRCI+Davidson/aug-cc-pV(T+d)Z':  # Calculated atomic energies (unfitted)
                 atomEnergies = {'H':-0.49982118 + SOC['H'], 'C':-37.78321274 + SOC['C'], 'N':-54.51729444 + SOC['N'], 'O':-74.97847534 + SOC['O'], 'S':-397.6571654 + SOC['S']}

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -94,7 +94,7 @@ Model Chemistry                                  AEC   BC   SOC  Freq Scale Supp
 ``'B3LYP/6-311+G(3df,2p)'``                       v    v    v    v (0.967)  H, C, N, O, P, S
 ``'B3LYP/6-31G**'``                               v    v         v (0.961)  H, C, O, S
 ``'MRCI+Davidson/aug-cc-pV(T+d)Z'``               v         v               H, C, N, O, S
-``'wb97x-d/aug-cc-pvtz'``                         v                         H, C, N, O
+``'wb97x-d/aug-cc-pvtz'``                         v         v               H, C, N, O
 ================================================ ===== ==== ==== ========== ====================
 
 Notes:

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -94,6 +94,7 @@ Model Chemistry                                  AEC   BC   SOC  Freq Scale Supp
 ``'B3LYP/6-311+G(3df,2p)'``                       v    v    v    v (0.967)  H, C, N, O, P, S
 ``'B3LYP/6-31G**'``                               v    v         v (0.961)  H, C, O, S
 ``'MRCI+Davidson/aug-cc-pV(T+d)Z'``               v         v               H, C, N, O, S
+``'wb97x-d/aug-cc-pvtz'``                         v                         H, C, N, O
 ================================================ ===== ==== ==== ========== ====================
 
 Notes:


### PR DESCRIPTION
Values were obtained from NIST Computational
Chemistry Comparison and Benchmark DataBase

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
A method's atom correction energies were not defined by cantherm

### Description of Changes
Added the atom correction energies from https://cccbdb.nist.gov/energy2x.asp using the ground electronic states.

### Testing
n/a

### Reviewer Tips
make sure the numbers match those in https://cccbdb.nist.gov/energy2x.asp or if my method of adding them was screwed up
<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
