### PR TITLE
Omit test files from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ exclude_lines =
     raise NotImplementedError
     if 0:
     if __name__ == .__main__.:
+omit = *Test.py
 
 [html]
 directory = testing/coverage


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Changes were made in coverage v4.5 to how omit was handled
This makes sure test files are not included the coverage report

### Description of Changes
Add an omit setting to the [report] block of `.coveragerc`.

### Testing
Check that Travis reports the true coverage.
