### PR TITLE
Auto optical isomer ex symmetry arkane

### DIFF
--- a/arkane/gaussian.py
+++ b/arkane/gaussian.py
@@ -38,11 +38,12 @@ from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, Har
 from rmgpy.exceptions import InputError
 
 from arkane.common import check_conformer_energy, get_element_mass
+from arkane.statmech import Log
 
 ################################################################################
 
 
-class GaussianLog:
+class GaussianLog(Log):
     """
     Represent a log file from Gaussian. The attribute `path` refers to the
     location on disk of the Gaussian log file of interest. Methods are provided

--- a/arkane/gaussian.py
+++ b/arkane/gaussian.py
@@ -38,7 +38,7 @@ from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, Har
 from rmgpy.exceptions import InputError
 
 from arkane.common import check_conformer_energy, get_element_mass
-from arkane.statmech import Log
+from arkane.log import Log
 
 ################################################################################
 
@@ -157,7 +157,7 @@ class GaussianLog(Log):
         
         return coord, number, mass
 
-    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=1, symfromlog=None, label=''):
+    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=None, symfromlog=None, label=''):
         """
         Load the molecular degree of freedom data from a log file created as
         the result of a Gaussian "Freq" quantum chemistry calculation. As
@@ -252,7 +252,8 @@ class GaussianLog(Log):
 
         # Close file when finished
         f.close()
-
+        if opticalIsomers is None:
+            opticalIsomers = self.get_optical_isomers_and_symmetry_number()[0]
         return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
                          opticalIsomers=opticalIsomers), unscaled_frequencies
 

--- a/arkane/gaussianTest.py
+++ b/arkane/gaussianTest.py
@@ -54,7 +54,7 @@ class GaussianTest(unittest.TestCase):
         """
 
         log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','ethylene.log'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)
@@ -81,7 +81,7 @@ class GaussianTest(unittest.TestCase):
         """
 
         log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','oxygen.log'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)
@@ -109,7 +109,7 @@ class GaussianTest(unittest.TestCase):
         """
 
         log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','ethylene_G3.log'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)

--- a/arkane/gaussianTest.py
+++ b/arkane/gaussianTest.py
@@ -37,6 +37,7 @@ import rmgpy.constants as constants
 from external.wip import work_in_progress
 
 from arkane.gaussian import GaussianLog
+from arkane.statmech import determine_qm_software
 
 ################################################################################
 
@@ -129,6 +130,33 @@ class GaussianTest(unittest.TestCase):
         self.assertAlmostEqual(E0 / constants.Na / constants.E_h, -78.562189, 4)
         self.assertEqual(conformer.spinMultiplicity, 1)
         self.assertEqual(conformer.opticalIsomers, 1)
+
+    def testLoadSymmetryAndOptics(self):
+        """
+        Uses a Gaussian03 log file for oxygen (O2) to test that its
+        molecular degrees of freedom can be properly read.
+        """
+
+        log = GaussianLog(os.path.join(os.path.dirname(__file__),'data','oxygen.log'))
+        optical, symmetry = log.get_optical_isomers_and_symmetry_number()
+        self.assertEqual(optical,1)
+        self.assertEqual(symmetry,2)
+
+        conf = log.loadConformer()[0]
+        self.assertEqual(conf.opticalIsomers, 1)
+        found_rotor = False
+        for mode in conf.modes:
+            if isinstance(mode,LinearRotor):
+                self.assertEqual(mode.symmetry,2)
+                found_rotor = True
+        self.assertTrue(found_rotor)
+
+    def testDetermineQMSoftware(self):
+        """
+        Ensures that determine_qm_software returns a GaussianLog object
+        """
+        log = determine_qm_software(os.path.join(os.path.dirname(__file__),'data','oxygen.log'))
+        self.assertIsInstance(log,GaussianLog)
 
 if __name__ == '__main__':
     unittest.main( testRunner = unittest.TextTestRunner(verbosity=2) )

--- a/arkane/log.py
+++ b/arkane/log.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+A general class for parsing quantum mechanical log files
+"""
+
+class Log(object):
+    """
+    Represent a general log file.
+    The attribute `path` refers to the location on disk of the log file of interest.
+    """
+    def __init__(self, path):
+        self.path = path
+
+    def getNumberOfAtoms(self):
+        """
+        Return the number of atoms in the molecular configuration used in
+        the MolPro log file.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadForceConstantMatrix(self):
+        """
+        Return the force constant matrix (in Cartesian coordinates) from the
+        QChem log file. If multiple such matrices are identified,
+        only the last is returned. The units of the returned force constants
+        are J/m^2. If no force constant matrix can be found in the log file,
+        ``None`` is returned.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadGeometry(self):
+        """
+        Return the optimum geometry of the molecular configuration from the
+        log file. If multiple such geometries are identified, only the
+        last is returned.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=None, symfromlog=None, label=''):
+        """
+        Load the molecular degree of freedom data from an output file created as the result of a
+        QChem "Freq" calculation. As QChem's guess of the external symmetry number is not always correct,
+        you can use the `symmetry` parameter to substitute your own value;
+        if not provided, the value in the QChem output file will be adopted.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadEnergy(self, frequencyScaleFactor=1.):
+        """
+        Load the energy in J/mol from a QChem log file. Only the last energy
+        in the file is returned. The zero-point energy is *not* included in
+        the returned value.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadZeroPointEnergy(self,frequencyScaleFactor=1.):
+        """
+        Load the unscaled zero-point energy in J/mol from a QChem output file.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadScanEnergies(self):
+        """
+        Extract the optimized energies in J/mol from a QChem log file, e.g. the
+        result of a QChem "PES Scan" quantum chemistry calculation.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+
+    def loadNegativeFrequency(self):
+        """
+        Return the imaginary frequency from a transition state frequency
+        calculation in cm^-1.
+        """
+        raise NotImplementedError("loadGeometry is not implemented for the Log class")
+

--- a/arkane/molpro.py
+++ b/arkane/molpro.py
@@ -167,7 +167,7 @@ class MolproLog(Log):
 
         return coord, number, mass
 
-    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=None, symfromlog=None, label=''):
+    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=None, label=''):
         """
         Load the molecular degree of freedom data from a log file created as
         the result of a MolPro "Freq" quantum chemistry calculation with the thermo printed.
