### PR TITLE
Make Kekule structures non-representative and refactor aromatic resonance

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -48,7 +48,7 @@ from rmgpy import settings
 from rmgpy.reaction import Reaction
 from rmgpy.kinetics import Arrhenius
 from rmgpy.molecule import Bond, GroupBond, Group, Molecule
-from rmgpy.molecule.resonance import generate_aromatic_resonance_structures
+from rmgpy.molecule.resonance import generate_optimal_aromatic_resonance_structures
 from rmgpy.species import Species
 
 from .common import saveEntry, ensure_species, find_degenerate_reactions, generate_molecule_combos,\
@@ -1934,7 +1934,7 @@ class KineticsFamily(Database):
                 if prod_resonance:
                     for i, product in enumerate(products0):
                         if product.isCyclic:
-                            aromaticStructs = generate_aromatic_resonance_structures(product)
+                            aromaticStructs = generate_optimal_aromatic_resonance_structures(product)
                             if aromaticStructs:
                                 products0[i] = aromaticStructs[0]
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -293,7 +293,9 @@ multiplicity 2
 """)
         spec.generate_resonance_structures()
 
-        self.assertTrue(arom.isIsomorphic(spec.molecule[1]))  # The aromatic structure should be the second one
+        self.assertTrue(arom.isIsomorphic(spec.molecule[0]))  # The aromatic structure should be the first one
+        # Move the aromatic structure to the end for testing
+        spec.molecule.append(spec.molecule.pop(0))
 
         initial = list(spec.molecule)  # Make a copy of the list
         thermo = self.database.getThermoData(spec)
@@ -1168,7 +1170,7 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         smiles = "C1=CC=C2C=CC=CC2=C1"
         spe = Species().fromSMILES(smiles)
         spe.generate_resonance_structures()
-        mol = spe.molecule[1]
+        mol = spe.molecule[0]
 
         # get two SSSRs
         SSSR = mol.getSmallestSetOfSmallestRings()
@@ -1415,14 +1417,14 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         smiles = 'C1=CC=C2CCCCC2=C1'
         spe = Species().fromSMILES(smiles)
         spe.generate_resonance_structures()
-        mol = spe.molecule[1]
+        mol = spe.molecule[0]
         ring_submol = convertRingToSubMolecule(mol.getDisparateRings()[1][0])[0]
 
         saturated_ring_submol, alreadySaturated = saturate_ring_bonds(ring_submol)
 
         expected_spe = Species().fromSMILES('C1=CC=C2CCCCC2=C1')
         expected_spe.generate_resonance_structures()
-        expected_saturated_ring_submol = expected_spe.molecule[1]
+        expected_saturated_ring_submol = expected_spe.molecule[0]
 
         expected_saturated_ring_submol.updateConnectivityValues()
 
@@ -1438,14 +1440,14 @@ class TestMolecularManipulationInvolvedInThermoEstimation(unittest.TestCase):
         smiles = 'C1=CC=C2CC=CCC2=C1'
         spe = Species().fromSMILES(smiles)
         spe.generate_resonance_structures()
-        mol = spe.molecule[1]
+        mol = spe.molecule[0]
         ring_submol = convertRingToSubMolecule(mol.getDisparateRings()[1][0])[0]
 
         saturated_ring_submol, alreadySaturated = saturate_ring_bonds(ring_submol)
 
         expected_spe = Species().fromSMILES('C1=CC=C2CCCCC2=C1')
         expected_spe.generate_resonance_structures()
-        expected_saturated_ring_submol = expected_spe.molecule[1]
+        expected_saturated_ring_submol = expected_spe.molecule[0]
         
         expected_saturated_ring_submol.updateConnectivityValues()
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -493,7 +493,7 @@ class TestThermoAccuracy(unittest.TestCase):
             ['C=[C]C=CCC',      3,  61.15, 87.08, 29.68, 36.91, 43.03, 48.11, 55.96, 61.78, 71.54],
             ['C=C[C]=CCC',      3,  61.15, 87.08, 29.68, 36.91, 43.03, 48.11, 55.96, 61.78, 71.54],
             ['C=CC=[C]CC',      3,  70.35, 88.18, 29.15, 36.46, 42.6,  47.6,  55.32, 61.04, 69.95],
-            ['C=CC=C[CH]C',     6,  38.24, 84.41, 27.79, 35.46, 41.94, 47.43, 55.74, 61.92, 71.86],
+            ['C=CC=C[CH]C',     3,  38.24, 84.41, 27.79, 35.46, 41.94, 47.43, 55.74, 61.92, 71.86],
             ['C=CC=CC[CH2]',    2,  62.45, 89.78, 28.72, 36.31, 42.63, 47.72, 55.50, 61.21, 70.05],
             ['[CH3]',           6,  34.81, 46.37,  9.14, 10.18, 10.81, 11.34, 12.57, 13.71, 15.2],
             ['C=CC=C[CH2]',     2,  46.11, 75.82, 22.54, 28.95, 34.24, 38.64, 45.14, 49.97, 57.85],
@@ -544,20 +544,9 @@ class TestThermoAccuracy(unittest.TestCase):
         """
         for smiles, symm, H298, S298, Cp300, Cp400, Cp500, Cp600, Cp800, Cp1000, Cp1500 in self.testCases:
             species = Species().fromSMILES(smiles)
-            species.generate_resonance_structures()
-            thermoData = self.database.getThermoDataFromGroups(species)
-            # pick the molecule with lowest H298
-            molecule = species.molecule[0]
-            for mol in species.molecule[1:]:
-                thermoData0 = self.database.getAllThermoData(Species(molecule=[mol]))[0][0]
-                for data in self.database.getAllThermoData(Species(molecule=[mol]))[1:]:
-                    if data[0].getEnthalpy(298) < thermoData0.getEnthalpy(298):
-                        thermoData0 = data[0]
-                if thermoData0.getEnthalpy(298) < thermoData.getEnthalpy(298):
-                    thermoData = thermoData0
-                    molecule = mol
-            self.assertEqual(symm, molecule.calculateSymmetryNumber(),
-                             msg="Symmetry number error for {0}. Expected {1} but calculated {2}.".format(smiles, symm, molecule.calculateSymmetryNumber()))
+            calc_symm = species.getSymmetryNumber()
+            self.assertEqual(symm, calc_symm,
+                             msg="Symmetry number error for {0}. Expected {1} but calculated {2}.".format(smiles, symm, calc_symm))
 
 
 class TestThermoAccuracyAromatics(TestThermoAccuracy):

--- a/rmgpy/molecule/filtrationTest.py
+++ b/rmgpy/molecule/filtrationTest.py
@@ -31,8 +31,9 @@
 import unittest
 
 from rmgpy.molecule.molecule import Molecule
