### PR TITLE
Allow setting of the frequency at which edge fluxes are checked (Edgeless RMG Part 2)

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -580,6 +580,26 @@ For example ::
 		toleranceMoveSurfaceReactionToCore=5.0,
 	)
 
+Advanced Setting: Reducing Edge Checking
+-----------------------------------------
+It is possible to reduce the frequency at which RMG calculates and checks the edge reactions in order to 
+speed up RMG.    
+
+This might look like::
+
+    model(
+        toleranceMoveToCore=0.5,
+        toleranceInterruptSimulation=0.5,
+        edgeCheckFrequency=0.1,
+	)
+
+- ``edgeCheckFrequency`` is the frequency at which RMG will calculate and check edge information.  Thus, 0.1 corresponds to checking every 10 time steps and the default value of 1 corresponds to checking every time step.  Note that it rounds the inverse of the frequency down.  
+
+Changing this value will change the model generated and setting this value low enough will cause you to 
+miss chemistry.  However, in general tests indicate that 0.1 is a relatively safe setting at which differences 
+are usually minimal.  
+
+
 On the fly Quantum Calculations
 ===============================
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -315,7 +315,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
           toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, filterThreshold=1e8, ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale=(0.0,'sec')):
+          maxNumSpecies=None,maxNumObjsPerIter=1,terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale=(0.0,'sec'),
+          edgeCheckFrequency=1.0):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -350,9 +351,11 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=numpy.inf,to
             maxNumObjsPerIter=maxNumObjsPerIter,
             terminateAtMaxObjects=terminateAtMaxObjects,
             toleranceThermoKeepSpeciesInEdge=toleranceThermoKeepSpeciesInEdge,
-            dynamicsTimeScale=Quantity(dynamicsTimeScale)
+            dynamicsTimeScale=Quantity(dynamicsTimeScale),
+            edgeCheckFrequency=edgeCheckFrequency,
         )
     )
