### PR TITLE
 Output unscaled frequencies in Arkane's supporting information file 

### DIFF
--- a/arkane/gaussian.py
+++ b/arkane/gaussian.py
@@ -165,6 +165,7 @@ class GaussianLog:
         """
 
         modes = []
+        unscaled_frequencies = []
         E0 = 0.0
 
         f = open(self.path, 'r')
@@ -224,6 +225,7 @@ class GaussianLog:
                         # Convert from K to cm^-1
                         if len(frequencies) > 0:
                             frequencies = [freq * 0.695039 for freq in frequencies]  # kB = 0.695039 cm^-1/K
+                            unscaled_frequencies = frequencies
                             vibration = HarmonicOscillator(frequencies=(frequencies,"cm^-1"))
                             modes.append(vibration)
 
@@ -247,7 +249,8 @@ class GaussianLog:
         # Close file when finished
         f.close()
 
-        return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity, opticalIsomers=opticalIsomers)
+        return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
+                         opticalIsomers=opticalIsomers), unscaled_frequencies
 
     def loadEnergy(self,frequencyScaleFactor=1.):
         """

--- a/arkane/gaussianTest.py
+++ b/arkane/gaussianTest.py
@@ -54,7 +54,7 @@ class GaussianTest(unittest.TestCase):
         """
 
         log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','ethylene.log'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)
@@ -81,7 +81,7 @@ class GaussianTest(unittest.TestCase):
         """
 
         log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','oxygen.log'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)
@@ -109,7 +109,7 @@ class GaussianTest(unittest.TestCase):
         """
 
         log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','ethylene_G3.log'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)

--- a/arkane/main.py
+++ b/arkane/main.py
@@ -289,7 +289,7 @@ class Arkane:
                     freq = ''
                     if len(row) == 4:
                         freq = '{0:.1f}'.format(abs(row[3])) + 'i, '
-                    freq += ', '.join(['{0:.1f}'.format(s) for s in row[2].frequencies.value_si])
+                    freq += ', '.join(['{0:.1f}'.format(s) for s in row[2]])
                 writer.writerow([label, rot, freq])
 
         # run kinetics and pdep jobs (also writes reaction blocks to Chemkin file)

--- a/arkane/molpro.py
+++ b/arkane/molpro.py
@@ -173,6 +173,7 @@ class MolproLog:
         """
 
         modes = []
+        unscaled_frequencies = []
         E0 = 0.0
 
         f = open(self.path, 'r')
@@ -252,6 +253,7 @@ class MolproLog:
                         # Convert from K to cm^-1
                         if len(frequencies) > 0:
                             frequencies = [freq * 0.695039 for freq in frequencies]  # kB = 0.695039 cm^-1/K
+                            unscaled_frequencies = frequencies
                             vibration = HarmonicOscillator(frequencies=(frequencies,"cm^-1"))
                             modes.append(vibration)
 
@@ -264,7 +266,7 @@ class MolproLog:
         # Close file when finished
         f.close()
         return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
-                         opticalIsomers=opticalIsomers)
+                         opticalIsomers=opticalIsomers), unscaled_frequencies
 
     def loadEnergy(self, frequencyScaleFactor=1.):
         """

--- a/arkane/molproTest.py
+++ b/arkane/molproTest.py
@@ -86,7 +86,7 @@ class MolproTest(unittest.TestCase):
         """
 
         log = MolproLog(os.path.join(os.path.dirname(__file__),'data','HOSI_ccsd_t1.out'))
-        conformer = log.loadConformer(symfromlog=True, spinMultiplicity=1)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True, spinMultiplicity=1)
         E0 = log.loadEnergy()
 
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)

