### PR TITLE
Improve kekulization algorithm for reacting PAHs

### DIFF
--- a/rmgpy/molecule/kekulize.pyx
+++ b/rmgpy/molecule/kekulize.pyx
@@ -59,7 +59,7 @@ from rmgpy.exceptions import KekulizationError, AtomTypeError
 cpdef kekulize(Molecule mol):
     """
     Kekulize an aromatic molecule in place. If the molecule cannot be kekulized,
-    an AtomTypeError will be raised. However, the molecule will be left in
+    a KekulizationError will be raised. However, the molecule will be left in
     a semi-kekulized state. Therefore, if the original molecule needs to be kept,
     it is advisable to create a copy before kekulizing.
 
@@ -119,6 +119,9 @@ cpdef kekulize(Molecule mol):
             # Put it back in the list, which will get resorted by DOF in the next iteration
             aromaticRings.append(aromaticRing)
         itercount += 1
+
+    if aromaticRings:
+        raise KekulizationError('Unable to kekulize molecule, reached maximum attempts:/n{0}'.format(mol.toAdjacencyList()))
 
     try:
         mol.updateAtomTypes(logSpecies=False)

--- a/rmgpy/molecule/kekulize.pyx
+++ b/rmgpy/molecule/kekulize.pyx
@@ -65,22 +65,22 @@ cpdef kekulize(Molecule mol):
 
     Args: :class:`Molecule` object to be kekulized
     """
-    cdef list ring, rings, aromaticRings, resolvedRings
-    cdef set endoBonds, exoBonds
+    cdef list ring, rings, aromatic_rings, resolved_rings
+    cdef set endo_bonds, exo_bonds
     cdef Atom atom1, atom2, atom
     cdef Bond bond
     cdef bint aromatic, successful, bridged
     cdef int itercount, maxiter
-    cdef AromaticRing aromaticRing
+    cdef AromaticRing aromatic_ring
 
     # Get all potentially aromatic rings
     rings = mol.getAllCyclesOfSize(6)
 
     # Identify aromatic rings and categorize endocyclic and exocyclic bonds for each ring
-    aromaticRings = []
+    aromatic_rings = []
     for ring in rings:
-        endoBonds = set()
-        exoBonds = set()
+        endo_bonds = set()
+        exo_bonds = set()
         aromatic = True
         for atom1 in ring:
             # Check if this is a bridged ring
@@ -88,39 +88,39 @@ cpdef kekulize(Molecule mol):
             for atom2, bond in atom1.bonds.iteritems():
                 if bridged and sum([1 if atom in ring else 0 for atom in atom2.bonds.iterkeys()]) > 2:
                     # This atom2 is the other end of the bridging bond, so don't consider it as a part of the ring
-                    exoBonds.add(bond)
+                    exo_bonds.add(bond)
                     continue
                 elif atom2 in ring:
                     if abs(round(bond.order) - bond.order) < 1e-9:
                         aromatic = False
                         break
-                    endoBonds.add(bond)
+                    endo_bonds.add(bond)
                 else:
-                    exoBonds.add(bond)
+                    exo_bonds.add(bond)
             if not aromatic:
                 break
         if aromatic:
             # Use an AromaticRing object to store the info about this ring
-            aromaticRings.append(AromaticRing(atoms=ring, endoBonds=endoBonds, exoBonds=exoBonds))
+            aromatic_rings.append(AromaticRing(atoms=ring, endo_bonds=endo_bonds, exo_bonds=exo_bonds))
 
-    resolvedRings = []
+    resolved_rings = []
     itercount = 0
-    maxiter = 2 * len(aromaticRings)
-    while aromaticRings and itercount < maxiter:
+    maxiter = 2 * len(aromatic_rings)
+    while aromatic_rings and itercount < maxiter:
         # Update and sort the remaining rings
-        prioritizeRings(aromaticRings)
+        prioritize_rings(aromatic_rings)
         # Take the next ring off the stack
-        aromaticRing = aromaticRings.pop()
+        aromatic_ring = aromatic_rings.pop()
         # Try to kekulize this ring
