### PR TITLE
Use the QC partition function by default in Torsion

### DIFF
--- a/rmgpy/pdep/configuration.pyx
+++ b/rmgpy/pdep/configuration.pyx
@@ -367,7 +367,7 @@ cdef class Configuration:
             
             Blist = []
             for spec in self.species:
-                Jrotor, Krotor = spec.conformer.getSymmetricTopRotors()
+                Jrotor = spec.conformer.getSymmetricTopRotors()[0]
                 Blist.append(float(Jrotor.rotationalConstant.value_si))
         
             for r0 in range(Ngrains):
@@ -431,7 +431,7 @@ cdef class Configuration:
             
             Blist = []
             for spec in self.species:
-                Jrotor, Krotor = spec.conformer.getSymmetricTopRotors()
+                Jrotor = spec.conformer.getSymmetricTopRotors()[0]
                 Blist.append(float(Jrotor.rotationalConstant.value_si))
         
             for r0 in range(Ngrains):

--- a/rmgpy/statmech/__init__.py
+++ b/rmgpy/statmech/__init__.py
@@ -29,7 +29,7 @@
 ###############################################################################
 
 from .translation import Translation, IdealGasTranslation
-from .rotation import Rotation, LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor
+from .rotation import Rotation, LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor, SymmetricTopRotor
 from .vibration import Vibration, HarmonicOscillator
 from .torsion import Torsion, HinderedRotor
 from .conformer import Conformer

--- a/rmgpy/statmech/conformer.pyx
+++ b/rmgpy/statmech/conformer.pyx
@@ -462,9 +462,9 @@ cdef class Conformer(RMGObject):
         constant and the J-rotor rotational constant.
         """
         cdef double A, B
-        cdef numpy.ndarray[numpy.float64_t,ndim=1] Blist
+        cdef numpy.ndarray[numpy.float64_t, ndim=1] Blist
 
-        Jrotor = None; Krotor = None
+        Jrotor, Krotor = None, None
         for mode in self.modes:
             if isinstance(mode, LinearRotor):
                 Jrotor = mode
@@ -478,8 +478,8 @@ cdef class Conformer(RMGObject):
                 else:
                     B = sqrt(Blist[1] * Blist[2])
                     A = Blist[0]
-                Jrotor = LinearRotor(rotationalConstant=(B,"cm^-1"), symmetry=1)
-                Krotor = KRotor(rotationalConstant=(A-B,"cm^-1"), symmetry=mode.symmetry)
+                Jrotor = LinearRotor(rotationalConstant=(B, "cm^-1"), symmetry=1)
+                Krotor = KRotor(rotationalConstant=(A-B, "cm^-1"), symmetry=mode.symmetry)
 
         return Jrotor, Krotor
     
@@ -500,8 +500,8 @@ cdef class Conformer(RMGObject):
                 if activeJRotor and activeKRotor: 
                     modes.append(mode)
                 elif not activeJRotor and activeKRotor:
-                    Jrotor, Krotor = self.getSymmetricTopRotors()
-                    modes.append(Krotor)
+                    k_rotor = self.getSymmetricTopRotors()[1]
+                    modes.append(k_rotor)
                 else:
                     continue
             else:

--- a/rmgpy/statmech/conformer.pyx
+++ b/rmgpy/statmech/conformer.pyx
@@ -48,6 +48,7 @@ from rmgpy.statmech.torsion cimport *
 from rmgpy.exceptions import StatmechError
 ################################################################################
 
+
 cdef class Conformer(RMGObject):
     """
     A representation of an individual molecular conformation. The attributes 
@@ -261,6 +262,8 @@ cdef class Conformer(RMGObject):
             elif type(mode) == KRotor:
                 N += 1
             elif type(mode) == SphericalTopRotor:
+                N += 3
+            elif type(mode) == SymmetricTopRotor:
                 N += 3
             else:
                 raise TypeError("Mode type {0!r} not supported".format(mode))

