### PR TITLE
Update charge after using the NH3_elimination families

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1460,7 +1460,8 @@ class KineticsFamily(Database):
             elif isinstance(struct, Group):
                 struct.resetRingMembership()
                 if label in ['1,2_insertion_co', 'r_addition_com', 'co_disproportionation',
-                             'intra_no2_ono_conversion', 'lone_electron_pair_bond']:
+                             'intra_no2_ono_conversion', 'lone_electron_pair_bond',
+                             '1,2_nh3_elimination', '1,3_nh3_elimination']:
                     struct.update_charge()
             else:
                 raise TypeError('Expecting Molecule or Group object, not {0}'.format(struct.__class__.__name__))


### PR DESCRIPTION
In a sibling PR (https://github.com/ReactionMechanismGenerator/RMG-database/pull/296) we introduce two new families, `1,2_NH3_elimination` and `1,3 NH3_elimination`. This PR adds them to the list of families for which the formal charges of the products must be updated. We should merge this PR before merging the related database one.