### PR TITLE
Move where we start calling the reactantStructure the productStructure

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1313,16 +1313,19 @@ class KineticsFamily(Database):
         else:
             self.reverseRecipe.applyForward(reactantStructure, unique)
 
-        if not reactantStructure.props['validAromatic']:
-            if isinstance(reactantStructure, Molecule):
+        # Now that we have applied the recipe, let's start calling
+        # this thing the productStructure (although it's the same object in memory)
+        productStructure = reactantStructure
+
+        if not productStructure.props['validAromatic']:
+            if isinstance(productStructure, Molecule):
                 # For molecules, kekulize the product to redistribute bonds appropriately
-                reactantStructure.kekulize()
+                productStructure.kekulize()
             else:
                 # For groups, we ignore the product template for a purely aromatic group
                 # If there is an analagous aliphatic group in the family, then the product template will be identical
                 # There should NOT be any families that consist solely of aromatic reactant templates
                 return []
-        productStructure = reactantStructure
 
         if not forward:
             # Hardcoding of reaction family for reverse of radical recombination


### PR DESCRIPTION
These are in fact the same object in memory, just with different
names. But to clarify the code, I think we should start calling it a productStructure
as soon as we have applied the recipe and turned it into products.

This commit moves where the renaming occurs up a few lines.

It is a small change.