### PR TITLE
Add option to ignore atom type errors when making molecules

### DIFF
--- a/rmgpy/molecule/converter.pxd
+++ b/rmgpy/molecule/converter.pxd
@@ -30,8 +30,8 @@ cimport rmgpy.molecule.molecule as mm
 
 cpdef to_rdkit_mol(mm.Molecule mol, bint remove_h=*, bint return_mapping=*, bint sanitize=*)
 
-cpdef mm.Molecule from_rdkit_mol(mm.Molecule mol, object rdkitmol)
+cpdef mm.Molecule from_rdkit_mol(mm.Molecule mol, object rdkitmol, bint raise_atomtype_exception=?)
 
 cpdef to_ob_mol(mm.Molecule mol, bint return_mapping=*)
 
-cpdef mm.Molecule from_ob_mol(mm.Molecule mol, object obmol)
+cpdef mm.Molecule from_ob_mol(mm.Molecule mol, object obmol, bint raise_atomtype_exception=?)

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -107,7 +107,7 @@ def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True):
     return rdkitmol
 
 
-def from_rdkit_mol(mol, rdkitmol):
+def from_rdkit_mol(mol, rdkitmol, raise_atomtype_exception=True):
     """
     Convert a RDKit Mol object `rdkitmol` to a molecular structure. Uses
     `RDKit <http://rdkit.org/>`_ to perform the conversion.
@@ -172,7 +172,7 @@ def from_rdkit_mol(mol, rdkitmol):
     # We need to update lone pairs first because the charge was set by RDKit
     mol.update_lone_pairs()
     # Set atom types and connectivity values
-    mol.update()
+    mol.update(raise_atomtype_exception=raise_atomtype_exception)
 
     # Assume this is always true
     # There are cases where 2 radical_electrons is a singlet, but
@@ -253,7 +253,7 @@ def to_ob_mol(mol, return_mapping=False):
     return obmol
 
 
-def from_ob_mol(mol, obmol):
+def from_ob_mol(mol, obmol, raise_atomtype_exception=True):
     """
     Convert a OpenBabel Mol object `obmol` to a molecular structure. Uses
     `OpenBabel <http://openbabel.org/>`_ to perform the conversion.
@@ -299,7 +299,7 @@ def from_ob_mol(mol, obmol):
 
     # Set atom types and connectivity values
     mol.update_connectivity_values()
-    mol.update_atomtypes()
+    mol.update_atomtypes(log_species=True, raise_exception=raise_atomtype_exception)
     mol.update_multiplicity()
     mol.identify_ring_membership()
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -204,13 +204,13 @@ cdef class Molecule(Graph):
 
     cpdef draw(self, str path)
 
-    cpdef from_inchi(self, str inchistr, backend=?)
+    cpdef from_inchi(self, str inchistr, backend=?, bint raise_atomtype_exception=?)
 
-    cpdef from_smiles(self, str smilesstr, backend=?)
+    cpdef from_smiles(self, str smilesstr, backend=?, bint raise_atomtype_exception=?)
 
-    cpdef from_adjacency_list(self, str adjlist, bint saturate_h=?)
+    cpdef from_adjacency_list(self, str adjlist, bint saturate_h=?, bint raise_atomtype_exception=?)
 
-    cpdef from_xyz(self, np.ndarray atomic_nums, np.ndarray coordinates)
+    cpdef from_xyz(self, np.ndarray atomic_nums, np.ndarray coordinates, bint raise_atomtype_exception=?)
     
     cpdef str to_inchi(self)
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -208,7 +208,8 @@ cdef class Molecule(Graph):
 
     cpdef from_smiles(self, str smilesstr, backend=?, bint raise_atomtype_exception=?)
 
-    cpdef from_adjacency_list(self, str adjlist, bint saturate_h=?, bint raise_atomtype_exception=?)
+    cpdef from_adjacency_list(self, str adjlist, bint saturate_h=?, bint raise_atomtype_exception=?,
+                              bint raise_charge_exception=?)
 
     cpdef from_xyz(self, np.ndarray atomic_nums, np.ndarray coordinates, bint raise_atomtype_exception=?)
     

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1679,7 +1679,8 @@ class Molecule(Graph):
         translator.from_smarts(self, smartsstr, raise_atomtype_exception=raise_atomtype_exception)
         return self
 