@@ -176,7 +176,12 @@ class MolproLog(Log):
         modes = []
         unscaled_frequencies = []
         E0 = 0.0
-
+        if opticalIsomers is None or symmetry is None:
+            _opticalIsomers, _symmetry = self.get_optical_isomers_and_symmetry_number()
+            if opticalIsomers is None:
+                opticalIsomers = _opticalIsomers
+            if symmetry is None:
+                symmetry = _symmetry
         f = open(self.path, 'r')
         line = f.readline()
         while line != '':
@@ -224,10 +229,6 @@ class MolproLog(Log):
                         mass = float(line.split()[2])
                         translation = IdealGasTranslation(mass=(mass,"amu"))
                         modes.append(translation)
-                    # Read MolPro's estimate of the external symmetry number
-                    elif 'Rotational Symmetry factor' in line and symmetry is None:
-                        if symfromlog is True:
-                            symmetry = int(float(line.split()[3]))
 
                     # Read moments of inertia for external rotational modes
                     elif 'Rotational Constants' in line and line.split()[-1]=='[GHz]':
@@ -266,8 +267,6 @@ class MolproLog(Log):
 
         # Close file when finished
         f.close()
-        if opticalIsomers is None:
-            opticalIsomers = self.get_optical_isomers_and_symmetry_number()[0]
         return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
                          opticalIsomers=opticalIsomers), unscaled_frequencies
 

--- a/arkane/molpro.py
+++ b/arkane/molpro.py
@@ -37,11 +37,11 @@ from rmgpy.exceptions import InputError
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 
 from arkane.common import get_element_mass
-
+from arkane.statmech import Log
 ################################################################################
 
 
-class MolproLog:
+class MolproLog(Log):
     """
     Represents a Molpro log file. The attribute `path` refers to the
     location on disk of the Molpro log file of interest. Methods are provided

--- a/arkane/molpro.py
+++ b/arkane/molpro.py
@@ -37,7 +37,7 @@ from rmgpy.exceptions import InputError
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 
 from arkane.common import get_element_mass
-from arkane.statmech import Log
+from arkane.log import Log
 ################################################################################
 
 
@@ -167,7 +167,7 @@ class MolproLog(Log):
 
         return coord, number, mass
 
-    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=1, symfromlog=None, label=''):
+    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=None, symfromlog=None, label=''):
         """
         Load the molecular degree of freedom data from a log file created as
         the result of a MolPro "Freq" quantum chemistry calculation with the thermo printed.
@@ -266,6 +266,8 @@ class MolproLog(Log):
 
         # Close file when finished
         f.close()
+        if opticalIsomers is None:
+            opticalIsomers = self.get_optical_isomers_and_symmetry_number()[0]
         return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
                          opticalIsomers=opticalIsomers), unscaled_frequencies
 

--- a/arkane/molproTest.py
+++ b/arkane/molproTest.py
@@ -86,7 +86,7 @@ class MolproTest(unittest.TestCase):
         """
 
         log = MolproLog(os.path.join(os.path.dirname(__file__),'data','HOSI_ccsd_t1.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True, spinMultiplicity=1)
+        conformer, unscaled_frequencies = log.loadConformer(spinMultiplicity=1)
         E0 = log.loadEnergy()
 
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)

--- a/arkane/qchem.py
+++ b/arkane/qchem.py
@@ -38,7 +38,7 @@ from rmgpy.exceptions import InputError
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 
 from arkane.common import check_conformer_energy, get_element_mass
-from arkane.statmech import Log
+from arkane.log import Log
 
 ################################################################################
 
@@ -167,7 +167,7 @@ class QChemLog(Log):
 
         return coord, number, mass
 
-    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=1, symfromlog=None, label=''):
+    def loadConformer(self, symmetry=None, spinMultiplicity=0, opticalIsomers=None, symfromlog=None, label=''):
         """
         Load the molecular degree of freedom data from an output file created as the result of a
         QChem "Freq" calculation. As QChem's guess of the external symmetry number is not always correct,
