### PR TITLE
Load and dump TS YAML files in Arkane

### DIFF
--- a/arkane/common.py
+++ b/arkane/common.py
@@ -182,10 +182,10 @@ class ArkaneSpecies(RMGObject):
         """
         Save the species with all statMech data to a .yml file
         """
-        if not os.path.exists(os.path.join(os.path.abspath(path),'ArkaneSpecies', '')):
-            os.mkdir(os.path.join(os.path.abspath(path),'ArkaneSpecies', ''))
+        if not os.path.exists(os.path.join(os.path.abspath(path), 'species', '')):
+            os.mkdir(os.path.join(os.path.abspath(path), 'species', ''))
         valid_chars = "-_.()<=>+ %s%s" % (string.ascii_letters, string.digits)
-        filename = os.path.join('ArkaneSpecies',
+        filename = os.path.join('species',
                                 ''.join(c for c in self.label if c in valid_chars) + '.yml')
         full_path = os.path.join(path, filename)
         with open(full_path, 'w') as f:

--- a/arkane/common.py
+++ b/arkane/common.py
@@ -188,11 +188,8 @@ class ArkaneSpecies(RMGObject):
         filename = os.path.join('ArkaneSpecies',
                                 ''.join(c for c in self.label if c in valid_chars) + '.yml')
         full_path = os.path.join(path, filename)
-        content = yaml.dump(data=self.as_dict(), Dumper=Dumper)
-        # remove empty lines from the file (multi-line strings have excess new line brakes for some reason):
-        content = content.replace('\n\n', '\n')
         with open(full_path, 'w') as f:
-            f.write(content)
+            f.write(yaml.dump(data=self.as_dict(), Dumper=Dumper))
         logging.debug('Dumping species {0} data as {1}'.format(self.label, filename))
 
     def load_yaml(self, path, species, pdep=False):

--- a/arkane/common.py
+++ b/arkane/common.py
@@ -247,7 +247,17 @@ class ArkaneSpecies(RMGObject):
                       'Wilhoit': Wilhoit,
                       'NASA': NASA,
                       }
+        freq_data = None
+        if 'imaginary_frequency' in data:
+            freq_data = data['imaginary_frequency']
+            del data['imaginary_frequency']
         self.make_object(data=data, class_dict=class_dict)
+        if freq_data is not None:
+            self.imaginary_frequency = ScalarQuantity()
+            self.imaginary_frequency.make_object(data=freq_data, class_dict=dict())
+        self.adjacency_list = data['adjacency_list'] if 'adjacency_list' in data else None
+        self.inchi = data['inchi'] if 'inchi' in data else None
+        self.smiles = data['smiles'] if 'smiles' in data else None
         if pdep and (self.transport_data is None or self.energy_transfer_model is None):
             raise ValueError('Transport data and an energy transfer model must be given if pressure-dependent '
                              'calculations are requested. Check file {0}'.format(path))

--- a/arkane/common.py
+++ b/arkane/common.py
@@ -53,6 +53,7 @@ from rmgpy.statmech.vibration import HarmonicOscillator
 from rmgpy.pdep.collision import SingleExponentialDown
 from rmgpy.transport import TransportData
 from rmgpy.thermo import NASA, Wilhoit
+from rmgpy.species import Species, TransitionState
 import rmgpy.constants as constants
 
 from arkane.pdep import PressureDependenceJob
@@ -68,11 +69,14 @@ class ArkaneSpecies(RMGObject):
                  frequency_scale_factor=None, use_hindered_rotors=None, use_bond_corrections=None, atom_energies='',
                  chemkin_thermo_string='', smiles=None, adjacency_list=None, inchi=None, inchi_key=None, xyz=None,
                  molecular_weight=None, symmetry_number=None, transport_data=None, energy_transfer_model=None,
-                 thermo=None, thermo_data=None, label=None, datetime=None, RMG_version=None):
+                 thermo=None, thermo_data=None, label=None, datetime=None, RMG_version=None, reactants=None,
+                 products=None, reaction_label=None):
+        # reactants/products/reaction_label need to be in the init() to avoid error when loading a TS YAML file,
+        # but we don't use them
         if species is None and conformer is None:
-            # Expecting to get a `species` when generating the object within Arkane,
-            # or a `conformer` when parsing from YAML.
-            raise ValueError('No species or conformer was passed to the ArkaneSpecies object')
+            # Expecting to get a species or a TS when generating the object within Arkane,
+            # or a conformer when parsing from YAML.
+            raise ValueError('No species (or TS) or conformer was passed to the ArkaneSpecies object')
         if conformer is not None:
             self.conformer = conformer
         if label is None and species is not None:
@@ -86,18 +90,26 @@ class ArkaneSpecies(RMGObject):
         self.use_hindered_rotors = use_hindered_rotors
         self.use_bond_corrections = use_bond_corrections
         self.atom_energies = atom_energies
-        self.chemkin_thermo_string = chemkin_thermo_string
-        self.smiles = smiles
-        self.adjacency_list = adjacency_list
-        self.inchi = inchi
-        self.inchi_key = inchi_key
         self.xyz = xyz
         self.molecular_weight = molecular_weight
         self.symmetry_number = symmetry_number
-        self.transport_data = transport_data
-        self.energy_transfer_model = energy_transfer_model  # check pdep flag
-        self.thermo = thermo
-        self.thermo_data = thermo_data
+        is_ts = isinstance(species, TransitionState)
+        if not is_ts:
+            self.chemkin_thermo_string = chemkin_thermo_string
+            self.smiles = smiles
+            self.adjacency_list = adjacency_list
+            self.inchi = inchi
+            self.inchi_key = inchi_key
+            self.transport_data = transport_data
+            self.energy_transfer_model = energy_transfer_model
+            self.thermo = thermo
+            self.thermo_data = thermo_data
+        else:
+            # initialize TS-related attributes
+            self.imaginary_frequency = None
+            self.reaction_label = ''
+            self.reactants = list()
+            self.products = list()
         if species is not None:
             self.update_species_attributes(species)
         self.RMG_version = RMG_version if RMG_version is not None else __version__
