### PR TITLE
fix diffusion limited rate calculations

### DIFF
--- a/documentation/source/users/rmg/liquids.rst
+++ b/documentation/source/users/rmg/liquids.rst
@@ -218,8 +218,8 @@ radii, and diffusivities are estimated with the Stokes-Einstein equation using e
 viscosities (`\eta` (T)). In a unimolecular to bimolecular reaction, for example, the forward rate
 constant (`k`\ :sub:`f`\ ) can be slowed down if the reverse rate (`k`\ :sub:`r, eff`\ ) is diffusion-limited
 since the equilibrium constant (`K`\ :sub:`eq`\ ) is not affected by diffusion limitations. In cases
-where both the forward and the reverse reaction rates are multimolecular, both diffusive limits are
-estimated and RMG uses the direction with the larger magnitude.
+where both the forward and the reverse reaction rates are multimolecular, the forward rate coefficients limited in the
+forward and reverse directions are calculated and the limit with the smaller forward rate coefficient is used.  
 
 The viscosity of the solvent is calculated Pa.s using the solvent specified in the command line 
 and a correlation for the viscosity using parameters `A, B, C, D, E`:

--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -84,13 +84,12 @@ class DiffusionLimited(object):
                 k_diff = self.getDiffusionLimit(T, reaction, forward=True)
                 k_eff = k_forward*k_diff/(k_forward+k_diff)
             else: # 2 or 3 products
-                if Keq > 1.0: # forward rate is faster and thus limited
-                    k_diff = self.getDiffusionLimit(T, reaction, forward=True)
-                    k_eff = k_forward*k_diff/(k_forward+k_diff)
-                else: # reverse rate is faster and thus limited
-                    k_diff = self.getDiffusionLimit(T, reaction, forward=False)
-                    k_eff_reverse = k_reverse*k_diff/(k_reverse+k_diff)
-                    k_eff = k_eff_reverse * Keq
+                kf_diff = self.getDiffusionLimit(T,reaction,forward=True)
+                krev_diff = self.getDiffusionLimit(T,reaction,forward=False)
+                kff = k_forward*kf_diff/(k_forward+kf_diff)
+                krevr = k_reverse*krev_diff/(k_reverse+krev_diff)
+                kfr = Keq*krevr
+                k_eff = min(kff,kfr)
         return k_eff
 
     def getDiffusionFactor(self, reaction, T):


### PR DESCRIPTION
The original algorithm used an inexact criterion for deciding whether the rate was limited in the forward or reverse direction.  This PR causes it to be calculated in both directions and the the direction that results in the slowest forward rate to be used.  