### PR TITLE
Benzyne resonance structures

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1946,6 +1946,8 @@ class Molecule(Graph):
                         break
                     for atom2 in ring0[i + 1:]:
                         if self.hasBond(atom1, atom2):
+                            # Check for aromaticity using the bond type rather than GetIsAromatic because
+                            # aryne triple bonds return True for GetIsAromatic but are not aromatic bonds
                             if rdkitmol.GetBondBetweenAtoms(rdAtomIndices[atom1],
                                                             rdAtomIndices[atom2]).GetBondType() is AROMATIC:
                                 aromaticBondsInRing.append(self.getBond(atom1, atom2))

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -64,6 +64,6 @@ cpdef list generate_opposite_kekule_structure(Molecule mol)
 
 cpdef list generate_clar_structures(Molecule mol)
 
-cpdef list _clar_optimization(Molecule mol, list constraints=?, maxNum=?)
+cpdef list _clar_optimization(Molecule mol, list constraints=?, max_num=?)
 
-cpdef list _clar_transformation(Molecule mol, list ring)
+cpdef list _clar_transformation(Molecule mol, list aromatic_ring)

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -56,6 +56,8 @@ cpdef list generate_isomorphic_resonance_structures(Molecule mol, bint saturate_
 
 cpdef list generate_aromatic_resonance_structures(Molecule mol, dict features=?)
 
+cpdef list generate_aryne_resonance_structures(Molecule mol)
+
 cpdef list generate_kekule_structure(Molecule mol)
 
 cpdef list generate_opposite_kekule_structure(Molecule mol)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -46,6 +46,7 @@ Currently supported resonance types:
     - ``generate_N5ddc_N5tc_resonance_structures``: shift between nitrogen with two double bonds and single + triple bond
     - ``generate_N5dc_radical_resonance_structures``: shift between radical and lone pair mediated by an N5dc atom
     - ``generate_N5dc_resonance_structures``: shift between double bond and lone pair mediated by an N5dc atom
+    - ``generate_aryne_resonance_structures``: shift between cumulene and alkyne forms of arynes, which are not considered aromatic in RMG
 - Aromatic species only:
     - ``generate_aromatic_resonance_structures``: fully delocalized structure, where all aromatic rings have benzene bonds
     - ``generate_kekule_structure``: generate a single Kekule structure for an aromatic compound (single/double bond form)
@@ -87,6 +88,7 @@ def populate_resonance_algorithms(features=None):
             generate_N5dc_radical_resonance_structures,
             generate_N5dc_resonance_structures,
             generate_aromatic_resonance_structures,
+            generate_aryne_resonance_structures,
             generate_kekule_structure,
             generate_opposite_kekule_structure,
             generate_clar_structures,
@@ -97,6 +99,8 @@ def populate_resonance_algorithms(features=None):
         # cases where the radical is in an orbital that is orthogonal to the pi orbitals.
         if features['isRadical'] and not features['isAromatic'] and not features['isArylRadical']:
             method_list.append(generate_allyl_delocalization_resonance_structures)
+        if features['isCyclic']:
+            method_list.append(generate_aryne_resonance_structures)
         if features['hasNitrogen']:
             method_list.append(generate_N5ddc_N5tc_resonance_structures)
             method_list.append(generate_N5dc_radical_resonance_structures)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -773,15 +773,21 @@ def generate_aromatic_resonance_structures(mol, features=None):
     # Then determine which ones are aromatic
     aromaticBonds = molecule.getAromaticRings(rings)[1]
 
-    # If the species is a radical, then there is a chance that the radical can be shifted
-    #   to a location that increases the number of perceived aromatic rings.
+    # Attempt to rearrange electrons to obtain a structure with the most aromatic rings
+    # Possible rearrangements include aryne resonance and allyl resonance
+    res_list = [generate_aryne_resonance_structures]
     if features['isRadical'] and not features['isArylRadical']:
-        if molecule.isAromatic():
-            kekuleList = generate_kekule_structure(molecule)
-        else:
-            kekuleList = [molecule]
-        _generate_resonance_structures(kekuleList, [generate_allyl_delocalization_resonance_structures])
+        res_list.append(generate_allyl_delocalization_resonance_structures)
 
+    if molecule.isAromatic():
+        kekuleList = generate_kekule_structure(molecule)
+    else:
+        kekuleList = [molecule]
+
+    _generate_resonance_structures(kekuleList, res_list)
+
+    if len(kekuleList) > 1:
+        # We found additional structures, so we need to evaluate all of them
         maxNum = 0
         mol_list = []
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -139,13 +139,13 @@ def analyze_molecule(mol):
                 }
 
     if features['isCyclic']:
