### PR TITLE
Processing monoatomic species in Arkane/molpro

### DIFF
--- a/arkane/molpro.py
+++ b/arkane/molpro.py
@@ -66,7 +66,7 @@ class MolproLog:
             # Automatically determine the number of atoms
             if 'ATOMIC COORDINATES' in line and Natoms == 0:
                 for i in range(4): line = f.readline()
-                while 'Bond lengths' not in line:
+                while 'Bond lengths' not in line and 'nuclear charge' not in line.lower():
                     Natoms += 1
                     line = f.readline()
             line = f.readline()
@@ -137,12 +137,13 @@ class MolproLog:
         # Close file when finished
         f.close()
 
-        #If no optimized coordinates were found, uses the input geometry (for example if reading the geometry from a frequency file
+        # If no optimized coordinates were found, uses the input geometry
+        # (for example if reading the geometry from a frequency file)
         if coord == []:
             f = open(self.path, 'r')
             line = f.readline()
             while line != '':
-                if 'Atomic Coordinates' in line:
+                if 'atomic coordinates' in line.lower():
                     symbol = []; coord = []
                     for i in range(4):
                         line = f.readline()

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -394,7 +394,11 @@ class StatMechJob(object):
                                         atomEnergies=self.atomEnergies,
                                         applyAtomEnergyCorrections=self.applyAtomEnergyCorrections,
                                         applyBondEnergyCorrections=self.applyBondEnergyCorrections)
-            ZPE = statmechLog.loadZeroPointEnergy() * self.frequencyScaleFactor
+            if len(number) > 1:
+                ZPE = statmechLog.loadZeroPointEnergy() * self.frequencyScaleFactor
+            else:
+                # Monoatomic species don't have frequencies
+                ZPE = 0.0
             logging.debug('Corrected minimum energy is {0} J/mol'.format(E0))
             # The E0_withZPE at this stage contains the ZPE
             E0_withZPE = E0 + ZPE


### PR DESCRIPTION
Minor fixes allowing Arkane to process monoatomic species (atoms) calculated using molpro.
An example for an atom sp job output:
[output.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/2680516/output.txt)

Specifically we care about parsing the following part:
```
 Point group  D2h 



 ATOMIC COORDINATES

 NR  ATOM    CHARGE       X              Y              Z

   1  H       1.00    0.000000000    0.000000000    0.000000000

 NUCLEAR CHARGE:                    1
 NUMBER OF PRIMITIVE AOS:          21
```