### PR TITLE
Save sensitivity files for all species by specifying 'all'

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -193,9 +193,13 @@ def simpleReactor(temperature,
     
     sensitiveSpecies = []
     if sensitivity:
-        if isinstance(sensitivity, str): sensitivity = [sensitivity]
-        for spec in sensitivity:
-            sensitiveSpecies.append(speciesDict[spec])
+        if sensitivity != 'all':
+            if isinstance(sensitivity, str): sensitivity = [sensitivity]
+            for spec in sensitivity:
+                sensitiveSpecies.append(speciesDict[spec])
+
+        else:
+            sensitiveSpecies.append('all')
     
     if not isinstance(T,list):
         sensitivityTemperature = T

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -896,6 +896,9 @@ class RMG(util.Subject):
             
             if reactionSystem.sensitiveSpecies and reactionSystem.sensConditions:
                 logging.info('Conducting sensitivity analysis of reaction system %s...' % (index+1))
+
+                if reactionSystem.sensitiveSpecies == ['all']:
+                    reactionSystem.sensitiveSpecies = self.reactionModel.core.species
                     
                 sensWorksheet = []
                 for spec in reactionSystem.sensitiveSpecies:

--- a/rmgpy/tools/loader.py
+++ b/rmgpy/tools/loader.py
@@ -108,7 +108,8 @@ def loadRMGPyJob(inputFile, chemkinFile=None, speciesDict=None, generateImages=T
         for t in reactionSystem.termination:
             if isinstance(t, TerminationConversion):
                 t.species = speciesDict[t.species]
-        reactionSystem.sensitiveSpecies = [speciesDict[spec] for spec in reactionSystem.sensitiveSpecies]
+        if reactionSystem.sensitiveSpecies != ['all']:
+            reactionSystem.sensitiveSpecies = [speciesDict[spec] for spec in reactionSystem.sensitiveSpecies]
     
     # Set reaction model to match model loaded from Chemkin file
     rmg.reactionModel.core.species = speciesList

--- a/rmgpy/tools/simulate.py
+++ b/rmgpy/tools/simulate.py
@@ -90,6 +90,8 @@ def simulate(rmg, diffusionLimited=True):
             
         if reactionSystem.sensitiveSpecies:
             logging.info('Conducting simulation and sensitivity analysis of reaction system %s...' % (index+1))
+            if reactionSystem.sensitiveSpecies == ['all']:
+                reactionSystem.sensitiveSpecies = rmg.reactionModel.core.species
         
         else:
             logging.info('Conducting simulation of reaction system %s...' % (index+1))


### PR DESCRIPTION
### Motivation or Problem
For large RMG models, it can be useful to save the sensitivity information for all species so that sensitivity analysis does not have to be run again if information for another species is desired later. This information is calculated regardless, so saving the information for all species only adds an additional small I/O overhead.

### Description of Changes
Using `sensitivty='all'` in the RMG input file adds all species to the sensitive species list. This is true for calls to simulate.py and mechanism building jobs.

### Testing
Locally I have tested that the sensitivity example mechanism saves information for all species using simulate.py. I have also set `sensitivty='all'` in the super-minimal example and built the mechanism, in which sensitivity analysis after model generation was successful and saved all of the information.