@@ -262,6 +262,8 @@ class QChemLog(Log):
 
         # Close file when finished
         f.close()
+        if opticalIsomers is None:
+            opticalIsomers = self.get_optical_isomers_and_symmetry_number()[0]
         modes = mmass + rot + freq
         return Conformer(E0=(E0*0.001,"kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
                          opticalIsomers=opticalIsomers), unscaled_frequencies

--- a/arkane/qchem.py
+++ b/arkane/qchem.py
@@ -38,11 +38,12 @@ from rmgpy.exceptions import InputError
 from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
 
 from arkane.common import check_conformer_energy, get_element_mass
+from arkane.statmech import Log
 
 ################################################################################
 
 
-class QChemLog:
+class QChemLog(Log):
     """
     Represent an output file from QChem. The attribute `path` refers to the
     location on disk of the QChem output file of interest. Methods are provided

--- a/arkane/qchemTest.py
+++ b/arkane/qchemTest.py
@@ -74,11 +74,11 @@ class QChemTest(unittest.TestCase):
         molecular energies can be properly read.
         """
         log = QChemLog(os.path.join(os.path.dirname(__file__),'data','npropyl.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         self.assertEqual(len(conformer.modes[2]._frequencies.getValue()), 24)    
         self.assertEqual(conformer.modes[2]._frequencies.getValue()[5], 881.79)       
         log = QChemLog(os.path.join(os.path.dirname(__file__),'data','co.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         self.assertEqual(len(conformer.modes[2]._frequencies.getValue()), 1)         
         self.assertEqual(conformer.modes[2]._frequencies.getValue(), 2253.16)    
                            
@@ -88,7 +88,7 @@ class QChemTest(unittest.TestCase):
         molecular modes can be properly read.
         """
         log = QChemLog(os.path.join(os.path.dirname(__file__),'data','npropyl.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
 
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,NonlinearRotor)]) == 1)
@@ -101,10 +101,10 @@ class QChemTest(unittest.TestCase):
         molecular degrees of freedom can be properly read.
         """
         log = QChemLog(os.path.join(os.path.dirname(__file__),'data','npropyl.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         self.assertEqual(conformer.spinMultiplicity, 2)
         log = QChemLog(os.path.join(os.path.dirname(__file__),'data','co.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         self.assertEqual(conformer.spinMultiplicity, 1)
     
     def testLoadCOModesFromQChemLog(self):
@@ -113,7 +113,7 @@ class QChemTest(unittest.TestCase):
         molecular degrees of freedom can be properly read.
         """
         log = QChemLog(os.path.join(os.path.dirname(__file__),'data','co.out'))
-        conformer, unscaled_frequencies = log.loadConformer(symfromlog=True)
+        conformer, unscaled_frequencies = log.loadConformer()
         E0 = log.loadEnergy()
         
         self.assertTrue(len([mode for mode in conformer.modes if isinstance(mode,IdealGasTranslation)]) == 1)

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -254,7 +254,8 @@ class StatMechJob(object):
         try:
             linear = local_context['linear']
         except KeyError:
-            externalSymmetry = None
+            logging.error('You did not set whether the molecule is linear with the required `linear` parameter')
+            raise
 
         try:
             externalSymmetry = local_context['externalSymmetry']

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -253,17 +253,13 @@ class StatMechJob(object):
 
         try:
             linear = local_context['linear']
-            symfromlog = False
         except KeyError:
             externalSymmetry = None
-            symfromlog = True
 
         try:
             externalSymmetry = local_context['externalSymmetry']
-            symfromlog = False
         except KeyError:
             externalSymmetry = None
-            symfromlog = True
 
         try:
             spinMultiplicity = local_context['spinMultiplicity']
@@ -364,7 +360,6 @@ class StatMechJob(object):
         conformer, unscaled_frequencies = statmechLog.loadConformer(symmetry=externalSymmetry,
                                                                     spinMultiplicity=spinMultiplicity,
                                                                     opticalIsomers=opticalIsomers,
-                                                                    symfromlog=symfromlog,
                                                                     label=self.species.label)
         for mode in conformer.modes:
             if isinstance(mode, (LinearRotor, NonlinearRotor)):

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -273,7 +273,8 @@ class StatMechJob(object):
         try:
             opticalIsomers = local_context['opticalIsomers']
         except KeyError:
-            raise InputError('Required attribute "opticalIsomers" not found in species file {0!r}.'.format(path))
+            logging.debug('No opticalIsomers provided, estimating them from the quantum file.')
+            opticalIsomers = None
 
         try:
             energy = local_context['energy']


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Currently Arkane requires optical isomer input.

### Description of Changes
This PR allows Arkane to estimate optical isomer and symmetry using the qm symmetry package.

### Testing
* I wrote test methods to ensure that the arkane
* I have not tested compatibility with ARC, which may cause an issue since the redundant `symfromlog` boolean was removed.

### Reviewer Tips
Run an arkane calculation with & without the symmetry and optical isomer parameter.
<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