+
     
 def quantumMechanics(
                     software,

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -52,6 +52,7 @@ This module contains settings classes for manipulation of RMG run parameters
     `ignoreOverallFluxCriterion`                    flag indicating that the ordinary flux criterion should be ignored except for pdep purposes
     `maxNumSpecies`                                 Number of core species at which a stage/job will terminate
     `maxNumObjPerIter`                              Maximum number of objects that can be sent for enlargement from a single simulation
+    `edgeCheckFrequency`                            Fraction of solver time steps at which the edge reaction rates will be calculated and checked
 ==================================================================================================================================================
 """
 import numpy
@@ -65,8 +66,7 @@ class ModelSettings(object):
           toleranceMoveEdgeReactionToSurface=numpy.inf, toleranceMoveSurfaceSpeciesToCore=numpy.inf, toleranceMoveSurfaceReactionToCore=numpy.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
           minSpeciesExistIterationsForPrune=2, filterReactions=False, filterThreshold=1e8, ignoreOverallFluxCriterion=False, maxNumSpecies=None, maxNumObjsPerIter=1,
-          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale = Quantity((0.0,'sec'))):
-
+          terminateAtMaxObjects=False,toleranceThermoKeepSpeciesInEdge=numpy.inf,dynamicsTimeScale = Quantity((0.0,'sec')), edgeCheckFrequency=1.0):
         
         self.fluxToleranceKeepInEdge = toleranceKeepInEdge
         self.fluxToleranceMoveToCore = toleranceMoveToCore
@@ -84,6 +84,7 @@ class ModelSettings(object):
         self.toleranceThermoKeepSpeciesInEdge = toleranceThermoKeepSpeciesInEdge
         self.terminateAtMaxObjects = terminateAtMaxObjects
         self.dynamicsTimeScale = dynamicsTimeScale.value_si
+        self.edgeCheckFrequency = edgeCheckFrequency
         
         if toleranceInterruptSimulation:
             self.fluxToleranceInterrupt = toleranceInterruptSimulation

--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -325,10 +325,10 @@ cdef class SimpleReactor(ReactionSystem):
         """
         cdef numpy.ndarray[numpy.int_t, ndim=2] ir, ip, inet
         cdef numpy.ndarray[numpy.float64_t, ndim=1] res, kf, kr, knet, delta, equilibriumConstants
-        cdef int numCoreSpecies, numCoreReactions, numEdgeSpecies, numEdgeReactions, numPdepNetworks
+        cdef int numCoreSpecies, numCoreReactions
         cdef int i, j, z, first, second, third
         cdef double k, V, reactionRate, revReactionRate, T, P, Peff
-        cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesConcentrations, coreSpeciesRates, coreReactionRates, edgeSpeciesRates, edgeReactionRates, networkLeakRates, coreSpeciesConsumptionRates, coreSpeciesProductionRates
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesRates
         cdef numpy.ndarray[numpy.float64_t, ndim=1] C, y_coreSpecies
         cdef numpy.ndarray[numpy.float64_t, ndim=2] jacobian, dgdk, colliderEfficiencies
         cdef numpy.ndarray[numpy.int_t, ndim=1] pdepColliderReactionIndices, pdepSpecificColliderReactionIndices
@@ -339,9 +339,7 @@ cdef class SimpleReactor(ReactionSystem):
         
         numCoreSpecies = len(self.coreSpeciesRates)
         numCoreReactions = len(self.coreReactionRates)
-        numEdgeSpecies = len(self.edgeSpeciesRates)
-        numEdgeReactions = len(self.edgeReactionRates)
-        numPdepNetworks = len(self.networkLeakRates)
+
         kf = self.kf
         kr = self.kb
         
@@ -384,23 +382,17 @@ cdef class SimpleReactor(ReactionSystem):
         coreSpeciesConcentrations = numpy.zeros_like(self.coreSpeciesConcentrations)
         coreSpeciesRates = numpy.zeros_like(self.coreSpeciesRates)
         coreReactionRates = numpy.zeros_like(self.coreReactionRates)
-        coreSpeciesConsumptionRates = numpy.zeros_like(self.coreSpeciesConsumptionRates)
-        coreSpeciesProductionRates = numpy.zeros_like(self.coreSpeciesProductionRates)
-        edgeSpeciesRates = numpy.zeros_like(self.edgeSpeciesRates)
-        edgeReactionRates = numpy.zeros_like(self.edgeReactionRates)
-        networkLeakRates = numpy.zeros_like(self.networkLeakRates)
 
         C = numpy.zeros_like(self.coreSpeciesConcentrations)
         
         # Use ideal gas law to compute volume
         V = constants.R * self.T.value_si * numpy.sum(y_coreSpecies) / self.P.value_si
         self.V = V
-
+        self.y = y
         for j in xrange(numCoreSpecies):
             C[j] = y[j] / V
-            coreSpeciesConcentrations[j] = C[j]
         
-        for j in xrange(ir.shape[0]):
+        for j in xrange(numCoreReactions):
             k = kf[j]
             if ir[j,0] >= numCoreSpecies or ir[j,1] >= numCoreSpecies or ir[j,2] >= numCoreSpecies:
                 fReactionRate = 0.0
@@ -423,85 +415,34 @@ cdef class SimpleReactor(ReactionSystem):
             reactionRate = fReactionRate-revReactionRate
             
             # Set the reaction and species rates
-            if j < numCoreReactions:
-                # The reaction is a core reaction
-                coreReactionRates[j] = reactionRate
 
-                # Add/substract the total reaction rate from each species rate
-                # Since it's a core reaction we know that all of its reactants
-                # and products are core species
-                first = ir[j,0]
-                coreSpeciesRates[first] -= reactionRate
-                coreSpeciesConsumptionRates[first] += fReactionRate
-                coreSpeciesProductionRates[first] += revReactionRate
-                second = ir[j,1]
-                if second != -1:
-                    coreSpeciesRates[second] -= reactionRate
-                    coreSpeciesConsumptionRates[second] += fReactionRate
-                    coreSpeciesProductionRates[second] += revReactionRate
-                    third = ir[j,2]
-                    if third != -1:
-                        coreSpeciesRates[third] -= reactionRate
-                        coreSpeciesConsumptionRates[third] += fReactionRate
-                        coreSpeciesProductionRates[third] += revReactionRate
-                first = ip[j,0]
-                coreSpeciesRates[first] += reactionRate
-                coreSpeciesProductionRates[first] += fReactionRate
-                coreSpeciesConsumptionRates[first] += revReactionRate
-                second = ip[j,1]
-                if second != -1:
-                    coreSpeciesRates[second] += reactionRate
-                    coreSpeciesProductionRates[second] += fReactionRate
-                    coreSpeciesConsumptionRates[second] += revReactionRate
-                    third = ip[j,2]
-                    if third != -1:
-                        coreSpeciesRates[third] += reactionRate
-                        coreSpeciesProductionRates[third] += fReactionRate
-                        coreSpeciesConsumptionRates[third] += revReactionRate
+            # The reaction is a core reaction
+            coreReactionRates[j] = reactionRate
 
-            else:
-                # The reaction is an edge reaction
-                edgeReactionRates[j-numCoreReactions] = reactionRate
+            # Add/substract the total reaction rate from each species rate
+            # Since it's a core reaction we know that all of its reactants
+            # and products are core species
+            first = ir[j,0]
+            coreSpeciesRates[first] -= reactionRate
+            second = ir[j,1]
+            if second != -1:
+                coreSpeciesRates[second] -= reactionRate
+                third = ir[j,2]
+                if third != -1:
+                    coreSpeciesRates[third] -= reactionRate
+            first = ip[j,0]
+            coreSpeciesRates[first] += reactionRate
+            second = ip[j,1]
+            if second != -1:
+                coreSpeciesRates[second] += reactionRate
+                third = ip[j,2]
+                if third != -1:
+                    coreSpeciesRates[third] += reactionRate
 
-                # Add/substract the total reaction rate from each species rate
-                # Since it's an edge reaction its reactants and products could
-                # be either core or edge species
-                # We're only interested in the edge species
-                first = ir[j,0]
-                if first >= numCoreSpecies: edgeSpeciesRates[first-numCoreSpecies] -= reactionRate
-                second = ir[j,1]
-                if second != -1:
-                    if second >= numCoreSpecies: edgeSpeciesRates[second-numCoreSpecies] -= reactionRate
-                    third = ir[j,2]
-                    if third != -1:
-                        if third >= numCoreSpecies: edgeSpeciesRates[third-numCoreSpecies] -= reactionRate
-                first = ip[j,0]
-                if first >= numCoreSpecies: edgeSpeciesRates[first-numCoreSpecies] += reactionRate
-                second = ip[j,1]
-                if second != -1:
-                    if second >= numCoreSpecies: edgeSpeciesRates[second-numCoreSpecies] += reactionRate
-                    third = ip[j,2]
-                    if third != -1:
-                        if third >= numCoreSpecies: edgeSpeciesRates[third-numCoreSpecies] += reactionRate
-
-        for j in xrange(inet.shape[0]):
-            k = knet[j]
-            if inet[j,1] == -1: # only one reactant
-                reactionRate = k * C[inet[j,0]]
-            elif inet[j,2] == -1: # only two reactants
-                reactionRate = k * C[inet[j,0]] * C[inet[j,1]]
-            else: # three reactants!! (really?)
-                reactionRate = k * C[inet[j,0]] * C[inet[j,1]] * C[inet[j,2]]
-            networkLeakRates[j] = reactionRate
-
-        self.coreSpeciesConcentrations = coreSpeciesConcentrations
+        self.coreSpeciesConcentrations = C
         self.coreSpeciesRates = coreSpeciesRates
-        self.coreSpeciesProductionRates = coreSpeciesProductionRates
-        self.coreSpeciesConsumptionRates = coreSpeciesConsumptionRates
         self.coreReactionRates = coreReactionRates
-        self.edgeSpeciesRates = edgeSpeciesRates
-        self.edgeReactionRates = edgeReactionRates
-        self.networkLeakRates = networkLeakRates
+
 
         res = coreSpeciesRates * V 
         
@@ -526,6 +467,116 @@ cdef class SimpleReactor(ReactionSystem):
         
         # Return DELTA, IRES.  IRES is set to 1 in order to tell DASPK to evaluate the sensitivity residuals
         return delta, 1
+    
+    @cython.boundscheck(False)
+    def generateEdgeInfo(self, double t, numpy.ndarray[numpy.float64_t, ndim=1] y):
+
+        """
+        Return the residual function for the governing DAE system for the
+        simple reaction system.
+        """
+        cdef numpy.ndarray[numpy.int_t, ndim=2] ir, ip, inet
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] res, kf, kr, knet, delta, equilibriumConstants
+        cdef int numCoreSpecies, numCoreReactions, numEdgeSpecies, numEdgeReactions, numPdepNetworks
+        cdef int i, j, z, first, second, third
+        cdef double k, V, reactionRate, revReactionRate, T, P, Peff
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] coreSpeciesConcentrations, coreSpeciesRates, coreReactionRates, edgeSpeciesRates, edgeReactionRates, networkLeakRates, coreSpeciesConsumptionRates, coreSpeciesProductionRates
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] C, y_coreSpecies
+        cdef numpy.ndarray[numpy.float64_t, ndim=2] jacobian, dgdk, colliderEfficiencies
+        cdef numpy.ndarray[numpy.int_t, ndim=1] pdepColliderReactionIndices, pdepSpecificColliderReactionIndices
+        cdef list pdepColliderKinetics, pdepSpecificColliderKinetics
+
+        ir = self.reactantIndices
+        ip = self.productIndices
+        
+        numCoreSpecies = len(self.coreSpeciesRates)
+        numCoreReactions = len(self.coreReactionRates)
+        numEdgeSpecies = len(self.edgeSpeciesRates)
+        numEdgeReactions = len(self.edgeReactionRates)
+        numPdepNetworks = len(self.networkLeakRates)
+        kf = self.kf
+        kr = self.kb
+        
+        y_coreSpecies = y[:numCoreSpecies]
+        
+            
+        inet = self.networkIndices
+        knet = self.networkLeakCoefficients
+        
+        
+        edgeSpeciesRates = numpy.zeros_like(self.edgeSpeciesRates)
+        edgeReactionRates = numpy.zeros_like(self.edgeReactionRates)
+        networkLeakRates = numpy.zeros_like(self.networkLeakRates)
+
+        
+        # Use ideal gas law to compute volume
+        V = constants.R * self.T.value_si * numpy.sum(y_coreSpecies) / self.P.value_si
+        self.V = V
+
+
+        C = self.coreSpeciesConcentrations
+        
+        for j in xrange(numCoreReactions,ir.shape[0]):
+            k = kf[j]
+            if ir[j,0] >= numCoreSpecies or ir[j,1] >= numCoreSpecies or ir[j,2] >= numCoreSpecies:
+                fReactionRate = 0.0
+            elif ir[j,1] == -1: # only one reactant
+                fReactionRate = k * C[ir[j,0]]
+            elif ir[j,2] == -1: # only two reactants
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]]
+            else: # three reactants!! (really?)
+                fReactionRate = k * C[ir[j,0]] * C[ir[j,1]] * C[ir[j,2]]
+            k = kr[j]
+            if ip[j,0] >= numCoreSpecies or ip[j,1] >= numCoreSpecies or ip[j,2] >= numCoreSpecies:
+                revReactionRate = 0.0
+            elif ip[j,1] == -1: # only one reactant
+                revReactionRate = k * C[ip[j,0]]
+            elif ip[j,2] == -1: # only two reactants
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]]
+            else: # three reactants!! (really?)
+                revReactionRate = k * C[ip[j,0]] * C[ip[j,1]] * C[ip[j,2]]
+                
+            reactionRate = fReactionRate-revReactionRate
+            
+
+            edgeReactionRates[j-numCoreReactions] = reactionRate
+
+            # Add/substract the total reaction rate from each species rate
+            # Since it's an edge reaction its reactants and products could
+            # be either core or edge species
+            # We're only interested in the edge species
+            first = ir[j,0]
+            if first >= numCoreSpecies: edgeSpeciesRates[first-numCoreSpecies] -= reactionRate
+            second = ir[j,1]
+            if second != -1:
+                if second >= numCoreSpecies: edgeSpeciesRates[second-numCoreSpecies] -= reactionRate
+                third = ir[j,2]
+                if third != -1:
+                    if third >= numCoreSpecies: edgeSpeciesRates[third-numCoreSpecies] -= reactionRate
+            first = ip[j,0]
+            if first >= numCoreSpecies: edgeSpeciesRates[first-numCoreSpecies] += reactionRate
+            second = ip[j,1]
+            if second != -1:
+                if second >= numCoreSpecies: edgeSpeciesRates[second-numCoreSpecies] += reactionRate
+                third = ip[j,2]
+                if third != -1:
+                    if third >= numCoreSpecies: edgeSpeciesRates[third-numCoreSpecies] += reactionRate
+
+        for j in xrange(inet.shape[0]):
+            k = knet[j]
+            if inet[j,1] == -1: # only one reactant
+                reactionRate = k * C[inet[j,0]]
+            elif inet[j,2] == -1: # only two reactants
+                reactionRate = k * C[inet[j,0]] * C[inet[j,1]]
+            else: # three reactants!! (really?)
+                reactionRate = k * C[inet[j,0]] * C[inet[j,1]] * C[inet[j,2]]
+            networkLeakRates[j] = reactionRate
+
+        self.edgeSpeciesRates = edgeSpeciesRates
+        self.edgeReactionRates = edgeReactionRates
+        self.networkLeakRates = networkLeakRates
+
+        return
     
     @cython.boundscheck(False)
     def jacobian(self, double t, numpy.ndarray[numpy.float64_t, ndim=1] y, numpy.ndarray[numpy.float64_t, ndim=1] dydt, double cj, numpy.ndarray[numpy.float64_t, ndim=1] senpar = numpy.zeros(1, numpy.float64)):


### PR DESCRIPTION
Currently when RMG simulates a system at every time step it calculates both the core and edge fluxes.  This PR seperates these calculations and allows the user to specify the frequency (implicitly the number of time steps between each calculation of edge fluxes) at which the edge fluxes are calculated.  Since the edge is so much larger than the core this in theory significantly reduces simulation time.  I've measured slight but measurable improvements in small jobs such as the minimal example and ethane combustion example and on an extended minimal example I achieved between a factor of 2 and factor of 3 reduction in simulation time.  The option this provides is of course primarily useful when model construction is in the simulate regime.  

(This PR is independent of Edgeless RMG Part 1).  