### PR TITLE
Determine a species linearity from xyz

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -36,7 +36,7 @@ information for a single species or transition state.
 
 import os.path
 import math
-import numpy
+import numpy as np
 import logging
 
 from rdkit.Chem import GetPeriodicTable
@@ -120,8 +120,8 @@ class ScanLog(object):
                     angles.append(float(tokens[0]) / angleFactor)
                     energies.append(float(tokens[1]) / energyFactor)
 
-        angles = numpy.array(angles)
-        energies = numpy.array(energies)
+        angles = np.array(angles)
+        energies = np.array(energies)
         energies -= energies[0]
 
         return angles, energies
@@ -489,8 +489,8 @@ class StatMechJob(object):
                     fourierRotor = HinderedRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
                     fourierRotor.fitFourierPotentialToData(angle, v_list)
 
-                    Vlist_cosine = numpy.zeros_like(angle)
-                    Vlist_fourier = numpy.zeros_like(angle)
+                    Vlist_cosine = np.zeros_like(angle)
+                    Vlist_fourier = np.zeros_like(angle)
                     for i in range(angle.shape[0]):
                         Vlist_cosine[i] = cosineRotor.getPotential(angle[i])
                         Vlist_fourier[i] = fourierRotor.getPotential(angle[i])
@@ -504,9 +504,9 @@ class StatMechJob(object):
                         rotorCount += 1
                         conformer.modes.append(rotor)
                     elif fit == 'best':
