### PR TITLE
Ignore PyCharm Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ nbproject/*
 .pydevproject
 .settings/*
 
+# PyCharm project files
+.idea/*
+
 # Unit test files
 .coverage
 testing/*


### PR DESCRIPTION
Work around for GitKraken errors in recognizing global .gitignore in Ubuntu 18.04