### PR TITLE
Improve error/warning messages concerning energy barriers in Arkane

### DIFF
--- a/arkane/kinetics.py
+++ b/arkane/kinetics.py
@@ -242,7 +242,7 @@ class KineticsJob(object):
                 except (SpeciesError, ZeroDivisionError):
                     k = reaction.getRateCoefficient(T)
                     kappa = 0
-                    logging.info("The species in reaction {} do not have adequate information for TST, "
+                    logging.info("The species in reaction {0} do not have adequate information for TST, "
                                  "using default kinetics values.".format(reaction))
                 tunneling = reaction.transitionState.tunneling
                 ks.append(k)
@@ -270,9 +270,8 @@ class KineticsJob(object):
                 krev = k / Keq
                 k0revs.append(k0rev)
                 krevs.append(krev)
-                f.write('#    {0:4g} K {1:11.3e}   {2}  {3:11.3e}   {4:11.3e}      {5}\n'.format(T, Keq, self.Kequnits,
-                                                                                                 k0rev, krev,
-                                                                                                 self.krunits))
+                f.write('#    {0:4g} K {1:11.3e}   {2}  {3:11.3e}   {4:11.3e}      {5}\n'.format(
+                    T, Keq, self.Kequnits, k0rev, krev, self.krunits))
 
             f.write('#   ======= ============ =========== ============ ============= =========\n')
             f.write('\n\n')

--- a/arkane/kinetics.py
+++ b/arkane/kinetics.py
@@ -435,6 +435,13 @@ class KineticsDrawer:
         """
         E0min = min(self.wells[0].E0, self.wells[1].E0, self.reaction.transitionState.conformer.E0.value_si)
         E0max = max(self.wells[0].E0, self.wells[1].E0, self.reaction.transitionState.conformer.E0.value_si)
+        if E0max - E0min > 5e5:
+            # the energy barrier in one of the reaction directions is larger than 500 kJ/mol, warn the user
+            logging.warning('The energy differences between the stationary points of reaction {0} '
+                            'seems too large.'.format(self.reaction))
+            logging.warning('Got the following energies:\nWell 1: {0} kJ/mol\nTS: {1} kJ/mol\nWell 2: {2}'
+                            ' kJ/mol'.format(self.wells[0].E0 / 1000., self.wells[1].E0 / 1000.,
+                                             self.reaction.transitionState.conformer.E0.value_si / 1000.))
         return E0min, E0max
 
     def __useStructureForLabel(self, configuration):

--- a/arkane/kinetics.py
+++ b/arkane/kinetics.py
@@ -353,7 +353,7 @@ class KineticsJob(object):
             ' + '.join([reactant.label for reactant in self.reaction.reactants]),
             '<=>', ' + '.join([product.label for product in self.reaction.products]))
         plt.title(reaction_str)
-        plt.xlabel('1000 / Temperature (1000/K)')
+        plt.xlabel('1000 / Temperature (K^-1)')
         plt.ylabel('Rate coefficient ({0})'.format(self.kunits))
 
         plot_path = os.path.join(outputDirectory, 'plots')

--- a/arkane/pdep.py
+++ b/arkane/pdep.py
@@ -603,7 +603,7 @@ class PressureDependenceJob(object):
                     if reaction.kinetics is not None:
                         plt.semilogy(1000.0 / Tlist, K2[:, p], color=cm(1. * p / (Pcount - 1)), marker='',
                                      linestyle='-')
-                plt.xlabel('1000 / Temperature (1000/K)')
+                plt.xlabel('1000 / Temperature (K^-1)')
                 plt.ylabel('Rate coefficient ({0})'.format(kunits))
                 plt.title(reaction_str)
                 plt.legend()

--- a/rmgpy/kinetics/tunneling.pyx
+++ b/rmgpy/kinetics/tunneling.pyx
@@ -33,7 +33,7 @@ a reaction barrier.
 """
 
 import numpy
-
+import logging
 import cython
 from libc.math cimport abs, exp, sqrt, cosh
 
@@ -172,7 +172,11 @@ cdef class Eckart(TunnelingModel):
             dV2 = E0_TS - E0_reac
 
         if dV1 < 0 or dV2 < 0:
-            raise ValueError('One or both of the barrier heights of {0:g} and {1:g} kJ/mol encountered in Eckart method are invalid.'.format(dV1 / 1000., dV2 / 1000.)) 
+            logging.info('\n')
+            logging.error('Got the following wells:\nReactants: {0:g} kJ/mol\nTS: {1:g} kJ/mol\n'
+                          'Products: {2:g} kJ/mol\n'.format(E0_reac / 1000., E0_TS / 1000., E0_prod / 1000.))
+            raise ValueError('One or both of the barrier heights of {0:g} and {1:g} kJ/mol encountered in Eckart '
+                             'method are invalid.'.format(dV1 / 1000., dV2 / 1000.))
 
         # Ensure that dV1 is smaller than dV2
         assert dV1 <= dV2


### PR DESCRIPTION
Added a warning if a reaction barrier is too high in Arkane.
Also enhanced a related error message in tunnelling.
Minor: corrected reciprocal T axis units in Arkane plots (`1000/K` is strange, should be either `1/K` or `K^-1`)