-                        rms_cosine = numpy.sqrt(numpy.sum((Vlist_cosine - v_list) * (Vlist_cosine - v_list)) /
+                        rms_cosine = np.sqrt(np.sum((Vlist_cosine - v_list) * (Vlist_cosine - v_list)) /
                                                 (len(v_list) - 1)) / 4184.
-                        rms_fourier = numpy.sqrt(numpy.sum((Vlist_fourier - v_list) * (Vlist_fourier - v_list)) /
+                        rms_fourier = np.sqrt(np.sum((Vlist_fourier - v_list) * (Vlist_fourier - v_list)) /
                                                  (len(v_list) - 1)) / 4184.
 
                         # Keep the rotor with the most accurate potential
@@ -525,7 +525,7 @@ class StatMechJob(object):
                         rotorCount += 1
 
             logging.debug('    Determining frequencies from reduced force constant matrix...')
-            frequencies = numpy.array(projectRotors(conformer, F, rotors, linear, is_ts, label=self.species.label))
+            frequencies = np.array(projectRotors(conformer, F, rotors, linear, is_ts, label=self.species.label))
 
         elif len(conformer.modes) > 2:
             if len(rotors) > 0:
@@ -534,15 +534,15 @@ class StatMechJob(object):
                              ' Gaussian to generate the force constant matrix, if running Molpro include keyword print,'
                              ' hessian')
             frequencies = conformer.modes[2].frequencies.value_si
-            rotors = numpy.array([])
+            rotors = np.array([])
         else:
             if len(rotors) > 0:
                 logging.warn('Force Constant Matrix Missing Ignoring rotors, if running Gaussian if not already'
                              ' present you need to add the keyword iop(7/33=1) in your Gaussian frequency job for'
                              ' Gaussian to generate the force constant matrix, if running Molpro include keyword print,'
                              ' hessian')
-            frequencies = numpy.array([])
-            rotors = numpy.array([])
+            frequencies = np.array([])
+            rotors = np.array([])
 
         for mode in conformer.modes:
             if isinstance(mode, HarmonicOscillator):
@@ -596,9 +596,9 @@ class StatMechJob(object):
         except ImportError:
             return
 
-        phi = numpy.arange(0, 6.3, 0.02, numpy.float64)
-        Vlist_cosine = numpy.zeros_like(phi)
-        Vlist_fourier = numpy.zeros_like(phi)
+        phi = np.arange(0, 6.3, 0.02, np.float64)
+        Vlist_cosine = np.zeros_like(phi)
+        Vlist_fourier = np.zeros_like(phi)
         for i in range(phi.shape[0]):
             Vlist_cosine[i] = cosineRotor.getPotential(phi[i])
             Vlist_fourier[i] = fourierRotor.getPotential(phi[i])
@@ -986,11 +986,11 @@ def is_linear(coordinates):
         return True
 
     # A tensor containing all distance vectors in the molecule
-    d = -numpy.array([c[:, numpy.newaxis] - c[numpy.newaxis, :] for c in coordinates.T])
+    d = -np.array([c[:, np.newaxis] - c[np.newaxis, :] for c in coordinates.T])
     for i in range(2, len(coordinates)):
-        u1 = d[:, 0, 1] / numpy.linalg.norm(d[:, 0, 1])  # unit vector between atoms 0 and 1
-        u2 = d[:, 1, i] / numpy.linalg.norm(d[:, 1, i])  # unit vector between atoms 1 and i
-        a = math.degrees(numpy.arccos(numpy.clip(numpy.dot(u1, u2), -1.0, 1.0)))  # angle between atoms 0, 1, i
+        u1 = d[:, 0, 1] / np.linalg.norm(d[:, 0, 1])  # unit vector between atoms 0 and 1
+        u2 = d[:, 1, i] / np.linalg.norm(d[:, 1, i])  # unit vector between atoms 1 and i
+        a = math.degrees(np.arccos(np.clip(np.dot(u1, u2), -1.0, 1.0)))  # angle between atoms 0, 1, i
         if abs(180 - a) > epsilon and abs(a) > epsilon:
             return False
     return True
@@ -1037,22 +1037,22 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
         coordinates[i, 1] -= ym
         coordinates[i, 2] -= zm
     # Make vector with the root of the mass in amu for each atom
-    amass = numpy.sqrt(mass / constants.amu)
+    amass = np.sqrt(mass / constants.amu)
 
     # Rotation matrix
     I = conformer.getMomentOfInertiaTensor()
-    PMoI, Ixyz = numpy.linalg.eigh(I)
+    PMoI, Ixyz = np.linalg.eigh(I)
 
     external = 6
     if linear:
         external = 5
 
-    D = numpy.zeros((Natoms * 3, external), numpy.float64)
+    D = np.zeros((Natoms * 3, external), np.float64)
 
-    P = numpy.zeros((Natoms, 3), numpy.float64)
+    P = np.zeros((Natoms, 3), np.float64)
 
     # Transform the coordinates to the principal axes
-    P = numpy.dot(coordinates, Ixyz)
+    P = np.dot(coordinates, Ixyz)
 
     for i in range(Natoms):
         # Projection vectors for translation
@@ -1076,9 +1076,9 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
     # Make sure projection matrix is orthonormal
     import scipy.linalg
 
-    I = numpy.identity(Natoms * 3, numpy.float64)
+    I = np.identity(Natoms * 3, np.float64)
 
-    P = numpy.zeros((Natoms * 3, 3 * Natoms + external), numpy.float64)
+    P = np.zeros((Natoms * 3, 3 * Natoms + external), np.float64)
 
     P[:, 0:external] = D[:, 0:external]
     P[:, external:external + 3 * Natoms] = I[:, 0:3 * Natoms]
@@ -1089,7 +1089,7 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
             norm += P[j, i] * P[j, i]
         for j in range(3 * Natoms):
             if norm > 1E-15:
-                P[j, i] /= numpy.sqrt(norm)
+                P[j, i] /= np.sqrt(norm)
             else:
                 P[j, i] = 0.0
         for j in range(i + 1, 3 * Natoms + external):
@@ -1111,7 +1111,7 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
             i += 1
 
     # T is the transformation vector from cartesian to internal coordinates
-    T = numpy.zeros((Natoms * 3, 3 * Natoms - external), numpy.float64)
+    T = np.zeros((Natoms * 3, 3 * Natoms - external), np.float64)
 
     T[:, 0:3 * Natoms - external] = P[:, external:3 * Natoms]
 
@@ -1125,19 +1125,19 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
                 for v in range(3):
                     Fm[3 * i + u, 3 * j + v] /= math.sqrt(mass[i] * mass[j])
 
-    Fint = numpy.dot(T.T, numpy.dot(Fm, T))
+    Fint = np.dot(T.T, np.dot(Fm, T))
 
     # Get eigenvalues of internal force constant matrix, V = 3N-6 * 3N-6
-    eig, V = numpy.linalg.eigh(Fint)
+    eig, V = np.linalg.eigh(Fint)
 
     logging.debug('Frequencies from internal Hessian')
     for i in range(3 * Natoms - external):
-        with numpy.warnings.catch_warnings():
-            numpy.warnings.filterwarnings('ignore', r'invalid value encountered in sqrt')
-            logging.debug(numpy.sqrt(eig[i]) / (2 * math.pi * constants.c * 100))
+        with np.warnings.catch_warnings():
+            np.warnings.filterwarnings('ignore', r'invalid value encountered in sqrt')
+            logging.debug(np.sqrt(eig[i]) / (2 * math.pi * constants.c * 100))
 
     # Now we can start thinking about projecting out the internal rotations
-    Dint = numpy.zeros((3 * Natoms, Nrotors), numpy.float64)
+    Dint = np.zeros((3 * Natoms, Nrotors), np.float64)
 
     counter = 0
     for i, rotor in enumerate(rotors):
@@ -1160,24 +1160,24 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
             atom = j + 1
             if atom in top:
                 e31 = coordinates[atom - 1, :] - coordinates[pivot1 - 1, :]
-                Dint[3 * (atom - 1):3 * (atom - 1) + 3, counter] = numpy.cross(e31, e12) * amass[atom - 1]
+                Dint[3 * (atom - 1):3 * (atom - 1) + 3, counter] = np.cross(e31, e12) * amass[atom - 1]
             else:
                 e31 = coordinates[atom - 1, :] - coordinates[pivot2 - 1, :]
-                Dint[3 * (atom - 1):3 * (atom - 1) + 3, counter] = numpy.cross(e31, -e12) * amass[atom - 1]
+                Dint[3 * (atom - 1):3 * (atom - 1) + 3, counter] = np.cross(e31, -e12) * amass[atom - 1]
         counter += 1
 
     # Normal modes in mass weighted cartesian coordinates
-    Vmw = numpy.dot(T, V)
-    eigM = numpy.zeros((3 * Natoms - external, 3 * Natoms - external), numpy.float64)
+    Vmw = np.dot(T, V)
+    eigM = np.zeros((3 * Natoms - external, 3 * Natoms - external), np.float64)
 
     for i in range(3 * Natoms - external):
         eigM[i, i] = eig[i]
 
-    Fm = numpy.dot(Vmw, numpy.dot(eigM, Vmw.T))
+    Fm = np.dot(Vmw, np.dot(eigM, Vmw.T))
 
     # Internal rotations are not normal modes => project them on the normal modes and orthogonalize
     # Dintproj =  (3N-6) x (3N) x (3N) x (Nrotors)
-    Dintproj = numpy.dot(Vmw.T, Dint)
+    Dintproj = np.dot(Vmw.T, Dint)
 
     # Reconstruct Dint
     for i in range(Nrotors):
@@ -1192,7 +1192,7 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
         for j in range(3 * Natoms):
             norm += Dint[j, i] * Dint[j, i]
         for j in range(3 * Natoms):
-            Dint[j, i] /= numpy.sqrt(norm)
+            Dint[j, i] /= np.sqrt(norm)
         for j in range(i + 1, Nrotors):
             proj = 0.0
             for k in range(3 * Natoms):
@@ -1200,13 +1200,13 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
             for k in range(3 * Natoms):
                 Dint[k, j] -= proj * Dint[k, i]
 
-    Dintproj = numpy.dot(Vmw.T, Dint)
-    Proj = numpy.dot(Dint, Dint.T)
-    I = numpy.identity(Natoms * 3, numpy.float64)
+    Dintproj = np.dot(Vmw.T, Dint)
+    Proj = np.dot(Dint, Dint.T)
+    I = np.identity(Natoms * 3, np.float64)
     Proj = I - Proj
-    Fm = numpy.dot(Proj, numpy.dot(Fm, Proj))
+    Fm = np.dot(Proj, np.dot(Fm, Proj))
     # Get eigenvalues of mass-weighted force constant matrix
-    eig, V = numpy.linalg.eigh(Fm)
+    eig, V = np.linalg.eigh(Fm)
     eig.sort()
 
     # Convert eigenvalues to vibrational frequencies in cm^-1
@@ -1214,11 +1214,11 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
 
     logging.debug('Frequencies from projected Hessian')
     for i in range(3 * Natoms):
-        with numpy.warnings.catch_warnings():
-            numpy.warnings.filterwarnings('ignore', r'invalid value encountered in sqrt')
-            logging.debug(numpy.sqrt(eig[i]) / (2 * math.pi * constants.c * 100))
+        with np.warnings.catch_warnings():
+            np.warnings.filterwarnings('ignore', r'invalid value encountered in sqrt')
+            logging.debug(np.sqrt(eig[i]) / (2 * math.pi * constants.c * 100))
 
-    return numpy.sqrt(eig[-Nvib:]) / (2 * math.pi * constants.c * 100)
+    return np.sqrt(eig[-Nvib:]) / (2 * math.pi * constants.c * 100)
 
 
 def assign_frequency_scale_factor(model_chemistry):

--- a/arkane/statmechTest.py
+++ b/arkane/statmechTest.py
@@ -34,11 +34,12 @@ This script contains unit tests of the :mod:`arkane.main` module.
 
 import unittest
 import os
+import numpy as np
 
 from rmgpy.exceptions import InputError
 
 from arkane import Arkane
-from arkane.statmech import StatMechJob, determine_rotor_symmetry
+from arkane.statmech import StatMechJob, determine_rotor_symmetry, is_linear
 from arkane.qchem import QChemLog
 
 ################################################################################
@@ -76,6 +77,79 @@ class TestStatmech(unittest.TestCase):
         symmetry2 = determine_rotor_symmetry(energies=v_list2, label='NCC', pivots=[])
         self.assertEqual(symmetry1, 1)
         self.assertEqual(symmetry2, 3)
+
+    def test_is_linear(self):
+        """Test that we can determine the linearity of a molecule from it's coordinates"""
+        xyz1 = np.array([
+            [0.000000, 0.000000, 0.000000],
+            [0.000000, 0.000000, 1.159076],
+            [0.000000, 0.000000, -1.159076]])  # a trivial case
+        xyz2 = np.array([
+            [-0.06618943, -0.12360663, -0.07631983],
+            [-0.79539707, 0.86755487, 1.02675668],
+            [-0.68919931, 0.25421823, -1.34830853],
+            [0.01546439, -1.54297548, 0.44580391],
+            [1.94428095, 0.40772394, 1.03719428],
+            [2.20318015, -0.14715186, -0.64755729],
+            [1.59252246, 1.51178950, -0.33908352],
+            [-0.87856890, -2.02453514, 0.38494433],
+            [-1.34135876, 1.49608206, 0.53295071]])  # a non-linear multi-atom molecule
+        xyz3 = np.array([
+            [0.0000000000, 0.0000000000, 0.3146069129],
+            [-1.0906813653, 0.0000000000, -0.1376405244],
+            [1.0906813653, 0.0000000000, -0.1376405244]])  # NO2, a non-linear 3-atom molecule
+        xyz4 = np.array([
+            [0.0000000000, 0.0000000000, 0.1413439534],
+            [-0.8031792912, 0.0000000000, -0.4947038368],
+            [0.8031792912, 0.0000000000, -0.4947038368]])  # NH2, a non-linear 3-atom molecule
+        xyz5 = np.array([
+            [-0.5417345330, 0.8208150346, 0.0000000000],
+            [0.9206183692, 1.6432038228, 0.0000000000],
+            [-1.2739176462, 1.9692549926, 0.0000000000]])  # HSO, a non-linear 3-atom molecule
+        xyz6 = np.array([
+            [1.18784533, 0.98526702, 0.00000000],
+            [0.04124533, 0.98526702, 0.00000000],
+            [-1.02875467, 0.98526702, 0.00000000]])  # HCN, a linear 3-atom molecule
+        xyz7 = np.array([
+            [-4.02394116, 0.56169428, 0.00000000],
+            [-5.09394116, 0.56169428, 0.00000000],
+            [-2.82274116, 0.56169428, 0.00000000],
+            [-1.75274116, 0.56169428, 0.00000000]])  # C2H2, a linear 4-atom molecule
+        xyz8 = np.array([
+            [-1.02600933, 2.12845307, 0.00000000],
+            [-0.77966935, 0.95278385, 0.00000000],
+            [-1.23666197, 3.17751246, 0.00000000],
+            [-0.56023545, -0.09447399, 0.00000000]])  # C2H2, just 0.5 degree off from linearity, so NOT linear
+        xyz9 = np.array([
+            [-1.1998, 0.1610, 0.0275],
+            [-1.4021, 0.6223, -0.8489],
+            [-1.48302, 0.80682, -1.19946]])  # just 3 points in space on a straight line (not a physical molecule)
+        xyz10 = np.array([
+            [-1.1998, 0.1610, 0.0275]])  # mono-atomic species, non-linear
+        xyz11 = np.array([
+            [1.06026500, -0.07706800, 0.03372800],
+            [3.37340700, -0.07706800, 0.03372800],
+            [2.21683600, -0.07706800, 0.03372800]])  # CO2 at wb97xd/6-311+g(d,p), linear
+        xyz12 = np.array([
+            [1.05503600, -0.00335000, 0.09823600],
+            [2.42816800, -0.00335000, 0.09823600],
+            [-0.14726400, -0.00335000, 0.09823600],
+            [3.63046800, -0.00335000, 0.09823600],
+            [-1.21103500, -0.00335000, 0.09823600],
+            [4.69423900, -0.00335000, 0.09823600]])  # C#CC#C at wb97xd/6-311+g(d,p), linear
+
+        self.assertTrue(is_linear(xyz1))
+        self.assertTrue(is_linear(xyz6))
+        self.assertTrue(is_linear(xyz7))
+        self.assertTrue(is_linear(xyz9))
+        self.assertTrue(is_linear(xyz11))
+        self.assertTrue(is_linear(xyz12))
+        self.assertFalse(is_linear(xyz2))
+        self.assertFalse(is_linear(xyz3))
+        self.assertFalse(is_linear(xyz4))
+        self.assertFalse(is_linear(xyz5))
+        self.assertFalse(is_linear(xyz8))
+        self.assertFalse(is_linear(xyz10))
 
 
 if __name__ == '__main__':

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -171,7 +171,7 @@ The species input file accepts the following parameters:
 Parameter               Required?                   Description
 ======================= =========================== ====================================
 ``bonds``               optional                    Type and number of bonds in the species
-``linear``              yes                         ``True`` if the molecule is linear, ``False`` if not
+``linear``              optional                    ``True`` if the molecule is linear, ``False`` if not
 ``externalSymmetry``    yes                         The external symmetry number for rotation
 ``spinMultiplicity``    yes                         The ground-state spin multiplicity (degeneracy)
 ``opticalIsomers``      yes                         The number of optical isomers of the species

--- a/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy.py
+++ b/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 
 bonds = {}
-linear = False
 
 externalSymmetry = 1
 

--- a/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
+++ b/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 
 bonds = {}
-linear = False
 
 externalSymmetry = 1
 

--- a/examples/arkane/reactions/CH3OH+HCO/ch3oh.py
+++ b/examples/arkane/reactions/CH3OH+HCO/ch3oh.py
@@ -7,8 +7,6 @@ bonds = {
     'O-H': 1,
 }
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 2

--- a/examples/arkane/reactions/CH3OH+HCO/hco.py
+++ b/examples/arkane/reactions/CH3OH+HCO/hco.py
@@ -6,8 +6,6 @@ bonds = {
     'C-H': 1,
 }
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 2

--- a/examples/arkane/reactions/CH3OH+HCO/ts.py
+++ b/examples/arkane/reactions/CH3OH+HCO/ts.py
@@ -3,8 +3,6 @@
 
 bonds = {}
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 2

--- a/examples/arkane/species/Benzyl/benzyl.py
+++ b/examples/arkane/species/Benzyl/benzyl.py
@@ -7,8 +7,6 @@ bonds = {
     'C-H': 7,
 }
 
-linear = False
-
 externalSymmetry = 2
 
 spinMultiplicity = 2

--- a/examples/arkane/species/C2H4/ethene.py
+++ b/examples/arkane/species/C2H4/ethene.py
@@ -6,8 +6,6 @@ bonds = {
     'C-H': 4,
 }
 
-linear = False
-
 externalSymmetry = 4
 
 spinMultiplicity = 1

--- a/examples/arkane/species/C2H5/ethyl.py
+++ b/examples/arkane/species/C2H5/ethyl.py
@@ -6,8 +6,6 @@ bonds = {
     'C-H': 5,
 }
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 2

--- a/examples/arkane/species/H/H.py
+++ b/examples/arkane/species/H/H.py
@@ -3,8 +3,6 @@
 
 bonds = {}
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 2

--- a/examples/arkane/species/Toulene_Free_Rotor/toluene_FreeRotor.py
+++ b/examples/arkane/species/Toulene_Free_Rotor/toluene_FreeRotor.py
@@ -7,8 +7,6 @@ bonds = {
     'C=C': 3,
 }
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 1

--- a/examples/arkane/species/Toulene_Hindered_Rotor/toluene_HinderedRotor.py
+++ b/examples/arkane/species/Toulene_Hindered_Rotor/toluene_HinderedRotor.py
@@ -7,8 +7,6 @@ bonds = {
     'C=C': 3,
 }
 
-linear = False
-
 externalSymmetry = 1
 
 spinMultiplicity = 1


### PR DESCRIPTION
Arkane uses the species linearity when projecting out rotor frequencies.
This PR automates the determination of the linearity attribute, so now it is optional in input files.
If the problem can be reduced in dimensionality, we first identify that. We then check that all atoms from the 3rd one on form a straight line (either in 2D space or in 3D space) within some precision with the first two atoms.
Examples and documentations were updated. Tests were added.