### PR TITLE
Modify test-database make target to not capture stdout and log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ endif
 	nosetests --nocapture --nologcapture --all-modules -A 'functional' --verbose --exe rmgpy arkane
 
 test-database:
-	nosetests -v -d testing/databaseTest.py	
+	nosetests --nocapture --nologcapture --verbose --detailed-errors testing/databaseTest.py
+
 eg0: all
 	mkdir -p testing/eg0
 	rm -rf testing/eg0/*


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
When database tests fail, you get a million lines of logging statements, making it a pain to find the actual test results.

### Description of Changes
Disable log capturing for `make test-database`.

### Testing
Break the database and try running the tests. A couple easy options: change an index in training reactions to be a duplicate or change a group definition to be more specific than its children.