@@ -117,12 +129,17 @@ class ArkaneSpecies(RMGObject):
 
     def update_species_attributes(self, species=None):
         """
-        Update the object with a new species (while keeping non-species-dependent attributes unchanged)
+        Update the object with a new species/TS (while keeping non-species-dependent attributes unchanged)
         """
         if species is None:
             raise ValueError('No species was passed to ArkaneSpecies')
         self.label = species.label
-        if species.molecule is not None and len(species.molecule) > 0:
+        if isinstance(species, TransitionState):
+            self.imaginary_frequency = species.frequency
+            if species.conformer is not None:
+                self.conformer = species.conformer
+                self.xyz = self.update_xyz_string()
+        elif species.molecule is not None and len(species.molecule) > 0:
             self.smiles = species.molecule[0].toSMILES()
             self.adjacency_list = species.molecule[0].toAdjacencyList()
             try:
@@ -202,7 +219,7 @@ class ArkaneSpecies(RMGObject):
             data = yaml.safe_load(stream=f)
         try:
             if species.label != data['label']:
-                logging.warning('Found different labels for species: {0} in input file, and {1} in the .yml file. '
+                logging.debug('Found different labels for species: {0} in input file, and {1} in the .yml file. '
                                 'Using the label "{0}" for this species.'.format(species.label, data['label']))
         except KeyError:
             # Lacking label in the YAML file is strange, but accepted

--- a/arkane/commonTest.py
+++ b/arkane/commonTest.py
@@ -308,7 +308,7 @@ class TestArkaneSpecies(unittest.TestCase):
         cls.dump_path = os.path.join(path, 'C2H6')
         cls.dump_input_path = os.path.join(cls.dump_path, 'input.py')
         cls.dump_output_file = os.path.join(cls.dump_path, 'output.py')
-        cls.dump_yaml_file = os.path.join(cls.dump_path, 'ArkaneSpecies', 'C2H6.yml')
+        cls.dump_yaml_file = os.path.join(cls.dump_path, 'species', 'C2H6.yml')
 
         cls.load_path = os.path.join(path, 'C2H6_from_yaml')
         cls.load_input_path = os.path.join(cls.load_path, 'input.py')

--- a/arkane/kinetics.py
+++ b/arkane/kinetics.py
@@ -44,6 +44,7 @@ from rmgpy.exceptions import SpeciesError
 
 from arkane.sensitivity import KineticsSensitivity as sa
 from arkane.output import prettify
+from arkane.common import ArkaneSpecies
 
 ################################################################################
 
@@ -293,7 +294,18 @@ class KineticsJob(object):
         f.write('{0}\n'.format(string))
             
         f.close()
-        
+
+        # We're saving a YAML file for TSs iff structures of the respective reactant/s and product/s are known
+        if all ([spc.molecule is not None and len(spc.molecule)
+                 for spc in self.reaction.reactants + self.reaction.products]):
+            self.arkane_species.update_species_attributes(self.reaction.transitionState)
+            self.arkane_species.reaction_label = reaction.label
+            self.arkane_species.reactants = [{'label': spc.label, 'adjacency_list': spc.molecule[0].toAdjacencyList()}
+                                             for spc in self.reaction.reactants]
+            self.arkane_species.products = [{'label': spc.label, 'adjacency_list': spc.molecule[0].toAdjacencyList()}
+                                             for spc in self.reaction.products]
+            self.arkane_species.save_yaml(path=os.path.dirname(outputFile))
+
     def plot(self, outputDirectory):
         """
         Plot both the raw kinetics data and the Arrhenius fit versus 

--- a/arkane/kinetics.py
+++ b/arkane/kinetics.py
@@ -78,8 +78,8 @@ class KineticsJob(object):
         
         if Tlist is not None:
             self.Tlist = quantity.Quantity(Tlist)
-            self.Tmin = quantity.Quantity(numpy.min(self.Tlist.value_si),"K")
-            self.Tmax = quantity.Quantity(numpy.max(self.Tlist.value_si),"K")
+            self.Tmin = quantity.Quantity(numpy.min(self.Tlist.value_si), "K")
+            self.Tmax = quantity.Quantity(numpy.max(self.Tlist.value_si), "K")
             self.Tcount = len(self.Tlist.value_si)
         else:
             if Tmin and Tmax is not None:
@@ -87,7 +87,7 @@ class KineticsJob(object):
                 if self.Tcount <= 3.:
                     self.Tcount = 50
                 
-                stepsize = (self.Tmax.value_si-self.Tmin.value_si)/self.Tcount
+                stepsize = (self.Tmax.value_si-self.Tmin.value_si) / self.Tcount
                 
                 self.Tlist = quantity.Quantity(numpy.arange(self.Tmin.value_si, self.Tmax.value_si+stepsize, stepsize),"K")
             else:
@@ -100,6 +100,8 @@ class KineticsJob(object):
             self.sensitivity_conditions = [quantity.Quantity(condition) for condition in sensitivity_conditions]
         else:
             self.sensitivity_conditions = None
+
+        self.arkane_species = ArkaneSpecies(species=self.reaction.transitionState)
     
     @property
     def Tmin(self):
@@ -203,8 +205,7 @@ class KineticsJob(object):
         f = open(outputFile, 'a')
 
         if self.usedTST:
-            #If TST is not used, eg. it was given in 'reaction', then this will
-            #throw an error.
+            # If TST is not used, eg. it was given in 'reaction', then this will throw an error.
             f.write('#   ======= =========== =========== =========== ===============\n')
             f.write('#   Temp.   k (TST)     Tunneling   k (TST+T)   Units\n')
             f.write('#   ======= =========== =========== =========== ===============\n')

--- a/arkane/qchem.py
+++ b/arkane/qchem.py
@@ -273,12 +273,13 @@ class QChemLog:
         """
         E0 = None
         with open(self.path, 'r') as f:
-            for line in f:
+            lines = f.readlines()
+            for line in lines:
                 if 'Final energy is' in line:
                     E0 = float(line.split()[3]) * constants.E_h * constants.Na
                     logging.debug('energy is {}'.format(str(E0)))
             if E0 is None:
-                for line in f:
+                for line in lines:
                     if 'Total energy in the final basis set' in line:
                         E0 = float(line.split()[8]) * constants.E_h * constants.Na
                         logging.debug('energy is {}'.format(str(E0)))

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -200,15 +200,15 @@ class StatMechJob(object):
         species object.
         """
         path = self.path
-        TS = isinstance(self.species, TransitionState)
+        is_ts = isinstance(self.species, TransitionState)
         _, file_extension = os.path.splitext(path)
         if file_extension in ['.yml', '.yaml']:
-            if TS:
                 raise NotImplementedError('Loading transition states from a YAML file is still unsupported.')
             self.arkane_species.load_yaml(path=path, species=self.species, pdep=pdep)
             self.species.conformer = self.arkane_species.conformer
             self.species.transportData = self.arkane_species.transport_data
             self.species.energyTransferModel = self.arkane_species.energy_transfer_model
+            if is_ts:
             return
 
         logging.info('Loading statistical mechanics parameters for {0}...'.format(self.species.label))
@@ -425,7 +425,7 @@ class StatMechJob(object):
         conformer.E0 = (E0_withZPE*0.001,"kJ/mol")
 
         # If loading a transition state, also read the imaginary frequency
-        if TS:
+        if is_ts:
             neg_freq = statmechLog.loadNegativeFrequency()
             self.species.frequency = (neg_freq * self.frequencyScaleFactor, "cm^-1")
             self.supporting_info.append(neg_freq)
@@ -523,7 +523,7 @@ class StatMechJob(object):
                         rotorCount += 1
 
             logging.debug('    Determining frequencies from reduced force constant matrix...')
-            frequencies = numpy.array(projectRotors(conformer, F, rotors, linear, TS))
+            frequencies = numpy.array(projectRotors(conformer, F, rotors, linear, is_ts))
 
         elif len(conformer.modes) > 2:
             if len(rotors) > 0:
@@ -905,7 +905,7 @@ class Log(object):
         self.software_log = software_log
 
 
-def projectRotors(conformer, F, rotors, linear, TS):
+def projectRotors(conformer, F, rotors, linear, is_ts):
     """
     For a given `conformer` with associated force constant matrix `F`, lists of
     rotor information `rotors`, `pivots`, and `top1`, and the linearity of the
@@ -919,7 +919,7 @@ def projectRotors(conformer, F, rotors, linear, TS):
 
     Nrotors = len(rotors)
     Natoms = len(conformer.mass.value)
-    Nvib = 3 * Natoms - (5 if linear else 6) - Nrotors - (1 if (TS) else 0)
+    Nvib = 3 * Natoms - (5 if linear else 6) - Nrotors - (1 if (is_ts) else 0)
     mass = conformer.mass.value_si
     coordinates = conformer.coordinates.getValue()
 

--- a/arkane/thermo.py
+++ b/arkane/thermo.py
@@ -78,9 +78,10 @@ class ThermoJob(object):
         if outputFile is not None:
             self.arkane_species.chemkin_thermo_string = self.save(outputFile)
             if self.species.molecule is None or len(self.species.molecule) == 0:
-                logging.debug("Not generating database YAML file for species {0}, since its structure wasn't"
+                logging.debug("Not generating a YAML file for species {0}, since its structure wasn't"
                               " specified".format(self.species.label))
             else:
+                # We're saving a YAML file for species iff Thermo is called and they're structure is known
                 self.arkane_species.update_species_attributes(self.species)
                 self.arkane_species.save_yaml(path=os.path.dirname(outputFile))
             if plot:

--- a/examples/arkane/reactions/H+C2H4=C2H5/input.py
+++ b/examples/arkane/reactions/H+C2H4=C2H5/input.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# This example also generates YAML files for all species and TS
+# A YAML file is generated for species if they're structure is defined and Thermo() is called,
+# and for TS if all the respective reactant/s and product/s have structures
+
 modelChemistry = "CBS-QB3"
 frequencyScaleFactor = 0.99
 useHinderedRotors = False
 useBondCorrections = True
 
-species('H', '../../species/H/H.py')
-species('C2H4', '../../species/C2H4/ethene.py')
-species('C2H5', '../../species/C2H5/ethyl.py')
+species('H', '../../species/H/H.py',
+       structure=SMILES('[H]'))
+species('C2H4', '../../species/C2H4/ethene.py',
+       structure=SMILES('C=C'))
+species('C2H5', '../../species/C2H5/ethyl.py',
+       structure=SMILES('[CH2]C'))
 transitionState('TS', 'TS.py')
 
 thermo('H','NASA')

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/N2H3.yml
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/N2H3.yml
@@ -1,0 +1,118 @@
+RMG_version: 2.3.0
+adjacency_list: 'multiplicity 2
+
+  1 N u0 p1 c0 {2,S} {3,S} {4,S}
+
+  2 N u1 p1 c0 {1,S} {5,S}
+
+  3 H u0 p0 c0 {1,S}
+
+  4 H u0 p0 c0 {1,S}
+
+  5 H u0 p0 c0 {2,S}
+
+'
+chemkin_thermo_string: "N2H3                    H   3N   2          G    10.000  3000.000
+  \ 478.04      1\n 2.42935350E+00 1.15088524E-02-6.01470204E-06 1.59974609E-09-1.70089224E-13
+  \   2\n 2.62991058E+04 1.15861374E+01 4.04880122E+00-4.38083729E-03 5.11833994E-05
+  \   3\n-8.84029667E-08 5.22512137E-11 2.61709988E+04 5.24801815E+00                   4\n"
+class: ArkaneSpecies
+conformer:
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 217.5941511308007}
+  class: Conformer
+  coordinates:
+    class: ArrayQuantity
+    units: angstroms
+    value:
+    - [0.5911145648999999, 0.0244451654, -0.0678630404]
+    - [1.0135987356, 0.9037019196, 0.192072468]
+    - [1.1319865485, -0.7946247076, 0.1523660207]
+    - [-0.7335224652, -0.15121609699999997, 0.0219065915]
+    - [-1.1487299823, 0.7783193088, -0.022743346499999997]
+  mass:
+    class: ArrayQuantity
+    units: amu
+    value: [14.00307400443, 1.00782503224, 1.00782503224, 14.00307400443, 1.00782503224]
+  modes:
+  - class: IdealGasTranslation
+    mass: {class: ScalarQuantity, units: amu, value: 31.02963}
+    quantum: false
+  - class: NonlinearRotor
+    inertia:
+      class: ArrayQuantity
+      units: amu*angstrom^2
+      value: [2.4406613783304905, 16.233158126996372, 18.436369321320495]
+    quantum: false
+    rotationalConstant:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [6.9069921796688485, 1.0384688500824495, 0.9143681578266991]
+    symmetry: 1
+  - class: HarmonicOscillator
+    frequencies:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [498.38599999999997, 689.379, 1119.6225, 1255.374, 1450.6834999999999,
+        1618.2994999999999, 3380.5179000000003, 3443.7716, 3578.3494]
+    quantum: true
+  number:
+    class: ArrayQuantity
+    value: [7.0, 1.0, 1.0, 7.0, 1.0]
+  opticalIsomers: 1
+  spinMultiplicity: 2
+datetime: 2019-02-08 10:54
+energy_transfer_model:
+  T0: {class: ScalarQuantity, units: K, value: 298.0}
+  alpha0: {class: ScalarQuantity, units: kcal/mol, value: 0.5718}
+  class: SingleExponentialDown
+  n: 0.85
+frequency_scale_factor: 0.97
+inchi: InChI=1S/H3N2/c1-2/h1H,2H2
+inchi_key: LURQBQNWDYASPJ-UHFFFAOYSA-N
+label: N2H3
+molecular_weight: {class: ScalarQuantity, units: amu, value: 31.037303539597616}
+smiles: N[NH]
+thermo:
+  Cp0: {class: ScalarQuantity, units: J/(mol*K), value: 33.257888}
+  CpInf: {class: ScalarQuantity, units: J/(mol*K), value: 108.08813599999999}
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 217.5982414374718}
+  Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+  Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+  class: NASA
+  polynomials:
+    polynomial1:
+      Tmax: {class: ScalarQuantity, units: K, value: 478.03958064238446}
+      Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+      class: NASAPolynomial
+      coeffs: [4.048801217514377, -0.004380837294145292, 5.1183399410225476e-05, -8.840296666123828e-08,
+        5.2251213652638824e-11, 26170.998820660265, 5.248018149320447]
+    polynomial2:
+      Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+      Tmin: {class: ScalarQuantity, units: K, value: 478.03958064238446}
+      class: NASAPolynomial
+      coeffs: [2.429353498535635, 0.011508852361713253, -6.014702036913381e-06, 1.5997460938324017e-09,
+        -1.7008922397812e-13, 26299.105807657168, 11.586137428890732]
+thermo_data:
+  Cp (cal/mol*K): {1000 K: '18.59', 1500 K: '21.26', 2000 K: '22.78', 2400 K: '23.60',
+    300 K: '10.69', 400 K: '12.25', 500 K: '13.65', 600 K: '14.89', 800 K: '16.96'}
+  H298: 54.62 kcal/mol
+  S298: 56.84 cal/mol*K
+transport_data:
+  class: TransportData
+  epsilon: {class: ScalarQuantity, units: J/mol, value: 1662.89}
+  sigma: {class: ScalarQuantity, units: angstrom, value: 3.9}
+use_bond_corrections: false
+use_hindered_rotors: true
+xyz: '5
+
+  N2H3
+
+  N 5.911145649e-11 2.44451654e-12 -6.78630404e-12
+
+  H 1.0135987356e-10 9.037019196e-11 1.92072468e-11
+
+  H 1.1319865485e-10 -7.946247076e-11 1.523660207e-11
+
+  N -7.335224652e-11 -1.51216097e-11 2.19065915e-12
+
+  H -1.1487299823e-10 7.783193088e-11 -2.27433465e-12'

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/N2H4.yml
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/N2H4.yml
@@ -1,0 +1,138 @@
+RMG_version: 2.3.0
+adjacency_list: '1 N u0 p1 c0 {2,S} {3,S} {4,S}
+
+  2 N u0 p1 c0 {1,S} {5,S} {6,S}
+
+  3 H u0 p0 c0 {1,S}
+
+  4 H u0 p0 c0 {1,S}
+
+  5 H u0 p0 c0 {2,S}
+
+  6 H u0 p0 c0 {2,S}
+
+'
+chemkin_thermo_string: "N2H4                    H   4N   2          G    10.000  3000.000
+  \ 518.12      1\n 2.07626136E+00 1.50450280E-02-8.07333094E-06 2.19438723E-09-2.37121857E-13
+  \   2\n 1.09263297E+04 1.25803299E+01 4.04389639E+00-3.84784751E-03 5.73417233E-05
+  \   3\n-9.57672684E-08 5.36855965E-11 1.07721286E+04 4.86099917E+00                   4\n"
+class: ArkaneSpecies
+conformer:
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 89.66936378637556}
+  class: Conformer
+  coordinates:
+    class: ArrayQuantity
+    units: angstroms
+    value:
+    - [0.7033634988, 0.0974820728, -0.073047392]
+    - [-0.7033634988, -0.0974820728, -0.073047392]
+    - [1.0539960456, 0.3871635195, 0.8315583036]
+    - [-1.0539960456, -0.3871635195, 0.8315583036]
+    - [1.1434808787, -0.7765990298, -0.3202265599]
+    - [-1.1434808787, 0.7765990298, -0.3202265599]
+  mass:
+    class: ArrayQuantity
+    units: amu
+    value: [14.00307400443, 14.00307400443, 1.00782503224, 1.00782503224, 1.00782503224,
+      1.00782503224]
+  modes:
+  - class: IdealGasTranslation
+    mass: {class: ScalarQuantity, units: amu, value: 32.03746}
+    quantum: false
+  - class: NonlinearRotor
+    inertia:
+      class: ArrayQuantity
+      units: amu*angstrom^2
+      value: [3.44830480556223, 20.50117361907408, 20.513920517329836]
+    quantum: false
+    rotationalConstant:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [4.8886713918550875, 0.8222762933759231, 0.8217653490032506]
+    symmetry: 2
+  - class: HarmonicOscillator
+    frequencies:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [804.702684789345, 944.3708351977593, 1119.46984675033, 1272.463775026473,
+        1302.3239030062555, 1630.6811051177392, 1642.2431546205037, 3409.856964259825,
+        3418.213837435375, 3510.5084760011173, 3514.9269546169958]
+    quantum: true
+  - class: HinderedRotor
+    fourier:
+      class: ArrayQuantity
+      units: kJ/mol
+      value:
+      - [0.16222862758185147, -12.202719567707382, -0.5684005641621309, -0.1593956207311421,
+        0.48039067463325136]
+      - [-7.938290746826625, -1.6277540956505094, 3.258060880870518, 0.6270040035271297,
+        -0.25036265237321]
+    frequency: 380.0250313439182
+    inertia: {class: ScalarQuantity, units: amu*angstrom^2, value: 0.8646202553741763}
+    quantum: false
+    rotationalConstant: {class: ScalarQuantity, units: cm^-1, value: 19.49714796590455}
+    semiclassical: true
+    symmetry: 1
+  number:
+    class: ArrayQuantity
+    value: [7.0, 7.0, 1.0, 1.0, 1.0, 1.0]
+  opticalIsomers: 1
+  spinMultiplicity: 1
+datetime: 2019-02-08 10:54
+energy_transfer_model:
+  T0: {class: ScalarQuantity, units: K, value: 298.0}
+  alpha0: {class: ScalarQuantity, units: kcal/mol, value: 0.5718}
+  class: SingleExponentialDown
+  n: 0.85
+frequency_scale_factor: 0.97
+inchi: InChI=1S/H4N2/c1-2/h1-2H2
+inchi_key: OAKJQQAXSVQMHS-UHFFFAOYSA-N
+label: N2H4
+molecular_weight: {class: ScalarQuantity, units: amu, value: 32.04524366207737}
+smiles: NN
+thermo:
+  Cp0: {class: ScalarQuantity, units: J/(mol*K), value: 33.257888}
+  CpInf: {class: ScalarQuantity, units: J/(mol*K), value: 128.874316}
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 89.56383542984594}
+  Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+  Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+  class: NASA
+  polynomials:
+    polynomial1:
+      Tmax: {class: ScalarQuantity, units: K, value: 518.1161610086507}
+      Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+      class: NASAPolynomial
+      coeffs: [4.043896387044359, -0.003847847505293266, 5.734172331592045e-05, -9.576726837706191e-08,
+        5.368559651207141e-11, 10772.128561212636, 4.860999168368832]
+    polynomial2:
+      Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+      Tmin: {class: ScalarQuantity, units: K, value: 518.1161610086507}
+      class: NASAPolynomial
+      coeffs: [2.0762613566635815, 0.015045027956297745, -8.073330938084796e-06, 2.1943872302302012e-09,
+        -2.3712185653252193e-13, 10926.329674899871, 12.580329942484507]
+thermo_data:
+  Cp (cal/mol*K): {1000 K: '21.87', 1500 K: '25.21', 2000 K: '27.09', 2400 K: '28.12',
+    300 K: '11.72', 400 K: '13.76', 500 K: '15.58', 600 K: '17.17', 800 K: '19.82'}
+  H298: 24.14 kcal/mol
+  S298: 56.75 cal/mol*K
+transport_data:
+  class: TransportData
+  epsilon: {class: ScalarQuantity, units: J/mol, value: 1704.47}
+  sigma: {class: ScalarQuantity, units: angstrom, value: 4.23}
+use_bond_corrections: false
+use_hindered_rotors: true
+xyz: '6
+
+  N2H4
+
+  N 7.033634988e-11 9.74820728e-12 -7.3047392e-12
+
+  N -7.033634988e-11 -9.74820728e-12 -7.3047392e-12
+
+  H 1.0539960456e-10 3.871635195e-11 8.315583036e-11
+
+  H -1.0539960456e-10 -3.871635195e-11 8.315583036e-11
+
+  H 1.1434808787e-10 -7.765990298e-11 -3.202265599e-11
+
+  H -1.1434808787e-10 7.765990298e-11 -3.202265599e-11'

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/NH.yml
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/NH.yml
@@ -1,0 +1,83 @@
+RMG_version: 2.3.0
+adjacency_list: 'multiplicity 3
+
+  1 N u2 p1 c0 {2,S}
+
+  2 H u0 p0 c0 {1,S}
+
+'
+chemkin_thermo_string: "! Thermo library: thermo_DFT_CCSDTF12_BAC\nNH                      H
+  \  1N   1          G   100.000  5000.000 1030.80      1\n 2.91320000E+00 1.04459000E-03-2.66510000E-07
+  2.82366000E-11-9.08496000E-16    2\n 4.22955000E+04 5.02249000E+00 3.52449000E+00-5.78193000E-07-6.76543000E-07
+  \   3\n 1.54227000E-09-6.70991000E-13 4.20990000E+04 1.71287000E+00                   4\n"
+class: ArkaneSpecies
+conformer:
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 350.04200000000003}
+  class: Conformer
+  coordinates:
+    class: ArrayQuantity
+    units: angstroms
+    value:
+    - [0.0, 0.0, 0.1296667233]
+    - [0.0, 0.0, -0.9076670631]
+  number:
+    class: ArrayQuantity
+    value: [7.0, 1.0]
+  mass:
+    class: ArrayQuantity
+    units: amu
+    value: [14.00307400443, 1.00782503224]
+  modes:
+  - class: HarmonicOscillator
+    frequencies:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [3215.17]
+    quantum: true
+  opticalIsomers: 1
+  spinMultiplicity: 3
+datetime: 2019-02-08 10:54
+energy_transfer_model:
+  T0: {class: ScalarQuantity, units: K, value: 298.0}
+  alpha0: {class: ScalarQuantity, units: kcal/mol, value: 0.5718}
+  class: SingleExponentialDown
+  n: 0.85
+frequency_scale_factor: 0.97
+inchi: InChI=1S/HN/h1H
+inchi_key: PDCKRJPYJMCOFO-UHFFFAOYSA-N
+label: NH
+molecular_weight: {class: ScalarQuantity, units: amu, value: 15.014700000000001}
+smiles: '[NH]'
+thermo:
+  Cp0: {class: ScalarQuantity, units: J/(mol*K), value: 29.1007}
+  CpInf: {class: ScalarQuantity, units: J/(mol*K), value: 37.4151}
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 350.04200000000003}
+  Tmax: {class: ScalarQuantity, units: K, value: 5000.0}
+  Tmin: {class: ScalarQuantity, units: K, value: 100.0}
+  class: NASA
+  comment: 'Thermo library: thermo_DFT_CCSDTF12_BAC'
+  label: NHJJ
+  polynomials:
+    polynomial1:
+      Tmax: {class: ScalarQuantity, units: K, value: 1030.8}
+      Tmin: {class: ScalarQuantity, units: K, value: 100.0}
+      class: NASAPolynomial
+      coeffs: [3.52449, -5.78193e-07, -6.76543e-07, 1.54227e-09, -6.70991e-13, 42099.0,
+        1.71287]
+    polynomial2:
+      Tmax: {class: ScalarQuantity, units: K, value: 5000.0}
+      Tmin: {class: ScalarQuantity, units: K, value: 1030.8}
+      class: NASAPolynomial
+      coeffs: [2.9132, 0.00104459, -2.6651e-07, 2.82366e-11, -9.08496e-16, 42295.5,
+        5.02249]
+thermo_data:
+  Cp (cal/mol*K): {1000 K: '7.39', 1500 K: '7.89', 2000 K: '8.24', 2400 K: '8.44',
+    300 K: '6.95', 400 K: '6.95', 500 K: '6.97', 600 K: '7.01', 800 K: '7.17'}
+  H298: 85.74 kcal/mol
+  S298: 43.27 cal/mol*K
+transport_data:
+  class: TransportData
+  epsilon: {class: ScalarQuantity, units: J/mol, value: 665.16}
+  sigma: {class: ScalarQuantity, units: angstrom, value: 2.6499999999999995}
+use_bond_corrections: false
+use_hindered_rotors: true

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/NH2.yml
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/NH2.yml
@@ -1,0 +1,107 @@
+RMG_version: 2.3.0
+adjacency_list: 'multiplicity 2
+
+  1 N u1 p1 c0 {2,S} {3,S}
+
+  2 H u0 p0 c0 {1,S}
+
+  3 H u0 p0 c0 {1,S}
+
+'
+chemkin_thermo_string: "NH2                     H   2N   1          G    10.000  3000.000
+  \ 778.28      1\n 3.25017643E+00 1.94032317E-03 1.13406469E-07-2.70139791E-10 4.68077802E-14
+  \   2\n 2.14812786E+04 4.36791930E+00 4.00636701E+00-3.22127712E-04 1.34384590E-06
+  \   3\n 1.35706359E-09-1.33714496E-12 2.13143884E+04 5.93306137E-01                   4\n"
+class: ArkaneSpecies
+conformer:
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 177.21601036014195}
+  class: Conformer
+  coordinates:
+    class: ArrayQuantity
+    units: angstroms
+    value:
+    - [0.0, 0.0, 0.1409929927]
+    - [-0.8042685605, 0.0, -0.4934754744]
+    - [0.8042685605, 0.0, -0.4934754744]
+  mass:
+    class: ArrayQuantity
+    units: amu
+    value: [14.00307400443, 1.00782503224, 1.00782503224]
+  modes:
+  - class: IdealGasTranslation
+    mass: {class: ScalarQuantity, units: amu, value: 16.01873}
+    quantum: false
+  - class: NonlinearRotor
+    inertia:
+      class: ArrayQuantity
+      units: amu*angstrom^2
+      value: [0.7093038417154423, 1.3038267931397467, 2.013130634855189]
+    quantum: false
+    rotationalConstant:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [23.76644261869291, 12.929347012998267, 8.373837624581734]
+    symmetry: 2
+  - class: HarmonicOscillator
+    frequencies:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [1474.303, 3315.4502999999995, 3405.0782999999997]
+    quantum: true
+  number:
+    class: ArrayQuantity
+    value: [7.0, 1.0, 1.0]
+  opticalIsomers: 1
+  spinMultiplicity: 2
+datetime: 2019-02-08 10:54
+energy_transfer_model:
+  T0: {class: ScalarQuantity, units: K, value: 298.0}
+  alpha0: {class: ScalarQuantity, units: kcal/mol, value: 0.5718}
+  class: SingleExponentialDown
+  n: 0.85
+frequency_scale_factor: 0.97
+inchi: InChI=1S/H2N/h1H2
+inchi_key: MDFFNEOEWAXZRQ-UHFFFAOYSA-N
+label: NH2
+molecular_weight: {class: ScalarQuantity, units: amu, value: 16.022621831038684}
+smiles: '[NH2]'
+thermo:
+  Cp0: {class: ScalarQuantity, units: J/(mol*K), value: 33.257888}
+  CpInf: {class: ScalarQuantity, units: J/(mol*K), value: 58.201304}
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 177.22030176019808}
+  Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+  Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+  class: NASA
+  polynomials:
+    polynomial1:
+      Tmax: {class: ScalarQuantity, units: K, value: 778.2767498531364}
+      Tmin: {class: ScalarQuantity, units: K, value: 10.0}
+      class: NASAPolynomial
+      coeffs: [4.006367014277517, -0.00032212771245316836, 1.3438459045034468e-06,
+        1.3570635908847209e-09, -1.3371449616397034e-12, 21314.388368821168, 0.5933061367830083]
+    polynomial2:
+      Tmax: {class: ScalarQuantity, units: K, value: 3000.0}
+      Tmin: {class: ScalarQuantity, units: K, value: 778.2767498531364}
+      class: NASAPolynomial
+      coeffs: [3.2501764307317664, 0.0019403231682141038, 1.134064685200783e-07, -2.70139790841264e-10,
+        4.680778022613316e-14, 21481.278600923553, 4.367919300555658]
+thermo_data:
+  Cp (cal/mol*K): {1000 K: '10.10', 1500 K: '11.41', 2000 K: '12.27', 2400 K: '12.68',
+    300 K: '8.06', 400 K: '8.24', 500 K: '8.48', 600 K: '8.78', 800 K: '9.45'}
+  H298: 44.73 kcal/mol
+  S298: 46.48 cal/mol*K
+transport_data:
+  class: TransportData
+  epsilon: {class: ScalarQuantity, units: J/mol, value: 665.16}
+  sigma: {class: ScalarQuantity, units: angstrom, value: 2.6499999999999995}
+use_bond_corrections: false
+use_hindered_rotors: true
+xyz: '3
+
+  NH2
+
+  N 0.0 0.0 1.409929927e-11
+
+  H -8.042685605e-11 0.0 -4.934754744e-11
+
+  H 8.042685605e-11 0.0 -4.934754744e-11'

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/TS1.yml
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/TS1.yml
@@ -1,0 +1,117 @@
+RMG_version: 2.3.0
+class: ArkaneSpecies
+conformer:
+  E0: {class: ScalarQuantity, units: kJ/mol, value: 482.108034193436}
+  class: Conformer
+  coordinates:
+    class: ArrayQuantity
+    units: angstroms
+    value:
+    - [-0.4465194713, 0.6830090994, -0.09326182169999997]
+    - [-0.45738259979999996, 1.1483344874, 0.8104886822999999]
+    - [0.6773598975, 0.3820642106, -0.21970002899999996]
+    - [-1.223901238, -0.4695695875, -0.006989120299999999]
+    - [-1.8039356973, -0.5112019151, 0.8166872835]
+    - [-1.7837217777, -0.5685801608, -0.8405154279]
+    - [1.9039017234999998, -0.1568337145, -0.0766247796]
+    - [1.7333130781, -0.8468572037999997, 0.6711695415]
+  mass:
+    class: ArrayQuantity
+    units: amu
+    value: [14.00307400443, 1.00782503224, 1.00782503224, 14.00307400443, 1.00782503224,
+      1.00782503224, 14.00307400443, 1.00782503224]
+  modes:
+  - class: IdealGasTranslation
+    mass: {class: ScalarQuantity, units: amu, value: 47.04836}
+    quantum: false
+  - class: NonlinearRotor
+    inertia:
+      class: ArrayQuantity
+      units: amu*angstrom^2
+      value: [15.46541103846559, 87.36935874794106, 97.42266742349076]
+    quantum: false
+    rotationalConstant:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [1.090021403984684, 0.1929466954425342, 0.1730360038292664]
+    symmetry: 1
+  - class: HarmonicOscillator
+    frequencies:
+      class: ArrayQuantity
+      units: cm^-1
+      value: [24.5119, 158.789, 236.8061, 449.62409999999994, 640.2776, 726.2002,
+        819.0098, 1128.6337999999998, 1140.1768, 1322.5077, 1399.9234, 1510.9981,
+        1617.3974, 3279.3372, 3414.8074, 3454.267, 3552.0914999999995]
+    quantum: true
+  number:
+    class: ArrayQuantity
+    value: [7.0, 1.0, 1.0, 7.0, 1.0, 1.0, 7.0, 1.0]
+  opticalIsomers: 1
+  spinMultiplicity: 3
+datetime: 2019-02-08 11:49
+imaginary_frequency: {class: ScalarQuantity, units: cm^-1, value: -1843.0291}
+label: TS1
+products:
+- {adjacency_list: 'multiplicity 3
+
+    1 N u2 p1 c0 {2,S}
+
+    2 H u0 p0 c0 {1,S}
+
+', label: NH}
+- {adjacency_list: '1 N u0 p1 c0 {2,S} {3,S} {4,S}
+
+    2 N u0 p1 c0 {1,S} {5,S} {6,S}
+
+    3 H u0 p0 c0 {1,S}
+
+    4 H u0 p0 c0 {1,S}
+
+    5 H u0 p0 c0 {2,S}
+
+    6 H u0 p0 c0 {2,S}
+
+', label: N2H4}
+reactants:
+- {adjacency_list: 'multiplicity 2
+
+    1 N u1 p1 c0 {2,S} {3,S}
+
+    2 H u0 p0 c0 {1,S}
+
+    3 H u0 p0 c0 {1,S}
+
+', label: NH2}
+- {adjacency_list: 'multiplicity 2
+
+    1 N u0 p1 c0 {2,S} {3,S} {4,S}
+
+    2 N u1 p1 c0 {1,S} {5,S}
+
+    3 H u0 p0 c0 {1,S}
+
+    4 H u0 p0 c0 {1,S}
+
+    5 H u0 p0 c0 {2,S}
+
+', label: N2H3}
+reaction_label: NH2 + N2H3 = NH + N2H4
+xyz: '8
+
+  TS1
+
+  N -4.465194713e-11 6.830090994e-11 -9.32618217e-12
+
+  H -4.573825998e-11 1.1483344874e-10 8.104886823e-11
+
+  H 6.773598975e-11 3.820642106e-11 -2.19700029e-11
+
+  N -1.223901238e-10 -4.695695875e-11 -6.9891203e-13
+
+  H -1.8039356973e-10 -5.112019151e-11 8.166872835e-11
+
+  H -1.7837217777e-10 -5.685801608e-11 -8.405154279e-11
+
+  N 1.9039017235e-10 -1.568337145e-11 -7.66247796e-12
+
+  H 1.7333130781e-10 -8.468572038e-11 6.711695415e-11'

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/input.py
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/input.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+title = 'NH2 + N2H3 = NH + N2H4'
+description = """
+This examples shows how to use species (and TS) YAML files to run Arkane
+"""
+
+modelChemistry = "CCSD(T)-F12/aug-cc-pVTZ"
+
+useHinderedRotors = True
+useBondCorrections = False
+
+species('NH', 'NH.yml')
+species('NH2','NH2.yml')
+species('N2H3','N2H3.yml')
+species('N2H4','N2H4.yml')
+transitionState('TS1','TS1.yml')
+
+reaction(
+    label = 'NH2 + N2H3 = NH + N2H4',
+    reactants = ['NH2','N2H3'],
+    products = ['NH','N2H4'],
+    transitionState = 'TS1',
+    tunneling = 'Eckart',
+)
+
+kinetics(
+label = 'NH2 + N2H3 = NH + N2H4',
+Tmin = (500,'K'), Tmax = (3000,'K'), Tcount = 30,
+)

--- a/examples/arkane/species/C2H6_from_yaml/C2H6.yml
+++ b/examples/arkane/species/C2H6_from_yaml/C2H6.yml
@@ -1,19 +1,31 @@
 RMG_version: 2.3.0
 adjacency_list: '1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+
   2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+
   3 H u0 p0 c0 {1,S}
+
   4 H u0 p0 c0 {1,S}
+
   5 H u0 p0 c0 {1,S}
+
   6 H u0 p0 c0 {2,S}
+
   7 H u0 p0 c0 {2,S}
+
   8 H u0 p0 c0 {2,S}
-  '
+
+'
 author: I.B. Modeling
 chemkin_thermo_string: 'C2H6                    H   6C   2          G    10.000  3000.000  650.75      1
+
   -3.07955238E-01 2.45265786E-02-1.24126639E-05 3.07709642E-09-3.01448276E-13    2
+
   -1.06954638E+04 2.26275649E+01 4.03054858E+00-2.14149353E-03 4.90589370E-05    3
+
   -5.98988799E-08 2.38924897E-11-1.12601125E+04 3.56080023E+00                   4
-  '
+
+'
 class: ArkaneSpecies
 conformer:
   E0: {class: ScalarQuantity, units: kJ/mol, value: -93.62123301113816}
@@ -73,7 +85,7 @@ conformer:
     value: [6.0, 1.0, 1.0, 1.0, 6.0, 1.0, 1.0, 1.0]
   opticalIsomers: 1
   spinMultiplicity: 1
-datetime: 2018-12-26 22:07
+datetime: 2019-02-08 12:09
 energy_transfer_model:
   T0: {class: ScalarQuantity, units: K, value: 300.0}
   alpha0: {class: ScalarQuantity, units: kJ/mol, value: 3.5886}
@@ -83,7 +95,7 @@ frequency_scale_factor: 0.99
 inchi: InChI=1S/C2H6/c1-2/h1-2H3
 inchi_key: OTMSDBZUPAUEDD-UHFFFAOYSA-N
 label: C2H6
-molecular_weight: {class: ScalarQuantity, units: amu, value: 30.069042884392132}
+molecular_weight: {class: ScalarQuantity, units: amu, value: 30.06904288439213}
 smiles: CC
 thermo:
   Cp0: {class: ScalarQuantity, units: J/(mol*K), value: 33.257888}
@@ -113,12 +125,21 @@ thermo_data:
 use_bond_corrections: false
 use_hindered_rotors: true
 xyz: '8
+
   C2H6
+
   C 7.54e-14 1.193e-13 5.52e-14
+
   H 7.4e-14 1.171e-13 1.094138e-10
+
   H 1.043766e-10 1.171e-13 -3.28202e-11
+
   H -4.47603e-11 9.42895e-11 -3.28253e-11
+
   C -7.60142e-11 -1.203896e-10 -5.57483e-11
+
   H -7.60128e-11 -1.203874e-10 -1.651069e-10
+
   H -3.11785e-11 -2.145598e-10 -2.28678e-11
+
   H -1.803154e-10 -1.203874e-10 -2.28729e-11'


### PR DESCRIPTION
### Motivation
For a more convenient workflow of archiving QM data and easily parsing it again (and soon automating this process and forming a database) it is important to also save and load YAML files of TSs in addition to stable species.

### Description of Changes
ArkaneSpecies can now process TSs as well.
So far, a YAML file was generated for stable species iff their structure was given and Thermo() was called (both important data to save)
Now, a TS YAML file is saved iff structures of all relevant reactant/s and product/s were given and Kinetics() was called. We're not saving the kinetics, though.
The RMGObject was changes slightly to save and load lists.
This PR has one small commit not directly related to the topic, changing how Arkane loads energy from QChem files. I could open a different PR if the reviewers prefer.

### Testing
An example for a reaction where all species and TS are loaded from YAML files was added (Arkane examples are also used as functional tests).

### Reviewer Tips
Run any reaction in Arkane, look at the YAML files generated, then run the reaction again, pointing the TS to the generated YAML file.