-        aromaticRings = mol.getAromaticRings()[0]
-        if len(aromaticRings) > 0:
+        aromatic_rings = mol.getAromaticRings()[0]
+        if len(aromatic_rings) > 0:
             features['isAromatic'] = True
-        if len(aromaticRings) > 1:
+        if len(aromatic_rings) > 1:
             features['isPolycyclicAromatic'] = True
         if features['isRadical'] and features['isAromatic']:
-            features['isArylRadical'] = mol.isArylRadical(aromaticRings)
+            features['isArylRadical'] = mol.isArylRadical(aromatic_rings)
     for atom in mol.vertices:
         if atom.isNitrogen():
             features['hasNitrogen'] = True
@@ -771,7 +771,7 @@ def generate_aromatic_resonance_structures(mol, features=None):
     rings = molecule.getAllSimpleCyclesOfSize(6)
 
     # Then determine which ones are aromatic
-    aromaticBonds = molecule.getAromaticRings(rings)[1]
+    aromatic_bonds = molecule.getAromaticRings(rings)[1]
 
     # Attempt to rearrange electrons to obtain a structure with the most aromatic rings
     # Possible rearrangements include aryne resonance and allyl resonance
@@ -780,45 +780,45 @@ def generate_aromatic_resonance_structures(mol, features=None):
         res_list.append(generate_allyl_delocalization_resonance_structures)
 
     if molecule.isAromatic():
-        kekuleList = generate_kekule_structure(molecule)
+        kekule_list = generate_kekule_structure(molecule)
     else:
-        kekuleList = [molecule]
+        kekule_list = [molecule]
 
-    _generate_resonance_structures(kekuleList, res_list)
+    _generate_resonance_structures(kekule_list, res_list)
 
-    if len(kekuleList) > 1:
+    if len(kekule_list) > 1:
         # We found additional structures, so we need to evaluate all of them
-        maxNum = 0
+        max_num = 0
         mol_list = []
 
         # Iterate through the adjacent resonance structures and keep the structures with the most aromatic rings
-        for mol0 in kekuleList:
-            aromaticBonds = mol0.getAromaticRings()[1]
-            if len(aromaticBonds) > maxNum:
-                maxNum = len(aromaticBonds)
-                mol_list = [(mol0, aromaticBonds)]
-            elif len(aromaticBonds) == maxNum:
-                mol_list.append((mol0, aromaticBonds))
+        for mol0 in kekule_list:
+            aromatic_bonds = mol0.getAromaticRings()[1]
+            if len(aromatic_bonds) > max_num:
+                max_num = len(aromatic_bonds)
+                mol_list = [(mol0, aromatic_bonds)]
+            elif len(aromatic_bonds) == max_num:
+                mol_list.append((mol0, aromatic_bonds))
     else:
         # Otherwise, it is not possible to increase the number of aromatic rings by moving electrons,
         # so go ahead with the inputted form of the molecule
-        mol_list = [(molecule, aromaticBonds)]
+        mol_list = [(molecule, aromatic_bonds)]
 
     new_mol_list = []
 
     # Generate the aromatic resonance structure(s)
-    for mol0, aromaticBonds in mol_list:
-        if not aromaticBonds:
+    for mol0, aromatic_bonds in mol_list:
+        if not aromatic_bonds:
             continue
         # Save original bond orders in case this doesn't work out
-        originalBonds = []
-        for ring in aromaticBonds:
-            originalOrder = []
+        original_bonds = []
+        for ring in aromatic_bonds:
+            original_order = []
             for bond in ring:
-                originalOrder.append(bond.order)
-            originalBonds.append(originalOrder)
+                original_order.append(bond.order)
+            original_bonds.append(original_order)
         # Change bond types to benzene bonds for all aromatic rings
-        for ring in aromaticBonds:
+        for ring in aromatic_bonds:
             for bond in ring:
                 bond.order = 1.5
 
