### PR TITLE
allow parsing of Trees with molecule objects

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -932,6 +932,8 @@ class Database:
         group = node.item
         if isinstance(group, LogicNode):
             return group.matchToStructure(self, structure, atoms, strict)
+        elif isinstance(group, Molecule):
+            return structure.isIsomorphic(group)
         else:
             # try to pair up labeled atoms
             centers = group.getLabeledAtoms()


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
previously, the decendTree method would treat molecule objects in
trees as group objects, throwing an error. Though it is entirely possible
to have molecule objects decend through the tree

### Description of Changes
 This fix uses isomorphism
of molecule objects instead of using subgraph isomorphism

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