-    def from_adjacency_list(self, adjlist, saturate_h=False, raise_atomtype_exception=True):
+    def from_adjacency_list(self, adjlist, saturate_h=False, raise_atomtype_exception=True,
+                            raise_charge_exception=True):
         """
         Convert a string adjacency list `adjlist` to a molecular structure.
         Skips the first line (assuming it's a label) unless `withLabel` is
@@ -1698,9 +1699,10 @@ class Molecule(Graph):
                 n_rad - 3 == multiplicity or n_rad - 5 == multiplicity):
             raise ValueError('Impossible multiplicity for molecule\n{0}\n multiplicity = {1} and number of '
                              'unpaired electrons = {2}'.format(self.to_adjacency_list(), multiplicity, n_rad))
-        if self.get_net_charge() != 0:
-            raise ValueError('Non-neutral molecule encountered. '
-                             'Currently, RMG does not support ion chemistry.\n {0}'.format(adjlist))
+        if raise_charge_exception:
+            if self.get_net_charge() != 0:
+                raise ValueError('Non-neutral molecule encountered. '
+                                 'Currently, RMG does not support ion chemistry.\n {0}'.format(adjlist))
         return self
 
     def from_xyz(self, atomic_nums, coordinates, raise_atomtype_exception=True):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1116,7 +1116,7 @@ class Molecule(Graph):
         for index, vertex in enumerate(self.vertices):
             vertex.sorting_label = index
 
-    def update(self, log_species=True):
+    def update(self, log_species=True, raise_atomtype_exception=True):
         """
         Update connectivity values, atom types of atoms.
         Update multiplicity, and sort atoms using the new
@@ -1126,7 +1126,7 @@ class Molecule(Graph):
         for atom in self.atoms:
             atom.update_charge()
 
-        self.update_atomtypes(log_species=log_species)
+        self.update_atomtypes(log_species=log_species, raise_exception=raise_atomtype_exception)
         self.update_multiplicity()
         self.sort_atoms()
         self.identify_ring_membership()
@@ -1283,7 +1283,7 @@ class Molecule(Graph):
         for atom in hydrogens:
             self.remove_atom(atom)
 
-    def connect_the_dots(self):
+    def connect_the_dots(self, raise_atomtype_exception=True):
         """
         Delete all bonds, and set them again based on the Atoms' coords.
         Does not detect bond type.
@@ -1326,7 +1326,7 @@ class Molecule(Graph):
                     # groupBond = GroupBond(atom1, atom2, [1,2,3,1.5])
                     bond = Bond(atom1, atom2, 1)
                     self.add_bond(bond)
-        self.update_atomtypes()
+        self.update_atomtypes(raise_exception=raise_atomtype_exception)
 
     def update_atomtypes(self, log_species=True, raise_exception=True):
         """
@@ -1649,37 +1649,37 @@ class Molecule(Graph):
         os.unlink(temp_file_name)
         return png
 
-    def from_inchi(self, inchistr, backend='try-all'):
+    def from_inchi(self, inchistr, backend='try-all', raise_atomtype_exception=True):
         """
         Convert an InChI string `inchistr` to a molecular structure.
         """
-        translator.from_inchi(self, inchistr, backend)
+        translator.from_inchi(self, inchistr, backend, raise_atomtype_exception=raise_atomtype_exception)
         return self
 
-    def from_augmented_inchi(self, aug_inchi):
+    def from_augmented_inchi(self, aug_inchi, raise_atomtype_exception=True):
         """
         Convert an Augmented InChI string `aug_inchi` to a molecular structure.
         """
-        translator.from_augmented_inchi(self, aug_inchi)
+        translator.from_augmented_inchi(self, aug_inchi, raise_atomtype_exception=raise_atomtype_exception)
         return self
 
-    def from_smiles(self, smilesstr, backend='try-all'):
+    def from_smiles(self, smilesstr, backend='try-all', raise_atomtype_exception=True):
         """
         Convert a SMILES string `smilesstr` to a molecular structure.
         """
-        translator.from_smiles(self, smilesstr, backend)
+        translator.from_smiles(self, smilesstr, backend, raise_atomtype_exception=raise_atomtype_exception)
         return self
 
-    def from_smarts(self, smartsstr):
+    def from_smarts(self, smartsstr, raise_atomtype_exception=True):
         """
         Convert a SMARTS string `smartsstr` to a molecular structure. Uses
         `RDKit <http://rdkit.org/>`_ to perform the conversion.
         This Kekulizes everything, removing all aromatic atom types.
         """