@@ -827,27 +827,27 @@ def generate_aromatic_resonance_structures(mol, features=None):
         except AtomTypeError:
             # If this didn't work the first time, then there might be a ring that is not actually aromatic
             # Reset our changes
-            for ring, originalOrder in itertools.izip(aromaticBonds, originalBonds):
-                for bond, order in itertools.izip(ring, originalOrder):
+            for ring, original_order in itertools.izip(aromatic_bonds, original_bonds):
+                for bond, order in itertools.izip(ring, original_order):
                     bond.order = order
             # Try to make each ring aromatic, one by one
             i = 0
             counter = 0
-            while i < len(aromaticBonds) and counter < 2*len(aromaticBonds):
+            while i < len(aromatic_bonds) and counter < 2*len(aromatic_bonds):
                 counter += 1
-                originalOrder = []
-                for bond in aromaticBonds[i]:
-                    originalOrder.append(bond.order)
+                original_order = []
+                for bond in aromatic_bonds[i]:
+                    original_order.append(bond.order)
                     bond.order = 1.5
                 try:
                     mol0.updateAtomTypes(logSpecies=False)
                 except AtomTypeError:
                     # This ring could not be made aromatic, possibly because it depends on other rings
                     # Undo changes
-                    for bond, order in itertools.izip(aromaticBonds[i], originalOrder):
+                    for bond, order in itertools.izip(aromatic_bonds[i], original_order):
                         bond.order = order
                     # Move it to the end of the list, and go on to the next ring
-                    aromaticBonds.append(aromaticBonds.pop(i))
+                    aromatic_bonds.append(aromatic_bonds.pop(i))
                     mol0.updateAtomTypes(logSpecies=False)
                     continue
                 else:
@@ -981,6 +981,7 @@ def generate_kekule_structure(mol):
 
     return [molecule]
 
+
 def generate_opposite_kekule_structure(mol):
     """
     Generate the Kekule structure with opposite single/double bond arrangement
@@ -995,26 +996,26 @@ def generate_opposite_kekule_structure(mol):
 
     molecule = mol.copy(deep=True)
 
-    aromaticBonds = molecule.getAromaticRings()[1]
+    aromatic_bonds = molecule.getAromaticRings()[1]
 
     # We can only do this for single ring aromatics for now
-    if len(aromaticBonds) != 1:
+    if len(aromatic_bonds) != 1:
         return []
 
-    numS = 0
-    numD = 0
-    for bond in aromaticBonds[0]:
+    num_s = 0
+    num_d = 0
+    for bond in aromatic_bonds[0]:
         if bond.isSingle():
-            numS += 1
+            num_s += 1
             bond.order = 2
         elif bond.isDouble():
-            numD += 1
+            num_d += 1
             bond.order = 1
         else:
             # Something is wrong: there is a bond that is not single or double
             return []
 
-    if numS != 3 or numD != 3:
+    if num_s != 3 or num_d != 3:
         return []
 
     try:
@@ -1023,6 +1024,7 @@ def generate_opposite_kekule_structure(mol):
         return []
     else:
         return [molecule]
+
 
 def generate_isomorphic_resonance_structures(mol, saturate_h=False):
     """
@@ -1055,11 +1057,11 @@ def generate_isomorphic_resonance_structures(mol, saturate_h=False):
     while index < len(isomers):
         isomer = isomers[index]
         
-        newIsomers = []
+        new_isomers = []
         for algo in populate_resonance_algorithms():
-            newIsomers.extend(algo(isomer))
+            new_isomers.extend(algo(isomer))
         
-        for newIsomer in newIsomers:
+        for newIsomer in new_isomers:
             # Append to isomer list if unique
             for isom in isomers:
                 if isom.copy(deep=True).isIsomorphic(newIsomer.copy(deep=True)):
@@ -1102,13 +1104,13 @@ def generate_clar_structures(mol):
 
     mol_list = []
 
-    for new_mol, aromaticRings, bonds, solution in output:
+    for new_mol, aromatic_rings, bonds, solution in output:
 
         # The solution includes a part corresponding to rings, y, and a part corresponding to bonds, x, using
         # nomenclature from the paper. In y, 1 means the ring as a sextet, 0 means it does not.
         # In x, 1 corresponds to a double bond, 0 either means a single bond or the bond is part of a sextet.
