### PR TITLE
Clear atom labels from products after reaction generation

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -244,7 +244,7 @@ def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kine
     This algorithm used to exist in family.__generateReactions, but was moved
     here so it could operate across reaction families.
 
-    This method modifies the rxnList in place and also returns it.
+    This method returns an updated list with degenerate reactions removed.
 
     Args:
         rxn_list (list):                                reactions to be analyzed

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1956,9 +1956,9 @@ class KineticsFamily(Database):
             reaction.pairs = self.getReactionPairs(reaction)
             reaction.template = self.getReactionTemplateLabels(reaction)
 
-            # Unlabel the atoms
-            for label, atom in reaction.labeledAtoms:
-                atom.label = ''
+            # Unlabel the atoms for both reactants and products
+            for species in itertools.chain(reaction.reactants, reaction.products):
+                species.clearLabeledAtoms()
             
             # We're done with the labeled atoms, so delete the attribute
             del reaction.labeledAtoms


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
After reaction generation, product labels are currently retained even though they are no longer used, while reactant labels are being cleared.

### Description of Changes
Clear atom labels from reaction products as well, at the end of `KineticsFamily.__generateReactions`.

Also change an unrelated docstring which was incorrect. (Let me know if this should go in a separate PR.)

### Testing
Check RMG-tests for any unanticipated effects. This change should not affect model generation.
