### PR TITLE
Allow a BAC dictionary to be assigned to a StatMechJob object

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -174,6 +174,7 @@ class StatMechJob(object):
         self.applyBondEnergyCorrections = True
         self.atomEnergies = None
         self.supporting_info = [self.species.label]
+        self.bonds = None
     
     def execute(self, outputFile=None, plot=False):
         """
@@ -223,11 +224,12 @@ class StatMechJob(object):
             except (NameError, TypeError, SyntaxError), e:
                 logging.error('The species file {0} was invalid:'.format(path))
                 raise
-        
-        try:
-            bonds = local_context['bonds']
-        except KeyError:
-            bonds = {}
+
+        if self.bonds is None:
+            try:
+                self.bonds = local_context['bonds']
+            except KeyError:
+                self.bonds = {}
             
         try:
             linear = local_context['linear']
@@ -389,7 +391,7 @@ class StatMechJob(object):
             E0 = applyEnergyCorrections(E0,
                                         self.modelChemistry,
                                         atoms,
-                                        bonds,
+                                        self.bonds,
                                         atomEnergies=self.atomEnergies,
                                         applyAtomEnergyCorrections=self.applyAtomEnergyCorrections,
                                         applyBondEnergyCorrections=self.applyBondEnergyCorrections)


### PR DESCRIPTION
This small change allows us to assign a BAC dictionary to a StatMechJob object after the object is created. It is useful when working with scripts that pass arguments into Arkane. Specifically, this is how ARC passes BAC.

For the reviewer:
Try creating a `StatMechJob` object on this branch, then pass a BAC dictionary to it using the `.bonds` attribute.
```python
stat_mech_job = StatMechJob(spec, input_file_path)
bac_dict = {'C-C': 1, 'C-H':4}
stat_mech_job.bonds = bac_dict
```