### PR TITLE
Symmetry fixes

### DIFF
--- a/rmgpy/molecule/symmetry.pxd
+++ b/rmgpy/molecule/symmetry.pxd
@@ -37,4 +37,6 @@ cpdef float calculateAxisSymmetryNumber(Molecule molecule) except -1
 
 cpdef float calculateCyclicSymmetryNumber(Molecule molecule) except -1
 
+cpdef bint _indistinguishable(Atom atom1, Atom atom2) except -2
+
 cpdef float calculateSymmetryNumber(Molecule molecule) except -1

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -241,10 +241,6 @@ def calculateAxisSymmetryNumber(molecule):
            
     # For each set of adjacent double bonds, check for axis symmetry
     for bonds in cumulatedBonds:
-        
-        # Do nothing if less than two cumulated bonds
-        if len(bonds) < 1: continue
-
         # Do nothing if axis is in cycle
         found = False
         for atom1, atom2 in bonds:

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -109,6 +109,9 @@ def calculateAtomSymmetryNumber(molecule, atom):
             if count == [3]: symmetryNumber *= 6
             elif count == [2, 1]: symmetryNumber *= 2
             elif count == [1, 1, 1]: symmetryNumber *= 1
+        elif single == 1:
+            if count == [2, 1]: symmetryNumber *= 2
+            elif count == [1, 1, 1]: symmetryNumber *= 1
     elif atom.radicalElectrons == 2:
         if single == 2:
             # Two single bonds