-        successful = aromaticRing.kekulize()
+        successful = aromatic_ring.kekulize()
         if successful:
-            resolvedRings.append(aromaticRing)
+            resolved_rings.append(aromatic_ring)
         else:
             # Put it back in the list, which will get resorted by DOF in the next iteration
-            aromaticRings.append(aromaticRing)
+            aromatic_rings.append(aromatic_ring)
         itercount += 1
 
-    if aromaticRings:
+    if aromatic_rings:
         raise KekulizationError('Unable to kekulize molecule, reached maximum attempts:/n{0}'.format(mol.toAdjacencyList()))
 
     try:
@@ -129,19 +129,19 @@ cpdef kekulize(Molecule mol):
         logging.debug('Unable to kekulize molecule, final result was invalid:/n{0}'.format(mol.toAdjacencyList()))
         raise KekulizationError('Unable to kekulize molecule, final result was invalid.')
 
-cdef list prioritizeRings(list aromaticList):
+cdef list prioritize_rings(list item_list):
     """Update list of AromaticRing objects, then sort by DOF."""
     cdef AromaticRing item, x
-    for item in aromaticList:
+    for item in item_list:
         item.update()
-    return aromaticList.sort(key=lambda x: (x.endoDOF, x.exoDOF), reverse=True)
+    return item_list.sort(key=lambda x: (x.endo_dof, x.exo_dof), reverse=True)
 
-cdef list prioritizeBonds(list aromaticList):
+cdef list prioritize_bonds(list item_list):
     """Update list of Aromatic Bond objects, then sort by DOF."""
     cdef AromaticBond item, x
-    for item in aromaticList:
+    for item in item_list:
         item.update()
-    return aromaticList.sort(key=lambda x: (x.doublePossible, not x.doubleRequired, x.endoDOF, x.exoDOF), reverse=True)
+    return item_list.sort(key=lambda x: (x.double_possible, not x.double_required, x.endo_dof, x.exo_dof), reverse=True)
 
 cdef class AromaticRing(object):
     """
@@ -150,15 +150,15 @@ cdef class AromaticRing(object):
     DO NOT use outside of this module. This class does not do any aromaticity perception.
     """
     cdef public list atoms, resolved, unresolved
-    cdef set endoBonds, exoBonds
-    cdef public int endoDOF, exoDOF
+    cdef set endo_bonds, exo_bonds
+    cdef public int endo_dof, exo_dof
 
-    def __init__(self, atoms=None, endoBonds=None, exoBonds=None, endoDOF=-1, exoDOF=-1):
+    def __init__(self, atoms=None, endo_bonds=None, exo_bonds=None, endo_dof=-1, exo_dof=-1):
         self.atoms = atoms
-        self.endoBonds = endoBonds
-        self.exoBonds = exoBonds
-        self.endoDOF = endoDOF
-        self.exoDOF = exoDOF
+        self.endo_bonds = endo_bonds
+        self.exo_bonds = exo_bonds
+        self.endo_dof = endo_dof
+        self.exo_dof = exo_dof
         self.resolved = []
         self.unresolved = []
 
@@ -166,36 +166,36 @@ cdef class AromaticRing(object):
         """
         Update the degree of freedom information for this aromatic ring.
 
-        `endoDOF` refers to the number of bonds in the ring without fixed bond orders.
-        `exoDOF`  refers to the number of bonds outside the ring without fixed bond orders.
+        `endo_dof` refers to the number of bonds in the ring without fixed bond orders.
+        `exo_dof`  refers to the number of bonds outside the ring without fixed bond orders.
         """
-        cdef int endoDOF, exoDOF
+        cdef int endo_dof, exo_dof
         cdef Bond bond
 
-        endoDOF = 0
-        for bond in self.endoBonds:
+        endo_dof = 0
+        for bond in self.endo_bonds:
             if bond.isBenzene():
                 # Add one dof for each aromatic bond
-                endoDOF += 1
-        exoDOF = 0
-        for bond in self.exoBonds:
+                endo_dof += 1
+        exo_dof = 0
+        for bond in self.exo_bonds:
             if bond.isBenzene():
                 # Add one dof for each aromatic bond
