### PR TITLE
SMILES with isotopes

### DIFF
--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -153,7 +153,7 @@ cdef class Molecule(Graph):
 
     cpdef sortAtoms(self)
     
-    cpdef str getFormula(self)
+    cpdef str getFormula(self, bint separate_isotopes=?)
 
     cpdef short getRadicalCount(self)
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -900,9 +900,12 @@ class Molecule(Graph):
         self.sortAtoms()
         self.identifyRingMembership()
 
-    def getFormula(self):
+    def getFormula(self, separate_isotopes=False):
         """
         Return the molecular formula for the molecule.
+
+        The `separate_isotopes` option allows for isotopes to be identified
+        separately and added alphabetically to the molecular formula.
         """
         cython.declare(atom=Atom, symbol=str, elements=dict, keys=list, formula=str)
         cython.declare(hasCarbon=cython.bint, hasHydrogen=cython.bint)
@@ -911,8 +914,10 @@ class Molecule(Graph):
         elements = {}
         for atom in self.vertices:
             symbol = atom.element.symbol
+            if separate_isotopes and atom.element.isotope != -1:
+                symbol = symbol + str(atom.element.isotope)
             elements[symbol] = elements.get(symbol, 0) + 1
-        
+
         # Use the Hill system to generate the formula
         formula = ''
         

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -660,7 +660,8 @@ class TestMolecule(unittest.TestCase):
         
         
         self.mHBonds = Molecule().fromSMILES('C(NC=O)OO')
-        
+        self.isotopic_molecule = Molecule().fromSMILES('[13CH4]')
+
     def testClearLabeledAtoms(self):
         """
         Test the Molecule.clearLabeledAtoms() method.
@@ -736,6 +737,13 @@ class TestMolecule(unittest.TestCase):
         self.assertEqual(self.molecule[0].getFormula(), 'CH2NO2')
         self.assertEqual(self.molecule[1].getFormula(), 'CH2NO2')
 
+    def test_getFormula_with_isotopes(self):
+        """
+        Tests that Molecule.getFormula's separate_isotopes parameter.
+        """
+        self.assertEqual(self.isotopic_molecule.getFormula(), 'CH4')
+        self.assertEqual(self.isotopic_molecule.getFormula(separate_isotopes=False), 'CH4')
+        self.assertEqual(self.isotopic_molecule.getFormula(separate_isotopes=True), 'C13H4')
 
     def testRadicalCount(self):
         """

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -234,9 +234,9 @@ def toSMILES(mol, backend='default'):
     # The dictionary is defined at the top of this file.
     try:
         if mol.isRadical():
-            output = RADICAL_LOOKUPS[mol.getFormula()]
+            output = RADICAL_LOOKUPS[mol.getFormula(separate_isotopes=True)]
         else:
-            output = MOLECULE_LOOKUPS[mol.getFormula()]
+            output = MOLECULE_LOOKUPS[mol.getFormula(separate_isotopes=True)]
     except KeyError:
         if backend == 'default':
             for atom in mol.atoms:

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -359,9 +359,9 @@ def _rdkit_translator(input_object, identifier_type, mol=None):
             output = Chem.MolToSmarts(rdkitmol)
         elif identifier_type == 'smi':
             if input_object.isAromatic():
-                output = Chem.MolToSmiles(rdkitmol)
+                output = Chem.MolToSmiles(rdkitmol, isomericSmiles=True)
             else:
-                output = Chem.MolToSmiles(rdkitmol, kekuleSmiles=True)
+                output = Chem.MolToSmiles(rdkitmol, kekuleSmiles=True, isomericSmiles=True)
         else:
             raise ValueError('Identifier type {0} is not supported for writing using RDKit.'.format(identifier_type))
     else:

--- a/rmgpy/molecule/translatorTest.py
+++ b/rmgpy/molecule/translatorTest.py
@@ -434,7 +434,7 @@ multiplicity 2
 class SMILESGenerationTest(unittest.TestCase):
     def compare(self, adjlist, smiles):
         mol = Molecule().fromAdjacencyList(adjlist)
-        self.assertEquals(smiles, mol.toSMILES())
+        self.assertEquals(smiles, mol.toSMILES(), 'Returned SMILES {1} does not match intended SMILES {0}'.format(smiles, mol.toSMILES()))
 
     def test_CH4(self):
         "Test the SMILES generation for methane"
@@ -449,6 +449,46 @@ class SMILESGenerationTest(unittest.TestCase):
         smiles = "C"
         self.compare(adjlist, smiles)
 
+    def test_13CH4(self):
+        """
+        Test the SMILES generation for isotopic molecule whose structure is
+        similar to those hardcoded in MOLECULE_LOOKUP
+        """
+
+        adjlist = """
+1 C u0 p0 c0 i13 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+        """
+        smiles = "[13CH4]"
+        self.compare(adjlist, smiles)
+
+    def test_large_isotope_molecule(self):
+        """
+        Test the SMILES generation for isotopic molecule whose structure is
+        different than those hardcoded in MOLECULE_LOOKUP
+        """
+
+        adjlist = """
+1  C u0 p0 c0 i13 {2,S} {5,S} {6,S} {7,S}
+2  C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+3  C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  C u0 p0 c0 {3,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+        """
+        smiles = "CCC[13CH3]"
+        self.compare(adjlist, smiles)
     def test_C(self):
         "Test the SMILES generation for atomic carbon mult=(1,3,5)"
         adjlist = "1 C u0 p2 c0"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG should be able to generate SMILES with isotopic information

### Description of Changes

* Added argument to getFormula to contain isotopic information
* Added parameter to rdkit's moltoSMILES which allows isotopic smiles

### Testing
The unittests currently failing on some aromatic compounds. I am not sure the cause of it.

This code works when rdkit is used to generate smiles. Not sure what would happen with Nitrogen using openbabel. 

### Reviewer Tips
read code?