### PR TITLE
Move variable initiation to avoid undefined variable error

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -811,13 +811,13 @@ class CoreEdgeReactionModel:
             if rxn is None:
                 # Skip this reaction because there was something wrong with it
                 continue
+            spcs = []
             if isNew:
                 # We've made a new reaction, so make sure the species involved
                 # are in the core or edge
                 allSpeciesInCore = True
                 # Add the reactant and product species to the edge if necessary
                 # At the same time, check if all reactants and products are in the core
-                spcs = []
                 for spec in rxn.reactants:
                     if spec not in self.core.species:
                         allSpeciesInCore = False


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
When using thermodynamic pruning, can encounter undefined variable error in `processNewReactions()`.

### Description of Changes
Move initiation of `spcs` variable earlier.

### Testing
This input file crashes at 10 species without this fix. [input.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/2826031/input.txt)
