### PR TITLE
Remove extra quotes from pretty repr of references classes

### DIFF
--- a/rmgpy/data/reference.py
+++ b/rmgpy/data/reference.py
@@ -100,11 +100,11 @@ class Reference:
         reconstruct the object.
         """
         string = u'Reference(\n'
-        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['"{0!r}"'.format(author.encode("utf-8")) for author in self.authors]))
+        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['{0!r}'.format(author.encode("utf-8")) for author in self.authors]))
         if self.title != '':       string += u'    title = {0!r},\n'.format(self.title.encode("utf-8"))
-        if self.year != '':        string += u'    year = "{0!r}",\n'.format(self.year.encode("utf-8"))
-        if self.doi != '':         string += u'    doi = "{0!r}",\n'.format(self.doi.encode("utf-8"))
-        if self.url != '':         string += u'    url = "{0!r}",\n'.format(self.url.encode("utf-8"))
+        if self.year != '':        string += u'    year = {0!r},\n'.format(self.year.encode("utf-8"))
+        if self.doi != '':         string += u'    doi = {0!r},\n'.format(self.doi.encode("utf-8"))
+        if self.url != '':         string += u'    url = {0!r},\n'.format(self.url.encode("utf-8"))
         return string + u')'
 
     def getAuthorString(self):
@@ -188,15 +188,15 @@ class Article(Reference):
         reconstruct the object.
         """
         string = u'Article(\n'
-        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['"{0!r}"'.format(author.encode("utf-8")) for author in self.authors]))
+        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['{0!r}'.format(author.encode("utf-8")) for author in self.authors]))
         if self.title != '':       string += u'    title = {0!r},\n'.format(self.title.encode("utf-8"))
-        if self.journal != '':     string += u'    journal = "{0!r}",\n'.format(self.journal.encode("utf-8"))
-        if self.volume != '':      string += u'    volume = "{0!r}",\n'.format(self.volume.encode("utf-8"))
-        if self.number != '':      string += u'    number = "{0!r}",\n'.format(self.number.encode("utf-8"))
-        if self.pages != '':       string += u'    pages = """{0!r}""",\n'.format(self.pages.encode("utf-8"))
-        if self.year != '':        string += u'    year = "{0!r}",\n'.format(self.year.encode("utf-8"))
-        if self.doi != '':         string += u'    doi = "{0!r}",\n'.format(self.doi.encode("utf-8"))
-        if self.url != '':         string += u'    url = "{0!r}",\n'.format(self.url.encode("utf-8"))
+        if self.journal != '':     string += u'    journal = {0!r},\n'.format(self.journal.encode("utf-8"))
+        if self.volume != '':      string += u'    volume = {0!r},\n'.format(self.volume.encode("utf-8"))
+        if self.number != '':      string += u'    number = {0!r},\n'.format(self.number.encode("utf-8"))
+        if self.pages != '':       string += u'    pages = {0!r},\n'.format(self.pages.encode("utf-8"))
+        if self.year != '':        string += u'    year = {0!r},\n'.format(self.year.encode("utf-8"))
+        if self.doi != '':         string += u'    doi = {0!r},\n'.format(self.doi.encode("utf-8"))
+        if self.url != '':         string += u'    url = {0!r},\n'.format(self.url.encode("utf-8"))
         return string + u')'
     
 ################################################################################
@@ -256,16 +256,16 @@ class Book(Reference):
         reconstruct the object.
         """
         string = u'Book(\n'
-        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['"{0!r}"'.format(author.encode("utf-8")) for author in self.authors]))
+        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['{0!r}'.format(author.encode("utf-8")) for author in self.authors]))
         if self.title != '':       string += u'    title = {0!r},\n'.format(self.title.encode("utf-8"))
-        if self.publisher != '':   string += u'    publisher = "{0!r}",\n'.format(self.publisher.encode("utf-8"))
-        if self.address != '':     string += u'    address = "{0!r}",\n'.format(self.address.encode("utf-8"))
-        if self.volume != '':      string += u'    volume = "{0!r}",\n'.format(self.volume.encode("utf-8"))
-        if self.series != '':      string += u'    series = """{0!r}""",\n'.format(self.series.encode("utf-8"))
-        if self.edition != '':     string += u'    edition = """{0!r}""",\n'.format(self.edition.encode("utf-8"))
-        if self.year != '':        string += u'    year = "{0!r}",\n'.format(self.year.encode("utf-8"))
-        if self.doi != '':         string += u'    doi = "{0!r}",\n'.format(self.doi.encode("utf-8"))
-        if self.url != '':         string += u'    url = "{0!r}",\n'.format(self.url.encode("utf-8"))
+        if self.publisher != '':   string += u'    publisher = {0!r},\n'.format(self.publisher.encode("utf-8"))
+        if self.address != '':     string += u'    address = {0!r},\n'.format(self.address.encode("utf-8"))
+        if self.volume != '':      string += u'    volume = {0!r},\n'.format(self.volume.encode("utf-8"))
+        if self.series != '':      string += u'    series = {0!r},\n'.format(self.series.encode("utf-8"))
+        if self.edition != '':     string += u'    edition = {0!r},\n'.format(self.edition.encode("utf-8"))
+        if self.year != '':        string += u'    year = {0!r},\n'.format(self.year.encode("utf-8"))
+        if self.doi != '':         string += u'    doi = {0!r},\n'.format(self.doi.encode("utf-8"))
+        if self.url != '':         string += u'    url = {0!r},\n'.format(self.url.encode("utf-8"))
         return string + u')'
 
 ################################################################################
@@ -316,13 +316,13 @@ class Thesis(Reference):
         reconstruct the object.
         """
         string = u'Thesis(\n'
-        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['"{0!r}"'.format(author.encode("utf-8")) for author in self.authors]))
+        if len(self.authors) != 0: string += u'    authors = [{0}],\n'.format(', '.join(['{0!r}'.format(author.encode("utf-8")) for author in self.authors]))
         if self.title != '':       string += u'    title = {0!r},\n'.format(self.title.encode("utf-8"))
-        if self.degree != '':      string += u'    degree = "{0!r}",\n'.format(self.degree.encode("utf-8"))
-        if self.school != '':      string += u'    school = "{0!r}",\n'.format(self.school.encode("utf-8"))
-        if self.year != '':        string += u'    year = "{0!r}",\n'.format(self.year.encode("utf-8"))
-        if self.doi != '':         string += u'    doi = "{0!r}",\n'.format(self.doi.encode("utf-8"))
-        if self.url != '':         string += u'    url = "{0!r}",\n'.format(self.url.encode("utf-8"))
+        if self.degree != '':      string += u'    degree = {0!r},\n'.format(self.degree.encode("utf-8"))
+        if self.school != '':      string += u'    school = {0!r},\n'.format(self.school.encode("utf-8"))
+        if self.year != '':        string += u'    year = {0!r},\n'.format(self.year.encode("utf-8"))
+        if self.doi != '':         string += u'    doi = {0!r},\n'.format(self.doi.encode("utf-8"))
+        if self.url != '':         string += u'    url = {0!r},\n'.format(self.url.encode("utf-8"))
         return string + u')'
 
 ################################################################################


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Extra quotes are being added when generating the repr for Reference objects because using `{0!r}` for strings automatically includes quotes.

### Description of Changes
Remove extra quotes being added in the `toPrettyRepr` methods of Reference classes.

### Testing
To verify that this works, simply call `repr` on any string to see that it adds a set of quotes.
```
>>> repr('abcd')
"'abcd'"
>>> 'title = {0!r}'.format('abcd')
"title = 'abcd'"
```