--- a/rmgpy/molecule/symmetry.py
+++ b/rmgpy/molecule/symmetry.py
@@ -344,10 +344,6 @@ def calculateCyclicSymmetryNumber(molecule):
     Get the symmetry number correction for cyclic regions of a molecule.
     For complicated fused rings the smallest set of smallest rings is used.
     """
-    from rmgpy.molecule.vf2 import VF2
-    # setup isomorphism checker
-    vf2 = VF2(molecule, molecule)
-    
     symmetryNumber = 1
     
     # for polycyclics, We should be getting the largest ring, not the smallest
@@ -370,7 +366,7 @@ def calculateCyclicSymmetryNumber(molecule):
                 starting_index = 0
                 while all_the_same and starting_index < size / 2: 
                     for atom_index in range(num_rotations,size,num_rotations):
-                        if not vf2.feasible(ring[starting_index],ring[(starting_index + atom_index) % size]):
+                        if not _indistinguishable(ring[starting_index],ring[(starting_index + atom_index) % size]):
                             all_the_same = False
                             break
                     starting_index += 1
@@ -393,7 +389,7 @@ def calculateCyclicSymmetryNumber(molecule):
             while min_index <= max_index:
                 # ensure the two atoms are different. use mod size to loop to the start
                 # of the list when index out of bounds
-                if not vf2.feasible(ring[min_index % size], ring[max_index % size]):
+                if not _indistinguishable(ring[min_index % size], ring[max_index % size]):
                     all_the_same = False
                     break
                 min_index += 1
@@ -409,19 +405,19 @@ def calculateCyclicSymmetryNumber(molecule):
                         pass # all_the_same still true
                     elif len(non_ring_bonded_atoms) == 3:
                         # at least one of these much be a match for flipping to happen
-                        identical = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1])
-                        identical2 = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[2])
-                        identical3 = vf2.feasible(non_ring_bonded_atoms[1],non_ring_bonded_atoms[2])
+                        identical = _indistinguishable(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1])
+                        identical2 = _indistinguishable(non_ring_bonded_atoms[0],non_ring_bonded_atoms[2])
+                        identical3 = _indistinguishable(non_ring_bonded_atoms[1],non_ring_bonded_atoms[2])
                         if not (identical or identical2 or identical3):
                             all_the_same = False
                     elif len(non_ring_bonded_atoms) == 4:
-                        same_sides = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1]) and \
-                                     vf2.feasible(non_ring_bonded_atoms[2],non_ring_bonded_atoms[3])
+                        same_sides = _indistinguishable(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1]) and \
+                                     _indistinguishable(non_ring_bonded_atoms[2],non_ring_bonded_atoms[3])
                         if not same_sides:
-                            atom0_matching = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[2]) or\
-                                             vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[3])
-                            atom1_matching = vf2.feasible(non_ring_bonded_atoms[1],non_ring_bonded_atoms[2]) or\
-                                             vf2.feasible(non_ring_bonded_atoms[1],non_ring_bonded_atoms[3])
+                            atom0_matching = _indistinguishable(non_ring_bonded_atoms[0],non_ring_bonded_atoms[2]) or\
+                                             _indistinguishable(non_ring_bonded_atoms[0],non_ring_bonded_atoms[3])
+                            atom1_matching = _indistinguishable(non_ring_bonded_atoms[1],non_ring_bonded_atoms[2]) or\
+                                             _indistinguishable(non_ring_bonded_atoms[1],non_ring_bonded_atoms[3])
                             if not (atom0_matching and atom1_matching):
                                 all_the_same = False
                 else:
@@ -430,7 +426,7 @@ def calculateCyclicSymmetryNumber(molecule):
                     if len(non_ring_bonded_atoms) < 2:
                         pass # all_the_same still true
                     elif len(non_ring_bonded_atoms) == 2:
-                        identical = vf2.feasible(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1])
+                        identical = _indistinguishable(non_ring_bonded_atoms[0],non_ring_bonded_atoms[1])
                         if not identical:
                             # flipping a tetrahedral will not work
                             all_the_same = False
@@ -445,7 +441,7 @@ def calculateCyclicSymmetryNumber(molecule):
                 while min_index < max_index:
                     # ensure the two atoms are different. use mod size to loop to the start
                     # of the list when index out of bounds
-                    if not vf2.feasible(ring[min_index % size], ring[max_index % size]):
+                    if not _indistinguishable(ring[min_index % size], ring[max_index % size]):
                         all_the_same = False
                         break
                     min_index += 1
@@ -456,6 +452,39 @@ def calculateCyclicSymmetryNumber(molecule):
                 break
     return symmetryNumber
 ################################################################################
+
+
+def _indistinguishable(atom1, atom2):
+    """
+    Determine if two atoms are feasibly indistinguishable based on connections
+    to nearest neighbors.
+    """
+    if (not atom1.equivalent(atom2)
+            or atom1.connectivity1 != atom2.connectivity1
+            or atom1.connectivity2 != atom2.connectivity2
+            or atom1.connectivity3 != atom2.connectivity3):
+        return False
+
+    bond_orders_1 = [bond.order for bond in atom1.bonds.itervalues()].sort()
+    bond_orders_2 = [bond.order for bond in atom2.bonds.itervalues()].sort()
+
+    if bond_orders_1 != bond_orders_2:
+        return False
+
+    bonds_1 = atom1.bonds.items()
+    bonds_2 = atom2.bonds.items()
+
+    for i, (neighbor1, bond1) in enumerate(bonds_1):
+        for j, (neighbor2, bond2) in enumerate(bonds_2):
+            if bond1.equivalent(bond2) and neighbor1.equivalent(neighbor2):
+                del bonds_2[j]
+                break
+        else:
+            return False
+
+    # We were able to match up all neighbors
+    return True
+
 
 def calculateSymmetryNumber(molecule):
     """

--- a/rmgpy/molecule/symmetryTest.py
+++ b/rmgpy/molecule/symmetryTest.py
@@ -32,7 +32,7 @@ import unittest
 from external.wip import work_in_progress
 
 from rmgpy.molecule.molecule import Molecule
-from rmgpy.molecule.symmetry import calculateAtomSymmetryNumber, calculateAxisSymmetryNumber, calculateBondSymmetryNumber, calculateCyclicSymmetryNumber
+from rmgpy.molecule.symmetry import calculateAtomSymmetryNumber, calculateAxisSymmetryNumber, calculateBondSymmetryNumber, calculateCyclicSymmetryNumber, _indistinguishable
 from rmgpy.species import Species
 from rmgpy.molecule.resonance import generate_aromatic_resonance_structures
 ################################################################################