-                exoDOF += 1
-        self.endoDOF = endoDOF
-        self.exoDOF = exoDOF
+                exo_dof += 1
+        self.endo_dof = endo_dof
+        self.exo_dof = exo_dof
 
-        self.processBonds()
+        self.process_bonds()
 
-    cpdef tuple processBonds(self):
+    cpdef tuple process_bonds(self):
         """Create AromaticBond objects for each endocyclic bond."""
         cdef Bond bond0
         cdef int i
 
         if not self.unresolved and not self.resolved:
             # We just started on this ring
-            for bond0 in self.endoBonds:
-                self.unresolved.append(AromaticBond(bond=bond0, ringBonds=self.endoBonds))
+            for bond0 in self.endo_bonds:
+                self.unresolved.append(AromaticBond(bond=bond0, ring_bonds=self.endo_bonds))
 
         i = 0
         while i < len(self.unresolved):
@@ -214,7 +214,7 @@ cdef class AromaticRing(object):
             else:
                 i += 1
 
-        assert len(self.resolved) + len(self.unresolved) == len(self.endoBonds)
+        assert len(self.resolved) + len(self.unresolved) == len(self.endo_bonds)
 
     cpdef bint kekulize(self) except -2:
         """
@@ -234,30 +234,30 @@ cdef class AromaticRing(object):
         maxiter = 2 * len(self.unresolved)
         while self.unresolved and itercount < maxiter:
             # Update and sort the unresolved bonds
-            prioritizeBonds(self.unresolved)
+            prioritize_bonds(self.unresolved)
             # Take the next bond off the stack
             bond = self.unresolved.pop()
 
-            if bond.doublePossible and bond.doubleRequired:
+            if bond.double_possible and bond.double_required:
                 # This bond must be a double bond to satisfy atom valence
                 bond.bond.order = 2
                 self.resolved.append(bond)
-                self.endoDOF -= 1
-            elif bond.doublePossible and not bond.doubleRequired:
+                self.endo_dof -= 1
+            elif bond.double_possible and not bond.double_required:
                 # This could be a double bond, but we don't know for sure
                 # There are a few cases where it's safe to assume that it is a double bond:
                 #   - All exo bonds are defined, and no endo bonds have been defined
                 #   - Exo bonds adjacent to the current bond are defined, and no endo bonds have been defined
                 #   - Exo bonds adjacent to the current bond are not defined, but one adjacent endo bond is defined
                 #   - This is the last undefined endo bond
-                if ((self.endoDOF == 6 and self.exoDOF == 0)
-                        or (self.endoDOF == 6 and bond.exoDOF == 0)
-                        or (bond.endoDOF == 1 and (bond.exoDOF == 1 or bond.exoDOF == 2))
-                        or self.endoDOF == 1):
+                if ((self.endo_dof == 6 and self.exo_dof == 0)
+                        or (self.endo_dof == 6 and bond.exo_dof == 0)
+                        or (bond.endo_dof == 1 and (bond.exo_dof == 1 or bond.exo_dof == 2))
+                        or self.endo_dof == 1):
                     # Go ahead an assume this bond is double
                     bond.bond.order = 2
                     self.resolved.append(bond)
-                    self.endoDOF -= 1
+                    self.endo_dof -= 1
                 else:
                     # Come back to this bond later
                     self.unresolved.append(bond)
@@ -265,7 +265,7 @@ cdef class AromaticRing(object):
                 # Double bond is not possible, so it must be a single bond
                 bond.bond.order = 1
                 self.resolved.append(bond)
-                self.endoDOF -= 1
+                self.endo_dof -= 1
 
             itercount += 1
 
@@ -282,35 +282,35 @@ cdef class AromaticBond(object):
     DO NOT use outside of this module. This class does not do any aromaticity perception.
     """
     cdef public Bond bond
-    cdef public set ringBonds
-    cdef public int endoDOF, exoDOF
-    cdef public bint doublePossible, doubleRequired
+    cdef public set ring_bonds
+    cdef public int endo_dof, exo_dof
+    cdef public bint double_possible, double_required
 