--- a/arkane/qchem.py
+++ b/arkane/qchem.py
@@ -174,6 +174,7 @@ class QchemLog:
         if not provided, the value in the Qchem output file will be adopted.
         """
         modes = []; freq = []; mmass = []; rot = []; inertia = []
+        unscaled_frequencies = []
         E0 = 0.0
         f = open(self.path, 'r')
         line = f.readline()
@@ -211,6 +212,7 @@ class QchemLog:
                         if frequencies[0] < 0.0:
                             frequencies = frequencies[1:]
 
+                        unscaled_frequencies = frequencies
                         vibration = HarmonicOscillator(frequencies=(frequencies,"cm^-1"))
                         # modes.append(vibration)
                         freq.append(vibration)
@@ -260,7 +262,8 @@ class QchemLog:
         # Close file when finished
         f.close()
         modes = mmass + rot + freq
-        return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity, opticalIsomers=opticalIsomers)
+        return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
+                         opticalIsomers=opticalIsomers), unscaled_frequencies
 
     def loadEnergy(self, frequencyScaleFactor=1.):
         """

--- a/arkane/qchemTest.py
+++ b/arkane/qchemTest.py
@@ -72,11 +72,11 @@ class QChemTest(unittest.TestCase):
         molecular energies can be properly read.
         """        
         log = QchemLog(os.path.join(os.path.dirname(__file__),'data','npropyl.out'))    
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         self.assertEqual(len(conformer.modes[2]._frequencies.getValue()), 24)    
         self.assertEqual(conformer.modes[2]._frequencies.getValue()[5], 881.79)       
         log = QchemLog(os.path.join(os.path.dirname(__file__),'data','co.out'))        
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         self.assertEqual(len(conformer.modes[2]._frequencies.getValue()), 1)         
         self.assertEqual(conformer.modes[2]._frequencies.getValue(), 2253.16)    
                            
@@ -86,7 +86,7 @@ class QChemTest(unittest.TestCase):
         molecular modes can be properly read.
         """
         log = QchemLog(os.path.join(os.path.dirname(__file__),'data','npropyl.out'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
 
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,NonlinearRotor)]) == 1)
@@ -99,10 +99,10 @@ class QChemTest(unittest.TestCase):
         molecular degrees of freedom can be properly read.
         """
         log = QchemLog(os.path.join(os.path.dirname(__file__),'data','npropyl.out'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         self.assertEqual(conformer.spinMultiplicity, 2)
         log = QchemLog(os.path.join(os.path.dirname(__file__),'data','co.out'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         self.assertEqual(conformer.spinMultiplicity, 1)
     
     def testLoadCOModesFromQchemLog(self):
@@ -111,7 +111,7 @@ class QChemTest(unittest.TestCase):
         molecular degrees of freedom can be properly read.
         """
         log = QchemLog(os.path.join(os.path.dirname(__file__),'data','co.out'))
-        conformer = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -342,18 +342,17 @@ class StatMechJob(object):
                                     'Please verify that the geometry and Hessian of {0!r} are defined in the same coordinate system'.format(self.species.label))
 
         logging.debug('    Reading molecular degrees of freedom...')
-        conformer = statmechLog.loadConformer(symmetry=externalSymmetry, spinMultiplicity=spinMultiplicity,
-                                              opticalIsomers=opticalIsomers, symfromlog=symfromlog,
-                                              label=self.species.label)
+        conformer, unscaled_frequencies = statmechLog.loadConformer(symmetry=externalSymmetry,
+                                                                    spinMultiplicity=spinMultiplicity,
+                                                                    opticalIsomers=opticalIsomers,
+                                                                    symfromlog=symfromlog,
+                                                                    label=self.species.label)
         for mode in conformer.modes:
             if isinstance(mode, (LinearRotor, NonlinearRotor)):
                 self.supporting_info.append(mode)
                 break
-        for mode in conformer.modes:
-            # repeat loop so the frequencies are added last
-            if isinstance(mode, HarmonicOscillator):
-                self.supporting_info.append(mode)
-                break
+        if unscaled_frequencies:
+            self.supporting_info.append(unscaled_frequencies)
 
         if conformer.spinMultiplicity == 0:
             raise ValueError("Could not read spin multiplicity from log file {0},\n"


### PR DESCRIPTION
Previously, non-imaginary frequencies outputted to the supporting information file in Arkane were extracted from the HarmonicOscillator mode, which later gets multiplied by the frequency scaling factor. With this fix, unscaled frequencies are reported.

How to test:
Run any species in arkane (e.g., the C2H4 example) and compare the reported frequencies in the supporting information file generated on this branch and on master with the frequencies reported in the QM log file (easier if the QM software is QChem, where the units are already in cm-1)