-        translator.from_smarts(self, smartsstr)
+        translator.from_smarts(self, smartsstr, raise_atomtype_exception=raise_atomtype_exception)
         return self
 
-    def from_adjacency_list(self, adjlist, saturate_h=False):
+    def from_adjacency_list(self, adjlist, saturate_h=False, raise_atomtype_exception=True):
         """
         Convert a string adjacency list `adjlist` to a molecular structure.
         Skips the first line (assuming it's a label) unless `withLabel` is
@@ -1688,7 +1688,7 @@ class Molecule(Graph):
         from rmgpy.molecule.adjlist import from_adjacency_list
 
         self.vertices, self.multiplicity = from_adjacency_list(adjlist, group=False, saturate_h=saturate_h)
-        self.update_atomtypes()
+        self.update_atomtypes(raise_exception=raise_atomtype_exception)
         self.identify_ring_membership()
 
         # Check if multiplicity is possible
@@ -1703,7 +1703,7 @@ class Molecule(Graph):
                              'Currently, RMG does not support ion chemistry.\n {0}'.format(adjlist))
         return self
 
-    def from_xyz(self, atomic_nums, coordinates):
+    def from_xyz(self, atomic_nums, coordinates, raise_atomtype_exception=True):
         """
         Create an RMG molecule from a list of coordinates and a corresponding
         list of atomic numbers. These are typically received from CCLib and the
@@ -1716,9 +1716,9 @@ class Molecule(Graph):
             atom = Atom(_rdkit_periodic_table.GetElementSymbol(int(at_num)))
             atom.coords = coordinates[i]
             self.add_atom(atom)
-        return self.connect_the_dots()
+        return self.connect_the_dots(raise_atomtype_exception=raise_atomtype_exception)
 
-    def to_single_bonds(self):
+    def to_single_bonds(self, raise_atomtype_exception=True):
         """
         Returns a copy of the current molecule, consisting of only single bonds.
         
@@ -1738,7 +1738,7 @@ class Molecule(Graph):
             for atom2 in atom1.bonds:
                 bond = Bond(mapping[atom1], mapping[atom2], 1)
                 new_mol.add_bond(bond)
-        new_mol.update_atomtypes()
+        new_mol.update_atomtypes(raise_exception=raise_atomtype_exception)
         return new_mol
 
     def to_inchi(self):
@@ -2157,7 +2157,7 @@ class Molecule(Graph):
         saturator.saturate(self.atoms)
         if update: self.update()
 
-    def saturate_radicals(self):
+    def saturate_radicals(self, raise_atomtype_exception=True):
         """
         Saturate the molecule by replacing all radicals with bonds to hydrogen atoms.  Changes self molecule object.  
         """
@@ -2179,7 +2179,7 @@ class Molecule(Graph):
         # changing atom types, but it doesn't hurt anything and is not
         # very expensive, so will do it anyway)
         self.sort_atoms()
-        self.update_atomtypes()
+        self.update_atomtypes(raise_exception=raise_atomtype_exception)
         self.multiplicity = 1
 
         return added

--- a/rmgpy/molecule/translator.pxd
+++ b/rmgpy/molecule/translator.pxd
@@ -43,13 +43,13 @@ cpdef str to_smarts(mm.Molecule mol, backend=?)
 
 cpdef str to_smiles(mm.Molecule mol, backend=?)
 
-cpdef mm.Molecule from_inchi(mm.Molecule mol, str inchistr, backend=?)
+cpdef mm.Molecule from_inchi(mm.Molecule mol, str inchistr, backend=?, bint raise_atomtype_exception=?)
 
-cpdef mm.Molecule from_smiles(mm.Molecule mol, str smilesstr, str backend=?)
+cpdef mm.Molecule from_smiles(mm.Molecule mol, str smilesstr, str backend=?, bint raise_atomtype_exception=?)
 
-cpdef mm.Molecule from_smarts(mm.Molecule mol, str smartsstr, str backend=?)
+cpdef mm.Molecule from_smarts(mm.Molecule mol, str smartsstr, str backend=?, bint raise_atomtype_exception=?)
 
-cpdef mm.Molecule from_augmented_inchi(mm.Molecule mol, aug_inchi)
+cpdef mm.Molecule from_augmented_inchi(mm.Molecule mol, aug_inchi, bint raise_atomtype_exception=?)
 
 cpdef object _rdkit_translator(object input_object, str identifier_type, mm.Molecule mol=?)
 
@@ -59,7 +59,7 @@ cdef mm.Molecule _lookup(mm.Molecule mol, str identifier, str identifier_type)
 
 cpdef _check_output(mm.Molecule mol, str identifier)
 
-cdef mm.Molecule _read(mm.Molecule mol, str identifier, str identifier_type, str backend)
+cdef mm.Molecule _read(mm.Molecule mol, str identifier, str identifier_type, str backend, bint raise_atomtype_exception=?)
 
 cdef str _write(mm.Molecule mol, str identifier_type, str backend)
 

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -251,19 +251,20 @@ def to_smiles(mol, backend='default'):
         return output
 
 
-def from_inchi(mol, inchistr, backend='try-all'):
+def from_inchi(mol, inchistr, backend='try-all', raise_atomtype_exception=True):
     """
     Convert an InChI string `inchistr` to a molecular structure. Uses
     a user-specified backend for conversion, currently supporting
     rdkit (default) and openbabel.
     """
     if inchiutil.INCHI_PREFIX in inchistr:
-        return _read(mol, inchistr, 'inchi', backend)
+        return _read(mol, inchistr, 'inchi', backend, raise_atomtype_exception=raise_atomtype_exception)
     else:
-        return _read(mol, inchiutil.INCHI_PREFIX + '/' + inchistr, 'inchi', backend)
+        return _read(mol, inchiutil.INCHI_PREFIX + '/' + inchistr, 'inchi', backend,
+                     raise_atomtype_exception=raise_atomtype_exception)
 
 
-def from_augmented_inchi(mol, aug_inchi):
+def from_augmented_inchi(mol, aug_inchi, raise_atomtype_exception=True):
     """
     Creates a Molecule object from the augmented inchi.
 