-    def __init__(self, bond=None, ringBonds=None, endoDOF=-1, exoDOF=-1, doublePossible=True, doubleRequired=False):
+    def __init__(self, bond=None, ring_bonds=None, endo_dof=-1, exo_dof=-1, double_possible=True, double_required=False):
         self.bond = bond
-        self.ringBonds = ringBonds
-        self.endoDOF = endoDOF
-        self.exoDOF = exoDOF
-        self.doublePossible = doublePossible
-        self.doubleRequired = doubleRequired
+        self.ring_bonds = ring_bonds
+        self.endo_dof = endo_dof
+        self.exo_dof = exo_dof
+        self.double_possible = double_possible
+        self.double_required = double_required
 
     cpdef update(self):
         """
         Update the local degree of freedom information for this aromatic bond.
         The DOF counts do not include the bond itself, only its adjacent bonds.
 
-        `endoDOF` refers to the number of adjacent bonds in the ring without fixed bond orders.
-        `exoDOF`  refers to the number of adjacent bonds outside the ring without fixed bond orders.
+        `endo_dof` refers to the number of adjacent bonds in the ring without fixed bond orders.
+        `exo_dof`  refers to the number of adjacent bonds outside the ring without fixed bond orders.
         """
-        cdef dict bondOrders, valences
+        cdef dict valences
         cdef Atom atom
         cdef Bond bond
-        cdef int endoDOF, exoDOF, occupied, uncertain, available
+        cdef int endo_dof, exo_dof, occupied, uncertain, available
 
         valences = PeriodicSystem.valences
 
-        endoDOF = 0
-        exoDOF = 0
+        endo_dof = 0
+        exo_dof = 0
         for atom in [self.bond.atom1, self.bond.atom2]:
             occupied = 0
             uncertain = 0
@@ -324,10 +324,10 @@ cdef class AromaticBond(object):
                     occupied += 1
                     uncertain += 1
                     if bond is not self.bond:
-                        if bond in self.ringBonds:
-                            endoDOF += 1
+                        if bond in self.ring_bonds:
+                            endo_dof += 1
                         else:
-                            exoDOF += 1
+                            exo_dof += 1
                 else:
                     raise KekulizationError('Unexpected bond order {0}.'.format(bond.order))
             # Count radicals and lone pairs
@@ -339,11 +339,11 @@ cdef class AromaticBond(object):
                 raise KekulizationError('Atom {0} cannot have negative available valence.'.format(atom))
             elif available == 0:
                 # There are no extra electrons available, so this bond cannot be a double bond
-                self.doublePossible = False
+                self.double_possible = False
             elif available == 1 and uncertain == 1:
                 # There is an extra electron available, but the current bond is the only uncertain one,
                 # so it must be a double bond
-                self.doubleRequired = True
+                self.double_required = True
 
-        self.endoDOF = endoDOF
-        self.exoDOF = exoDOF
+        self.endo_dof = endo_dof
+        self.exo_dof = exo_dof

--- a/rmgpy/molecule/kekulizeTest.py
+++ b/rmgpy/molecule/kekulizeTest.py
@@ -61,6 +61,7 @@ class KekulizeTest(unittest.TestCase):
         self.aromaticRing = AromaticRing(ringAtoms[0], set(ringBonds[0]), bonds - set(ringBonds[0]))
 
     def testAromaticRing(self):
+        """Test that the AromaticRing class works properly for kekulization."""
         self.aromaticRing.update()
 
         self.assertEqual(self.aromaticRing.endoDOF, 6)
@@ -71,7 +72,9 @@ class KekulizeTest(unittest.TestCase):
         self.assertTrue(result)
 
     def testAromaticBond(self):
-        resolved, unresolved = self.aromaticRing.processBonds()
+        """Test that the AromaticBond class works properly for kekulization."""
+        self.aromaticRing.processBonds()
+        resolved, unresolved = self.aromaticRing.resolved, self.aromaticRing.unresolved
 
         self.assertEqual(len(resolved), 0)
         self.assertEqual(len(unresolved), 6)