--- a/rmgpy/statmech/rotation.pxd
+++ b/rmgpy/statmech/rotation.pxd
@@ -121,3 +121,31 @@ cdef class SphericalTopRotor(Rotation):
     cpdef numpy.ndarray getSumOfStates(self, numpy.ndarray Elist, numpy.ndarray sumStates0=?)
     
     cpdef numpy.ndarray getDensityOfStates(self, numpy.ndarray Elist, numpy.ndarray densStates0=?)
+
+################################################################################
+
+cdef class SymmetricTopRotor(Rotation):
+
+    cdef public ArrayQuantity _inertia
+
+    cpdef double getIA(self) except -1
+
+    cpdef double getIC(self) except -1
+
+    cpdef double getLevelEnergy(self, int J) except -1
+
+    cpdef double getKLevelEnergy(self, int J, double T) except -1
+
+    cpdef int getLevelDegeneracy(self, int J) except -1
+
+    cpdef double getPartitionFunction(self, double T) except -1
+
+    cpdef double getHeatCapacity(self, double T) except -100000000
+
+    cpdef double getEnthalpy(self, double T) except 100000000
+
+    cpdef double getEntropy(self, double T) except -100000000
+
+    cpdef numpy.ndarray getSumOfStates(self, numpy.ndarray Elist, numpy.ndarray sumStates0=?)
+
+    cpdef numpy.ndarray getDensityOfStates(self, numpy.ndarray Elist, numpy.ndarray densStates0=?)

--- a/rmgpy/statmech/schrodinger.pxd
+++ b/rmgpy/statmech/schrodinger.pxd
@@ -29,14 +29,20 @@ cimport numpy
 
 ################################################################################
 