@@ -503,7 +503,6 @@ multiplicity 3
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 12)
 
-    @work_in_progress
     def testTotalSymmetryNumberChlorobenzene(self):
         """
         Test the Species.getSymmetryNumber() (total symmetry) on c1ccccc1Cl
@@ -523,7 +522,6 @@ multiplicity 3
         symmetryNumber = species.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 2)
 
-    @work_in_progress
     def testTotalSymmetryNumberPhenoxyBenzene(self):
         """
         Test symmetry on c1ccccc1[O] using phenoxy benzene structure
@@ -710,6 +708,33 @@ multiplicity 3
         Test the Molecule.calculateSymmetryNumber() on CC1CC(C)C1
         """
         self.assertEqual(Species().fromSMILES('CC1CC(C)C1').getSymmetryNumber(),36)
+
+    def test_indistinguishable(self):
+        """
+        Test that the _indistinguishable function works properly
+        """
+        mol = Molecule().fromSMILES('c1ccccc1')
+        self.assertTrue(_indistinguishable(mol.atoms[0], mol.atoms[1]))
+        self.assertTrue(_indistinguishable(mol.atoms[0], mol.atoms[2]))
+        self.assertTrue(_indistinguishable(mol.atoms[0], mol.atoms[3]))
+
+    def test_indistinguishable_2(self):
+        """
+        Test that the _indistinguishable function works properly
+        """
+        mol = Molecule().fromSMILES('c1ccccc1[O]')
+        # Carbon with O different from other carbons (with H)
+        self.assertFalse(_indistinguishable(mol.atoms[5], mol.atoms[4]))
+        self.assertFalse(_indistinguishable(mol.atoms[5], mol.atoms[3]))
+        self.assertFalse(_indistinguishable(mol.atoms[5], mol.atoms[2]))
+        # Ortho carbons are the same
+        self.assertTrue(_indistinguishable(mol.atoms[0], mol.atoms[4]))
+        # Meta carbons are the same
+        self.assertTrue(_indistinguishable(mol.atoms[1], mol.atoms[3]))
+        # O is different from H
+        self.assertFalse(_indistinguishable(mol.atoms[6], mol.atoms[7]))
+
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -494,13 +494,17 @@ class Species(object):
             oldAtoms = atomsFromStructures[structureNum]
 
             for index1, atom1 in enumerate(oldAtoms):
+                # make bond orders average of resonance structures
                 for atom2 in atom1.bonds:
                     index2 = oldAtoms.index(atom2)
 
                     newBond = newMol.getBond(newAtoms[index1], newAtoms[index2])
                     oldBondOrder = oldMol.getBond(oldAtoms[index1], oldAtoms[index2]).getOrderNum()
                     newBond.applyAction(('CHANGE_BOND',None,oldBondOrder / numResonanceStructures / 2))
-
+                # set radicals in resonance hybrid to maximum of all structures
+                if atom1.radicalElectrons > 0:
+                    newAtoms[index1].radicalElectrons = max(atom1.radicalElectrons,
+                                                            newAtoms[index1].radicalElectrons)
         newMol.updateAtomTypes(logSpecies = False, raiseException=False)
         return newMol
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This fixes the second issue in #1482. Cyclic symmetry numbers were not being properly determined because the `vf2.feasible` method wasn't working properly out of context.

### Description of Changes
A new method called `_indistinguishable` was created in `rmgpy.molecule.symmetry` to perform the task that `vf2.feasible` was being used for, without the additional infrastructure of `vf2`. The new method checks connectivity values, atom equivalence, and nearest neighbor equivalence to determine if two atoms are feasibly indistinguishable.

### Testing
All unit tests should be passing, and two tests previously marked as `@work_in_progress` are also now passing. Any additional test cases which are found be necessary should probably be added as new unit tests.

### Reviewer Tips
Review the new `_indistinguishable` method to see that it makes sense.

Also, @goldmanm, if you figure out the problem with the first issue in #1482, you can add the fix to this PR. 