-from rmgpy.molecule.resonance import generate_resonance_structures
-from rmgpy.molecule.filtration import get_octet_deviation_list, get_octet_deviation, filter_structures,charge_filtration, get_charge_span_list
+from rmgpy.molecule.resonance import generate_resonance_structures, analyze_molecule
+from rmgpy.molecule.filtration import get_octet_deviation_list, get_octet_deviation, filter_structures, \
+                                      charge_filtration, get_charge_span_list, aromaticity_filtration
 
 ################################################################################
 
@@ -251,3 +252,80 @@ class FiltrationTest(unittest.TestCase):
                 for atom in mol.vertices:
                     if abs(atom.charge) == 1:
                         self.assertTrue(atom.isNitrogen())
+
+    def aromaticity_test(self):
+        """Test that aromatics are properly filtered."""
+        adj1 = """multiplicity 2
+1  C u0 p0 c0 {2,D} {3,S} {7,S}
+2  C u0 p0 c0 {1,D} {4,S} {8,S}
+3  C u0 p0 c0 {1,S} {6,D} {12,S}
+4  C u0 p0 c0 {2,S} {5,D} {9,S}
+5  C u0 p0 c0 {4,D} {6,S} {10,S}
+6  C u0 p0 c0 {3,D} {5,S} {11,S}
+7  C u1 p0 c0 {1,S} {13,S} {14,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {7,S}
+14 H u0 p0 c0 {7,S}
+"""
+        adj2 = """multiplicity 2
+1  C u0 p0 c0 {2,B} {3,B} {7,S}
+2  C u0 p0 c0 {1,B} {4,B} {8,S}
+3  C u0 p0 c0 {1,B} {6,B} {12,S}
+4  C u0 p0 c0 {2,B} {5,B} {9,S}
+5  C u0 p0 c0 {4,B} {6,B} {10,S}
+6  C u0 p0 c0 {3,B} {5,B} {11,S}
+7  C u1 p0 c0 {1,S} {13,S} {14,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {7,S}
+14 H u0 p0 c0 {7,S}
+"""
+        adj3 = """multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {7,D}
+2  C u1 p0 c0 {1,S} {4,S} {8,S}
+3  C u0 p0 c0 {1,S} {6,D} {12,S}
+4  C u0 p0 c0 {2,S} {5,D} {9,S}
+5  C u0 p0 c0 {4,D} {6,S} {10,S}
+6  C u0 p0 c0 {3,D} {5,S} {11,S}
+7  C u0 p0 c0 {1,D} {13,S} {14,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {7,S}
+14 H u0 p0 c0 {7,S}
+"""
+        adj4 = """multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {7,D}
+2  C u0 p0 c0 {1,S} {5,D} {8,S}
+3  C u0 p0 c0 {1,S} {6,D} {12,S}
+4  C u1 p0 c0 {5,S} {6,S} {10,S}
+5  C u0 p0 c0 {2,D} {4,S} {9,S}
+6  C u0 p0 c0 {3,D} {4,S} {11,S}
+7  C u0 p0 c0 {1,D} {13,S} {14,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {7,S}
+14 H u0 p0 c0 {7,S}
+"""
+
+        mol_list = [
+            Molecule().fromAdjacencyList(adj1),
+            Molecule().fromAdjacencyList(adj2),
+            Molecule().fromAdjacencyList(adj3),
+            Molecule().fromAdjacencyList(adj4),
+        ]
+
+        filtered_list = aromaticity_filtration(mol_list, analyze_molecule(mol_list[0]))
+        self.assertEqual(len(filtered_list), 3)

--- a/rmgpy/molecule/graph.pxd
+++ b/rmgpy/molecule/graph.pxd
@@ -157,3 +157,5 @@ cdef class Graph:
     cpdef list getLargestRing(self, Vertex vertex)
     
     cpdef bint isMappingValid(self, Graph other, dict mapping, bint equivalent=?) except -2
+
+    cpdef list get_edges_in_cycle(self, list vertices, bint sort=?)

--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -1106,3 +1106,28 @@ cdef class Graph:
         # mapping is valid
         return True
         
+    cpdef list get_edges_in_cycle(self, list vertices, bint sort=False):
+        """
+        For a given list of atoms comprising a ring, return the set of bonds
+        connecting them, in order around the ring.
+
+        If `sort=True`, then sort the vertices to match their connectivity.
+        Otherwise, assumes that they are already sorted, which is true for
+        cycles returned by getRelevantCycles or getSmallestSetOfSmallestRings.
+        """
+        cdef list edges
+        cdef int i, j
+
+        if sort:
+            self._sortCyclicVertices(vertices)
+
+        edges = []
+        for i, j in zip(range(len(vertices)), range(-1, len(vertices)-1)):
+            try:
+                edges.append(self.getEdge(vertices[i], vertices[j]))
+            except ValueError:
+                raise ValueError('Edge does not exist between vertices in ring. '
+                                 'Check that the vertices are properly ordered '
+                                 'such that consecutive vertices are connected.')
+
+        return edges

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -799,6 +799,9 @@ class GroupBond(Edge):
         if 2.5 in newOrder:
             newOrder.remove(2.5)
             newOrder.add(2)
+        # Allow formation of benzene bonds if a double bond can be formed
+        if 2 in newOrder:
+            newOrder.add(1.5)
         # Set the new bond orders
         self.order = list(newOrder)
 

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -50,9 +50,9 @@ cpdef list generate_N5dc_radical_resonance_structures(Molecule mol)
 
 cpdef list generate_isomorphic_resonance_structures(Molecule mol, bint saturate_h=?)
 
-cpdef list generate_aromatic_resonance_structures(Molecule mol, dict features=?)
+cpdef list generate_optimal_aromatic_resonance_structures(Molecule mol, dict features=?)
 
-cpdef list aromatize(Molecule mol, list aromatic_bonds=?)
+cpdef list generate_aromatic_resonance_structure(Molecule mol, list aromatic_bonds=?, bint copy=?)
 
 cpdef list generate_aryne_resonance_structures(Molecule mol)
 

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -58,8 +58,6 @@ cpdef list generate_aryne_resonance_structures(Molecule mol)
 
 cpdef list generate_kekule_structure(Molecule mol)
 
-cpdef list generate_opposite_kekule_structure(Molecule mol)
-
 cpdef list generate_clar_structures(Molecule mol)
 
 cpdef list _clar_optimization(Molecule mol, list constraints=?, max_num=?)

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -52,6 +52,8 @@ cpdef list generate_isomorphic_resonance_structures(Molecule mol, bint saturate_
 
 cpdef list generate_aromatic_resonance_structures(Molecule mol, dict features=?)
 
+cpdef list aromatize(Molecule mol, list aromatic_bonds=?)
+
 cpdef list generate_aryne_resonance_structures(Molecule mol)
 
 cpdef list generate_kekule_structure(Molecule mol)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -86,7 +86,6 @@ def populate_resonance_algorithms(features=None):
             generate_optimal_aromatic_resonance_structures,
             generate_aryne_resonance_structures,
             generate_kekule_structure,
-            generate_opposite_kekule_structure,
             generate_clar_structures,
         ]
     else:
@@ -884,50 +883,6 @@ def generate_kekule_structure(mol):
         return []
 
     return [molecule]
-
-
-def generate_opposite_kekule_structure(mol):
-    """
-    Generate the Kekule structure with opposite single/double bond arrangement
-    for single ring aromatics.
-
-    Returns a single Kekule structure as an element of a list of length 1.
-    """
-
-    # This won't work with the aromatic form of the molecule
-    if mol.isAromatic():
-        return []
-
-    molecule = mol.copy(deep=True)
-
-    aromatic_bonds = molecule.getAromaticRings()[1]
-
-    # We can only do this for single ring aromatics for now
-    if len(aromatic_bonds) != 1:
-        return []
-
-    num_s = 0
-    num_d = 0
-    for bond in aromatic_bonds[0]:
-        if bond.isSingle():
-            num_s += 1
-            bond.order = 2
-        elif bond.isDouble():
-            num_d += 1
-            bond.order = 1
-        else:
-            # Something is wrong: there is a bond that is not single or double
-            return []
-
-    if num_s != 3 or num_d != 3:
-        return []
-
-    try:
-        molecule.updateAtomTypes()
-    except AtomTypeError:
-        return []
-    else:
-        return [molecule]
 
 
 def generate_isomorphic_resonance_structures(mol, saturate_h=False):

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -802,17 +802,8 @@ def generate_aryne_resonance_structures(mol):
 
     new_mol_list = []
     for ring in rings:
-        # Here we assume that consecutive atoms in ring are actually connected to each other
-        # This should always be true because getRelevantCycles sorts the atoms in this way
-        bond_list = []
-        for i, j in zip(range(6), range(-1, 5)):
-            try:
-                bond_list.append(mol.getBond(ring[i], ring[j]))
-            except ValueError:
-                raise ValueError('Bond does not exist between atoms in ring. '
-                                 'Check that the atoms are properly ordered '
-                                 'such that consecutive atoms are connected.')
         # Get bond orders
+        bond_list = mol.get_edges_in_cycle(ring)
         bond_orders = ''.join([bond.getOrderStr() for bond in bond_list])
         new_orders = None
         # Check for expected bond patterns

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -216,17 +216,18 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
     if len(new_mol_list) > 0:
         if features['isRadical'] and not features['isArylRadical']:
             if features['isPolycyclicAromatic']:
+                _generate_resonance_structures(new_mol_list, [generate_kekule_structure],
+                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
+                _generate_resonance_structures(new_mol_list, [generate_allyl_delocalization_resonance_structures],
+                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
                 if clar_structures:
-                    _generate_resonance_structures(new_mol_list, [generate_kekule_structure],
-                                                   keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-                    _generate_resonance_structures(new_mol_list, [generate_allyl_delocalization_resonance_structures],
-                                                   keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
                     _generate_resonance_structures(new_mol_list, [generate_clar_structures],
                                                    keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-                    # Remove non-aromatic structures under the assumption that they aren't important resonance contributors
-                    new_mol_list = [m for m in new_mol_list if m.isAromatic()]
                 else:
-                    pass
+                    _generate_resonance_structures(new_mol_list, [generate_aromatic_resonance_structure],
+                                                   keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
+                # Remove non-aromatic structures under the assumption that they aren't important resonance contributors
+                new_mol_list = [m for m in new_mol_list if m.isAromatic()]
             else:
                 _generate_resonance_structures(new_mol_list, [generate_kekule_structure,
                                                               generate_opposite_kekule_structure],
@@ -238,7 +239,8 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
                 _generate_resonance_structures(new_mol_list, [generate_clar_structures],
                                                keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
             else:
-                pass
+                _generate_resonance_structures(new_mol_list, [generate_aromatic_resonance_structure],
+                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
         else:
             # The molecule is an aryl radical or stable mono-ring aromatic
             # In this case, generate the kekulized form

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -220,29 +220,16 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
     # Special handling for aromatic species
     if features['isAromatic']:
         if features['isRadical'] and not features['isArylRadical']:
-            if features['isPolycyclicAromatic']:
-                _generate_resonance_structures(mol_list, [generate_kekule_structure],
-                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-                _generate_resonance_structures(mol_list, [generate_allyl_delocalization_resonance_structures],
-                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-                if clar_structures:
-                    _generate_resonance_structures(mol_list, [generate_clar_structures],
-                                                   keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-                else:
-                    _generate_resonance_structures(mol_list, [generate_aromatic_resonance_structure],
-                                                   keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-            else:
-                _generate_resonance_structures(mol_list, [generate_kekule_structure],
-                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-                _generate_resonance_structures(mol_list, [generate_allyl_delocalization_resonance_structures],
-                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-        elif features['isPolycyclicAromatic']:
-            if clar_structures:
-                _generate_resonance_structures(mol_list, [generate_clar_structures],
-                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
-            else:
-                _generate_resonance_structures(mol_list, [generate_aromatic_resonance_structure],
-                                               keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
+            _generate_resonance_structures(mol_list, [generate_kekule_structure],
+                                           keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
+            _generate_resonance_structures(mol_list, [generate_allyl_delocalization_resonance_structures],
+                                           keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
+        if features['isPolycyclicAromatic'] and clar_structures:
+            _generate_resonance_structures(mol_list, [generate_clar_structures],
+                                           keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
+        else:
+            _generate_resonance_structures(mol_list, [generate_aromatic_resonance_structure],
+                                           keep_isomorphic=keep_isomorphic, filter_structures=filter_structures)
 
     # Generate remaining resonance structures
     method_list = populate_resonance_algorithms(features)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -251,7 +251,7 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
                                    filter_structures=filter_structures)
 
     if filter_structures:
-        return filtration.filter_structures(mol_list)
+        return filtration.filter_structures(mol_list, features=features)
 
     return mol_list
 

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -223,7 +223,7 @@ class ResonanceTest(unittest.TestCase):
 
         In this case, the radical can be delocalized into the aromatic ring"""
         molList = generate_resonance_structures(Molecule(SMILES="C=C=C1C=C[CH]C=C1"))
-        self.assertEqual(len(molList), 4)
+        self.assertEqual(len(molList), 3)
 
     def testNaphthyl(self):
         """Test resonance structure generation for naphthyl radical
@@ -256,7 +256,7 @@ class ResonanceTest(unittest.TestCase):
     def testAromaticWithLonePairResonance(self):
         """Test resonance structure generation for aromatic species with lone pair <=> radical resonance"""
         molList = generate_resonance_structures(Molecule(SMILES="c1ccccc1CC=N[O]"))
-        self.assertEqual(len(molList), 6)
+        self.assertEqual(len(molList), 4)
 
     @work_in_progress
     def testAromaticWithNResonance(self):
@@ -345,7 +345,7 @@ class ResonanceTest(unittest.TestCase):
         """Test cyclopropylmethyl benzene, aromatic SMILES"""
         mol = Molecule(SMILES="C1CC1c1c(C)cccc1")
         molList = generate_resonance_structures(mol)
-        self.assertEqual(len(molList), 3)
+        self.assertEqual(len(molList), 2)
 
     def test_C9H10_aro_2(self):
         """Test cyclopropyl benzene, generate aromatic resonance isomers"""
@@ -596,7 +596,7 @@ multiplicity 2
         out = generate_resonance_structures(mol)
 
         self.assertEqual(len(out), 3)
-        self.assertTrue(arom.isIsomorphic(out[1]))
+        self.assertTrue(arom.isIsomorphic(out[0]))
 
     def testPolycyclicAromaticWithNonAromaticRing(self):
         """Test that we can make aromatic resonance structures when there is a pseudo-aromatic ring.
@@ -628,7 +628,7 @@ multiplicity 2
         out = generate_resonance_structures(mol)
 
         self.assertEqual(len(out), 2)
-        self.assertTrue(arom.isIsomorphic(out[1]))
+        self.assertTrue(arom.isIsomorphic(out[0]))
 
     def testPolycyclicAromaticWithNonAromaticRing2(self):
         """Test that we can make aromatic resonance structures when there is a pseudo-aromatic ring.
@@ -682,7 +682,7 @@ multiplicity 2
         out = generate_resonance_structures(mol)
 
         self.assertEqual(len(out), 4)
-        self.assertTrue(arom.isIsomorphic(out[1]))
+        self.assertTrue(arom.isIsomorphic(out[0]))
 
     def testKekulizeBenzene(self):
         """Test that we can kekulize benzene."""
@@ -989,85 +989,6 @@ multiplicity 2
 
         self.assertEqual(dBonds, 5)
 
-    def testKekulizeResonanceIsomer(self):
-        """
-        Tests that an aromatic molecule returns at least one Kekulized resonance isomer.
-        
-        A molecule formed using an aromatic adjacency list returns both
-        the aromatic and a kekulized form as resonance isomers.
-        """
-        toluene = Molecule().fromAdjacencyList("""
-1  H 0 {2,S}
-2  C 0 {3,S} {9,S} {10,S} {1,S}
-3  C 0 {4,B} {8,B} {2,S}
-4  C 0 {3,B} {5,B} {11,S}
-5  C 0 {4,B} {6,B} {12,S}
-6  C 0 {5,B} {7,B} {13,S}
-7  C 0 {6,B} {8,B} {14,S}
-8  C 0 {3,B} {7,B} {15,S}
-9  H 0 {2,S}
-10  H 0 {2,S}
-11  H 0 {4,S}
-12  H 0 {5,S}
-13  H 0 {6,S}
-14  H 0 {7,S}
-15  H 0 {8,S}""")
-        
-        toluene_kekulized = Molecule().fromAdjacencyList("""
-1  C u0 p0 c0 {2,D} {6,S} {7,S}
-2  C u0 p0 c0 {1,D} {3,S} {8,S}
-3  C u0 p0 c0 {2,S} {4,D} {9,S}
-4  C u0 p0 c0 {3,D} {5,S} {10,S}
-5  C u0 p0 c0 {4,S} {6,D} {11,S}
-6  C u0 p0 c0 {1,S} {5,D} {12,S}
-7  C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
-8  H u0 p0 c0 {2,S}
-9  H u0 p0 c0 {3,S}
-10 H u0 p0 c0 {4,S}
-11 H u0 p0 c0 {5,S}
-12 H u0 p0 c0 {6,S}
-13 H u0 p0 c0 {7,S}
-14 H u0 p0 c0 {7,S}
-15 H u0 p0 c0 {7,S}
-""")
-        kekulized_isomer = generate_kekule_structure(toluene)[0]
-        self.assertTrue(kekulized_isomer.isIsomorphic(toluene_kekulized))
-
-        for isomer in generate_resonance_structures(toluene):
-            if isomer.isIsomorphic(toluene_kekulized):
-                break
-        else:  # didn't brake
-            self.assertTrue(False, "Didn't find the Kekulized toulene in the result of getResonanceIsomers()")
-
-    def testMultipleKekulizedResonanceIsomers(self):
-        """Test we can make both Kekule structures of o-cresol"""
-
-        adjlist_aromatic = """
-1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
-2 C u0 p0 c0 {1,S} {3,B} {4,B}
-3 C u0 p0 c0 {2,B} {5,B} {8,S}
-4 C u0 p0 c0 {2,B} {7,B} {15,S}
-5 C u0 p0 c0 {3,B} {6,B} {12,S}
-6 C u0 p0 c0 {5,B} {7,B} {13,S}
-7 C u0 p0 c0 {4,B} {6,B} {14,S}
-8 O u0 p2 c0 {3,S} {16,S}
-9 H u0 p0 c0 {1,S}
-10 H u0 p0 c0 {1,S}
-11 H u0 p0 c0 {1,S}
-12 H u0 p0 c0 {5,S}
-13 H u0 p0 c0 {6,S}
-14 H u0 p0 c0 {7,S}
-15 H u0 p0 c0 {4,S}
-16 H u0 p0 c0 {8,S}
-"""
-        molecule = Molecule().fromAdjacencyList(adjlist_aromatic)
-        self.assertTrue(molecule.isAromatic(), "Starting molecule should be aromatic")
-        isomers = generate_resonance_structures(molecule)
-        self.assertEqual(len(isomers), 3, "Didn't generate 3 resonance isomers")
-        self.assertFalse(isomers[1].isAromatic(), "Second resonance isomer shouldn't be aromatic")
-        self.assertFalse(isomers[2].isAromatic(), "Third resonance isomer shouldn't be aromatic")
-        self.assertFalse(isomers[1].isIsomorphic(isomers[2]), "Second and third resonance isomers should be different")
-
     def testMultipleKekulizedResonanceIsomersRad(self):
         """Test we can make all resonance structures of o-cresol radical"""
 
@@ -1091,173 +1012,12 @@ multiplicity 2
         molecule = Molecule().fromAdjacencyList(adjlist_aromatic)
         self.assertTrue(molecule.isAromatic(), "Starting molecule should be aromatic")
         molList = generate_resonance_structures(molecule)
-        self.assertEqual(len(molList), 6, "Expected 6 resonance structures, but generated {0}.".format(len(molList)))
+        self.assertEqual(len(molList), 4, "Expected 4 resonance structures, but generated {0}.".format(len(molList)))
         aromatic = 0
         for mol in molList:
             if mol.isAromatic():
                 aromatic += 1
         self.assertEqual(aromatic, 1, "Should only have 1 aromatic resonance structure")
-
-    @work_in_progress
-    def testKekulizedResonanceIsomersFused(self):
-        """Test we can make aromatic and Kekulized resonance isomers of 2-methylanthracen-1-ol
-        
-        This fused ring PAH will be harder"""
-
-        kekulized1 = """multiplicity 1
-1 C u0 p0 c0 {2,S} {17,S} {18,S} {19,S}
-2 C u0 p0 c0 {1,S} {7,S} {10,D}
-3 C u0 p0 c0 {4,S} {7,D} {9,S}
-4 C u0 p0 c0 {3,S} {8,S} {11,D}
-5 C u0 p0 c0 {6,S} {8,D} {12,S}
-6 C u0 p0 c0 {5,S} {9,D} {13,S}
-7 C u0 p0 c0 {2,S} {3,D} {16,S}
-8 C u0 p0 c0 {4,S} {5,D} {22,S}
-9 C u0 p0 c0 {3,S} {6,D} {27,S}
-10 C u0 p0 c0 {2,D} {11,S} {20,S}
-11 C u0 p0 c0 {4,D} {10,S} {21,S}
-12 C u0 p0 c0 {5,S} {14,D} {23,S}
-13 C u0 p0 c0 {6,S} {15,D} {26,S}
-14 C u0 p0 c0 {12,D} {15,S} {24,S}
-15 C u0 p0 c0 {13,D} {14,S} {25,S}
-16 O u0 p2 c0 {7,S} {28,S}
-17 H u0 p0 c0 {1,S}
-18 H u0 p0 c0 {1,S}
-19 H u0 p0 c0 {1,S}
-20 H u0 p0 c0 {10,S}
-21 H u0 p0 c0 {11,S}
-22 H u0 p0 c0 {8,S}
-23 H u0 p0 c0 {12,S}
-24 H u0 p0 c0 {14,S}
-25 H u0 p0 c0 {15,S}
-26 H u0 p0 c0 {13,S}
-27 H u0 p0 c0 {9,S}
-28 H u0 p0 c0 {16,S}
-"""
-        kekulized2 = """multiplicity 1
-1 C u0 p0 c0 {2,S} {17,S} {18,S} {19,S}
-2 C u0 p0 c0 {1,S} {7,D} {10,S}
-3 C u0 p0 c0 {4,S} {7,S} {9,D}
-4 C u0 p0 c0 {3,S} {8,D} {11,S}
-5 C u0 p0 c0 {6,S} {8,S} {12,D}
-6 C u0 p0 c0 {5,S} {9,S} {13,D}
-7 C u0 p0 c0 {2,D} {3,S} {16,S}
-8 C u0 p0 c0 {4,D} {5,S} {22,S}
-9 C u0 p0 c0 {3,D} {6,S} {27,S}
-10 C u0 p0 c0 {2,S} {11,D} {20,S}
-11 C u0 p0 c0 {4,S} {10,D} {21,S}
-12 C u0 p0 c0 {5,D} {14,S} {23,S}
-13 C u0 p0 c0 {6,D} {15,S} {26,S}
-14 C u0 p0 c0 {12,S} {15,D} {24,S}
-15 C u0 p0 c0 {13,S} {14,D} {25,S}
-16 O u0 p2 c0 {7,S} {28,S}
-17 H u0 p0 c0 {1,S}
-18 H u0 p0 c0 {1,S}
-19 H u0 p0 c0 {1,S}
-20 H u0 p0 c0 {10,S}
-21 H u0 p0 c0 {11,S}
-22 H u0 p0 c0 {8,S}
-23 H u0 p0 c0 {12,S}
-24 H u0 p0 c0 {14,S}
-25 H u0 p0 c0 {15,S}
-26 H u0 p0 c0 {13,S}
-27 H u0 p0 c0 {9,S}
-28 H u0 p0 c0 {16,S}
-"""
-        kekulized3 = """multiplicity 1
-1 C u0 p0 c0 {2,S} {17,S} {18,S} {19,S}
-2 C u0 p0 c0 {1,S} {7,D} {10,S}
-3 C u0 p0 c0 {4,S} {7,S} {9,D}
-4 C u0 p0 c0 {3,S} {8,D} {11,S}
-5 C u0 p0 c0 {6,D} {8,S} {12,S}
-6 C u0 p0 c0 {5,D} {9,S} {13,S}
-7 C u0 p0 c0 {2,D} {3,S} {16,S}
-8 C u0 p0 c0 {4,D} {5,S} {20,S}
-9 C u0 p0 c0 {3,D} {6,S} {21,S}
-10 C u0 p0 c0 {2,S} {11,D} {22,S}
-11 C u0 p0 c0 {4,S} {10,D} {23,S}
-12 C u0 p0 c0 {5,S} {14,D} {24,S}
-13 C u0 p0 c0 {6,S} {15,D} {25,S}
-14 C u0 p0 c0 {12,D} {15,S} {26,S}
-15 C u0 p0 c0 {13,D} {14,S} {27,S}
-16 O u0 p2 c0 {7,S} {28,S}
-17 H u0 p0 c0 {1,S}
-18 H u0 p0 c0 {1,S}
-19 H u0 p0 c0 {1,S}
-20 H u0 p0 c0 {8,S}
-21 H u0 p0 c0 {9,S}
-22 H u0 p0 c0 {10,S}
-23 H u0 p0 c0 {11,S}
-24 H u0 p0 c0 {12,S}
-25 H u0 p0 c0 {13,S}
-26 H u0 p0 c0 {14,S}
-27 H u0 p0 c0 {15,S}
-28 H u0 p0 c0 {16,S}
-"""
-        kekulized4 = """multiplicity 1
-1  C u0 p0 c0 {2,S} {17,S} {18,S} {19,S}
-2  C u0 p0 c0 {1,S} {7,D} {10,S}
-3  C u0 p0 c0 {4,D} {7,S} {9,S}
-4  C u0 p0 c0 {3,D} {8,S} {11,S}
-5  C u0 p0 c0 {6,S} {8,D} {12,S}
-6  C u0 p0 c0 {5,S} {9,D} {13,S}
-7  C u0 p0 c0 {2,D} {3,S} {16,S}
-8  C u0 p0 c0 {4,S} {5,D} {20,S}
-9  C u0 p0 c0 {3,S} {6,D} {21,S}
-10 C u0 p0 c0 {2,S} {11,D} {22,S}
-11 C u0 p0 c0 {4,S} {10,D} {23,S}
-12 C u0 p0 c0 {5,S} {14,D} {24,S}
-13 C u0 p0 c0 {6,S} {15,D} {25,S}
-14 C u0 p0 c0 {12,D} {15,S} {26,S}
-15 C u0 p0 c0 {13,D} {14,S} {27,S}
-16 O u0 p2 c0 {7,S} {28,S}
-17 H u0 p0 c0 {1,S}
-18 H u0 p0 c0 {1,S}
-19 H u0 p0 c0 {1,S}
-20 H u0 p0 c0 {8,S}
-21 H u0 p0 c0 {9,S}
-22 H u0 p0 c0 {10,S}
-23 H u0 p0 c0 {11,S}
-24 H u0 p0 c0 {12,S}
-25 H u0 p0 c0 {13,S}
-26 H u0 p0 c0 {14,S}
-27 H u0 p0 c0 {15,S}
-28 H u0 p0 c0 {16,S}
-"""
-        m1 = Molecule().fromAdjacencyList(kekulized1)
-        m2 = Molecule().fromAdjacencyList(kekulized2)
-        m3 = Molecule().fromAdjacencyList(kekulized3)
-        m4 = Molecule().fromAdjacencyList(kekulized4)
-        resonance_forms = (m1, m2, m3, m4)
-
-        for starting in resonance_forms:
-            self.assertFalse(starting.isAromatic(), "Starting molecule should not be aromatic")
-
-            isomers = generate_resonance_structures(starting)
-            # print "starting with {0!r} I generated these:".format(starting)
-            # print repr(isomers)
-            for isomer in isomers:
-                if isomer.isAromatic():
-                    break
-            else:  # didn't break
-                self.fail("None of the generated resonance isomers {0!r} are aromatic".format(isomers))
-
-            for generated in isomers:
-                for expected in resonance_forms:
-                    if generated.isIsomorphic(expected):
-                        break
-                else:  # didn't break
-                    if generated.isAromatic():
-                        continue  # because the aromatic isomer isn't in our resonance_forms list
-                    self.fail("Generated a resonance form {0!r} that was not expected!\n{1}\nAlthough that may be a bug in the unit test (not sure I got them all)".format(generated, generated.toAdjacencyList()))
-
-            for expected in resonance_forms:
-                for generated in isomers:
-                    if expected.isIsomorphic(generated):
-                        break
-                else:  # didn't break
-                    self.fail(("Expected a resonance form {0!r} that was not generated.\n"
-                              "Only generated these:\n{1}").format(expected, '\n'.join([repr(g) for g in isomers])))
 
     def testKeepIsomorphicStructuresFunctionsWhenTrue(self):
         """Test that keep_isomorphic works for resonance structure generation when True."""
@@ -1304,7 +1064,7 @@ multiplicity 2
 18 H u0 p0 c0 {9,S}
 """)
 
-        self.assertEqual(len(out), 5)
+        self.assertEqual(len(out), 4)
         self.assertTrue(any([m.isIsomorphic(aromatic) for m in out]))
 
     def testFalseNegativePolycyclicAromaticityPerception(self):

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -350,7 +350,7 @@ class ResonanceTest(unittest.TestCase):
     def test_C9H10_aro_2(self):
         """Test cyclopropyl benzene, generate aromatic resonance isomers"""
         mol = Molecule(SMILES="C1CC1c1ccccc1")
-        molList = generate_aromatic_resonance_structures(mol)
+        molList = generate_optimal_aromatic_resonance_structures(mol)
         self.assertEqual(len(molList), 1)
 
     def test_benzyne(self):
@@ -422,7 +422,7 @@ class ResonanceTest(unittest.TestCase):
 32 H u0 p0 c0 {16,S}
 """)
         perylene2 = Molecule().fromSMILES('c1cc2cccc3c4cccc5cccc(c(c1)c23)c54')
-        for isomer in generate_aromatic_resonance_structures(perylene2):
+        for isomer in generate_optimal_aromatic_resonance_structures(perylene2):
             if perylene.isIsomorphic(isomer):
                 break
         else:  # didn't break
@@ -454,7 +454,7 @@ class ResonanceTest(unittest.TestCase):
 18 H u0 p0 c0 {6,S}
 """)
         naphthalene2 = Molecule().fromSMILES('C1=CC=C2C=CC=CC2=C1')
-        for isomer in generate_aromatic_resonance_structures(naphthalene2):
+        for isomer in generate_optimal_aromatic_resonance_structures(naphthalene2):
             if naphthalene.isIsomorphic(isomer):
                 break
         else:  # didn't break
@@ -464,7 +464,7 @@ class ResonanceTest(unittest.TestCase):
             ))
 
     def testAromaticResonanceStructures(self):
-        """Test that generate_aromatic_resonance_structures gives consistent output
+        """Test that generate_optimal_aromatic_resonance_structures gives consistent output
 
         Check that we get the same resonance structure regardless of which structure we start with"""
         # Kekulized form, radical on methyl
@@ -557,9 +557,9 @@ multiplicity 2
 25 H u0 p0 c0 {15,S}
 26 H u0 p0 c0 {15,S}
 """)
-        result1 = generate_aromatic_resonance_structures(struct1)
-        result2 = generate_aromatic_resonance_structures(struct2)
-        result3 = generate_aromatic_resonance_structures(struct3)
+        result1 = generate_optimal_aromatic_resonance_structures(struct1)
+        result2 = generate_optimal_aromatic_resonance_structures(struct2)
+        result3 = generate_optimal_aromatic_resonance_structures(struct3)
 
         self.assertEqual(len(result1), 1)
         self.assertEqual(len(result2), 1)

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -353,8 +353,8 @@ class ResonanceTest(unittest.TestCase):
         molList = generate_optimal_aromatic_resonance_structures(mol)
         self.assertEqual(len(molList), 1)
 
-    def test_benzyne(self):
-        """Test benzyne resonance"""
+    def test_aryne_1_ring(self):
+        """Test aryne resonance for benzyne"""
         mol1 = Molecule(SMILES="C1=CC=C=C=C1")
         mol2 = Molecule(SMILES="C1C#CC=CC=1")
 
@@ -367,23 +367,29 @@ class ResonanceTest(unittest.TestCase):
         self.assertTrue(mol_list1[1].isIsomorphic(mol2))
         self.assertTrue(mol_list2[1].isIsomorphic(mol1))
 
-    def test_benzyne_polycyclic(self):
-        """Test benzyne resonance when in polycyclic molecule"""
+    def test_aryne_2_rings(self):
+        """Test aryne resonance in naphthyne"""
         mol1 = Molecule(SMILES="C12=CC=C=C=C1C=CC=C2")
         mol2 = Molecule(SMILES="C12C#CC=CC=1C=CC=C2")
 
         mol_list1 = generate_resonance_structures(mol1)
-        self.assertEqual(len(mol_list1), 4)
+        self.assertEqual(len(mol_list1), 2)
+        self.assertEqual(sum(1 for mol in mol_list1 if mol.reactive), 2)
 
         mol_list2 = generate_resonance_structures(mol2)
-        self.assertEqual(len(mol_list2), 4)
+        self.assertEqual(len(mol_list2), 3)
+        self.assertEqual(sum(1 for mol in mol_list2 if mol.reactive), 2)
 
         # Check that they both have an aromatic resonance form
-        self.assertTrue(mol_list1[1].isIsomorphic(mol_list2[1]))
+        self.assertTrue(mol_list1[1].isIsomorphic(mol_list2[0]))
 
-        # Check that the other structure is generated for each
-        self.assertTrue(any([mol1.isIsomorphic(mol) for mol in mol_list2]))
-        self.assertTrue(any([mol2.isIsomorphic(mol) for mol in mol_list1]))
+    def test_aryne_3_rings(self):
+        """Test aryne resonance in phenanthryne"""
+        mol = Molecule(SMILES="C12C#CC=CC=1C=CC3=C2C=CC=C3")
+
+        mol_list = generate_resonance_structures(mol)
+        self.assertEqual(len(mol_list), 5)
+        self.assertEqual(sum(1 for mol in mol_list if mol.reactive), 4)
 
     def testFusedAromatic1(self):
         """Test we can make aromatic perylene from both adjlist and SMILES"""

--- a/rmgpy/molecule/symmetryTest.py
+++ b/rmgpy/molecule/symmetryTest.py
@@ -34,7 +34,7 @@ from external.wip import work_in_progress
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.molecule.symmetry import calculateAtomSymmetryNumber, calculateAxisSymmetryNumber, calculateBondSymmetryNumber, calculateCyclicSymmetryNumber, _indistinguishable
 from rmgpy.species import Species
-from rmgpy.molecule.resonance import generate_aromatic_resonance_structures
+from rmgpy.molecule.resonance import generate_optimal_aromatic_resonance_structures
 ################################################################################
 
 class TestMoleculeSymmetry(unittest.TestCase):
@@ -528,7 +528,7 @@ multiplicity 3
         """
         molecule = Molecule().fromSMILES('c1ccccc1[O]')
         species = Species(molecule=[molecule])
-        aromatic_molecule = generate_aromatic_resonance_structures(molecule)[0]
+        aromatic_molecule = generate_optimal_aromatic_resonance_structures(molecule)[0]
         symmetryNumber = aromatic_molecule.getSymmetryNumber()
         self.assertEqual(symmetryNumber, 2)
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -257,8 +257,8 @@ class CoreEdgeReactionModel:
         # within the list of isomers for a species object describing a unique aromatic compound
         if molecule.isCyclic():
             obj = Species(molecule=[molecule])
-            from rmgpy.molecule.resonance import generate_aromatic_resonance_structures
-            aromaticIsomers = generate_aromatic_resonance_structures(molecule)
+            from rmgpy.molecule.resonance import generate_optimal_aromatic_resonance_structures
+            aromaticIsomers = generate_optimal_aromatic_resonance_structures(molecule)
             obj.molecule.extend(aromaticIsomers)
 
         # First check cache and return if species is found

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -462,9 +462,12 @@ class Species(object):
         # get labeled resonance isomers
         self.generate_resonance_structures(keep_isomorphic=True)
 
+        # only consider reactive molecules as representative structures
+        molecules = [mol for mol in self.molecule if mol.reactive]
+
         # return if no resonance
-        if len(self.molecule) == 1:
-            return self.molecule[0]
+        if len(molecules) == 1:
+            return molecules[0]
 
         # create a sorted list of atom objects for each resonance structure
         cython.declare(atomsFromStructures = list, oldAtoms = list, newAtoms = list,
@@ -477,11 +480,11 @@ class Species(object):
                       atoms=list,)
 
         atomsFromStructures = []
-        for newMol in self.molecule:
+        for newMol in molecules:
             newMol.atoms.sort(key=lambda atom: atom.id)
             atomsFromStructures.append(newMol.atoms)
 
-        numResonanceStructures = len(self.molecule)
+        numResonanceStructures = len(molecules)
 
         # make original structure with no bonds
         newMol = Molecule()
@@ -500,7 +503,7 @@ class Species(object):
                 newMol.addBond(bond)
 
         # set bonds to the proper value
-        for structureNum, oldMol in enumerate(self.molecule):
+        for structureNum, oldMol in enumerate(molecules):
             oldAtoms = atomsFromStructures[structureNum]
 
             for index1, atom1 in enumerate(oldAtoms):

--- a/rmgpy/test_data/testing_database/kinetics/families/R_Addition_MultipleBond/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/R_Addition_MultipleBond/groups.py
@@ -21,7 +21,11 @@ recipe(actions=[
 entry(
     index = 0,
     label = "R_R",
-    group = "OR{Cd_R, Ct_R, Od_R, Sd_R, Nd_R, Nt_R}",
+    group =
+"""
+1 *1 R!H u0 {2,[D,T,B]}
+2 *2 R!H u0 {1,[D,T,B]}
+""",
     kinetics = None,
 )
 
@@ -34,6 +38,17 @@ entry(
 
 entry(
     index = 2,
+    label = "Cb_Cb",
+    group =
+"""
+1 *1 [Cb,Cbf] u0 {2,B}
+2 *2 [Cb,Cbf] u0 {1,B}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
     label = "Cd_R",
     group = 
 """
@@ -44,7 +59,7 @@ entry(
 )
 
 entry(
-    index = 3,
+    index = 4,
     label = "Ck_O",
     group = 
 """
@@ -56,7 +71,7 @@ entry(
 )
 
 entry(
-    index = 127,
+    index = 5,
     label = "Ck_Ca",
     group = 
 """
@@ -69,7 +84,7 @@ entry(
 )
 
 entry(
-    index = 838,
+    index = 6,
     label = "Ct_R",
     group = 
 """
@@ -80,7 +95,7 @@ entry(
 )
 
 entry(
-    index = 4,
+    index = 7,
     label = "Od_R",
     group = 
 """
@@ -91,14 +106,14 @@ entry(
 )
 
 entry(
-    index = 5,
+    index = 8,
     label = "Nd_R",
     group = "OR{N1dc_R, N3d_R}",
     kinetics = None,
 )
 
 entry(
-    index = 6,
+    index = 9,
     label = "N1dc_R",
     group = 
 """
@@ -109,7 +124,7 @@ entry(
 )
 
 entry(
-    index = 7,
+    index = 10,
     label = "N3d_R",
     group = 
 """
@@ -120,14 +135,14 @@ entry(
 )
 
 entry(
-    index = 8,
+    index = 11,
     label = "Nt_R",
     group = "OR{N3t_R, N5t_R}",
     kinetics = None,
 )
 
 entry(
-    index = 9,
+    index = 12,
     label = "N3t_R",
     group = 
 """
@@ -138,7 +153,7 @@ entry(
 )
 
 entry(
-    index = 10,
+    index = 13,
     label = "N5t_R",
     group = 
 """
@@ -149,7 +164,7 @@ entry(
 )
 
 entry(
-    index = 11,
+    index = 14,
     label = "Sd_R",
     group = 
 """
@@ -160,7 +175,7 @@ entry(
 )
 
 entry(
-    index = 12,
+    index = 15,
     label = "HJ",
     group = 
 """
@@ -170,14 +185,14 @@ entry(
 )
 
 entry(
-    index = 13,
+    index = 16,
     label = "Y_1centerquadrad",
     group = "OR{C_quintet, C_triplet}",
     kinetics = None,
 )
 
 entry(
-    index = 14,
+    index = 17,
     label = "C_quintet",
     group = 
 """
@@ -187,7 +202,7 @@ entry(
 )
 
 entry(
-    index = 15,
+    index = 18,
     label = "C_triplet",
     group = 
 """
@@ -197,14 +212,14 @@ entry(
 )
 
 entry(
-    index = 16,
+    index = 19,
     label = "Y_1centertrirad",
     group = "OR{N_atom_quartet, N_atom_doublet, CH_quartet, CH_doublet}",
     kinetics = None,
 )
 
 entry(
-    index = 17,
+    index = 20,
     label = "N_atom_quartet",
     group = 
 """
@@ -214,7 +229,7 @@ entry(
 )
 
 entry(
-    index = 18,
+    index = 21,
     label = "N_atom_doublet",
     group = 
 """
@@ -224,7 +239,7 @@ entry(
 )
 
 entry(
-    index = 19,
+    index = 22,
     label = "CH_quartet",
     group = 
 """
@@ -235,7 +250,7 @@ entry(
 )
 
 entry(
-    index = 20,
+    index = 23,
     label = "CH_doublet",
     group = 
 """
@@ -246,7 +261,7 @@ entry(
 )
 
 entry(
-    index = 21,
+    index = 24,
     label = "Y_1centerbirad",
     group = 
 """
@@ -256,7 +271,7 @@ entry(
 )
 
 entry(
-    index = 22,
+    index = 25,
     label = "CJ",
     group = 
 """
@@ -266,7 +281,7 @@ entry(
 )
 
 entry(
-    index = 23,
+    index = 26,
     label = "CbJ",
     group = 
 """
@@ -276,7 +291,7 @@ entry(
 )
 
 entry(
-    index = 24,
+    index = 27,
     label = "CtJ",
     group = 
 """
@@ -287,7 +302,7 @@ entry(
 )
 
 entry(
-    index = 25,
+    index = 28,
     label = "C2b",
     group = 
 """
@@ -298,7 +313,7 @@ entry(
 )
 
 entry(
-    index = 26,
+    index = 29,
     label = "C=SJ",
     group = 
 """
@@ -309,7 +324,7 @@ entry(
 )
 
 entry(
-    index = 27,
+    index = 30,
     label = "CO_rad",
     group = 
 """
@@ -321,7 +336,7 @@ entry(
 )
 
 entry(
-    index = 28,
+    index = 31,
     label = "CsJ",
     group = 
 """
@@ -334,14 +349,14 @@ entry(
 )
 
 entry(
-    index = 29,
+    index = 32,
     label = "OJ",
     group = "OR{OJ_pri, OJ_sec, O2b}",
     kinetics = None,
 )
 
 entry(
-    index = 30,
+    index = 33,
     label = "OJ_pri",
     group = 
 """
@@ -352,7 +367,7 @@ entry(
 )
 
 entry(
-    index = 31,
+    index = 34,
     label = "OJ_sec",
     group = 
 """
@@ -363,7 +378,7 @@ entry(
 )
 
 entry(
-    index = 32,
+    index = 35,
     label = "O2b",
     group = 
 """
@@ -374,7 +389,7 @@ entry(
 )
 
 entry(
-    index = 33,
+    index = 36,
     label = "SJ",
     group = 
 """
@@ -384,7 +399,7 @@ entry(
 )
 
 entry(
-    index = 34,
+    index = 37,
     label = "SsJ",
     group = 
 """
@@ -395,14 +410,14 @@ entry(
 )
 
 entry(
-    index = 35,
+    index = 38,
     label = "NJ",
     group = "OR{N3J}",
     kinetics = None,
 )
 
 entry(
-    index = 36,
+    index = 39,
     label = "N3J",
     group = 
 """
@@ -412,7 +427,7 @@ entry(
 )
 
 entry(
-    index = 37,
+    index = 40,
     label = "N3sJ",
     group = 
 """
@@ -422,7 +437,7 @@ entry(
 )
 
 entry(
-    index = 38,
+    index = 41,
     label = "N3dJ",
     group = 
 """
@@ -434,6 +449,7 @@ entry(
 tree(
 """
 L1: R_R
+    L2: Cb_Cb
     L2: Cd_R
         L3: Ck_O
         L3: Ck_Ca


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
With recent changes to resonance structure generation and the implementation of resonance structure filtration, I felt that aromatic resonance structure generation could be refactored to fit better with the new infrastructure. In particular, some filtration which was being done for aromatic species could be relocated to the filtration module for clarity and improved code organization.

Additionally, removing Kekule structures as a representative aromatic resonance structure has been on the to do list for a while. With changes enabling benzene bond reactivity and the new capability to mark non-representative structures as non-reactive, I also felt this was a good opportunity to do that as well. The benefit of doing so would primarily be to reduce the number of resonance structures for aromatics, and also to avoid cases where the Kekule structure may give poor thermo or kinetics estimates.

### Description of Changes
Changes to aromatic resonance algorithm:
- Split generate_aromatic_resonance structures into two functions. One does the actual conversion to benzene bonds, one is the wrapper function which finds the structure with the most aromatic rings. The new function are named `generate_aromatic_resonance_structure` and `generate_optimal_aromatic_resonance_structure`. This is a backwards incompatible change. If desired, I can also add a function declaration to map the old `generate_aromatic_resonance_structures` name to call `generate_optimal_aromatic_resonance_structure`.
- Resonance structure filtration moved to new `aromaticity_filtration` method in the filtration module. This does similar filtering as before, removing all non-aromatic (i.e. with no benzene bonds) structures for polycyclic aromatics. For monocyclic aromatics, the new function also removes Kekule structures, which is different from before.

Changes related to Kekule structure demotion:
- Remove `generate_opposite_kekule_structure` function, which is no longer necessary.
- Remove some unit tests for checking Kekule structure generation.

Other changes:
- Updated a number of unit tests based on differences resonance structure output.
- Update R_Addition_MultipleBond in testing database
- Only use representative resonance structures when generating resonance hybrid

### Testing
See how RMG-tests does, particularly for the aromatics test. The other tests should be unaffected. I might run a longer test case as well.