@@ -287,27 +288,27 @@ def from_augmented_inchi(mol, aug_inchi):
 
     inchiutil.fix_molecule(mol, aug_inchi)
 
-    mol.update_atomtypes()
+    mol.update_atomtypes(log_species=True, raise_exception=raise_atomtype_exception)
 
     return mol
 
 
-def from_smarts(mol, smartsstr, backend='rdkit'):
+def from_smarts(mol, smartsstr, backend='rdkit', raise_atomtype_exception=True):
     """
     Convert a SMARTS string `smartsstr` to a molecular structure. Uses
     `RDKit <http://rdkit.org/>`_ to perform the conversion.
     This Kekulizes everything, removing all aromatic atom types.
     """
-    return _read(mol, smartsstr, 'sma', backend)
+    return _read(mol, smartsstr, 'sma', backend, raise_atomtype_exception=raise_atomtype_exception)
 
 
-def from_smiles(mol, smilesstr, backend='try-all'):
+def from_smiles(mol, smilesstr, backend='try-all', raise_atomtype_exception=True):
     """
     Convert a SMILES string `smilesstr` to a molecular structure. Uses
     a user-specified backend for conversion, currently supporting
     rdkit (default) and openbabel.
     """
-    return _read(mol, smilesstr, 'smi', backend)
+    return _read(mol, smilesstr, 'smi', backend, raise_atomtype_exception=raise_atomtype_exception)
 
 
 def _rdkit_translator(input_object, identifier_type, mol=None):
@@ -460,7 +461,7 @@ def _check_output(mol, identifier):
     return all(conditions)
 
 