-        y = solution[0:len(aromaticRings)]
-        x = solution[len(aromaticRings):]
+        y = solution[0:len(aromatic_rings)]
+        x = solution[len(aromatic_rings):]
 
         # Apply results to molecule - double bond locations first
         for index, bond in enumerate(bonds):
@@ -1120,7 +1122,7 @@ def generate_clar_structures(mol):
                 raise ValueError('Unaccepted bond value {0} obtained from optimization.'.format(x[index]))
 
         # Then apply locations of aromatic sextets by converting to benzene bonds
-        for index, ring in enumerate(aromaticRings):
+        for index, ring in enumerate(aromatic_rings):
             if y[index] == 1:
                 _clar_transformation(new_mol, ring)
 
@@ -1134,7 +1136,7 @@ def generate_clar_structures(mol):
     return mol_list
 
 
-def _clar_optimization(mol, constraints=None, maxNum=None):
+def _clar_optimization(mol, constraints=None, max_num=None):
     """
     Implements linear programming algorithm for finding Clar structures. This algorithm maximizes the number
     of Clar sextets within the constraints of molecular geometry and atom valency.
@@ -1164,15 +1166,15 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
     # Make a copy of the molecule so we don't destroy the original
     molecule = mol.copy(deep=True)
 
-    aromaticRings = molecule.getAromaticRings()[0]
-    aromaticRings.sort(key=lambda x: sum([atom.id for atom in x]))
+    aromatic_rings = molecule.getAromaticRings()[0]
+    aromatic_rings.sort(key=lambda x: sum([atom.id for atom in x]))
 
-    if not aromaticRings:
+    if not aromatic_rings:
         return []
 
     # Get list of atoms that are in rings
     atoms = set()
-    for ring in aromaticRings:
+    for ring in aromatic_rings:
         atoms.update(ring)
     atoms = sorted(atoms, key=lambda x: x.id)
 
@@ -1194,7 +1196,7 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
             exo.append(None)
 
     # Dimensions
-    l = len(aromaticRings)
+    l = len(aromatic_rings)
     m = len(atoms)
     n = l + len(bonds)
 
@@ -1202,9 +1204,9 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
     # Part of equality constraint Ax=b
     a = []
     for atom in atoms:
-        inRing = [1 if atom in ring else 0 for ring in aromaticRings]
-        inBond = [1 if atom in [bond.atom1, bond.atom2] else 0 for bond in bonds]
-        a.append(inRing + inBond)
+        in_ring = [1 if atom in ring else 0 for ring in aromatic_rings]
+        in_bond = [1 if atom in [bond.atom1, bond.atom2] else 0 for bond in bonds]
+        a.append(in_ring + in_bond)
 
     # Objective vector for optimization: sextets have a weight of 1, double bonds have a weight of 0
     objective = [1] * l + [0] * len(bonds)
@@ -1240,7 +1242,7 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
                     raise e
 
     status = lpsolve('solve', lp)
-    objVal, solution = lpsolve('get_solution', lp)[0:2]
+    obj_val, solution = lpsolve('get_solution', lp)[0:2]
     lpsolve('delete_lp', lp)  # Delete the LP problem to clear up memory
 
     # Reset signal handling since lpsolve changed it
@@ -1255,13 +1257,13 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
         raise ILPSolutionError('Optimization could not find a valid solution.')
 
     # Check that we the result contains at least one aromatic sextet
-    if objVal == 0:
+    if obj_val == 0:
         return []
 
     # Check that the solution contains the maximum number of sextets possible
-    if maxNum is None:
-        maxNum = objVal  # This is the first solution, so the result should be an upper limit
-    elif objVal < maxNum:
+    if max_num is None:
+        max_num = obj_val  # This is the first solution, so the result should be an upper limit
+    elif obj_val < max_num:
         raise ILPSolutionError('Optimization obtained a sub-optimal solution.')
 
     if any([x != 1 and x != 0 for x in solution]):
@@ -1278,14 +1280,14 @@ def _clar_optimization(mol, constraints=None, maxNum=None):
 
     # Run optimization with additional constraints
     try:
-        innerSolutions = _clar_optimization(mol, constraints=constraints, maxNum=maxNum)
+        inner_solutions = _clar_optimization(mol, constraints=constraints, max_num=max_num)
     except ILPSolutionError:
-        innerSolutions = []
+        inner_solutions = []
 
-    return innerSolutions + [(molecule, aromaticRings, bonds, solution)]
+    return inner_solutions + [(molecule, aromatic_rings, bonds, solution)]
 
 
-def _clar_transformation(mol, aromaticRing):
+def _clar_transformation(mol, aromatic_ring):
     """
     Performs Clar transformation for given ring in a molecule, ie. conversion to aromatic sextet.
 