--- a/rmgpy/molecule/kekulizeTest.py
+++ b/rmgpy/molecule/kekulizeTest.py
@@ -34,6 +34,7 @@ from external.wip import work_in_progress
 from rmgpy.molecule import Molecule
 from rmgpy.molecule.kekulize import *
 
+
 class KekulizeTest(unittest.TestCase):
 
     def setUp(self):
@@ -56,32 +57,32 @@ class KekulizeTest(unittest.TestCase):
         for atom in molecule.atoms:
             bonds.update(atom.bonds.values())
 
-        ringAtoms, ringBonds = molecule.getAromaticRings()
+        ring_atoms, ring_bonds = molecule.getAromaticRings()
 
-        self.aromaticRing = AromaticRing(ringAtoms[0], set(ringBonds[0]), bonds - set(ringBonds[0]))
+        self.aromatic_ring = AromaticRing(ring_atoms[0], set(ring_bonds[0]), bonds - set(ring_bonds[0]))
 
-    def testAromaticRing(self):
+    def test_aromatic_ring(self):
         """Test that the AromaticRing class works properly for kekulization."""
-        self.aromaticRing.update()
+        self.aromatic_ring.update()
 
-        self.assertEqual(self.aromaticRing.endoDOF, 6)
-        self.assertEqual(self.aromaticRing.exoDOF, 0)
+        self.assertEqual(self.aromatic_ring.endo_dof, 6)
+        self.assertEqual(self.aromatic_ring.exo_dof, 0)
 
-        result = self.aromaticRing.kekulize()
+        result = self.aromatic_ring.kekulize()
 
         self.assertTrue(result)
 
-    def testAromaticBond(self):
+    def test_aromatic_bond(self):
         """Test that the AromaticBond class works properly for kekulization."""
-        self.aromaticRing.processBonds()
-        resolved, unresolved = self.aromaticRing.resolved, self.aromaticRing.unresolved
+        self.aromatic_ring.process_bonds()
+        resolved, unresolved = self.aromatic_ring.resolved, self.aromatic_ring.unresolved
 
         self.assertEqual(len(resolved), 0)
         self.assertEqual(len(unresolved), 6)
 
         for bond in unresolved:
             bond.update()
-            self.assertEqual(bond.endoDOF, 2)
-            self.assertEqual(bond.exoDOF, 0)
-            self.assertTrue(bond.doublePossible)
-            self.assertFalse(bond.doubleRequired)
+            self.assertEqual(bond.endo_dof, 2)
+            self.assertEqual(bond.exo_dof, 0)
+            self.assertTrue(bond.double_possible)
+            self.assertFalse(bond.double_required)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The kekulization module could not properly handle cases where bonds in different aromatic rings were modified as a result of a reaction. For example, Diels_alder_addition of acetylene to the bay site of phenanthrene, which results in bond change in all three rings of phenanthrene.

### Description of Changes
This updates the kekulization algorithm to do initial bond processing at once at the start of the entire procedure instead of waiting until the start of kekulizing each ring.

Additionally, naming in the entire kekulization module has been redone to conform to PEP-8. Compatibility issues are not expected to be significant because the only outward facing method is `kekulize`, which was not modified.

#### Technical details
> The initial bond processing is done by `AromaticRing.process_bonds()`. That method will directly assign bond orders to bonds which have been modified (incremented or decremented). That method was previously called by `AromaticRing.kekulize()`, which is called for each aromatic ring in the molecule, sequentially. The changes here adds another call to `process_bonds()` in the `AromaticRing.update()` method, which is called by `prioritize_rings()` for all aromatic rings in the molecule on each iteration. Therefore, when calling the main `kekulize()` function, the bonds for every aromatic ring will be processed before continuing to kekulize each ring individually. To avoid repeatedly processing the same bonds, the `resolved` and `unresolved` lists were converted to class attributes rather than being regenerated on each call.

### Testing
Unit tests should pass, RMG-tests should not show any differences from master. This PR is necessary for ReactionMechanismGenerator/RMG-database#293 to pass.

### Reviewer Tips
Skim the code, ask questions, verify RMG-tests.
