### PR TITLE
Move Forbidden Structure Checking from Edge to Core (Edgeless RMG Part 1)

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1509,17 +1509,12 @@ class KineticsFamily(Database):
         Return ``True`` if the molecule is forbidden in this family, or
         ``False`` otherwise. 
         """
-        from rmgpy.data.rmg import getDB
-        
-        forbidden_structures = getDB('forbidden')
 
         # check family-specific forbidden structures 
         if self.forbidden is not None and self.forbidden.isMoleculeForbidden(molecule):
             return True
 
-        # check RMG globally forbidden structures
-        if forbidden_structures.isMoleculeForbidden(molecule):
-            return True
+
         return False
 
     def __createReaction(self, reactants, products, is_forward):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -53,6 +53,9 @@ from rmgpy.data.kinetics.family import KineticsFamily, TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 
 from rmgpy.kinetics import KineticsData, Arrhenius
+
+from rmgpy.data.rmg import getDB
+        
 import rmgpy.data.rmg
 from .react import reactAll
 
@@ -1052,6 +1055,28 @@ class CoreEdgeReactionModel:
 
         assert spec not in self.core.species, "Tried to add species {0} to core, but it's already there".format(spec.label)
 
+        forbidden_structures = getDB('forbidden')
+        
+        # check RMG globally forbidden structures
+        if forbidden_structures.isMoleculeForbidden(spec.molecule[0]):
+            
+            rxnList = []
+            if spec in self.edge.species:
+
+                #remove forbidden species from edge
+                logging.info("Species {0} was Forbidden and not added to Core...Removing from Edge.".format(spec))
+                self.edge.species.remove(spec)
+                # Search edge for reactions that contain forbidden species
+                for rxn in self.edge.reactions:
+                    if spec in rxn.reactants or spec in rxn.products:                        
+                        rxnList.append(rxn)
+                
+                #Remove any reactions that are globally forbidden from Edge
+                for rxn in rxnList:
+                    self.edge.reactions.remove(rxn)
+                    logging.info("Removing Forbidden Reaction from Edge: {0}".format(rxn))
+                return []
+        
         # Add the species to the core
         self.core.species.append(spec)
         

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1058,7 +1058,7 @@ class CoreEdgeReactionModel:
         forbidden_structures = getDB('forbidden')
         
         # check RMG globally forbidden structures
-        if forbidden_structures.isMoleculeForbidden(spec.molecule[0]):
+        if not spec.explicitlyAllowed and forbidden_structures.isMoleculeForbidden(spec.molecule[0]):
             
             rxnList = []
             if spec in self.edge.species:
@@ -1505,6 +1505,7 @@ class CoreEdgeReactionModel:
         for spec in self.newSpeciesList:
             if database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0]):
                 if 'allowed' in rmg.speciesConstraints and 'seed mechanisms' in rmg.speciesConstraints['allowed']:
+                    spec.explicitlyAllowed = True
                     logging.warning("Species {0} from seed mechanism {1} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.".format(spec.label, seedMechanism.label))
                 else:
                     raise ForbiddenStructureException("Species {0} from seed mechanism {1} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label, seedMechanism.label))
@@ -1593,6 +1594,7 @@ class CoreEdgeReactionModel:
         for spec in self.newSpeciesList:
             if database.forbiddenStructures.isMoleculeForbidden(spec.molecule[0]):
                 if 'allowed' in rmg.speciesConstraints and 'reaction libraries' in rmg.speciesConstraints['allowed']:
+                    spec.explicitlyAllowed = True
                     logging.warning("Species {0} from reaction library {1} is globally forbidden.  It will behave as an inert unless found in a seed mechanism or reaction library.".format(spec.label, reactionLibrary.label))
                 else:
                     raise ForbiddenStructureException("Species {0} from reaction library {1} is globally forbidden. You may explicitly allow it, but it will remain inert unless found in a seed mechanism or reaction library.".format(spec.label, reactionLibrary.label))

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -52,6 +52,7 @@ cdef class Species:
     cdef public float symmetryNumber
     cdef public bint isSolvent
     cdef public int creationIteration
+    cdef public bint explicitlyAllowed
 
     cpdef generate_resonance_structures(self, bint keep_isomorphic=?, bint filter_structures=?)
     

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -90,7 +90,7 @@ class Species(object):
     def __init__(self, index=-1, label='', thermo=None, conformer=None, 
                  molecule=None, transportData=None, molecularWeight=None, 
                  energyTransferModel=None, reactive=True, props=None, aug_inchi=None,
-                 symmetryNumber = -1, creationIteration = 0):
+                 symmetryNumber = -1, creationIteration = 0, explicitlyAllowed=False):
         self.index = index
         self.label = label
         self.thermo = thermo
@@ -105,6 +105,7 @@ class Species(object):
         self.symmetryNumber = symmetryNumber
         self.isSolvent = False
         self.creationIteration = creationIteration
+        self.explicitlyAllowed = explicitlyAllowed
         # Check multiplicity of each molecule is the same
         if molecule is not None and len(molecule)>1:
             mult = molecule[0].multiplicity


### PR DESCRIPTION
This moves global forbidden structure checking from when species are created in the edge to when a species attempts to enter the core. In a test constructing a dodecane combustion model this reduced time spent checking forbidden structures by 148x and overall runtime (in the react regime) by 4.5x without impacting the output model.  