-def _read(mol, identifier, identifier_type, backend):
+def _read(mol, identifier, identifier_type, backend, raise_atomtype_exception=True):
     """
     Parses the identifier based on the type of identifier (inchi/smi/sma)
     and the backend used.
@@ -479,7 +480,7 @@ def _read(mol, identifier, identifier_type, backend):
 
     if _lookup(mol, identifier, identifier_type) is not None:
         if _check_output(mol, identifier):
-            mol.update_atomtypes()
+            mol.update_atomtypes(log_species=True, raise_exception=raise_atomtype_exception)
             return mol
 
     for option in _get_backend_list(backend):
@@ -491,7 +492,7 @@ def _read(mol, identifier, identifier_type, backend):
             raise NotImplementedError("Unrecognized backend {0}".format(option))
 
         if _check_output(mol, identifier):
-            mol.update_atomtypes()
+            mol.update_atomtypes(log_species=True, raise_exception=raise_atomtype_exception)
             return mol
         else:
             logging.debug('Backend {0} is not able to parse identifier {1}'.format(option, identifier))

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -65,7 +65,7 @@ cdef class Species:
 
     cpdef bint is_structure_in_list(self, list species_list) except -2
     
-    cpdef from_adjacency_list(self, adjlist, bint raise_atomtype_exception=?)
+    cpdef from_adjacency_list(self, adjlist, bint raise_atomtype_exception=?, bint raise_charge_exception=?)
 
     cpdef from_smiles(self, smiles)
     

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -65,7 +65,7 @@ cdef class Species:
 
     cpdef bint is_structure_in_list(self, list species_list) except -2
     
-    cpdef from_adjacency_list(self, adjlist)
+    cpdef from_adjacency_list(self, adjlist, bint raise_atomtype_exception=?)
 
     cpdef from_smiles(self, smiles)
     

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -333,7 +333,7 @@ class Species(object):
                                 ' should be a List of Species objects.'.format(species))
         return False
 
-    def from_adjacency_list(self, adjlist, raise_atomtype_exception=True):
+    def from_adjacency_list(self, adjlist, raise_atomtype_exception=True, raise_charge_exception=True):
         """
         Load the structure of a species as a :class:`Molecule` object from the
         given adjacency list `adjlist` and store it as the first entry of a 
@@ -341,7 +341,8 @@ class Species(object):
         of the loaded molecule.
         """
         self.molecule = [Molecule().from_adjacency_list(adjlist, saturate_h=False,
-                                                        raise_atomtype_exception=raise_atomtype_exception)]
+                                                        raise_atomtype_exception=raise_atomtype_exception,
+                                                        raise_charge_exception=raise_charge_exception)]
         # If the first line is a label, then save it to the label attribute
         for label in adjlist.splitlines():
             if label.strip():

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -333,14 +333,15 @@ class Species(object):
                                 ' should be a List of Species objects.'.format(species))
         return False
 
-    def from_adjacency_list(self, adjlist):
+    def from_adjacency_list(self, adjlist, raise_atomtype_exception=True):
         """
         Load the structure of a species as a :class:`Molecule` object from the
         given adjacency list `adjlist` and store it as the first entry of a 
         list in the `molecule` attribute. Does not generate resonance isomers
         of the loaded molecule.
         """
-        self.molecule = [Molecule().from_adjacency_list(adjlist)]
+        self.molecule = [Molecule().from_adjacency_list(adjlist, saturate_h=False,
+                                                        raise_atomtype_exception=raise_atomtype_exception)]
         # If the first line is a label, then save it to the label attribute
         for label in adjlist.splitlines():
             if label.strip():


### PR DESCRIPTION
### Motivation or Problem
RMG's atom types are relatively limited when dealing with non-standard molecules and an `AtomTypeError` might be raised upon calling `Molecule.updateAtomTypes`. Often, it is desirable to use the RMG API simply to create arbitrary molecule objects and use useful RMG methods that may not be as readily available in other cheminformatics packages. One possible application, is to use RMG's isomorphism checks to compare molecules that have been converted to their respective single-bonded versions.

### Description of Changes
This PR implements a new option, `raise_atomtype_exception` for many methods in the `Molecule` class and functions in the `translator` and `converter` modules, which enables setting the `raiseException` argument that was already available in `Molecule.updateAtomTypes.`

### Question for Reviewer
A typical application for me is to read in two molecules and check if they are isomorphic. Would having a generic atom type potentially yield unexpected behavior? I usually do something along the lines of the following:
```python
mol1 = Molecule().fromSMILES(smi, raise_atomtype_exception=False).toSingleBonds()
mol2 = Molecule().fromXYZ(nums, coords, raise_atomtype_exception=False).toSingleBonds()
if not mol1.isIsomorphic(mol2):
    # do something
```
Note that I don't usually need `raise_atomtype_exception` in the call to `toSingleBonds` because it seems that RMG's atom types are general enough to deal with all molecules that have only single bonds.

### Final Comment
If you think, this PR has serious potential for unexpected behavior, then we don't have to merge it, but it would be nice to find a way to avoid frequently getting an `AtomTypeError`.