@@ -1297,12 +1299,12 @@ def _clar_transformation(mol, aromaticRing):
     """
     cython.declare(bondList=list, i=cython.int, atom1=Atom, atom2=Atom, bond=Bond)
 
-    bondList = []
+    bond_list = []
 
-    for i, atom1 in enumerate(aromaticRing):
-        for atom2 in aromaticRing[i + 1:]:
+    for i, atom1 in enumerate(aromatic_ring):
+        for atom2 in aromatic_ring[i + 1:]:
             if mol.hasBond(atom1, atom2):
-                bondList.append(mol.getBond(atom1, atom2))
+                bond_list.append(mol.getBond(atom1, atom2))
 
-    for bond in bondList:
+    for bond in bond_list:
         bond.order = 1.5

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -351,6 +351,38 @@ class ResonanceTest(unittest.TestCase):
         molList = generate_aromatic_resonance_structures(mol)
         self.assertEqual(len(molList), 1)
 
+    def test_benzyne(self):
+        """Test benzyne resonance"""
+        mol1 = Molecule(SMILES="C1=CC=C=C=C1")
+        mol2 = Molecule(SMILES="C1C#CC=CC=1")
+
+        mol_list1 = generate_resonance_structures(mol1)
+        self.assertEqual(len(mol_list1), 2)
+
+        mol_list2 = generate_resonance_structures(mol2)
+        self.assertEqual(len(mol_list2), 2)
+
+        self.assertTrue(mol_list1[1].isIsomorphic(mol2))
+        self.assertTrue(mol_list2[1].isIsomorphic(mol1))
+
+    def test_benzyne_polycyclic(self):
+        """Test benzyne resonance when in polycyclic molecule"""
+        mol1 = Molecule(SMILES="C12=CC=C=C=C1C=CC=C2")
+        mol2 = Molecule(SMILES="C12C#CC=CC=1C=CC=C2")
+
+        mol_list1 = generate_resonance_structures(mol1)
+        self.assertEqual(len(mol_list1), 4)
+
+        mol_list2 = generate_resonance_structures(mol2)
+        self.assertEqual(len(mol_list2), 4)
+
+        # Check that they both have an aromatic resonance form
+        self.assertTrue(mol_list1[1].isIsomorphic(mol_list2[1]))
+
+        # Check that the other structure is generated for each
+        self.assertTrue(any([mol1.isIsomorphic(mol) for mol in mol_list2]))
+        self.assertTrue(any([mol2.isIsomorphic(mol) for mol in mol_list1]))
+
     def testFusedAromatic1(self):
         """Test we can make aromatic perylene from both adjlist and SMILES"""
         perylene = Molecule().fromAdjacencyList("""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Benzyne and other arynes were previously neglected by the resonance algorithm. As a result, we would treat `C1=C=C=CC=C1` and `C1=CC#CC=C1` as different molecules. As we work towards adding more PAH formation pathways, including ones involving benzyne, this becomes more of an important issue.

### Description of Changes
This PR adds a new resonance function, `generate_aryne_resonance_structures`, which generates both cumulene and alkyne resonance forms for benzyne and polycyclic arynes. The approach used was to hard-code bond orders which are capable of this transformation. Specifically, two potential bond order arrangements are checked for, corresponding to the two main resonance structures of benzyne.

This is sufficient for a wide range of cases, but does fail to consider certain polycyclic cases which may have different bond order arrangements. Additionally, the diradical resonance form is not considered in the current implementation. At the moment, I think that these are acceptable since the top priority was addressing the two main forms of benzyne.

### Testing
Basic unit tests have been written for benzyne and naphthyne. Existing resonance tests have been confirmed to be unaffected. RMG-tests should be checked, no changes are expected except maybe in the aromatic test case.

### Reviewer Tips
Read through the code, maybe run `generate_resonance_structures` on a random aryne, besides benzyne and naphthyne.