### PR TITLE
Added Hf data for addiitonal elements in Arkane

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -749,20 +749,30 @@ def applyEnergyCorrections(E0, modelChemistry, atoms, bonds,
                 )
 
         # Step 2: Atom energy corrections to reach gas-phase reference state
-        # Experimental enthalpy of formation at 0 K
+        # Experimental enthalpy of formation at 0 K, 1 bar for gas phase
         # See Gaussian thermo whitepaper at http://www.gaussian.com/g_whitepap/thermo.htm)
-        # Note: these values are relatively old and some improvement may be possible by using newer values, particularly for carbon
+        # Note: These values are relatively old and some improvement may be possible by using newer values
+        # (particularly for carbon).
         # However, care should be taken to ensure that they are compatible with the BAC values (if BACs are used)
         # The enthalpies listed here should correspond to the allowed elements in atom_num_dict
-        # Iodine value is from Cox, J. D., Wagman, D. D., and Medvedev, V. A., CODATA Key Values for Thermodynamics, Hemisphere Publishing Corp., New York, 1989.
-        atomHf = {'H': 51.63,
-                  'Li': 37.69, 'Be': 76.48, 'B': 136.2, 'C': 169.98, 'N': 112.53, 'O': 58.99, 'F': 18.47,
-                  'Na': 25.69, 'Mg': 34.87, 'Al': 78.23, 'Si': 106.6, 'P': 75.42, 'S': 65.66, 'Cl': 28.59, 'I':24.04}
+        # He, Ne, K, Ca, Ti, Cu, Zn, Ge, Br, Kr, Rb, Ag, Cd, Sn, I, Xe, Cs, Hg, and Pb are taken from CODATA
+        # Codata: Cox, J. D., Wagman, D. D., and Medvedev, V. A., CODATA Key Values for Thermodynamics, Hemisphere
+        # Publishing Corp., New York, 1989. (http://www.science.uwaterloo.ca/~cchieh/cact/tools/thermodata.html)
+        atomHf = {'H': 51.63, 'He': -1.481,
+                  'Li': 37.69, 'Be': 76.48, 'B': 136.2, 'C': 169.98, 'N': 112.53, 'O': 58.99, 'F': 18.47, 'Ne': -1.481,
+                  'Na': 25.69, 'Mg': 34.87, 'Al': 78.23, 'Si': 106.6, 'P': 75.42, 'S': 65.66, 'Cl': 28.59,
+                  'K': 36.841, 'Ca': 41.014, 'Ti': 111.2, 'Cu': 79.16, 'Zn': 29.685, 'Ge': 87.1, 'Br': 25.26, 'Kr': -1.481,
+                  'Rb': 17.86, 'Ag': 66.61, 'Cd': 25.240, 'Sn': 70.50, 'I': 24.04, 'Xe': -1.481,
+                  'Cs': 16.80, 'Hg': 13.19, 'Pb': 15.17}
         # Thermal contribution to enthalpy Hss(298 K) - Hss(0 K) reported by Gaussian thermo whitepaper
-        # This will be subtracted from the corresponding value in atomHf to produce an enthalpy used in calculating the enthalpy of formation at 298 K
-        atomThermal = {'H': 1.01,
-                       'Li': 1.1, 'Be': 0.46, 'B': 0.29, 'C': 0.25, 'N': 1.04, 'O': 1.04, 'F': 1.05,
-                       'Na': 1.54, 'Mg': 1.19, 'Al': 1.08, 'Si': 0.76, 'P': 1.28, 'S': 1.05, 'Cl': 1.1, 'I':1.48}
+        # This will be subtracted from the corresponding value in atomHf to produce an enthalpy used in calculating
+        # the enthalpy of formation at 298 K
+        atomThermal = {'H': 1.01, 'He': 1.481,
+                       'Li': 1.1, 'Be': 0.46, 'B': 0.29, 'C': 0.25, 'N': 1.04, 'O': 1.04, 'F': 1.05, 'Ne': 1.481,
+                       'Na': 1.54, 'Mg': 1.19, 'Al': 1.08, 'Si': 0.76, 'P': 1.28, 'S': 1.05, 'Cl': 1.1,
+                       'K': 1.481, 'Ca': 1.481, 'Ti': 1.802, 'Cu': 1.481, 'Zn': 1.481, 'Ge': 1.768, 'Br': 1.481, 'Kr': 1.481,
+                       'Rb': 1.481, 'Ag': 1.481, 'Cd': 1.481, 'Sn': 1.485, 'I': 1.481, 'Xe': 1.481,
+                       'Cs': 1.481, 'Hg': 1.481, 'Pb': 1.481}
         # Total energy correction used to reach gas-phase reference state
         # Note: Spin orbit coupling no longer included in these energies, since some model chemistries include it automatically
         atomEnthalpyCorrections = {element: atomHf[element] - atomThermal[element] for element in atomHf}


### PR DESCRIPTION
Added H(0 K) and Hf(298-0K) data of additional elements (He, Ne, K, Ca, Ti, Cu, Zn, Ge, Br, Kr, Rb, Ag, Cd, Sn, Xe, Cs, Hg, and Pb) into Arkane from [CODATA](http://www.science.uwaterloo.ca/~cchieh/cact/tools/thermodata.html).
Solves #1494