-cpdef double getPartitionFunction(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except -1
+cpdef double getPartitionFunction(double T, energy, degeneracy=?, int n0=?, qk_energy=?, int nmax=?,
+                                  double tol=?) except -1
 
-cpdef double getHeatCapacity(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except -100000000
+cpdef double getHeatCapacity(double T, energy, degeneracy=?, int n0=?, qk_energy=?, int nmax=?,
+                             double tol=?) except -100000000
 
-cpdef double getEnthalpy(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except 100000000
+cpdef double getEnthalpy(double T, energy, degeneracy=?, int n0=?, qk_energy=?, int nmax=?,
+                         double tol=?) except 100000000
 
-cpdef double getEntropy(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except -100000000
+cpdef double getEntropy(double T, energy, degeneracy=?, int n0=?, qk_energy=?, int nmax=?,
+                        double tol=?) except -100000000
 
-cpdef numpy.ndarray getSumOfStates(numpy.ndarray Elist, energy, degeneracy=?, int n0=?, numpy.ndarray sumStates0=?)
+cpdef numpy.ndarray getSumOfStates(numpy.ndarray Elist, energy, degeneracy=?, int n0=?, numpy.ndarray sumStates0=?,
+                                   qk_energy=?)
 
-cpdef numpy.ndarray getDensityOfStates(numpy.ndarray Elist, energy, degeneracy=?, int n0=?, numpy.ndarray densStates0=?)
+cpdef numpy.ndarray getDensityOfStates(numpy.ndarray Elist, energy, degeneracy=?, int n0=?, numpy.ndarray densStates0=?,
+                                       qk_energy=?)

--- a/rmgpy/statmech/schrodinger.pyx
+++ b/rmgpy/statmech/schrodinger.pyx
@@ -45,10 +45,13 @@ cimport rmgpy.constants as constants
 
 ################################################################################
 
+
 def unitDegeneracy(n):
     return 1
 
-cpdef double getPartitionFunction(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000, double tol=1e-12) except -1:
+
+cpdef double getPartitionFunction(double T, energy, degeneracy=unitDegeneracy, int n0=0,
+                                  int nmax=10000, double tol=1e-12) except -1:
     """
     Return the value of the partition function :math:`Q(T)` at a given
     temperature `T` in K. The solution to the Schrodinger equation is given
@@ -59,23 +62,25 @@ cpdef double getPartitionFunction(double T, energy, degeneracy=unitDegeneracy, i
     of the quantum number `nmax`.
     """
     cdef int n
-    cdef double Q, dQ, E_n
+    cdef double q, dq, e_n
     cdef int g_n
     cdef double beta = 1. / (constants.R * T) # [=] mol/J
-    
-    Q = 0.0
-    for n in range(n0, nmax):
-        E_n = energy(n); g_n = degeneracy(n)
-            
-        dQ = g_n * exp(-beta * E_n)
-        Q += dQ
 
-        if dQ < tol * Q:
+    q = 0.0
+    for n in range(n0, nmax):
+        e_n, g_n = energy(n), degeneracy(n)
+            
+        dq = g_n * exp(-beta * e_n)
+        q += dq
+
+        if dq < tol * q:
             break
 
-    return Q
+    return q
 
-cpdef double getHeatCapacity(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000, double tol=1e-12) except -100000000:
+
+cpdef double getHeatCapacity(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000,
+                             double tol=1e-12) except -100000000:
     """
     Return the value of the dimensionless heat capacity :math:`C_\\mathrm{v}(T)/R`
     at a given temperature `T` in K. The solution to the Schrodinger equation
@@ -86,27 +91,29 @@ cpdef double getHeatCapacity(double T, energy, degeneracy=unitDegeneracy, int n0
     maximum allowed value of the quantum number `nmax`.
     """    
     cdef int n
-    cdef double Q, dQ, sumE, dsumE, sumE2, dsumE2, E_n
+    cdef double q, dq, sum_e, dsum_e, sum_e2, dsum_e2, e_n
     cdef int g_n
-    cdef double beta = 1. / (constants.R * T) # [=] mol/J
+    cdef double beta = 1. / (constants.R * T)  # in mol/J
     
-    Q = 0.0; sumE = 0.0; sumE2 = 0.0
+    q, sum_e, sum_e2 = 0.0, 0.0, 0.0
     for n in range(n0, nmax):
-        E_n = energy(n); g_n = degeneracy(n)
+        e_n, g_n = energy(n), degeneracy(n)
             
-        dQ = g_n * exp(-beta * E_n)
-        dsumE = E_n * dQ
-        dsumE2 = E_n * dsumE
-        Q += dQ
-        sumE += dsumE
-        sumE2 += dsumE2
+        dq = g_n * exp(-beta * e_n)
+        dsum_e = e_n * dq
+        dsum_e2 = e_n * dsum_e
+        q += dq
+        sum_e += dsum_e
+        sum_e2 += dsum_e2
 
-        if dQ < tol * Q and dsumE < tol * sumE and dsumE2 < tol * sumE2:
+        if dq < tol * q and dsum_e < tol * sum_e and dsum_e2 < tol * sum_e2:
             break
 
-    return beta * beta * (sumE2 / Q - sumE * sumE / (Q * Q))
+    return beta * beta * (sum_e2 / q - sum_e * sum_e / (q * q))
 
-cpdef double getEnthalpy(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000, double tol=1e-12) except 100000000:
+
+cpdef double getEnthalpy(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000,
+                         double tol=1e-12) except 100000000:
     """
     Return the value of the dimensionless enthalpy :math:`H(T)/RT` at a given
     temperature `T` in K. The solution to the Schrodinger equation is given
@@ -117,25 +124,27 @@ cpdef double getEnthalpy(double T, energy, degeneracy=unitDegeneracy, int n0=0, 
     of the quantum number `nmax`.
     """
     cdef int n
-    cdef double Q, dQ, sumE, dsumE, E_n
+    cdef double q, dq, sum_e, dsum_e, e_n
     cdef int g_n
     cdef double beta = 1. / (constants.R * T) # [=] mol/J
     
-    Q = 0.0; sumE = 0.0
+    q, sum_e = 0.0, 0.0
     for n in range(n0, nmax):
-        E_n = energy(n); g_n = degeneracy(n)
+        e_n, g_n = energy(n), degeneracy(n)
             
-        dQ = g_n * exp(-beta * E_n)
-        dsumE = E_n * dQ
-        Q += dQ
-        sumE += dsumE
+        dq = g_n * exp(-beta * e_n)
+        dsum_e = e_n * dq
+        q += dq
+        sum_e += dsum_e
 
-        if dQ < tol * Q and dsumE < tol * sumE:
+        if dq < tol * q and dsum_e < tol * sum_e:
             break
 
-    return beta * sumE / Q
+    return beta * sum_e / q
 
-cpdef double getEntropy(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000, double tol=1e-12) except -100000000:
+
+cpdef double getEntropy(double T, energy, degeneracy=unitDegeneracy, int n0=0, int nmax=10000,
+                        double tol=1e-12) except -100000000:
     """
     Return the value of the dimensionless entropy :math:`S(T)/R` at a given
     temperature `T` in K. The solution to the Schrodinger equation is given
@@ -146,27 +155,29 @@ cpdef double getEntropy(double T, energy, degeneracy=unitDegeneracy, int n0=0, i
     of the quantum number `nmax`.
     """
     cdef int n
-    cdef double Q, dQ, sumE, dsumE, E_n
+    cdef double q, dq, sum_e, dsum_e, e_n
     cdef int g_n
     cdef double beta = 1. / (constants.R * T) # [=] mol/J
     
-    Q = 0.0; sumE = 0.0
+    q, sum_e = 0.0, 0.0
     for n in range(n0, nmax):
-        E_n = energy(n); g_n = degeneracy(n)
+        e_n, g_n = energy(n), degeneracy(n)
         
-        dQ = g_n * exp(-beta * E_n)
-        dsumE = E_n * dQ
-        Q += dQ
-        sumE += dsumE
+        dq = g_n * exp(-beta * e_n)
+        dsum_e = e_n * dq
+        q += dq
+        sum_e += dsum_e
         
-        if dQ < tol * Q and dsumE < tol * sumE:
+        if dq < tol * q and dsum_e < tol * sum_e:
             break
 
-    return log(Q) + beta * sumE / Q
+    return log(q) + beta * sum_e / q
 
 ################################################################################
 
-cpdef numpy.ndarray getSumOfStates(numpy.ndarray Elist, energy, degeneracy=unitDegeneracy, int n0=0, numpy.ndarray sumStates0=None):
+
+cpdef numpy.ndarray getSumOfStates(numpy.ndarray Elist, energy, degeneracy=unitDegeneracy,
+                                   int n0=0, numpy.ndarray sumStates0=None):
     """
     Return the values of the sum of states :math:`N(E)` for a given set of
     energies `Elist` in J/mol above the ground state using an initial sum of
@@ -179,7 +190,9 @@ cpdef numpy.ndarray getSumOfStates(numpy.ndarray Elist, energy, degeneracy=unitD
         sumStates0 = numpy.ones_like(Elist)
     return convolveBSSR(Elist, sumStates0, energy, degeneracy, n0)
 
-cpdef numpy.ndarray getDensityOfStates(numpy.ndarray Elist, energy, degeneracy=unitDegeneracy, int n0=0, numpy.ndarray densStates0=None):
+
+cpdef numpy.ndarray getDensityOfStates(numpy.ndarray Elist, energy, degeneracy=unitDegeneracy,
+                                       int n0=0, numpy.ndarray densStates0=None):
     """
     Return the values of the dimensionless density of states
     :math:`\\rho(E) \\ dE` for a given set of energies `Elist` in J/mol above
@@ -196,31 +209,33 @@ cpdef numpy.ndarray getDensityOfStates(numpy.ndarray Elist, energy, degeneracy=u
 
 ################################################################################
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def convolve(numpy.ndarray[numpy.float64_t,ndim=1] rho1, numpy.ndarray[numpy.float64_t,ndim=1] rho2):
+def convolve(numpy.ndarray[numpy.float64_t, ndim=1] rho1, numpy.ndarray[numpy.float64_t, ndim=1] rho2):
     """
     Return the convolution of two arrays `rho1` and `rho2`.
     """
-    cdef numpy.ndarray[numpy.float64_t,ndim=1] rho
-    cdef int i, j, nE
+    cdef numpy.ndarray[numpy.float64_t, ndim=1] rho
+    cdef int i, j, n_e
     
     if rho1.shape[0] != rho2.shape[0]:
-        raise ValueError('Attempted to convolve an array of length {0:d} with an array of length {1:d}.'.format(len(rho1), len(rho2)))
+        raise ValueError('Attempted to convolve an array of length {0:d} with an array of length {1:d}.'.format(
+            len(rho1), len(rho2)))
     
-    nE = rho1.shape[0]
+    n_e = rho1.shape[0]
     rho = numpy.zeros_like(rho1)
     
-    for i in range(nE):
+    for i in range(n_e):
         for j in range(i+1):
             rho[i] += rho2[i-j] * rho1[j]
 
     return rho
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def convolveBS(numpy.ndarray[numpy.float64_t,ndim=1] Elist,
-               numpy.ndarray[numpy.float64_t,ndim=1] rho0,
+def convolveBS(numpy.ndarray[numpy.float64_t, ndim=1] Elist, numpy.ndarray[numpy.float64_t, ndim=1] rho0,
                double energy, int degeneracy=1):
     """
     Convolve a molecular degree of freedom into a density or sum of states
@@ -231,24 +246,23 @@ def convolveBS(numpy.ndarray[numpy.float64_t,ndim=1] Elist,
     degeneracy `degeneracy`.
     """
     cdef int n = 0
-    cdef double Emax = numpy.max(Elist), E_n
-    cdef int i, j, nE = Elist.shape[0], g_n
-    cdef numpy.ndarray[numpy.float64_t,ndim=1] rho
+    cdef int i, j, n_e = Elist.shape[0], g_n
+    cdef numpy.ndarray[numpy.float64_t, ndim=1] rho
     
     rho = rho0.copy()
     
-    for i in range(nE):
-        for j in range(i, nE):
+    for i in range(n_e):
+        for j in range(i, n_e):
             if Elist[j] - Elist[i] >= 0.9999 * energy:
                 rho[j] += degeneracy * rho[i]
                 break
         
     return rho
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def convolveBSSR(numpy.ndarray[numpy.float64_t,ndim=1] Elist,
-                 numpy.ndarray[numpy.float64_t,ndim=1] rho0,
+def convolveBSSR(numpy.ndarray[numpy.float64_t, ndim=1] Elist, numpy.ndarray[numpy.float64_t, ndim=1] rho0,
                  energy, degeneracy=unitDegeneracy, int n0=0):
     """
     Convolve a molecular degree of freedom into a density or sum of states
@@ -258,22 +272,22 @@ def convolveBSSR(numpy.ndarray[numpy.float64_t,ndim=1] Elist,
     corresponding to the solution of the Schrodinger equation.
     """
     cdef int n = n0
-    cdef double Emax = numpy.max(Elist), E_n
-    cdef int i, j, nE = Elist.shape[0], g_n
-    cdef numpy.ndarray[numpy.float64_t,ndim=1] rho
+    cdef double e_max = numpy.max(Elist), e_n
+    cdef int i, j, n_e = Elist.shape[0], g_n
+    cdef numpy.ndarray[numpy.float64_t, ndim=1] rho
     
     rho = numpy.zeros_like(rho0)
     
-    E_n = energy(n); g_n = degeneracy(n)
-    while E_n < Emax:
+    e_n, g_n = energy(n), degeneracy(n)
+    while e_n < e_max:
 
-        for i in range(nE):
-            for j in range(i, nE):
-                if Elist[j] - Elist[i] >= 0.9999 * E_n:
+        for i in range(n_e):
+            for j in range(i, n_e):
+                if Elist[j] - Elist[i] >= 0.9999 * e_n:
                     rho[j] += g_n * rho0[i]
                     break
 
         n += 1
-        E_n = energy(n); g_n = degeneracy(n)
+        e_n, g_n = energy(n), degeneracy(n)
         
     return rho

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -274,11 +274,11 @@ cdef class HinderedRotor(Torsion):
         
         if self._fourier is not None:
             coeffs = self._fourier.value_si
-            V0 = -numpy.sum(coeffs[0,:])
+            V0 = -numpy.sum(coeffs[0, :])
         else:
             coeffs = numpy.zeros((2, self.symmetry), numpy.float64)
             V0 = 0.5 * self._barrier.value_si
-            coeffs[0, self.symmetry-1] = -V0
+            coeffs[0, self.symmetry - 1] = -V0
             
         # Populate Hamiltonian matrix (banded in lower triangular form)
         H = numpy.zeros((coeffs.shape[1] + 1, 2 * M + 1), numpy.complex64)

--- a/rmgpy/statmech/translation.pyx
+++ b/rmgpy/statmech/translation.pyx
@@ -44,6 +44,7 @@ import rmgpy.statmech.schrodinger as schrodinger
 
 ################################################################################
 
+
 cdef class Translation(Mode):
     """
     A base class for all vibrational degrees of freedom. The attributes are:
@@ -54,15 +55,16 @@ cdef class Translation(Mode):
     `quantum`                ``True`` to use the quantum mechanical model, ``False`` to use the classical model
     ======================== ===================================================
 
-    In the majority of chemical applications, the vibrational energy levels are
-    widely spaced compared to :math:`k_\\mathrm{B} T`, which makes a quantum
-    mechanical treatment required.
+    In the majority of chemical applications, the translational energy levels are
+    much smaller than :math:`k_\\mathrm{B} T`, which makes a classical
+    mechanical treatment adequate.
     """
 
     def __init__(self, quantum=True):
         Mode.__init__(self, quantum)
 
 ################################################################################
+
 
 cdef class IdealGasTranslation(Translation):
     """
@@ -119,8 +121,8 @@ cdef class IdealGasTranslation(Translation):
             raise NotImplementedError('Quantum mechanical model not yet implemented for IdealGasTranslation.')
         else:
             mass = self._mass.value_si
-            qt = ((2 * constants.pi * mass) / (constants.h * constants.h))**1.5 / 101325.
-            Q = qt * (constants.kB * T)**2.5
+            qt = ((2 * constants.pi * mass) / (constants.h ** 2)) ** 1.5 / 101325.  # assume P = 1 atm = 101325 Pa
+            Q = qt * (constants.kB * T) ** 2.5
         return Q
         
     cpdef double getHeatCapacity(self, double T) except -100000000:
@@ -175,8 +177,8 @@ cdef class IdealGasTranslation(Translation):
         else:
             mass = self._mass.value_si
             Elist = Elist / constants.Na
-            qt = ((2 * constants.pi * mass) / (constants.h * constants.h))**1.5 / 101325.
-            sumStates = qt * Elist**2.5 / (sqrt(constants.pi) * 15.0/8.0)
+            qt = ((2 * constants.pi * mass) / (constants.h ** 2)) ** 1.5 / 101325.
+            sumStates = qt * Elist ** 2.5 / (sqrt(constants.pi) * 15.0 / 8.0)
         return sumStates
             
     cpdef numpy.ndarray getDensityOfStates(self, numpy.ndarray Elist, numpy.ndarray densStates0=None):
@@ -194,8 +196,8 @@ cdef class IdealGasTranslation(Translation):
             mass = self._mass.value_si
             Elist = Elist / constants.Na
             dE = Elist[1] - Elist[0]
-            qt = ((2 * constants.pi * mass) / (constants.h * constants.h))**1.5 / 101325.
-            densStates = qt * Elist**1.5 / (sqrt(constants.pi) * 0.75) * dE
+            qt = ((2 * constants.pi * mass) / (constants.h ** 2)) ** 1.5 / 101325.
+            densStates = qt * Elist ** 1.5 / (sqrt(constants.pi) * 0.75) * dE
             if densStates0 is not None:
                 densStates = schrodinger.convolve(densStates0, densStates)
         return densStates


### PR DESCRIPTION
Thanks @mjohnson541 for spotting this...!
This PR changes the default of `Torsion` (practically of `HinderedRotor`) to `quantum=True`.
From playing around with and without this flag on, I got only insignificant changes to thermo (e.g., less than 0.1 cal /mol*K). Speed wasn't affected either.

Also, a bunch of minor changes to RMG's statmech were added to this PR.