### PR TITLE
Set KERAS_BACKEND=theano before importing DDE

### DIFF
--- a/rmgpy/ml/estimator.py
+++ b/rmgpy/ml/estimator.py
@@ -31,6 +31,7 @@
 import os
 import numpy as np
 
+os.environ['KERAS_BACKEND'] = 'theano'
 from dde.predictor import Predictor
 
 from rmgpy.thermo import ThermoData


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This ensures that the keras backend is set to theano so that dde works properly, regardless of the environment variables set originally. Fixes #1532.

### Description of Changes
Change the `KERAS_BACKEND` environment variable using `os.environ`.

### Testing
Should be tested on mac:
- Activate rmg_env
- Check `echo $KERAS_BACKEND`, should be tensorflow
- Verify that `make test` passes
