### PR TITLE
Branching Algorithm

### DIFF
--- a/examples/rmg/propane_branching/input.py
+++ b/examples/rmg/propane_branching/input.py
@@ -1,0 +1,81 @@
+database(
+    thermoLibraries = ['BurkeH2O2','primaryThermoLibrary','thermo_DFT_CCSDTF12_BAC','CBS_QB3_1dHR','DFT_QCI_thermo'],
+    reactionLibraries = [],
+    seedMechanisms = ['BurkeH2O2inN2','ERC-FoundationFuelv0.9'],
+    kineticsDepositories = 'default', 
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+
+species(
+    label='propane',
+    reactive=True,	
+    structure=SMILES("CCC"),
+)
+species(
+    label='O2',
+    structure=SMILES("[O][O]"),
+)
+species(
+    label='N2',
+    reactive=False,
+    structure=adjacencyList("""
+    1 N u0 p1 c0 {2,T}
+	2 N u0 p1 c0 {1,T}
+	"""),
+)
+
+
+simpleReactor(
+    temperature=(700,'K'),
+    pressure=(10.0,'bar'),
+    initialMoleFractions={
+        "N2": 4,
+        "O2": 1,
+        "propane": 1./5.0,
+    },
+
+    terminationConversion={
+        'propane': .90,
+    },
+    terminationTime=(40,'s'),
+
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceMoveToCore=0.3,
+    toleranceInterruptSimulation=0.3,
+    maxNumObjsPerIter=1,
+    terminateAtMaxObjects=True,
+    filterReactions=True,
+    toleranceBranchReactionToCore=0.001,
+    branchingIndex=0.5,
+    branchingRatioMax=1.0,
+)
+
+options(
+    units='si',
+    generateSeedEachIteration=False,
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveSimulationProfiles=False,
+    verboseComments=False,
+    saveEdgeSpecies=False,
+    keepIrreversible=False,
+)
+
+generatedSpeciesConstraints(
+    allowed=['input species','seed mechanisms','reaction libraries'],
+    maximumCarbonAtoms=5,
+    maximumOxygenAtoms=8,
+    maximumNitrogenAtoms=0,
+    maximumSiliconAtoms=0,
+    maximumSulfurAtoms=0,
+    maximumRadicalElectrons=2,
+)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -315,7 +315,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, filterThreshold=1e8, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale=(0.0,'sec')):
+          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale=(0.0,'sec'),
+          toleranceBranchReactionToCore=0.0, branchingIndex=0.5, branchingRatioMax=1.0):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -350,7 +351,10 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
             maxNumObjsPerIter=maxNumObjsPerIter,
             terminateAtMaxObjects=terminateAtMaxObjects,
             toleranceThermoKeepSpeciesInEdge=toleranceThermoKeepSpeciesInEdge,
-            dynamicsTimeScale=Quantity(dynamicsTimeScale)
+            dynamicsTimeScale=Quantity(dynamicsTimeScale),
+            toleranceBranchReactionToCore=toleranceBranchReactionToCore,
+            branchingIndex=branchingIndex,
+            branchingRatioMax=branchingRatioMax,
         )
     )
     

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -65,7 +65,8 @@ class ModelSettings(object):
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, filterThreshold=1e8, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
-          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale = Quantity((0.0,'sec'))):
+          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale = Quantity((0.0,'sec')),
+          toleranceBranchReactionToCore=0.0, branchingIndex=0.5, branchingRatioMax=1.0):
 
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
@@ -84,6 +85,9 @@ class ModelSettings(object):
         self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
         self.terminateAtMaxObjects = terminateAtMaxObjects
         self.dynamicsTimeScale = dynamicsTimeScale.value_si
+        self.toleranceBranchReactionToCore = toleranceBranchReactionToCore
+        self.branchingIndex = branchingIndex
+        self.branchingRatioMax = branchingRatioMax
         
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -791,6 +791,7 @@ cdef class ReactionSystem(DASx):
             coreSpeciesProductionRates = self.coreSpeciesProductionRates
             edgeSpeciesRates = numpy.abs(self.edgeSpeciesRates)
             networkLeakRates = numpy.abs(self.networkLeakRates)
+            coreSpeciesRateRatios = numpy.abs(self.coreSpeciesRates/charRate)
             edgeSpeciesRateRatios = numpy.abs(self.edgeSpeciesRates/charRate)
             networkLeakRateRatios = numpy.abs(self.networkLeakRates/charRate)
             numEdgeReactions = self.numEdgeReactions


### PR DESCRIPTION
This adds a new very significantly improved algorithm for chain branching/feedback loop pickup.  

In terms of the inputs we add a reaction if its 'core reactants' have no species of multiplicity >2 and has a species of multiplicity 2 that violates:  

1 < min(BR,branchingRatioMax) * RR**branchingIndex / toleranceBranchReactionToCore

Where the core reactants are the species on the side of the edge reaction that are all in the core.  BR = net reaction rate / consumption of the species, RR = net reaction rate / Rchar.  

This very significantly improves pickup of chain branching reactions as can be demonstrated in the provided example.  