### PR TITLE
Allow hasStatMech to assess atomic molecules

### DIFF
--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -328,7 +328,12 @@ class Species(object):
         Return ``True`` if the species has statistical mechanical parameters,
         or ``False`` otherwise.
         """
-        return self.conformer is not None and (len(self.conformer.modes) > 0 or (len(self.molecule) > 0 and len(self.molecule[0].atoms) == 1))
+        if (len(self.molecule) > 0 and len(self.molecule[0].atoms) == 1):
+            #atomic molecules have no modes, check only E0
+            return self.conformer is not None and self.conformer.E0 is not None
+        else:
+            #polyatomic molecules should have modes and E0, so check both
+            return self.conformer is not None and len(self.conformer.modes) > 0 and self.conformer.E0 is not None
 
     def hasThermo(self):
         """


### PR DESCRIPTION
Previously, hasStatMech would return True for any molecule with one atom, even if the E0 parameter was None. This raises issues when creating pdep networks from NASA polynomials in arkane since E0 is necessary. At the same time, this method does not check E0 parameters even for polyatomic
molecules.

This commit reworks hasStatMech to differentiate between atomic molecules, which it only checks the E0 parameter, and polyatomic molecules, which it checks both E0 and the number of modes.

I have tested the arkane example methoxy, which deals with atomic hydrogen, and this commit results in no change in that result. This commit does result in a fix when the user inputs an atomic molecule into the arkane input file given its NASA polynomial.

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Reviewer Tips

Look over the code and let me know if anything should be added/fixed/etc.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
