### PR TITLE
Allow RDKit to ignore hydrogen bonds

### DIFF
--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -85,6 +85,8 @@ def toRDKitMol(mol, removeHs=True, returnMapping=False, sanitize=True):
     # Add the bonds
     for atom1 in mol.vertices:
         for atom2, bond in atom1.edges.iteritems():
+            if bond.isHydrogenBond():
+                continue
             index1 = atoms.index(atom1)
             index2 = atoms.index(atom2)
             if index1 < index2:

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -227,6 +227,8 @@ def toOBMol(mol, returnMapping=False):
     orders = {1: 1, 2: 2, 3: 3, 4: 4, 1.5: 5}
     for atom1 in mol.vertices:
         for atom2, bond in atom1.edges.iteritems():
+            if bond.isHydrogenBond():
+                continue
             index1 = atoms.index(atom1)
             index2 = atoms.index(atom2)
             if index1 < index2:

--- a/rmgpy/molecule/converterTest.py
+++ b/rmgpy/molecule/converterTest.py
@@ -138,16 +138,17 @@ class ConverterTest(unittest.TestCase):
             Molecule().fromSMILES('C=CC=C'),
             Molecule().fromSMILES('C#C[CH2]'),
             Molecule().fromSMILES('c1ccccc1'),
-            Molecule().fromSMILES('[13CH3]C')
+            Molecule().fromSMILES('[13CH3]C'),
+            Molecule().fromSMILES('O=CCO').generate_H_bonded_structures()[0],
         ]
+        self.test_Hbond_free_mol = Molecule().fromSMILES('O=CCO')
 
     def test_rdkit_round_trip(self):
         """Test conversion to and from RDKitMol"""
         for mol in self.test_mols:
             rdkit_mol = toRDKitMol(mol)
             new_mol = fromRDKitMol(Molecule(), rdkit_mol)
-
-            self.assertTrue(mol.isIsomorphic(new_mol))
+            self.assertTrue(mol.isIsomorphic(new_mol) or self.test_Hbond_free_mol.isIsomorphic(new_mol))
             self.assertEqual(mol.get_element_count(), new_mol.get_element_count())
 
     def test_ob_round_trip(self):
@@ -155,6 +156,5 @@ class ConverterTest(unittest.TestCase):
         for mol in self.test_mols:
             ob_mol = toOBMol(mol)
             new_mol = fromOBMol(Molecule(), ob_mol)
-
-            self.assertTrue(mol.isIsomorphic(new_mol))
+            self.assertTrue(mol.isIsomorphic(new_mol) or self.test_Hbond_free_mol.isIsomorphic(new_mol))
             self.assertEqual(mol.get_element_count(), new_mol.get_element_count())


### PR DESCRIPTION
This PR lets RMG ignore hydrogen bonds when converting a molecule to an RDKit mol.  