### PR TITLE
Derive the frequency scaling factor in Arkane from the frequency level

### DIFF
--- a/arkane/inputTest.py
+++ b/arkane/inputTest.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+Unit tests for the input module of Arkane
+"""
+
+import unittest
+import os
+
+import rmgpy
+from rmgpy.pdep.collision import SingleExponentialDown
+from rmgpy.transport import TransportData
+from rmgpy.statmech.vibration import HarmonicOscillator
+from rmgpy.statmech.translation import IdealGasTranslation
+from rmgpy.statmech.rotation import NonlinearRotor
+from rmgpy.kinetics.tunneling import Eckart
+from rmgpy.exceptions import InputError
+
+from arkane.input import species, transitionState, reaction, SMILES, loadInputFile, process_model_chemistry
+
+################################################################################
+
+
+class InputTest(unittest.TestCase):
+    """
+    Contains unit tests for the Arkane input module
+    """
+
+    def test_species(self):
+        """
+        Test loading a species from input file-like kew word arguments
+        """
+        label0 = 'CH2O'
+        kwargs = {'E0': (28.69, 'kcal/mol'),
+                  'structure': SMILES('C=O'),
+                  'collisionModel': TransportData(sigma=(3.69e-10, 'm'), epsilon=(4.0, 'kJ/mol')),
+                  'energyTransferModel': SingleExponentialDown(alpha0=(0.956, 'kJ/mol'), T0=(300, 'K'), n=0.95),
+                  'spinMultiplicity': 1,
+                  'opticalIsomers': 1,
+                  'modes': [HarmonicOscillator(frequencies=([1180, 1261, 1529, 1764, 2931, 2999], 'cm^-1')),
+                            NonlinearRotor(rotationalConstant=([1.15498821005263, 1.3156969584727, 9.45570474524524],
+                                                               "cm^-1"), symmetry=2, quantum=False),
+                            IdealGasTranslation(mass=(30.0106, "g/mol")),
+                            ]}
+
+        spc0 = species(label0, **kwargs)
+        self.assertEqual(spc0.label, 'CH2O')
+        self.assertEqual(spc0.SMILES, 'C=O')
+        self.assertAlmostEqual(spc0.conformer.E0.value_si, 120038.96)
+        self.assertEqual(spc0.conformer.spinMultiplicity, 1)
+        self.assertEqual(spc0.conformer.opticalIsomers, 1)
+        self.assertEqual(len(spc0.conformer.modes), 3)
+        self.assertIsInstance(spc0.transportData, TransportData)
+        self.assertIsInstance(spc0.energyTransferModel, SingleExponentialDown)
+
+    def test_transitionState(self):
+        """
+        Test loading a transition state from input file-like kew word arguments
+        """
+        label0 = 'TS1'
+        kwargs = {'E0': (39.95, 'kcal/mol'),
+                  'spinMultiplicity': 2,
+                  'opticalIsomers': 1,
+                  'frequency': (-1934, 'cm^-1'),
+                  'modes': [HarmonicOscillator(frequencies=([792, 987, 1136, 1142, 1482, 2441, 3096, 3183], 'cm^-1')),
+                            NonlinearRotor(rotationalConstant=([0.928, 0.962, 5.807], "cm^-1"), symmetry=1,
+                                           quantum=False),
+                            IdealGasTranslation(mass=(31.01843, "g/mol"))]}
+
+        ts0 = transitionState(label0, **kwargs)
+        self.assertEqual(ts0.label, 'TS1')
+        self.assertAlmostEqual(ts0.conformer.E0.value_si, 167150.8)
+        self.assertEqual(ts0.conformer.spinMultiplicity, 2)
+        self.assertEqual(ts0.conformer.opticalIsomers, 1)
+        self.assertEqual(ts0.frequency.value_si, -1934.0)
+        self.assertEqual(len(ts0.conformer.modes), 3)
+
+    def test_reaction(self):
+        """
+        Test loading a reaction from input file-like kew word arguments
+        """
+
+        species(
+            label='methoxy',
+            structure=SMILES('C[O]'),
+            E0=(9.44, 'kcal/mol'),
+            modes=[
+                HarmonicOscillator(frequencies=([758, 960, 1106, 1393, 1403, 1518, 2940, 3019, 3065], 'cm^-1')),
+                NonlinearRotor(rotationalConstant=([0.916, 0.921, 5.251], "cm^-1"), symmetry=3, quantum=False),
+                IdealGasTranslation(mass=(31.01843, "g/mol"))],
+            spinMultiplicity=2,
+            opticalIsomers=1,
+            molecularWeight=(31.01843, 'amu'),
+            collisionModel=TransportData(sigma=(3.69e-10, 'm'), epsilon=(4.0, 'kJ/mol')),
+            energyTransferModel=SingleExponentialDown(alpha0=(0.956, 'kJ/mol'), T0=(300, 'K'), n=0.95))
+
+        species(
+            label='formaldehyde',
+            E0=(28.69, 'kcal/mol'),
+            molecularWeight=(30.0106, "g/mol"),
+            collisionModel=TransportData(sigma=(3.69e-10, 'm'), epsilon=(4.0, 'kJ/mol')),
+            energyTransferModel=SingleExponentialDown(alpha0=(0.956, 'kJ/mol'), T0=(300, 'K'), n=0.95),
+            spinMultiplicity=1,
+            opticalIsomers=1,
+            modes=[HarmonicOscillator(frequencies=([1180, 1261, 1529, 1764, 2931, 2999], 'cm^-1')),
+                   NonlinearRotor(rotationalConstant=([1.15498821005263, 1.3156969584727, 9.45570474524524], "cm^-1"),
+                                  symmetry=2, quantum=False),
+                   IdealGasTranslation(mass=(30.0106, "g/mol"))])
+
+        species(
+            label='H',
+            E0=(0.000, 'kcal/mol'),
+            molecularWeight=(1.00783, "g/mol"),
+            collisionModel=TransportData(sigma=(3.69e-10, 'm'), epsilon=(4.0, 'kJ/mol')),
+            energyTransferModel=SingleExponentialDown(alpha0=(0.956, 'kJ/mol'), T0=(300, 'K'), n=0.95),
+            modes=[IdealGasTranslation(mass=(1.00783, "g/mol"))],
+            spinMultiplicity=2,
+            opticalIsomers=1)
+
+        transitionState(
+            label='TS3',
+            E0=(34.1, 'kcal/mol'),
+            spinMultiplicity=2,
+            opticalIsomers=1,
+            frequency=(-967, 'cm^-1'),
+            modes=[HarmonicOscillator(frequencies=([466, 581, 1169, 1242, 1499, 1659, 2933, 3000], 'cm^-1')),
+                   NonlinearRotor(rotationalConstant=([0.970, 1.029, 3.717], "cm^-1"), symmetry=1, quantum=False),
+                   IdealGasTranslation(mass=(31.01843, "g/mol"))])
+
+        reactants = ['formaldehyde', 'H']
+        products = ['methoxy']
+        tunneling = 'Eckart'
+
+        rxn = reaction('CH2O+H=Methoxy', reactants, products, 'TS3', tunneling=tunneling)
+        self.assertEqual(rxn.label, 'CH2O+H=Methoxy')
+        self.assertEqual(len(rxn.reactants), 2)
+        self.assertEqual(len(rxn.products), 1)
+        self.assertAlmostEqual(rxn.reactants[0].conformer.E0.value_si, 120038.96)
+        self.assertAlmostEqual(rxn.reactants[1].conformer.E0.value_si, 0)
+        self.assertAlmostEqual(rxn.products[0].conformer.E0.value_si, 39496.96)
+        self.assertAlmostEqual(rxn.transitionState.conformer.E0.value_si, 142674.4)
+        self.assertAlmostEqual(rxn.transitionState.frequency.value_si, -967.0)
+        self.assertIsInstance(rxn.transitionState.tunneling, Eckart)
+
+    def test_load_input_file(self):
+        """Test loading an Arkane input file"""
+        path = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)), 'examples', 'arkane', 'networks',
+                            'acetyl+O2', 'input.py')
+        job_list, reaction_dict, species_dict, transition_state_dict, network_dict = loadInputFile(path)
+
+        self.assertEqual(len(job_list), 1)
+
+        self.assertEqual(len(reaction_dict), 5)
+        self.assertTrue('entrance1' in reaction_dict)
+        self.assertTrue('exit2' in reaction_dict)
+
+        self.assertEqual(len(species_dict), 9)
+        self.assertTrue('acetyl' in species_dict)
+        self.assertTrue('hydroperoxyl' in species_dict)
+
+        self.assertEqual(len(transition_state_dict), 5)
+        self.assertTrue('entrance1' in transition_state_dict)
+        self.assertTrue('isom1' in transition_state_dict)
+
+        self.assertEqual(len(network_dict), 1)
+        self.assertTrue('acetyl + O2' in network_dict)
+
+    def test_process_model_chemistry(self):
+        """
+        Test processing the model chemistry to derive the sp and freq levels
+        """
+        mc = 'ccsd(t)-f12a/aug-cc-pvtz//b3lyp/6-311++g(3df,3pd)'
+        sp, freq = process_model_chemistry(mc)
+        self.assertEqual(sp, 'ccsd(t)-f12a/aug-cc-pvtz')
+        self.assertEqual(freq, 'b3lyp/6-311++g(3df,3pd)')
+
+        mc = 'wb97x-d3/def2-tzvp'
+        sp, freq = process_model_chemistry(mc)
+        self.assertEqual(sp, 'wb97x-d3/def2-tzvp')
+        self.assertEqual(freq, 'wb97x-d3/def2-tzvp')
+
+        mc = 'cbs-qb3-paraskevas'
+        sp, freq = process_model_chemistry(mc)
+        self.assertEqual(sp, 'cbs-qb3-paraskevas')
+        self.assertEqual(freq, 'cbs-qb3')
+
+        with self.assertRaises(InputError):
+            process_model_chemistry('CCSD(T)-F12a/aug-cc-pVTZ//CCSD(T)-F12a/aug-cc-pVTZ//B3LYP/6-311++G(3df,3pd)')
+
+################################################################################
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1225,6 +1225,12 @@ def assign_frequency_scale_factor(model_chemistry):
     """
     Assign the frequency scaling factor according to the model chemistry.
     Refer to https://comp.chem.umn.edu/freqscale/index.html for future updates of these factors
+
+    Args:
+        model_chemistry (str, unicode): The frequency level of theory.
+
+    Returns:
+        float: The frequency scaling factor (1 by default).
     """
     freq_dict = {'cbs-qb3': 0.99,  # J. Chem. Phys. 1999, 110, 2822–2827
                  'cbs-qb3-paraskevas': 0.99,
@@ -1280,14 +1286,15 @@ def assign_frequency_scale_factor(model_chemistry):
                  'wb97x-d/aug-cc-pvtz': 0.974,
                  # Taken from https://comp.chem.umn.edu/freqscale/version3b2.htm as ωB97X-D/maug-cc-pVTZ
                  }
-    scale_factor = freq_dict.get(model_chemistry.lower(), 1)
-    if scale_factor == 1:
-        logging.warning('No frequency scale factor found for model chemistry {0}; assuming a value of unity.'.format(
-            model_chemistry))
+    scaling_factor = freq_dict.get(model_chemistry.lower(), 1)
+    if scaling_factor == 1:
+        logging.warning('No frequency scaling factor found for model chemistry {0}. Assuming a value of unity. '
+                        'This will affect the partition function and all quantities derived from it '
+                        '(thermo quantities and rate coefficients).'.format(model_chemistry))
     else:
         logging.info('Assigned a frequency scale factor of {0} for model chemistry {1}'.format(
-            scale_factor, model_chemistry))
-    return scale_factor
+            scaling_factor, model_chemistry))
+    return scaling_factor
 
 
 def determine_rotor_symmetry(energies, label, pivots):

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -49,19 +49,23 @@ Component                   Description
 Model Chemistry
 ===============
 
-The first item in the input file should be a ``modelChemistry`` assignment
-with a string describing the model chemistry.
+The first item in the input file should be a ``modelChemistry`` assignment with a string describing the model
+chemistry. The ``modelChemistry`` could either be in a `single point // frequency` format, e.g.,
+`CCSD(T)-F12a/aug-cc-pVTZ//B3LYP/6-311++G(3df,3pd)`, just the `single point`, e.g., `CCSD(T)-F12a/aug-cc-pVTZ`,
+or a composite method, e.g., `CBS-QB3`.
 
-Arkane uses this information to adjust the computed energies to the usual gas-phase reference
+Arkane uses the single point level to adjust the computed energies to the usual gas-phase reference
 states by applying atom, bond and spin-orbit coupling energy corrections. This is particularly
 important for ``thermo()`` calculations (see below). Note that the user must specify under the
 ``species()`` function the type and number of bonds for Arkane to apply these corrections.
+The frequency level is used to determine the frequency scaling factor if not given in the input file, and if it exists
+in Arkane (see the below table for existing frequency scaling factors).
 The example below specifies CBS-QB3 as the model chemistry::
 
     modelChemistry = "CBS-QB3"
 
-Alternatively, the atomic energies at the ``modelChemistry`` level of theory can be directly
-specified in the input file by providing a dictionary of these energies in the following format::
+Also, the atomic energies at the single point level of theory can be directly specified in the input file by providing
+a dictionary of these energies in the following format::
 
     atomEnergies = {
         'H': -0.499818,

--- a/examples/arkane/explorer/methyl+formaldehyde/input.py
+++ b/examples/arkane/explorer/methyl+formaldehyde/input.py
@@ -13,8 +13,6 @@ database(
     kineticsEstimator = 'rate rules',
 )
 
-
-
 species(
 label='CH3',
 structure=SMILES('[CH3]'),

--- a/examples/arkane/reactions/H+C2H4=C2H5/input.py
+++ b/examples/arkane/reactions/H+C2H4=C2H5/input.py
@@ -6,7 +6,6 @@
 # and for TS if all the respective reactant/s and product/s have structures
 
 modelChemistry = "CBS-QB3"
-frequencyScaleFactor = 0.99
 useHinderedRotors = False
 useBondCorrections = True
 
@@ -31,8 +30,8 @@ reaction(
 )
 
 statmech('TS')
-kinetics(    
-	label = 'H + C2H4 <=> C2H5',
+kinetics(
+    label = 'H + C2H4 <=> C2H5',
     Tmin = (400,'K'), Tmax = (1200,'K'), Tcount = 6, # this can be changed to any desired temperature range with any number of temperatures
     Tlist = ([400,500,700,900,1100,1200],'K'),
     )

--- a/examples/arkane/reactions/NH2+N2H3=NH+N2H4/input.py
+++ b/examples/arkane/reactions/NH2+N2H3=NH+N2H4/input.py
@@ -10,6 +10,7 @@ modelChemistry = "CCSD(T)-F12/aug-cc-pVTZ"
 
 useHinderedRotors = True
 useBondCorrections = False
+frequencyScaleFactor = 0.978
 
 species('NH', 'NH.yml')
 species('NH2','NH2.yml')

--- a/examples/arkane/species/N4H6/N4H6/N4H6.py
+++ b/examples/arkane/species/N4H6/N4H6/N4H6.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+bonds = {'N-N': 3, 'N-H': 6}
+
+externalSymmetry = 2
+
+spinMultiplicity = 1
+
+opticalIsomers = 2
+
+energy = {'CCSD(T)-F12/cc-pVTZ-f12': Log('sp.out')}
+
+geometry = Log('freq.log')
+
+frequencies = Log('freq.log')

--- a/examples/arkane/species/N4H6/N4H6/freq.log
+++ b/examples/arkane/species/N4H6/N4H6/freq.log
@@ -1,0 +1,1283 @@
+ Entering Gaussian System, Link 0=g16
+ Input=input.gjf
+ Output=input.log
+ Initial command:
+ /opt/g16/l1.exe "/scratch/{alongd}/{N4H6_freq}/Gau-6491.inp" -scrdir="/scratch/{alongd}/{N4H6_freq}/"
+ Entering Link 1 = /opt/g16/l1.exe PID=      6493.
+  
+ Copyright (c) 1988-2017, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision B.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  EM64L-G16RevB.01 20-Dec-2017
+                 1-Jun-2019 
+ ******************************************
+ %mem=2500mb
+ %nproc=48
+ Will use up to   48 processors via shared memory.
+ -------------------------------------------
+ #P freq B3LYP/6-311+G(3df,2p) iop(2/9=2000)
+ -------------------------------------------
+ 1/10=4,30=1,38=1/1,3;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=4,6=6,7=216,11=2,25=1,30=1,71=2,74=-5,140=1/1,2,3;
+ 4//1;
+ 5/5=2,38=5,98=1/2;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/8=1,10=1,25=1/1,2,3,16;
+ 1/10=4,30=1/3;
+ 99//99;
+ Leave Link    1 at Sat Jun  1 20:45:01 2019, MaxMem=   327680000 cpu:               5.3 elap:               0.2
+ (Enter /opt/g16/l101.exe)
+ ---------
+ N4H6 freq
+ ---------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ N                     1.35996  -0.53723  -0.18446 
+ H                     2.33958  -0.30093  -0.28991 
+ H                     1.27137  -1.27116   0.51544 
+ N                     0.66984   0.65956   0.21755 
+ H                     0.61618   0.71576   1.23168 
+ N                    -0.66984   0.65956  -0.21755 
+ H                    -0.61618   0.71576  -1.23168 
+ N                    -1.35997  -0.53723   0.18446 
+ H                    -2.33959  -0.30093   0.2899 
+ H                    -1.27137  -1.27116  -0.51544 
+ 
+ ITRead=  0  0  0  0  0  0  0  0  0  0
+ MicOpt= -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+ NAtoms=     10 NQM=       10 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          14           1           1          14           1          14           1          14           1           1
+ AtmWgt=  14.0030740   1.0078250   1.0078250  14.0030740   1.0078250  14.0030740   1.0078250  14.0030740   1.0078250   1.0078250
+ NucSpn=           2           1           1           2           1           2           1           2           1           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    2.0440000   0.0000000   0.0000000   2.0440000   0.0000000   2.0440000   0.0000000   2.0440000   0.0000000   0.0000000
+ NMagM=    0.4037610   2.7928460   2.7928460   0.4037610   2.7928460   0.4037610   2.7928460   0.4037610   2.7928460   2.7928460
+ AtZNuc=   7.0000000   1.0000000   1.0000000   7.0000000   1.0000000   7.0000000   1.0000000   7.0000000   1.0000000   1.0000000
+ Leave Link  101 at Sat Jun  1 20:45:01 2019, MaxMem=   327680000 cpu:              14.1 elap:               0.3
+ (Enter /opt/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sat Jun  1 20:45:01 2019, MaxMem=   327680000 cpu:               1.3 elap:               0.0
+ (Enter /opt/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        1.359965   -0.537228   -0.184462
+      2          1           0        2.339584   -0.300930   -0.289911
+      3          1           0        1.271374   -1.271160    0.515440
+      4          7           0        0.669838    0.659561    0.217548
+      5          1           0        0.616180    0.715758    1.231681
+      6          7           0       -0.669836    0.659561   -0.217548
+      7          1           0       -0.616179    0.715757   -1.231682
+      8          7           0       -1.359967   -0.537227    0.184463
+      9          1           0       -2.339586   -0.300928    0.289904
+     10          1           0       -1.271374   -1.271158   -0.515440
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  H    1.013218   0.000000
+     3  H    1.018021   1.652577   0.000000
+     4  N    1.438816   1.992011   2.044081   0.000000
+     5  H    2.031908   2.513765   2.211362   1.017105   0.000000
+     6  N    2.356585   3.159808   2.834299   1.408558   1.938365
+     7  H    2.563550   3.264524   3.250097   1.938367   2.754427
+     8  N    2.744838   3.737318   2.751756   2.356587   2.563551
+     9  H    3.737317   4.714957   3.745831   3.159811   3.264529
+    10  H    2.751753   3.745828   2.743771   2.834299   3.250096
+                    6          7          8          9         10
+     6  N    0.000000
+     7  H    1.017106   0.000000
+     8  N    1.438817   2.031909   0.000000
+     9  H    1.992012   2.513763   1.013217   0.000000
+    10  H    2.044080   2.211360   1.018021   1.652574   0.000000
+ Stoichiometry    H6N4
+ Framework group  C1[X(H6N4)]
+ Deg. of freedom    24
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        1.359965    0.537228    0.184462
+      2          1           0        2.339584    0.300930    0.289911
+      3          1           0        1.271374    1.271160   -0.515440
+      4          7           0        0.669838   -0.659561   -0.217548
+      5          1           0        0.616180   -0.715758   -1.231681
+      6          7           0       -0.669836   -0.659561    0.217548
+      7          1           0       -0.616179   -0.715757    1.231682
+      8          7           0       -1.359967    0.537227   -0.184463
+      9          1           0       -2.339586    0.300928   -0.289904
+     10          1           0       -1.271374    1.271158    0.515440
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):          16.4597974           5.9135684           4.8528509
+ Leave Link  202 at Sat Jun  1 20:45:01 2019, MaxMem=   327680000 cpu:               4.6 elap:               0.1
+ (Enter /opt/g16/l301.exe)
+ Standard basis: 6-311+G(3df,2p) (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   234 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   210 symmetry adapted basis functions of A   symmetry.
+   210 basis functions,   298 primitive gaussians,   234 cartesian basis functions
+    17 alpha electrons       17 beta electrons
+       nuclear repulsion energy       138.0818153093 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   10 NActive=   10 NUniq=   10 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Sat Jun  1 20:45:01 2019, MaxMem=   327680000 cpu:               4.7 elap:               0.1
+ (Enter /opt/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ PrsmSu:  requested number of processors reduced to:  42 ShMem   1 Linda.
+ NBasis=   210 RedAO= T EigKep=  1.05D-04  NBF=   210
+ NBsUse=   210 1.00D-06 EigRej= -1.00D+00 NBFU=   210
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   234   234   234   234   234 MxSgAt=    10 MxSgA2=    10.
+ Leave Link  302 at Sat Jun  1 20:45:02 2019, MaxMem=   327680000 cpu:              22.3 elap:               0.5
+ (Enter /opt/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sat Jun  1 20:45:02 2019, MaxMem=   327680000 cpu:               2.9 elap:               0.1
+ (Enter /opt/g16/l401.exe)
+ ExpMin= 6.39D-02 ExpMax= 6.29D+03 ExpMxC= 9.49D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -222.589781760288    
+ JPrj=0 DoOrth=F DoCkMO=F.
+ Leave Link  401 at Sat Jun  1 20:45:03 2019, MaxMem=   327680000 cpu:              34.9 elap:               0.8
+ (Enter /opt/g16/l502.exe)
+ Keep R1 ints in memory in canonical form, NReq=296475692.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  22155 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ CoulSu:  requested number of processors reduced to:  41 ShMem   1 Linda.
+ Two-electron integral symmetry not used.
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot=   327680000 LenX=    82124030 LenY=    82068833
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -222.507064838580    
+ DIIS: error= 2.03D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -222.507064838580     IErMin= 1 ErrMin= 2.03D-02
+ ErrMax= 2.03D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.41D-01 BMatP= 1.41D-01
+ IDIUse=3 WtCom= 7.97D-01 WtEn= 2.03D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ GapD=    0.210 DampG=1.000 DampE=0.500 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=3.93D-03 MaxDP=9.43D-02              OVMax= 1.84D-01
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -222.543147793379     Delta-E=       -0.036082954799 Rises=F Damp=T
+ DIIS: error= 6.88D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -222.543147793379     IErMin= 2 ErrMin= 6.88D-03
+ ErrMax= 6.88D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.25D-02 BMatP= 1.41D-01
+ IDIUse=3 WtCom= 9.31D-01 WtEn= 6.88D-02
+ Coeff-Com:  0.115D+00 0.885D+00
+ Coeff-En:   0.267D+00 0.733D+00
+ Coeff:      0.126D+00 0.874D+00
+ Gap=     0.285 Goal=   None    Shift=    0.000
+ RMSDP=1.12D-03 MaxDP=4.80D-02 DE=-3.61D-02 OVMax= 1.19D-01
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -222.606313516456     Delta-E=       -0.063165723077 Rises=F Damp=F
+ DIIS: error= 4.33D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -222.606313516456     IErMin= 3 ErrMin= 4.33D-03
+ ErrMax= 4.33D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.39D-03 BMatP= 1.25D-02
+ IDIUse=3 WtCom= 9.57D-01 WtEn= 4.33D-02
+ Coeff-Com: -0.294D-01 0.350D+00 0.680D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.282D-01 0.334D+00 0.694D+00
+ Gap=     0.268 Goal=   None    Shift=    0.000
+ RMSDP=3.50D-04 MaxDP=8.95D-03 DE=-6.32D-02 OVMax= 1.42D-02
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -222.609489241440     Delta-E=       -0.003175724984 Rises=F Damp=F
+ DIIS: error= 1.58D-03 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -222.609489241440     IErMin= 4 ErrMin= 1.58D-03
+ ErrMax= 1.58D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.98D-04 BMatP= 4.39D-03
+ IDIUse=3 WtCom= 9.84D-01 WtEn= 1.58D-02
+ Coeff-Com: -0.185D-01 0.897D-01 0.299D+00 0.630D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.182D-01 0.883D-01 0.294D+00 0.636D+00
+ Gap=     0.261 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-04 MaxDP=2.98D-03 DE=-3.18D-03 OVMax= 6.26D-03
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -222.609729209793     Delta-E=       -0.000239968353 Rises=F Damp=F
+ DIIS: error= 6.91D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -222.609729209793     IErMin= 5 ErrMin= 6.91D-04
+ ErrMax= 6.91D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.01D-04 BMatP= 3.98D-04
+ IDIUse=3 WtCom= 9.93D-01 WtEn= 6.91D-03
+ Coeff-Com: -0.827D-02 0.182D-01 0.107D+00 0.386D+00 0.497D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.198D+00 0.802D+00
+ Coeff:     -0.821D-02 0.181D-01 0.106D+00 0.385D+00 0.499D+00
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=4.19D-05 MaxDP=1.12D-03 DE=-2.40D-04 OVMax= 2.11D-03
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -222.609810926559     Delta-E=       -0.000081716766 Rises=F Damp=F
+ DIIS: error= 5.07D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -222.609810926559     IErMin= 6 ErrMin= 5.07D-05
+ ErrMax= 5.07D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.71D-07 BMatP= 1.01D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.155D-02 0.220D-02 0.224D-01 0.961D-01 0.144D+00 0.736D+00
+ Coeff:     -0.155D-02 0.220D-02 0.224D-01 0.961D-01 0.144D+00 0.736D+00
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=5.06D-06 MaxDP=1.35D-04 DE=-8.17D-05 OVMax= 1.76D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   7  Pass 1  IDiag  1:
+ E= -222.609821160529     Delta-E=       -0.000010233970 Rises=F Damp=F
+ DIIS: error= 9.53D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -222.609821160529     IErMin= 1 ErrMin= 9.53D-06
+ ErrMax= 9.53D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.76D-08 BMatP= 1.76D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=5.06D-06 MaxDP=1.35D-04 DE=-1.02D-05 OVMax= 5.81D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -222.609821167897     Delta-E=       -0.000000007368 Rises=F Damp=F
+ DIIS: error= 8.01D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -222.609821167897     IErMin= 2 ErrMin= 8.01D-06
+ ErrMax= 8.01D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.17D-08 BMatP= 1.76D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.443D+00 0.557D+00
+ Coeff:      0.443D+00 0.557D+00
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=7.52D-07 MaxDP=1.46D-05 DE=-7.37D-09 OVMax= 2.84D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -222.609821177415     Delta-E=       -0.000000009518 Rises=F Damp=F
+ DIIS: error= 2.48D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -222.609821177415     IErMin= 3 ErrMin= 2.48D-06
+ ErrMax= 2.48D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.06D-09 BMatP= 1.17D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.118D+00 0.257D+00 0.625D+00
+ Coeff:      0.118D+00 0.257D+00 0.625D+00
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=2.09D-07 MaxDP=3.95D-06 DE=-9.52D-09 OVMax= 8.50D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -222.609821178257     Delta-E=       -0.000000000843 Rises=F Damp=F
+ DIIS: error= 5.42D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -222.609821178257     IErMin= 4 ErrMin= 5.42D-07
+ ErrMax= 5.42D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.73D-11 BMatP= 1.06D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.803D-02 0.291D-01 0.235D+00 0.744D+00
+ Coeff:     -0.803D-02 0.291D-01 0.235D+00 0.744D+00
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=6.43D-08 MaxDP=1.76D-06 DE=-8.43D-10 OVMax= 1.79D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -222.609821178315     Delta-E=       -0.000000000057 Rises=F Damp=F
+ DIIS: error= 1.07D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -222.609821178315     IErMin= 5 ErrMin= 1.07D-07
+ ErrMax= 1.07D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.50D-12 BMatP= 6.73D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.620D-02 0.862D-02 0.962D-01 0.354D+00 0.547D+00
+ Coeff:     -0.620D-02 0.862D-02 0.962D-01 0.354D+00 0.547D+00
+ Gap=     0.263 Goal=   None    Shift=    0.000
+ RMSDP=8.27D-09 MaxDP=2.10D-07 DE=-5.72D-11 OVMax= 4.52D-07
+
+ SCF Done:  E(RB3LYP) =  -222.609821178     A.U. after   11 cycles
+            NFock= 11  Conv=0.83D-08     -V/T= 2.0040
+ KE= 2.217266116763D+02 PE=-7.970130102984D+02 EE= 2.145947621345D+02
+ Leave Link  502 at Sat Jun  1 20:45:27 2019, MaxMem=   327680000 cpu:             242.7 elap:              24.1
+ (Enter /opt/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   210
+ NBasis=   210 NAE=    17 NBE=    17 NFC=     0 NFV=     0
+ NROrb=    210 NOA=    17 NOB=    17 NVA=   193 NVB=   193
+
+ **** Warning!!: The largest alpha MO coefficient is  0.30009755D+02
+
+ Leave Link  801 at Sat Jun  1 20:45:27 2019, MaxMem=   327680000 cpu:               2.2 elap:               0.1
+ (Enter /opt/g16/l1101.exe)
+ Using compressed storage, NAtomX=    10.
+ Will process     11 centers per pass.
+ PrsmSu:  requested number of processors reduced to:  41 ShMem   1 Linda.
+ Leave Link 1101 at Sat Jun  1 20:45:28 2019, MaxMem=   327680000 cpu:              24.4 elap:               0.6
+ (Enter /opt/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Sat Jun  1 20:45:28 2019, MaxMem=   327680000 cpu:               2.6 elap:               0.1
+ (Enter /opt/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    10.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=     327679084.
+ G2DrvN: will do    11 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Sat Jun  1 20:45:41 2019, MaxMem=   327680000 cpu:             618.6 elap:              13.0
+ (Enter /opt/g16/l1002.exe)
+ Minotr:  Closed shell wavefunction.
+          IDoAtm=1111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         3023 words used for storage of precomputed grid.
+ Keep R1 ints in memory in canonical form, NReq=296317291.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  22155 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ CoulSu:  requested number of processors reduced to:  41 ShMem   1 Linda.
+ Two-electron integral symmetry not used.
+          MDV=     327680000 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+ CalDSu:  requested number of processors reduced to:  35 ShMem   1 Linda.
+          There are    33 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+     30 vectors produced by pass  0 Test12= 9.94D-15 3.03D-09 XBig12= 3.05D+01 2.05D+00.
+ AX will form    30 AO Fock derivatives at one time.
+ CalDSu:  requested number of processors reduced to:  36 ShMem   1 Linda.
+     30 vectors produced by pass  1 Test12= 9.94D-15 3.03D-09 XBig12= 3.57D+00 4.84D-01.
+ CalDSu:  requested number of processors reduced to:  36 ShMem   1 Linda.
+     30 vectors produced by pass  2 Test12= 9.94D-15 3.03D-09 XBig12= 3.36D-02 3.05D-02.
+ CalDSu:  requested number of processors reduced to:  36 ShMem   1 Linda.
+     30 vectors produced by pass  3 Test12= 9.94D-15 3.03D-09 XBig12= 1.68D-04 2.41D-03.
+ CalDSu:  requested number of processors reduced to:  36 ShMem   1 Linda.
+     30 vectors produced by pass  4 Test12= 9.94D-15 3.03D-09 XBig12= 3.20D-07 9.02D-05.
+ CalDSu:  requested number of processors reduced to:  36 ShMem   1 Linda.
+     28 vectors produced by pass  5 Test12= 9.94D-15 3.03D-09 XBig12= 5.19D-10 3.44D-06.
+ CalDSu:  requested number of processors reduced to:  37 ShMem   1 Linda.
+      4 vectors produced by pass  6 Test12= 9.94D-15 3.03D-09 XBig12= 5.56D-13 1.34D-07.
+      1 vectors produced by pass  7 Test12= 9.94D-15 3.03D-09 XBig12= 5.68D-16 4.21D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 8.88D-16
+ Solved reduced A of dimension   183 with    33 vectors.
+ FullF1:  Do perturbations      1 to       3.
+ Isotropic polarizability for W=    0.000000       41.83 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Sat Jun  1 20:46:14 2019, MaxMem=   327680000 cpu:            1248.6 elap:              33.4
+ (Enter /opt/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -14.35351 -14.35338 -14.32520 -14.32519  -1.02345
+ Alpha  occ. eigenvalues --   -0.91459  -0.80747  -0.68487  -0.54199  -0.51431
+ Alpha  occ. eigenvalues --   -0.49342  -0.47513  -0.47009  -0.28069  -0.27783
+ Alpha  occ. eigenvalues --   -0.26618  -0.25147
+ Alpha virt. eigenvalues --    0.01157   0.02841   0.04415   0.04711   0.07899
+ Alpha virt. eigenvalues --    0.08576   0.11197   0.11516   0.12182   0.13801
+ Alpha virt. eigenvalues --    0.14108   0.14973   0.16183   0.18476   0.18509
+ Alpha virt. eigenvalues --    0.19935   0.21973   0.22610   0.23091   0.24129
+ Alpha virt. eigenvalues --    0.26167   0.27285   0.28139   0.29365   0.35235
+ Alpha virt. eigenvalues --    0.44632   0.47879   0.49129   0.49381   0.52795
+ Alpha virt. eigenvalues --    0.53254   0.55710   0.56446   0.57452   0.58243
+ Alpha virt. eigenvalues --    0.58617   0.62494   0.63840   0.65494   0.66019
+ Alpha virt. eigenvalues --    0.66931   0.67900   0.72769   0.73501   0.73682
+ Alpha virt. eigenvalues --    0.77945   0.78235   0.80944   0.81927   0.86050
+ Alpha virt. eigenvalues --    0.88313   0.89213   0.91404   0.96765   0.98618
+ Alpha virt. eigenvalues --    0.99339   1.00499   1.03948   1.08080   1.08725
+ Alpha virt. eigenvalues --    1.10605   1.12043   1.15521   1.16099   1.24328
+ Alpha virt. eigenvalues --    1.28606   1.31283   1.31710   1.34978   1.36966
+ Alpha virt. eigenvalues --    1.40714   1.42862   1.43143   1.44326   1.48268
+ Alpha virt. eigenvalues --    1.50653   1.51156   1.51299   1.58433   1.60157
+ Alpha virt. eigenvalues --    1.74145   1.84892   1.90539   1.91668   1.94466
+ Alpha virt. eigenvalues --    2.08285   2.16268   2.23081   2.25150   2.28457
+ Alpha virt. eigenvalues --    2.32050   2.34224   2.39819   2.44320   2.44396
+ Alpha virt. eigenvalues --    2.48840   2.59029   2.59213   2.65120   2.67505
+ Alpha virt. eigenvalues --    2.69038   2.74244   2.82915   2.84413   2.90249
+ Alpha virt. eigenvalues --    2.99885   3.09263   3.09835   3.15759   3.20914
+ Alpha virt. eigenvalues --    3.22567   3.34770   3.37122   3.42040   3.44833
+ Alpha virt. eigenvalues --    3.46987   3.47081   3.49120   3.54625   3.55156
+ Alpha virt. eigenvalues --    3.64343   3.65855   3.71742   3.82557   3.85059
+ Alpha virt. eigenvalues --    3.88193   3.88682   3.91740   3.92765   3.94803
+ Alpha virt. eigenvalues --    3.97615   4.01983   4.05827   4.06616   4.13456
+ Alpha virt. eigenvalues --    4.17227   4.20003   4.21194   4.21549   4.28131
+ Alpha virt. eigenvalues --    4.30590   4.35219   4.41479   4.45714   4.52179
+ Alpha virt. eigenvalues --    4.53538   4.55569   4.62369   4.68170   4.74799
+ Alpha virt. eigenvalues --    4.77748   4.86394   4.88014   4.89791   5.02016
+ Alpha virt. eigenvalues --    5.02320   5.20492   5.29152   5.29717   5.44892
+ Alpha virt. eigenvalues --    5.78218   5.88695   6.06682   6.12331   6.23141
+ Alpha virt. eigenvalues --    6.26900   6.30099   6.32660   6.33917  10.11043
+ Alpha virt. eigenvalues --   10.11294  10.18271  10.20440  10.26271  10.27066
+ Alpha virt. eigenvalues --   10.32294  10.36377  10.38240  10.49472  10.55325
+ Alpha virt. eigenvalues --   10.60568  10.71057  10.72158  10.96837  11.13609
+ Alpha virt. eigenvalues --   11.21640  11.56874  11.65628  11.92635  35.68612
+ Alpha virt. eigenvalues --   35.82970  35.86061  35.88821
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  N    6.999902   0.399062   0.378991  -0.017221  -0.024684  -0.186119
+     2  H    0.399062   0.532060  -0.053896  -0.084442   0.004211   0.006142
+     3  H    0.378991  -0.053896   0.530138  -0.067987  -0.016027   0.019272
+     4  N   -0.017221  -0.084442  -0.067987   6.933400   0.407571   0.073741
+     5  H   -0.024684   0.004211  -0.016027   0.407571   0.549133  -0.111449
+     6  N   -0.186119   0.006142   0.019272   0.073741  -0.111449   6.933400
+     7  H    0.014830   0.000585  -0.000393  -0.111449   0.016388   0.407571
+     8  N    0.007567  -0.000858   0.013299  -0.186116   0.014830  -0.017219
+     9  H   -0.000858   0.000051  -0.000063   0.006142   0.000585  -0.084441
+    10  H    0.013299  -0.000063  -0.004030   0.019272  -0.000393  -0.067987
+               7          8          9         10
+     1  N    0.014830   0.007567  -0.000858   0.013299
+     2  H    0.000585  -0.000858   0.000051  -0.000063
+     3  H   -0.000393   0.013299  -0.000063  -0.004030
+     4  N   -0.111449  -0.186116   0.006142   0.019272
+     5  H    0.016388   0.014830   0.000585  -0.000393
+     6  N    0.407571  -0.017219  -0.084441  -0.067987
+     7  H    0.549133  -0.024684   0.004211  -0.016027
+     8  N   -0.024684   6.999900   0.399062   0.378992
+     9  H    0.004211   0.399062   0.532060  -0.053897
+    10  H   -0.016027   0.378992  -0.053897   0.530138
+ Mulliken charges:
+               1
+     1  N   -0.584770
+     2  H    0.197148
+     3  H    0.200696
+     4  N    0.027089
+     5  H    0.159837
+     6  N    0.027090
+     7  H    0.159836
+     8  N   -0.584771
+     9  H    0.197149
+    10  H    0.200696
+ Sum of Mulliken charges =  -0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.186925
+     4  N    0.186925
+     6  N    0.186926
+     8  N   -0.186926
+ APT charges:
+               1
+     1  N   -0.311220
+     2  H    0.136648
+     3  H    0.100171
+     4  N   -0.037472
+     5  H    0.111873
+     6  N   -0.037472
+     7  H    0.111873
+     8  N   -0.311220
+     9  H    0.136648
+    10  H    0.100171
+ Sum of APT charges =  -0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.074401
+     4  N    0.074402
+     6  N    0.074401
+     8  N   -0.074401
+ Electronic spatial extent (au):  <R**2>=            291.9612
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              1.4267    Z=              0.0000  Tot=              1.4267
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -20.5356   YY=            -28.0235   ZZ=            -24.4621
+   XY=              0.0000   XZ=             -3.0234   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              3.8048   YY=             -3.6831   ZZ=             -0.1217
+   XY=              0.0000   XZ=             -3.0234   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.0000  YYY=              7.7435  ZZZ=              0.0000  XYY=              0.0000
+  XXY=              4.8603  XXZ=              0.0001  XZZ=              0.0000  YZZ=             -3.5540
+  YYZ=             -0.0000  XYZ=             -2.2804
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -181.7804 YYYY=            -99.1795 ZZZZ=            -43.0185 XXXY=              0.0000
+ XXXZ=              5.8526 YYYX=              0.0000 YYYZ=             -0.0000 ZZZX=             -7.6546
+ ZZZY=              0.0000 XXYY=            -57.8635 XXZZ=            -49.0626 YYZZ=            -22.6513
+ XXYZ=              0.0000 YYXZ=             -5.3852 ZZXY=              0.0000
+ N-N= 1.380818153093D+02 E-N=-7.970130077019D+02  KE= 2.217266116763D+02
+  Exact polarizability:  48.815  -0.000  40.074  -1.182  -0.000  36.593
+ Approx polarizability:  60.939  -0.000  54.442  -1.247  -0.000  51.837
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Sat Jun  1 20:46:15 2019, MaxMem=   327680000 cpu:              16.1 elap:               0.4
+ (Enter /opt/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ PrsmSu:  requested number of processors reduced to:  42 ShMem   1 Linda.
+ PrsmSu:  requested number of processors reduced to:  43 ShMem   1 Linda.
+ Leave Link  701 at Sat Jun  1 20:46:16 2019, MaxMem=   327680000 cpu:              27.1 elap:               0.6
+ (Enter /opt/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sat Jun  1 20:46:16 2019, MaxMem=   327680000 cpu:               2.2 elap:               0.1
+ (Enter /opt/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ CoulSu:  requested number of processors reduced to:  43 ShMem   1 Linda.
+ Leave Link  703 at Sat Jun  1 20:46:51 2019, MaxMem=   327680000 cpu:            1578.0 elap:              34.9
+ (Enter /opt/g16/l716.exe)
+ Dipole        = 1.78877452D-06 5.61300153D-01 3.07615430D-06
+ Polarizability= 4.88153629D+01-5.41034350D-06 4.00744707D+01
+                -1.18169931D+00-3.35085731D-06 3.65925366D+01
+ Full mass-weighted force constant matrix:
+ Low frequencies ---   -0.0008   -0.0007    0.0008   28.1977   33.3933   60.4400
+ Low frequencies ---  230.0714  299.6316  340.2805
+ Diagonal vibrational polarizability:
+       18.9681301      14.4756173      11.8372864
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1                      2                      3
+                      A                      A                      A
+ Frequencies --    230.0651               299.4340               340.1822
+ Red. masses --      3.0504                 1.0550                 1.4833
+ Frc consts  --      0.0951                 0.0557                 0.1011
+ IR Inten    --      0.3028                71.9435                38.4430
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.22  -0.10   0.07    -0.02   0.03  -0.00     0.06   0.03  -0.08
+     2   1     0.16  -0.33   0.03    -0.10  -0.08   0.51    -0.01  -0.08   0.33
+     3   1     0.39   0.03   0.17     0.41  -0.12  -0.21     0.38  -0.17  -0.32
+     4   7    -0.03   0.10  -0.09    -0.01   0.02  -0.02     0.03   0.01   0.08
+     5   1    -0.16   0.27  -0.09     0.02   0.03  -0.02     0.19  -0.22   0.09
+     6   7     0.03   0.10   0.09    -0.01  -0.02  -0.02    -0.03   0.01  -0.08
+     7   1     0.16   0.27   0.09     0.02  -0.03  -0.02    -0.19  -0.22  -0.09
+     8   7    -0.22  -0.10  -0.07    -0.02  -0.03  -0.00    -0.06   0.03   0.08
+     9   1    -0.16  -0.33  -0.03    -0.10   0.08   0.51     0.01  -0.08  -0.33
+    10   1    -0.39   0.03  -0.17     0.41   0.12  -0.21    -0.38  -0.17   0.32
+                      4                      5                      6
+                      A                      A                      A
+ Frequencies --    458.4829               618.6826               793.1173
+ Red. masses --      1.6299                 2.5539                 3.0611
+ Frc consts  --      0.2019                 0.5760                 1.1345
+ IR Inten    --      3.7338                31.4100                 6.0250
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.11  -0.01  -0.01    -0.13  -0.10   0.01    -0.08  -0.16  -0.07
+     2   1    -0.18  -0.05   0.52    -0.09   0.22   0.31    -0.10  -0.07   0.16
+     3   1     0.25  -0.07  -0.10    -0.22  -0.04   0.10    -0.15   0.16   0.28
+     4   7    -0.03   0.00  -0.11     0.13  -0.11  -0.03    -0.10   0.18   0.04
+     5   1    -0.22   0.20  -0.11     0.31  -0.36  -0.03     0.22  -0.45   0.07
+     6   7     0.03   0.00   0.11     0.13   0.11  -0.03     0.10   0.18  -0.04
+     7   1     0.22   0.20   0.11     0.31   0.36  -0.03    -0.22  -0.45  -0.07
+     8   7     0.11  -0.01   0.01    -0.13   0.10   0.01     0.08  -0.16   0.07
+     9   1     0.18  -0.05  -0.52    -0.09  -0.22   0.31     0.10  -0.07  -0.16
+    10   1    -0.25  -0.07   0.10    -0.22   0.04   0.10     0.15   0.16  -0.28
+                      7                      8                      9
+                      A                      A                      A
+ Frequencies --    829.8935               866.5195               976.0764
+ Red. masses --      2.8792                 2.1175                 1.2268
+ Frc consts  --      1.1683                 0.9368                 0.6886
+ IR Inten    --     58.7753               109.0128               107.0145
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.01   0.11   0.10     0.04  -0.05  -0.07     0.00   0.05   0.06
+     2   1     0.03   0.05  -0.26     0.06   0.32   0.37    -0.01  -0.19  -0.23
+     3   1     0.07  -0.30  -0.36    -0.20   0.26   0.31     0.15  -0.03  -0.06
+     4   7     0.02  -0.22  -0.05     0.18  -0.00  -0.02    -0.04   0.02  -0.04
+     5   1    -0.14   0.32  -0.09    -0.00   0.13  -0.02     0.38  -0.48  -0.02
+     6   7     0.02   0.22  -0.05    -0.18  -0.00   0.02    -0.04  -0.02  -0.04
+     7   1    -0.14  -0.32  -0.09     0.00   0.13   0.02     0.38   0.48  -0.02
+     8   7    -0.01  -0.11   0.10    -0.04  -0.05   0.07     0.00  -0.05   0.06
+     9   1     0.03  -0.05  -0.26    -0.06   0.32  -0.37    -0.01   0.19  -0.23
+    10   1     0.07   0.30  -0.36     0.20   0.26  -0.31     0.15   0.03  -0.06
+                     10                     11                     12
+                      A                      A                      A
+ Frequencies --   1048.6908              1083.9982              1219.3302
+ Red. masses --      1.8111                 1.8915                 1.9526
+ Frc consts  --      1.1735                 1.3095                 1.7105
+ IR Inten    --     50.2030                 6.1043                22.7870
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.08  -0.08   0.02    -0.07  -0.08  -0.00     0.04  -0.02  -0.05
+     2   1    -0.06  -0.21  -0.34    -0.05  -0.16  -0.27     0.04   0.19   0.24
+     3   1     0.04  -0.39  -0.34     0.01  -0.32  -0.28    -0.22  -0.02   0.02
+     4   7     0.08   0.10   0.02     0.11   0.09   0.06    -0.13  -0.03   0.12
+     5   1     0.02   0.20   0.03    -0.06   0.42   0.04    -0.22   0.51   0.10
+     6   7     0.08  -0.10   0.02    -0.11   0.09  -0.06     0.13  -0.03  -0.12
+     7   1     0.02  -0.20   0.03     0.06   0.42  -0.04     0.22   0.51  -0.10
+     8   7    -0.08   0.08   0.02     0.07  -0.08   0.00    -0.04  -0.02   0.05
+     9   1    -0.06   0.21  -0.34     0.05  -0.16   0.27    -0.04   0.19  -0.24
+    10   1     0.04   0.39  -0.34    -0.01  -0.32   0.28     0.22  -0.02  -0.02
+                     13                     14                     15
+                      A                      A                      A
+ Frequencies --   1297.4285              1301.1276              1453.7081
+ Red. masses --      1.2223                 1.2613                 1.1086
+ Frc consts  --      1.2123                 1.2580                 1.3803
+ IR Inten    --      3.7816                 8.0542                 0.8856
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.03  -0.03   0.04     0.05  -0.02   0.03    -0.00  -0.00  -0.03
+     2   1     0.15   0.43   0.09     0.16   0.44   0.14    -0.04  -0.11   0.01
+     3   1    -0.22  -0.36  -0.27    -0.26  -0.32  -0.24    -0.03   0.07   0.05
+     4   7    -0.02   0.03  -0.05    -0.06   0.04  -0.02    -0.03  -0.03   0.03
+     5   1     0.09  -0.12  -0.04     0.17  -0.02  -0.02     0.57   0.39  -0.01
+     6   7     0.02   0.03   0.05    -0.06  -0.04  -0.02    -0.03   0.03   0.03
+     7   1    -0.09  -0.12   0.04     0.17   0.02  -0.02     0.57  -0.39  -0.01
+     8   7    -0.03  -0.03  -0.04     0.05   0.02   0.03    -0.00   0.00  -0.03
+     9   1    -0.15   0.43  -0.09     0.16  -0.43   0.14    -0.04   0.11   0.01
+    10   1     0.22  -0.36   0.27    -0.26   0.32  -0.24    -0.03  -0.07   0.05
+                     16                     17                     18
+                      A                      A                      A
+ Frequencies --   1564.3627              1639.8395              1655.5762
+ Red. masses --      1.0756                 1.0828                 1.0866
+ Frc consts  --      1.5509                 1.7155                 1.7547
+ IR Inten    --      1.8812                28.0937                 9.3096
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00   0.02    -0.03  -0.04  -0.00    -0.04  -0.04  -0.00
+     2   1     0.03   0.07  -0.01     0.13   0.43  -0.22     0.12   0.43  -0.21
+     3   1     0.04  -0.02  -0.01     0.47   0.13   0.07     0.48   0.13   0.07
+     4   7     0.02   0.02   0.04    -0.01  -0.00   0.01    -0.02  -0.01   0.01
+     5   1    -0.63  -0.30   0.08     0.05   0.05   0.01     0.05   0.07   0.01
+     6   7    -0.02   0.02  -0.04    -0.01   0.00   0.01     0.02  -0.01  -0.01
+     7   1     0.63  -0.30  -0.08     0.05  -0.05   0.01    -0.05   0.07  -0.01
+     8   7    -0.00  -0.00  -0.02    -0.03   0.04  -0.00     0.04  -0.04   0.00
+     9   1    -0.03   0.07   0.01     0.13  -0.43  -0.22    -0.12   0.43   0.21
+    10   1    -0.04  -0.02   0.01     0.47  -0.13   0.07    -0.48   0.13  -0.07
+                     19                     20                     21
+                      A                      A                      A
+ Frequencies --   3436.4415              3439.1401              3450.9627
+ Red. masses --      1.0524                 1.0584                 1.0650
+ Frc consts  --      7.3224                 7.3757                 7.4727
+ IR Inten    --      3.4478                 4.5028                 0.0015
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.01   0.03  -0.03     0.01   0.02  -0.02    -0.01  -0.02   0.01
+     2   1    -0.27   0.08  -0.06    -0.21   0.06  -0.04     0.19  -0.05   0.04
+     3   1     0.08  -0.46   0.43     0.07  -0.38   0.35    -0.05   0.27  -0.25
+     4   7     0.00   0.00   0.01     0.00   0.00   0.03     0.00   0.00   0.04
+     5   1    -0.00  -0.01  -0.14    -0.01  -0.03  -0.42    -0.02  -0.03  -0.56
+     6   7     0.00  -0.00   0.01    -0.00   0.00  -0.03    -0.00   0.00  -0.04
+     7   1    -0.00   0.01  -0.14     0.01  -0.03   0.42     0.02  -0.03   0.56
+     8   7     0.01  -0.03  -0.03    -0.01   0.02   0.02     0.01  -0.02  -0.01
+     9   1    -0.27  -0.08  -0.06     0.21   0.06   0.04    -0.19  -0.05  -0.04
+    10   1     0.08   0.46   0.43    -0.07  -0.38  -0.35     0.05   0.27   0.25
+                     22                     23                     24
+                      A                      A                      A
+ Frequencies --   3474.4783              3556.7439              3557.0280
+ Red. masses --      1.0754                 1.0916                 1.0915
+ Frc consts  --      7.6488                 8.1365                 8.1370
+ IR Inten    --      2.3771                 1.8589                10.4055
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00   0.01  -0.00    -0.05   0.03  -0.02    -0.05   0.03  -0.02
+     2   1    -0.08   0.02  -0.02     0.63  -0.16   0.07     0.61  -0.15   0.07
+     3   1     0.01  -0.09   0.08     0.02  -0.20   0.21     0.02  -0.20   0.20
+     4   7    -0.00  -0.01  -0.05    -0.00   0.00  -0.00     0.00  -0.00  -0.00
+     5   1     0.02   0.04   0.69     0.00   0.00   0.03     0.00   0.00   0.03
+     6   7    -0.00   0.01  -0.05     0.00   0.00   0.00     0.00   0.00  -0.00
+     7   1     0.02  -0.04   0.69    -0.00   0.00  -0.03     0.00  -0.00   0.03
+     8   7     0.00  -0.01  -0.00     0.05   0.03   0.02    -0.05  -0.03  -0.02
+     9   1    -0.08  -0.02  -0.02    -0.61  -0.16  -0.07     0.63   0.16   0.07
+    10   1     0.01   0.09   0.08    -0.02  -0.20  -0.20     0.02   0.20   0.21
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  7 and mass  14.00307
+ Atom     2 has atomic number  1 and mass   1.00783
+ Atom     3 has atomic number  1 and mass   1.00783
+ Atom     4 has atomic number  7 and mass  14.00307
+ Atom     5 has atomic number  1 and mass   1.00783
+ Atom     6 has atomic number  7 and mass  14.00307
+ Atom     7 has atomic number  1 and mass   1.00783
+ Atom     8 has atomic number  7 and mass  14.00307
+ Atom     9 has atomic number  1 and mass   1.00783
+ Atom    10 has atomic number  1 and mass   1.00783
+ Molecular mass:    62.05925 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --   109.64541 305.18649 371.89299
+           X            0.99980   0.00000  -0.01990
+           Y           -0.00000   1.00000   0.00000
+           Z            0.01990  -0.00000   0.99980
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Rotational temperatures (Kelvin)      0.78995     0.28381     0.23290
+ Rotational constants (GHZ):          16.45980     5.91357     4.85285
+ Zero-point vibrational energy     230827.3 (Joules/Mol)
+                                   55.16905 (Kcal/Mol)
+ Warning -- explicit consideration of   5 degrees of freedom as
+           vibrations may cause significant error
+ Vibrational temperatures:    331.01   430.82   489.45   659.65   890.15
+          (Kelvin)           1141.12  1194.03  1246.73  1404.36  1508.83
+                             1559.63  1754.34  1866.71  1872.03  2091.56
+                             2250.77  2359.36  2382.00  4944.27  4948.16
+                             4965.17  4999.00  5117.36  5117.77
+ 
+ Zero-point correction=                           0.087917 (Hartree/Particle)
+ Thermal correction to Energy=                    0.092827
+ Thermal correction to Enthalpy=                  0.093771
+ Thermal correction to Gibbs Free Energy=         0.061005
+ Sum of electronic and zero-point Energies=           -222.521904
+ Sum of electronic and thermal Energies=              -222.516994
+ Sum of electronic and thermal Enthalpies=            -222.516050
+ Sum of electronic and thermal Free Energies=         -222.548816
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   58.250             16.924             68.962
+ Electronic               0.000              0.000              0.000
+ Translational            0.889              2.981             38.296
+ Rotational               0.889              2.981             24.035
+ Vibrational             56.472             10.963              6.631
+ Vibration     1          0.652              1.795              1.878
+ Vibration     2          0.692              1.675              1.420
+ Vibration     3          0.720              1.595              1.211
+ Vibration     4          0.817              1.342              0.771
+ Vibration     5          0.979              0.992              0.419
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.870000D-28        -28.060481        -64.611644
+ Total V=0       0.239174D+13         12.378714         28.503042
+ Vib (Bot)       0.113377D-39        -39.945477        -91.977859
+ Vib (Bot)    1  0.856073D+00         -0.067489         -0.155400
+ Vib (Bot)    2  0.635322D+00         -0.197006         -0.453623
+ Vib (Bot)    3  0.545776D+00         -0.262985         -0.605546
+ Vib (Bot)    4  0.371445D+00         -0.430106         -0.990355
+ Vib (Bot)    5  0.236702D+00         -0.625797         -1.440951
+ Vib (V=0)       0.311686D+01          0.493718          1.136827
+ Vib (V=0)    1  0.149139D+01          0.173592          0.399711
+ Vib (V=0)    2  0.130848D+01          0.116766          0.268863
+ Vib (V=0)    3  0.124018D+01          0.093486          0.215259
+ Vib (V=0)    4  0.112287D+01          0.050331          0.115891
+ Vib (V=0)    5  0.105320D+01          0.022510          0.051831
+ Electronic      0.100000D+01          0.000000          0.000000
+ Translational   0.192160D+08          7.283664         16.771255
+ Rotational      0.399330D+05          4.601332         10.594960
+ 
+                                                              N4H6 freq
+                                                             IR Spectrum
+ 
+     333333                                                              11  1   1   11  1    11                                     
+     554444                                                              66  5   4   32  2    00  9   887     6     4   3 2 2        
+     557533                                                              54  6   5   09  1    84  7   639     1     5   4 9 3        
+     774196                                                              60  4   4   17  9    49  6   703     9     8   0 9 0        
+ 
+     XXX XX                                                              XX  X   X   XX  X    XX  X   XXX     X     X   X X X        
+     X                                                                   XX              X     X  X   XX      X         X X          
+                                                                          X              X     X  X   XX      X         X X          
+                                                                          X              X     X  X   XX      X         X X          
+                                                                          X                    X  X   XX      X         X X          
+                                                                                               X  X   XX      X         X X          
+                                                                                               X  X   XX                X X          
+                                                                                               X  X   XX                  X          
+                                                                                               X  X   XX                  X          
+                                                                                                  X   XX                  X          
+                                                                                                  X   XX                  X          
+                                                                                                  X   X                   X          
+                                                                                                  X   X                   X          
+                                                                                                  X   X                              
+                                                                                                  X   X                              
+                                                                                                  X   X                              
+                                                                                                  X   X                              
+                                                                                                  X   X                              
+                                                                                                  X   X                              
+                                                                                                  X   X                              
+ 
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.001050399    0.000741755    0.001942572
+      2        1          -0.001033262   -0.000484926   -0.000185544
+      3        1           0.000214546    0.000773898   -0.001249705
+      4        7          -0.002109472   -0.001146254    0.001722869
+      5        1           0.000987864    0.000115129   -0.001288980
+      6        7           0.002108422   -0.001145687   -0.001723457
+      7        1          -0.000987752    0.000115061    0.001289781
+      8        7          -0.001048945    0.000741703   -0.001943201
+      9        1           0.001032705   -0.000484399    0.000185755
+     10        1          -0.000214505    0.000773719    0.001249909
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.002109472 RMS     0.001164810
+ Z-matrix is all fixed cartesians, so copy forces.
+ Force constants in Cartesian coordinates: 
+                1             2             3             4             5 
+      1  0.601174D+00
+      2  0.388131D-01  0.455477D+00
+      3 -0.114993D+00 -0.175157D+00  0.318740D+00
+      4 -0.397025D+00 -0.878749D-01  0.604283D-01  0.417345D+00
+      5 -0.104090D+00 -0.802176D-01  0.285522D-01  0.872319D-01  0.898698D-01
+      6  0.111309D-01  0.179820D-01 -0.175819D-01 -0.524509D-01 -0.201109D-01
+      7 -0.592275D-01 -0.657475D-02  0.315067D-01 -0.257023D-02 -0.283278D-01
+      8 -0.222067D-01 -0.209156D+00  0.166409D+00 -0.699977D-03 -0.533765D-02
+      9  0.507258D-01  0.213345D+00 -0.219928D+00 -0.550338D-02 -0.788841D-03
+     10 -0.942165D-01  0.366040D-01 -0.403118D-02 -0.145577D-01  0.387455D-01
+     11  0.284193D-01 -0.144241D+00  0.953351D-02 -0.346129D-02  0.808406D-03
+     12  0.371573D-01 -0.673690D-01 -0.936842D-01 -0.475843D-02 -0.401733D-02
+     13 -0.508266D-02  0.555547D-02  0.184035D-01 -0.598392D-03  0.165504D-02
+     14  0.122445D-01 -0.200676D-01 -0.377214D-01 -0.634347D-03 -0.620284D-03
+     15  0.643305D-02  0.209608D-02 -0.252933D-02 -0.356750D-04 -0.175554D-02
+     16 -0.526627D-01  0.175537D-01  0.811087D-02 -0.488329D-02  0.591804D-02
+     17  0.424975D-01 -0.919914D-02  0.993850D-02  0.437727D-02 -0.513668D-02
+     18  0.624120D-02  0.553413D-02  0.135510D-01  0.171320D-02 -0.193234D-02
+     19  0.264551D-02 -0.968130D-05  0.425199D-03  0.288711D-03 -0.218469D-03
+     20 -0.203591D-02 -0.332347D-03  0.160967D-02 -0.348235D-03  0.407501D-03
+     21  0.215977D-02  0.138507D-02  0.188597D-02  0.613787D-03 -0.114570D-03
+     22  0.152940D-02 -0.484296D-02  0.124898D-03  0.147333D-02 -0.129877D-02
+     23  0.484297D-02  0.606232D-02 -0.283144D-02  0.151395D-02 -0.342612D-03
+     24  0.124901D-03  0.283142D-02  0.190178D-04  0.140027D-03 -0.168006D-03
+     25  0.147333D-02 -0.151396D-02  0.140028D-03  0.118197D-03 -0.142283D-04
+     26  0.129879D-02 -0.342608D-03  0.168007D-03  0.142291D-04  0.527316D-03
+     27 -0.107026D-03  0.250640D-03 -0.234958D-03  0.130818D-04 -0.133116D-03
+     28  0.139285D-02  0.228998D-02 -0.115603D-03  0.410120D-03  0.398388D-03
+     29  0.216118D-03  0.201657D-02 -0.500806D-03 -0.118676D-03  0.417362D-04
+     30  0.112684D-02 -0.897885D-03 -0.238162D-03 -0.160042D-03  0.468373D-03
+                6             7             8             9            10 
+      6  0.313472D-01
+      7  0.281628D-01  0.600564D-01
+      8  0.795551D-02  0.182125D-01  0.245020D+00
+      9 -0.717996D-02 -0.433944D-01 -0.191323D+00  0.216507D+00
+     10  0.142646D-01  0.898391D-03  0.552701D-02  0.295333D-03  0.373041D+00
+     11 -0.632760D-02  0.147152D-01 -0.327954D-01 -0.209987D-01 -0.405908D-01
+     12 -0.575048D-02 -0.152871D-01  0.171050D-01  0.877033D-02  0.380790D-01
+     13  0.245407D-02  0.150600D-03 -0.402004D-03 -0.118464D-02 -0.414760D-01
+     14 -0.514771D-03 -0.229078D-03  0.207209D-02 -0.198675D-02  0.144615D-01
+     15 -0.151576D-02 -0.145670D-03  0.640512D-03  0.320038D-02  0.541833D-02
+     16 -0.360568D-02  0.632657D-03 -0.966215D-03 -0.156052D-02 -0.150301D+00
+     17  0.112542D-02  0.517123D-02 -0.197926D-02  0.151673D-02 -0.400313D-01
+     18  0.394215D-03 -0.167102D-03 -0.714311D-03  0.112670D-03 -0.549882D-01
+     19 -0.253374D-03 -0.290380D-03  0.482921D-03  0.451909D-03 -0.164746D-01
+     20 -0.857915D-04 -0.128932D-03 -0.551830D-03 -0.311030D-03  0.778918D-02
+     21  0.373801D-03 -0.154218D-03 -0.363271D-03 -0.154994D-03 -0.198243D-02
+     22 -0.107043D-03  0.139284D-02 -0.216121D-03  0.112685D-02 -0.526625D-01
+     23 -0.250638D-03 -0.228996D-02  0.201656D-02  0.897902D-03 -0.175533D-01
+     24 -0.234963D-03 -0.115603D-03  0.500807D-03 -0.238150D-03  0.811079D-02
+     25  0.130824D-04  0.410119D-03  0.118674D-03 -0.160045D-03 -0.488324D-02
+     26  0.133115D-03 -0.398391D-03  0.417389D-04 -0.468373D-03 -0.591806D-02
+     27 -0.643733D-04  0.391536D-03 -0.936513D-04  0.212269D-03 -0.360564D-02
+     28  0.391535D-03 -0.145288D-02  0.149950D-03 -0.796881D-03  0.632694D-03
+     29  0.936486D-04 -0.149947D-03  0.669023D-03  0.116960D-03  0.966222D-03
+     30  0.212274D-03 -0.796888D-03 -0.116962D-03 -0.130197D-02 -0.156051D-02
+               11            12            13            14            15 
+     11  0.285527D+00
+     12  0.534427D-01  0.634946D+00
+     13  0.149124D-01  0.423708D-01  0.678799D-01
+     14 -0.285797D-01  0.188284D-01 -0.220065D-01  0.455388D-01
+     15 -0.312842D-01 -0.408298D+00 -0.837772D-02  0.234651D-01  0.425533D+00
+     16  0.400312D-01 -0.549883D-01 -0.164747D-01 -0.778921D-02 -0.198250D-02
+     17 -0.645637D-01 -0.155563D-01  0.198035D-02  0.159779D-03  0.734157D-02
+     18  0.155565D-01 -0.130109D+00 -0.503606D-01 -0.454073D-03 -0.199332D-01
+     19 -0.198036D-02 -0.503605D-01 -0.704256D-02  0.144001D-02 -0.392913D-02
+     20  0.159731D-03  0.454070D-03 -0.144000D-02  0.197354D-02  0.403668D-03
+     21 -0.734161D-02 -0.199331D-01 -0.392914D-02 -0.403659D-03  0.143787D-02
+     22 -0.424972D-01  0.624122D-02  0.264551D-02  0.203592D-02  0.215975D-02
+     23 -0.919889D-02 -0.553424D-02  0.966133D-05 -0.332347D-03 -0.138508D-02
+     24 -0.993852D-02  0.135510D-01  0.425195D-03 -0.160967D-02  0.188595D-02
+     25 -0.437724D-02  0.171321D-02  0.288716D-03  0.348236D-03  0.613788D-03
+     26 -0.513672D-02  0.193235D-02  0.218470D-03  0.407499D-03  0.114577D-03
+     27 -0.112542D-02  0.394198D-03 -0.253368D-03  0.857993D-04  0.373803D-03
+     28 -0.517123D-02 -0.167104D-03 -0.290381D-03  0.128932D-03 -0.154219D-03
+     29 -0.197926D-02  0.714318D-03 -0.482917D-03 -0.551830D-03  0.363274D-03
+     30 -0.151672D-02  0.112666D-03  0.451909D-03  0.311029D-03 -0.154993D-03
+               16            17            18            19            20 
+     16  0.373041D+00
+     17  0.405896D-01  0.285526D+00
+     18  0.380800D-01 -0.534420D-01  0.634944D+00
+     19 -0.414764D-01 -0.149123D-01  0.423702D-01  0.678802D-01
+     20 -0.144615D-01 -0.285799D-01 -0.188288D-01  0.220064D-01  0.455390D-01
+     21  0.541786D-02  0.312837D-01 -0.408295D+00 -0.837733D-02 -0.234646D-01
+     22 -0.942162D-01 -0.284184D-01  0.371568D-01 -0.508269D-02 -0.122445D-01
+     23 -0.366032D-01 -0.144240D+00  0.673688D-01 -0.555552D-02 -0.200675D-01
+     24 -0.403174D-02 -0.953387D-02 -0.936838D-01  0.184035D-01  0.377213D-01
+     25 -0.145577D-01  0.346141D-02 -0.475855D-02 -0.598399D-03  0.634352D-03
+     26 -0.387454D-01  0.808597D-03  0.401701D-02 -0.165502D-02 -0.620257D-03
+     27  0.142646D-01  0.632759D-02 -0.575048D-02  0.245405D-02  0.514760D-03
+     28  0.898363D-03 -0.147154D-01 -0.152871D-01  0.150601D-03  0.229070D-03
+     29 -0.552712D-02 -0.327956D-01 -0.171050D-01  0.402003D-03  0.207207D-02
+     30  0.295402D-03  0.209987D-01  0.877027D-02 -0.118462D-02  0.198677D-02
+               21            22            23            24            25 
+     21  0.425530D+00
+     22  0.643303D-02  0.601176D+00
+     23 -0.209610D-02 -0.388158D-01  0.455475D+00
+     24 -0.252935D-02 -0.114990D+00  0.175157D+00  0.318740D+00
+     25 -0.356537D-04 -0.397028D+00  0.878757D-01  0.604259D-01  0.417347D+00
+     26  0.175554D-02  0.104091D+00 -0.802176D-01 -0.285515D-01 -0.872330D-01
+     27 -0.151576D-02  0.111284D-01 -0.179813D-01 -0.175812D-01 -0.524485D-01
+     28 -0.145672D-03 -0.592278D-01  0.657543D-02  0.315069D-01 -0.257038D-02
+     29 -0.640504D-03  0.222073D-01 -0.209155D+00 -0.166409D+00  0.700059D-03
+     30  0.320038D-02  0.507260D-01 -0.213345D+00 -0.219928D+00 -0.550330D-02
+               26            27            28            29            30 
+     26  0.898698D-01
+     27  0.201104D-01  0.313463D-01
+     28  0.283279D-01  0.281629D-01  0.600568D-01
+     29 -0.533777D-02 -0.795568D-02 -0.182130D-01  0.245020D+00
+     30  0.788935D-03 -0.717982D-02 -0.433948D-01  0.191322D+00  0.216507D+00
+ Leave Link  716 at Sat Jun  1 20:46:51 2019, MaxMem=   327680000 cpu:               4.3 elap:               0.1
+ (Enter /opt/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---    0.00401   0.00540   0.00696   0.01909   0.02815
+     Eigenvalues ---    0.05068   0.05985   0.06612   0.08284   0.11687
+     Eigenvalues ---    0.12313   0.14850   0.18469   0.20164   0.29749
+     Eigenvalues ---    0.32926   0.38279   0.54361   0.73842   0.77612
+     Eigenvalues ---    0.81891   0.93422   1.00619   1.07818
+ Angle between quadratic step and forces=  68.45 degrees.
+ Linear search not attempted -- first point.
+ B after Tr=    -0.000000   -0.002782   -0.000001
+         Rot=    1.000000   -0.000000    0.000877   -0.000000 Ang=   0.10 deg.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    X1        2.56996   0.00105   0.00000   0.01435   0.01494   2.58490
+    Y1       -1.01521   0.00074   0.00000   0.00469   0.00191  -1.01331
+    Z1       -0.34858   0.00194   0.00000   0.01256   0.01709  -0.33149
+    X2        4.42117  -0.00103   0.00000   0.00572   0.00670   4.42788
+    Y2       -0.56867  -0.00048   0.00000   0.01403   0.01125  -0.55742
+    Z2       -0.54785  -0.00019   0.00000  -0.01597  -0.00820  -0.55605
+    X3        2.40255   0.00021   0.00000   0.03358   0.03186   2.43441
+    Y3       -2.40215   0.00077   0.00000  -0.00154  -0.00433  -2.40647
+    Z3        0.97404  -0.00125   0.00000   0.00283   0.00710   0.98114
+    X4        1.26581  -0.00211   0.00000  -0.00567  -0.00640   1.25941
+    Y4        1.24639  -0.00115   0.00000  -0.01314  -0.01592   1.23047
+    Z4        0.41111   0.00172   0.00000   0.00409   0.00630   0.41741
+    X5        1.16441   0.00099   0.00000   0.01055   0.00647   1.17088
+    Y5        1.35259   0.00012   0.00000   0.00987   0.00709   1.35968
+    Z5        2.32754  -0.00129   0.00000  -0.00043   0.00162   2.32916
+    X6       -1.26581   0.00211   0.00000   0.00566   0.00639  -1.25941
+    Y6        1.24639  -0.00115   0.00000  -0.01314  -0.01592   1.23047
+    Z6       -0.41111  -0.00172   0.00000  -0.00409  -0.00630  -0.41741
+    X7       -1.16441  -0.00099   0.00000  -0.01055  -0.00647  -1.17088
+    Y7        1.35258   0.00012   0.00000   0.00987   0.00709   1.35968
+    Z7       -2.32754   0.00129   0.00000   0.00043  -0.00163  -2.32917
+    X8       -2.56997  -0.00105   0.00000  -0.01435  -0.01493  -2.58490
+    Y8       -1.01521   0.00074   0.00000   0.00469   0.00191  -1.01331
+    Z8        0.34859  -0.00194   0.00000  -0.01256  -0.01709   0.33149
+    X9       -4.42118   0.00103   0.00000  -0.00572  -0.00670  -4.42788
+    Y9       -0.56867  -0.00048   0.00000   0.01403   0.01125  -0.55742
+    Z9        0.54784   0.00019   0.00000   0.01598   0.00821   0.55605
+   X10       -2.40255  -0.00021   0.00000  -0.03359  -0.03187  -2.43442
+   Y10       -2.40214   0.00077   0.00000  -0.00155  -0.00433  -2.40647
+   Z10       -0.97404   0.00125   0.00000  -0.00283  -0.00710  -0.98114
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.002109     0.000450     NO 
+ RMS     Force            0.001165     0.000300     NO 
+ Maximum Displacement     0.031867     0.001800     NO 
+ RMS     Displacement     0.012305     0.001200     NO 
+ Predicted change in Energy=-8.205147D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sat Jun  1 20:46:51 2019, MaxMem=   327680000 cpu:               1.1 elap:               0.0
+ (Enter /opt/g16/l9999.exe)
+
+ ----------------------------------------------------------------------
+
+ Electric dipole moment (input orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.561300D+00      0.142668D+01      0.475890D+01
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y         -0.561300D+00     -0.142668D+01     -0.475890D+01
+   z          0.000000D+00      0.000000D+00      0.000000D+00
+
+ Dipole polarizability, Alpha (input orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.418275D+02      0.619819D+01      0.689642D+01
+   aniso      0.110974D+02      0.164446D+01      0.182971D+01
+   xx         0.488154D+02      0.723369D+01      0.804857D+01
+   yx         0.000000D+00      0.000000D+00      0.000000D+00
+   yy         0.400745D+02      0.593842D+01      0.660739D+01
+   zx         0.118170D+01      0.175110D+00      0.194836D+00
+   zy         0.000000D+00      0.000000D+00      0.000000D+00
+   zz         0.365925D+02      0.542245D+01      0.603329D+01
+
+ ----------------------------------------------------------------------
+
+ Dipole orientation:
+     7          2.56995911         -0.34856956          1.01522469
+     1          4.42117280         -0.54783432          0.56869152
+     1          2.40253786          0.97406051          2.40214748
+     7          1.26581334          0.41110318         -1.24638717
+     1          1.16440908          2.32753593         -1.35259477
+     7         -1.26580118         -0.41111661         -1.24639114
+     1         -1.16439810         -2.32755240         -1.35257552
+     7         -2.56996952          0.34858239          1.01520199
+     1         -4.42118024          0.54782911          0.56865438
+     1         -2.40255369         -0.97403462          2.40213826
+
+ Electric dipole moment (dipole orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.561300D+00      0.142668D+01      0.475890D+01
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.561300D+00      0.142668D+01      0.475890D+01
+
+ Dipole polarizability, Alpha (dipole orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.418275D+02      0.619819D+01      0.689642D+01
+   aniso      0.110974D+02      0.164446D+01      0.182971D+01
+   xx         0.488154D+02      0.723369D+01      0.804856D+01
+   yx         0.118174D+01      0.175116D+00      0.194842D+00
+   yy         0.365925D+02      0.542246D+01      0.603330D+01
+   zx         0.159692D-04      0.236639D-05      0.263297D-05
+   zy         0.261992D-04      0.388232D-05      0.431967D-05
+   zz         0.400745D+02      0.593842D+01      0.660739D+01
+
+ ----------------------------------------------------------------------
+
+ Test job not archived.
+ 1\1\GINC-NODE68\Freq\RB3LYP\6-311+G(3df,2p)\H6N4\ALONGD\01-Jun-2019\0\
+ \#P freq B3LYP/6-311+G(3df,2p) iop(2/9=2000)\\N4H6 freq\\0,1\N,1.35996
+ 49182,-0.5372284269,-0.1844623478\H,2.3395839261,-0.3009295463,-0.2899
+ 105412\H,1.2713739751,-1.2711604794,0.5154396044\N,0.669838164,0.65956
+ 06271,0.2175479134\H,0.6161803941,0.7157575412,1.2316809303\N,-0.66983
+ 59315,0.6595608435,-0.2175477925\H,-0.6161791467,0.7157569294,-1.23168
+ 17991\N,-1.3599670009,-0.5372271025,0.1844632493\H,-2.3395859466,-0.30
+ 09279831,0.289904486\H,-1.2713742512,-1.27115805,-0.5154398374\\Versio
+ n=EM64L-G16RevB.01\State=1-A\HF=-222.6098212\RMSD=8.269e-09\RMSF=1.165
+ e-03\ZeroPoint=0.0879175\Thermal=0.0928272\Dipole=0.0000018,-0.5613002
+ ,-0.0000031\DipoleDeriv=-0.3574526,0.025499,-0.093714,0.2515597,-0.257
+ 1042,-0.1489968,-0.0641207,-0.1152942,-0.3191018,0.0254779,0.0199682,-
+ 0.0083189,-0.0200331,0.1263238,0.022033,-0.0732015,0.0284424,0.2581414
+ ,0.1431963,0.0468552,0.053857,0.10593,0.071239,0.0499443,0.019222,0.12
+ 83296,0.0860776,0.0652515,-0.4571926,-0.0118314,-0.3487507,-0.1167955,
+ 0.1272498,0.114343,0.0009333,-0.060871,0.1235279,0.1099486,0.0600075,0
+ .1396864,0.1763377,0.0355489,0.0037567,-0.0388217,0.0357541,0.0652512,
+ 0.4571925,-0.0118323,0.3487505,-0.1167976,-0.1272499,0.1143439,-0.0009
+ 328,-0.0608702,0.1235275,-0.1099484,0.0600075,-0.1396867,0.1763377,-0.
+ 0355491,0.0037568,0.0388218,0.0357535,-0.3574549,-0.0255009,-0.093712,
+ -0.2515595,-0.2571031,0.1489964,-0.0641187,0.115294,-0.3191012,0.02547
+ 89,-0.019967,-0.0083202,0.0200329,0.1263235,-0.0220323,-0.0732032,-0.0
+ 28442,0.2581411,0.1431963,-0.0468546,0.0538569,-0.1059296,0.0712389,-0
+ .0499443,0.0192216,-0.1283305,0.0860766\Polar=48.8153629,0.0000054,40.
+ 0744707,1.1816993,-0.0000034,36.5925366\Quadrupole=2.8287939,-2.738301
+ 4,-0.0904924,-0.0000046,2.2478525,0.0000026\PG=C01 [X(H6N4)]\NImag=0\\
+ 0.60117360,0.03881309,0.45547746,-0.11499274,-0.17515720,0.31874024,-0
+ .39702536,-0.08787486,0.06042830,0.41734465,-0.10408963,-0.08021757,0.
+ 02855225,0.08723193,0.08986984,0.01113093,0.01798199,-0.01758195,-0.05
+ 245087,-0.02011088,0.03134719,-0.05922747,-0.00657475,0.03150671,-0.00
+ 257023,-0.02832782,0.02816278,0.06005636,-0.02220673,-0.20915569,0.166
+ 40896,-0.00069998,-0.00533765,0.00795551,0.01821249,0.24502042,0.05072
+ 580,0.21334473,-0.21992766,-0.00550338,-0.00078884,-0.00717996,-0.0433
+ 9443,-0.19132262,0.21650709,-0.09421651,0.03660395,-0.00403118,-0.0145
+ 5772,0.03874552,0.01426457,0.00089839,0.00552701,0.00029533,0.37304058
+ ,0.02841929,-0.14424140,0.00953351,-0.00346129,0.00080841,-0.00632760,
+ 0.01471515,-0.03279541,-0.02099871,-0.04059075,0.28552691,0.03715727,-
+ 0.06736897,-0.09368419,-0.00475843,-0.00401733,-0.00575048,-0.01528712
+ ,0.01710504,0.00877033,0.03807896,0.05344269,0.63494626,-0.00508266,0.
+ 00555547,0.01840351,-0.00059839,0.00165504,0.00245407,0.00015060,-0.00
+ 040200,-0.00118464,-0.04147604,0.01491239,0.04237078,0.06787986,0.0122
+ 4448,-0.02006759,-0.03772143,-0.00063435,-0.00062028,-0.00051477,-0.00
+ 022908,0.00207209,-0.00198675,0.01446152,-0.02857970,0.01882841,-0.022
+ 00646,0.04553884,0.00643305,0.00209608,-0.00252933,-0.00003567,-0.0017
+ 5554,-0.00151576,-0.00014567,0.00064051,0.00320038,0.00541833,-0.03128
+ 417,-0.40829757,-0.00837772,0.02346511,0.42553282,-0.05266268,0.017553
+ 73,0.00811087,-0.00488329,0.00591804,-0.00360568,0.00063266,-0.0009662
+ 1,-0.00156052,-0.15030112,0.04003124,-0.05498829,-0.01647466,-0.007789
+ 21,-0.00198250,0.37304098,0.04249754,-0.00919914,0.00993850,0.00437727
+ ,-0.00513668,0.00112542,0.00517123,-0.00197926,0.00151673,-0.04003128,
+ -0.06456366,-0.01555634,0.00198035,0.00015978,0.00734157,0.04058958,0.
+ 28552587,0.00624120,0.00553413,0.01355102,0.00171320,-0.00193234,0.000
+ 39421,-0.00016710,-0.00071431,0.00011267,-0.05498821,0.01555655,-0.130
+ 10905,-0.05036059,-0.00045407,-0.01993317,0.03808004,-0.05344197,0.634
+ 94353,0.00264551,-0.00000968,0.00042520,0.00028871,-0.00021847,-0.0002
+ 5337,-0.00029038,0.00048292,0.00045191,-0.01647457,-0.00198036,-0.0503
+ 6049,-0.00704256,0.00144001,-0.00392913,-0.04147638,-0.01491230,0.0423
+ 7024,0.06788016,-0.00203591,-0.00033235,0.00160967,-0.00034823,0.00040
+ 750,-0.00008579,-0.00012893,-0.00055183,-0.00031103,0.00778918,0.00015
+ 973,0.00045407,-0.00144000,0.00197354,0.00040367,-0.01446146,-0.028579
+ 88,-0.01882878,0.02200642,0.04553899,0.00215977,0.00138507,0.00188597,
+ 0.00061379,-0.00011457,0.00037380,-0.00015422,-0.00036327,-0.00015499,
+ -0.00198243,-0.00734161,-0.01993312,-0.00392914,-0.00040366,0.00143787
+ ,0.00541786,0.03128372,-0.40829516,-0.00837733,-0.02346461,0.42553037,
+ 0.00152940,-0.00484296,0.00012490,0.00147333,-0.00129877,-0.00010704,0
+ .00139284,-0.00021612,0.00112685,-0.05266245,-0.04249720,0.00624122,0.
+ 00264551,0.00203592,0.00215975,-0.09421618,-0.02841838,0.03715684,-0.0
+ 0508269,-0.01224448,0.00643303,0.60117585,0.00484297,0.00606232,-0.002
+ 83144,0.00151395,-0.00034261,-0.00025064,-0.00228996,0.00201656,0.0008
+ 9790,-0.01755331,-0.00919889,-0.00553424,0.00000966,-0.00033235,-0.001
+ 38508,-0.03660315,-0.14424007,0.06736880,-0.00555552,-0.02006752,-0.00
+ 209610,-0.03881578,0.45547484,0.00012490,0.00283142,0.00001902,0.00014
+ 003,-0.00016801,-0.00023496,-0.00011560,0.00050081,-0.00023815,0.00811
+ 079,-0.00993852,0.01355096,0.00042519,-0.00160967,0.00188595,-0.004031
+ 74,-0.00953387,-0.09368384,0.01840354,0.03772129,-0.00252935,-0.114989
+ 91,0.17515659,0.31873952,0.00147333,-0.00151396,0.00014003,0.00011820,
+ -0.00001423,0.00001308,0.00041012,0.00011867,-0.00016004,-0.00488324,-
+ 0.00437724,0.00171321,0.00028872,0.00034824,0.00061379,-0.01455769,0.0
+ 0346141,-0.00475855,-0.00059840,0.00063435,-0.00003565,-0.39702780,0.0
+ 8787571,0.06042594,0.41734715,0.00129879,-0.00034261,0.00016801,0.0000
+ 1423,0.00052732,0.00013311,-0.00039839,0.00004174,-0.00046837,-0.00591
+ 806,-0.00513672,0.00193235,0.00021847,0.00040750,0.00011458,-0.0387454
+ 4,0.00080860,0.00401701,-0.00165502,-0.00062026,0.00175554,0.10409051,
+ -0.08021755,-0.02855152,-0.08723301,0.08986975,-0.00010703,0.00025064,
+ -0.00023496,0.00001308,-0.00013312,-0.00006437,0.00039154,-0.00009365,
+ 0.00021227,-0.00360564,-0.00112542,0.00039420,-0.00025337,0.00008580,0
+ .00037380,0.01426456,0.00632759,-0.00575048,0.00245405,0.00051476,-0.0
+ 0151576,0.01112837,-0.01798128,-0.01758120,-0.05244849,0.02011036,0.03
+ 134632,0.00139285,0.00228998,-0.00011560,0.00041012,0.00039839,0.00039
+ 154,-0.00145288,0.00014995,-0.00079688,0.00063269,-0.00517123,-0.00016
+ 710,-0.00029038,0.00012893,-0.00015422,0.00089836,-0.01471542,-0.01528
+ 707,0.00015060,0.00022907,-0.00014567,-0.05922780,0.00657543,0.0315068
+ 6,-0.00257038,0.02832791,0.02816292,0.06005681,0.00021612,0.00201657,-
+ 0.00050081,-0.00011868,0.00004174,0.00009365,-0.00014995,0.00066902,0.
+ 00011696,0.00096622,-0.00197926,0.00071432,-0.00048292,-0.00055183,0.0
+ 0036327,-0.00552712,-0.03279555,-0.01710502,0.00040200,0.00207207,-0.0
+ 0064050,0.02220727,-0.20915473,-0.16640851,0.00070006,-0.00533777,-0.0
+ 0795568,-0.01821301,0.24501973,0.00112684,-0.00089789,-0.00023816,-0.0
+ 0016004,0.00046837,0.00021227,-0.00079689,-0.00011696,-0.00130197,-0.0
+ 0156051,-0.00151672,0.00011267,0.00045191,0.00031103,-0.00015499,0.000
+ 29540,0.02099865,0.00877027,-0.00118462,0.00198677,0.00320038,0.050725
+ 99,-0.21334451,-0.21992793,-0.00550330,0.00078893,-0.00717982,-0.04339
+ 478,0.19132233,0.21650728\\-0.00105040,-0.00074175,-0.00194257,0.00103
+ 326,0.00048493,0.00018554,-0.00021455,-0.00077390,0.00124970,0.0021094
+ 7,0.00114625,-0.00172287,-0.00098786,-0.00011513,0.00128898,-0.0021084
+ 2,0.00114569,0.00172346,0.00098775,-0.00011506,-0.00128978,0.00104894,
+ -0.00074170,0.00194320,-0.00103271,0.00048440,-0.00018576,0.00021451,-
+ 0.00077372,-0.00124991\\\@
+
+
+ The lyf so short, the craft so long to lerne.
+                             -- Chaucer
+ Job cpu time:       0 days  1 hours  4 minutes 23.3 seconds.
+ Elapsed time:       0 days  0 hours  1 minutes 49.4 seconds.
+ File lengths (MBytes):  RWF=     41 Int=      0 D2E=      0 Chk=      4 Scr=      1
+ Normal termination of Gaussian 16 at Sat Jun  1 20:46:52 2019.

--- a/examples/arkane/species/N4H6/N4H6/sp.out
+++ b/examples/arkane/species/N4H6/N4H6/sp.out
@@ -1,0 +1,457 @@
+
+ Primary working directories    : /scratch/alongd/1771
+ Secondary working directories  : /scratch/alongd/1771
+ Wavefunction directory         : /home/alongd/wfu/
+ Main file repository           : /scratch/alongd/1771/
+
+ SHA1      : 5e3d8ac6839c721e2824de82269b4736200146bd
+ NAME      : 2015.1.37
+ ARCHNAME  : linux/x86_64
+ FC        : /opt/intel/composer_xe_2015.1.133/bin/intel64/ifort
+ BLASLIB   : -Wl,-_start-group /opt/intel/mkl/lib/intel64/libmkl_intel_ilp64.a /opt/intel/mkl/lib/intel64/libmkl_intel_thread.a /opt/intel/mkl/lib/intel64/libmkl_core.a -Wl,-_end-group
+ id        : phalgunlolur
+
+ Nodes     nprocs
+ node08       1
+
+ Using customized tuning parameters: mindgm=1; mindgv=20; mindgc=4; mindgr=1; noblas=0; minvec=7
+ default implementation of scratch files=df  
+
+ ***,name
+ memory,2000,m;
+ geometry={angstrom;
+ N       1.3490484161    -0.5314844833    -0.1781687194
+ H       2.3214880793    -0.3011380410    -0.3179857560
+ H       1.2707256173    -1.2643405250     0.5173714145
+ N       0.6654382198     0.6506499550     0.2125830005
+ H       0.6329406300     0.7312692022     1.2214206909
+ N      -0.6654229177     0.6506478699    -0.2125902295
+ H      -0.6329210946     0.7312494526    -1.2214263332
+ N      -1.3490555730    -0.5314742478     0.1781722706
+ H      -2.3214790432    -0.3010816245     0.3180235061
+ H      -1.2708112050    -1.2643321203    -0.5173777782
+ }
+ basis=cc-pVTZ-f12
+ int;
+ {hf;wf,spin=0,charge=0;}
+ ccsd(t)-F12a;
+
+ Variables initialized (889), CPU time= 0.01 sec
+ Commands  initialized (702), CPU time= 0.01 sec, 572 directives.
+ Default parameters read. Elapsed time= 0.07 sec
+
+ Checking input...
+ Passed
+1
+
+
+                                         ***  PROGRAM SYSTEM MOLPRO  ***
+                                       Copyright, TTI GmbH Stuttgart, 2015
+                                    Version 2015.1 linked Aug 10 2018 15:00:15
+
+
+ **********************************************************************************************************************************
+ LABEL *   name                                                                          
+  64 bit serial version                                                                  DATE: 02-Jan-19          TIME: 19:14:00  
+ **********************************************************************************************************************************
+
+ SHA1:             5e3d8ac6839c721e2824de82269b4736200146bd
+ **********************************************************************************************************************************
+
+Geometry recognized as XYZ
+
+
+ Variable memory set to 2000000000 words,  buffer space   230000 words
+
+ SETTING BASIS          =    CC-PVTZ-F12
+
+
+ Using spherical harmonics
+
+ Library entry N      S cc-pVTZ-F12          selected for orbital group  1
+ Library entry N      P cc-pVTZ-F12          selected for orbital group  1
+ Library entry N      D cc-pVTZ-F12          selected for orbital group  1
+ Library entry N      F cc-pVTZ-F12          selected for orbital group  1
+ Library entry H      S cc-pVTZ-F12          selected for orbital group  2
+ Library entry H      P cc-pVTZ-F12          selected for orbital group  2
+ Library entry H      D cc-pVTZ-F12          selected for orbital group  2
+
+
+ PROGRAM * SEWARD (Integral evaluation for generally contracted gaussian basis sets)     Author: Roland Lindh, 1990
+
+ Geometry written to block  1 of record 700
+
+
+ Point group  C1  
+
+
+
+ ATOMIC COORDINATES
+
+ NR  ATOM    CHARGE       X              Y              Z
+
+   1  N       7.00    2.549332035   -1.004360113   -0.336690084
+   2  H       1.00    4.386976671   -0.569068423   -0.600905990
+   3  H       1.00    2.401323396   -2.389257320    0.977690278
+   4  N       7.00    1.257495988    1.229550218    0.401723650
+   5  H       1.00    1.196084444    1.381898515    2.308150589
+   6  N       7.00   -1.257467071    1.229546278   -0.401737311
+   7  H       1.00   -1.196047527    1.381861194   -2.308161251
+   8  N       7.00   -2.549345560   -1.004340771    0.336696794
+   9  H       1.00   -4.386959596   -0.568961811    0.600977328
+  10  H       1.00   -2.401485133   -2.389241438   -0.977702304
+
+ Bond lengths in Bohr (Angstrom)
+
+ 1-2  1.906889276  1-3  1.915056805  1-4  2.684110761  4-5  1.913490281  4-6  2.640187248
+     ( 1.009082348)     ( 1.013404419)     ( 1.420370247)     ( 1.012575450)     ( 1.397126924)
+
+  6- 7  1.913484893   6- 8  2.684117416   8- 9  1.906888666   8-10  1.915060718
+       ( 1.012572599)       ( 1.420373768)       ( 1.009082026)       ( 1.013406489)
+
+ Bond angles
+
+  1-4-5  110.84250698   1-4-6  112.00832182   2-1-3  109.55169603   2-1-4  108.17654222
+
+  3-1-4  112.07713882   4-6-7  105.82027683   4-6-8  112.00920602   5-4-6  105.82051083
+
+  6- 8- 9  108.17540291   6- 8-10  112.07847792   7- 6- 8  110.84217350   9- 8-10  109.55058497
+
+ NUCLEAR CHARGE:                   34
+ NUMBER OF PRIMITIVE AOS:         414
+ NUMBER OF SYMMETRY AOS:          372
+ NUMBER OF CONTRACTIONS:          320   ( 320A   )
+ NUMBER OF CORE ORBITALS:           4   (   4A   )
+ NUMBER OF VALENCE ORBITALS:       22   (  22A   )
+
+
+ NUCLEAR REPULSION ENERGY  139.19462539
+
+
+ Eigenvalues of metric
+
+         1 0.496E-04 0.663E-04 0.922E-04 0.145E-03 0.183E-03 0.223E-03 0.224E-03 0.266E-03
+
+
+ Contracted 2-electron integrals neglected if value below      1.0D-12
+ AO integral compression algorithm  1   Integral accuracy      1.0D-12
+
+     6055.264 MB (compressed) written to integral file ( 51.4%)
+
+
+ NUMBER OF SORTED TWO-ELECTRON INTEGRALS: 1318950480.     BUFFER LENGTH:  32768
+ NUMBER OF SEGMENTS:  42  SEGMENT LENGTH:   31998710      RECORD LENGTH: 524288
+
+ Memory used in sort:      32.56 MW
+
+ SORT1 READ  1472898490. AND WROTE  1263573912. INTEGRALS IN   3636 RECORDS. CPU TIME:    17.44 SEC, REAL TIME:    38.60 SEC
+ SORT2 READ  1263573912. AND WROTE  1318950480. INTEGRALS IN  23099 RECORDS. CPU TIME:    16.85 SEC, REAL TIME:    22.73 SEC
+
+ FILE SIZES:   FILE 1:  6079.1 MBYTE,  FILE 4: 15250.5 MBYTE,   TOTAL:  21329.6 MBYTE
+
+ OPERATOR DM      FOR CENTER  0  COORDINATES:    0.000000    0.000000    0.000000
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      19     5527.93       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1300     1700   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
+
+ PROGRAMS   *        TOTAL       INT
+ CPU TIMES  *        81.98     81.86
+ REAL TIME  *       174.36 SEC
+ DISK USED  *        21.33 GB      
+ **********************************************************************************************************************************
+
+
+ PROGRAM * RHF-SCF (CLOSED SHELL)       Authors: W. Meyer, H.-J. Werner
+
+
+ NUMBER OF ELECTRONS:      17+   17-    SPACE SYMMETRY=1    SPIN SYMMETRY: Singlet 
+ CONVERGENCE THRESHOLDS:    1.00E-05 (Density)    1.00E-07 (Energy)
+ MAX. NUMBER OF ITERATIONS:       60
+ INTERPOLATION TYPE:            DIIS
+ INTERPOLATION STEPS:              2 (START)      1 (STEP)
+ LEVEL SHIFTS:                  0.00 (CLOSED)  0.00 (OPEN) 
+
+
+
+ Orbital guess generated from atomic densities. Full valence occupancy:   26
+
+ Molecular orbital dump at record        2100.2
+
+ Initial occupancy:  17
+
+ ITERATION    DDIFF          GRAD             ENERGY        2-EL.EN.            DIPOLE MOMENTS         DIIS   ORB.
+    1      0.000D+00      0.000D+00      -221.23004551    433.679388   -0.00003   -0.66168    0.00002    0    start
+    2      0.000D+00      0.311D-02      -221.27643288    433.168658   -0.00002   -0.58394    0.00001    1    diag
+    3      0.294D-02      0.928D-03      -221.28016515    433.551953   -0.00002   -0.51476    0.00001    2    diag
+    4      0.785D-03      0.370D-03      -221.28088833    433.439349   -0.00002   -0.55694    0.00001    3    diag
+    5      0.325D-03      0.967D-04      -221.28095197    433.440625   -0.00002   -0.54724    0.00001    4    diag
+    6      0.101D-03      0.170D-04      -221.28095577    433.450333   -0.00002   -0.54940    0.00001    5    diag
+    7      0.366D-04      0.529D-05      -221.28095613    433.443071   -0.00002   -0.54941    0.00001    6    diag
+    8      0.121D-04      0.209D-05      -221.28095618    433.446205   -0.00002   -0.54960    0.00001    7    diag
+    9      0.404D-05      0.645D-06      -221.28095618    433.445266   -0.00002   -0.54962    0.00001    0    orth
+
+ Final occupancy:  17
+
+ !RHF STATE 1.1 Energy               -221.280956182954
+ Nuclear energy                       139.19462539
+ One-electron energy                 -577.19821448
+ Two-electron energy                  216.72263291
+ Virial quotient                       -1.00105577
+ !RHF STATE 1.1 Dipole moment          -0.00002028    -0.54961866     0.00001223
+ Dipole moment /Debye                  -0.00005154    -1.39689978     0.00003108
+
+ Orbital energies:
+
+         1.1          2.1          3.1          4.1          5.1          6.1          7.1          8.1          9.1         10.1
+    -15.596124   -15.595573   -15.566891   -15.566887    -1.346808    -1.211887    -1.072562    -0.917505    -0.723656    -0.694763
+
+        11.1         12.1         13.1         14.1         15.1         16.1         17.1         18.1         19.1
+     -0.654415    -0.637656    -0.632248    -0.428784    -0.423876    -0.409918    -0.396920     0.066918     0.067756
+
+ HOMO     17.1    -0.396920 =     -10.8008eV
+ LUMO     18.1     0.066918 =       1.8209eV
+ LUMO-HOMO         0.463838 =      12.6217eV
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      19     5527.93       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1300     1700   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
+
+              2       4        5.00       700     1000      520     2100   
+                                         GEOM     BASIS   MCVARS     RHF  
+
+ PROGRAMS   *        TOTAL        HF       INT
+ CPU TIMES  *       214.71    132.73     81.86
+ REAL TIME  *       355.08 SEC
+ DISK USED  *        21.33 GB      
+ **********************************************************************************************************************************
+
+
+ PROGRAM * CCSD (Closed-shell coupled cluster)     Authors: C. Hampel, H.-J. Werner, 1991, M. Deegan, P.J. Knowles, 1992
+
+                                  CCSD-F12 implementation by  H.-J. Werner, 2007
+
+                   Density fitting integral evaluation by F.R. Manby, 2003,2007, G. Knizia, 2010
+
+ Basis set AUG-CC-PVTZ/JKFIT generated.  Number of basis functions:   692 
+ Basis set CC-PVTZ-F12/OPTRI generated.  Number of basis functions:   546 
+ Basis set AUG-CC-PVTZ/MP2FIT generated. Number of basis functions:   700 
+
+ Convergence thresholds:  THRVAR = 1.00D-08  THRDEN = 1.00D-06
+
+ CCSD(T)     terms to be evaluated (factor= 1.000)
+
+
+ Number of core orbitals:           4 (   4 )
+ Number of closed-shell orbitals:  13 (  13 )
+ Number of external orbitals:     303 ( 303 )
+
+ Molecular orbitals read from record     2100.2  Type=RHF/CANONICAL (state 1.1)
+
+ MP2-F12 correlation treatment (H.-J. Werner, 2006)
+ ==================================================
+
+ Using MP2-F12 with ansatz 3C(FIX)
+
+ Using projected zeroth-order Hamiltonian (+Z)
+
+ FOCKRIB=T FOCKRIC=T FOCKRIP=T CABSP=T CABSA=T CABSK=T CABSF=T GBC=F EBC=F DMAT=T NOFIK=T NOPAO=1 SOLVE=-1  USEPAO=0
+ EXCH_A= T EXCH_B= F EXCH_C= F EXCH_P= F
+ 
+ Geminal basis:    OPTFULL  GEM_TYPE=SLATER  BETA=1.0  NGEM=6
+
+ Optimizing Gaussian exponents for each gem_beta
+
+ Geminal optimization for beta= 1.0000
+ Weight function:   m=0, omega= 1.4646
+
+ Augmented Hessian optimization of geminal fit. Trust ratio= 0.40000
+ Convergence reached after   2 iterations. Final gradient= 8.41D-16, Step= 4.29D-06, Delta= 1.28D-09
+ 
+ Alpha:                 0.19532     0.81920     2.85917     9.50073    35.69989   197.79328
+ Coeff:                 0.27070     0.30552     0.18297     0.10986     0.06810     0.04224
+ 
+
+ All pairs explicitly correlated. Number of r12-pairs:           91
+
+ Excluding core orbitals from MO domains
+ 
+ AO(A)-basis ORBITAL           loaded. Number of functions:     320
+ RI(R)-basis CC-PVTZ-F12/OPTRI loaded. Number of functions:     546
+ DF-basis AUG-CC-PVTZ/JKFIT    loaded. Number of functions:     692
+
+ Screening thresholds:   THRAO=  1.00D-10  THRMO=  1.00D-09  THRPROD=  1.00D-09
+                         THRSW=  1.00D-05  THROV=  1.00D-12  THRAOF12=   1.00D-08
+
+ CPU time for Fock operators                      8.35 sec
+ 
+ Construction of ABS:
+ Smallest eigenvalue of S          1.14E-04  (threshold= 1.00E-08)
+ Ratio eigmin/eigmax               1.28E-05  (threshold= 1.00E-09)
+ Smallest eigenvalue of S kept     1.14E-04  (threshold= 1.14E-04, 0 functions deleted, 546 kept)
+ 
+ Construction of CABS:
+ Smallest eigenvalue of S          4.90E-07  (threshold= 1.00E-08)
+ Ratio eigmin/eigmax               4.90E-07  (threshold= 1.00E-09)
+ Smallest eigenvalue of S kept     4.90E-07  (threshold= 4.90E-07, 0 functions deleted, 546 kept)
+ 
+ CPU time for CABS singles                        0.25 sec
+
+ CABS-singles contribution of  -0.00270998 patched into reference energy.
+ New reference energy        -221.28366616
+ 
+ AO(A)-basis ORBITAL           loaded. Number of functions:     320
+ RI(R)-basis CC-PVTZ-F12/OPTRI loaded. Number of functions:     546
+ DF-basis AUG-CC-PVTZ/MP2FIT   loaded. Number of functions:     700
+
+ Screening thresholds:   THRAO=  1.00D-10  THRMO=  1.00D-09  THRPROD=  1.00D-09
+                         THRSW=  1.00D-05  THROV=  1.00D-12  THRAOF12=   1.00D-08
+
+ CPU time for 3-index integral evaluation        18.04 sec
+ CPU time for first  half transformation          1.58 sec (16307.2 MFLOP/sec)
+ CPU time for second half transformation          0.11 sec ( 6300.5 MFLOP/sec)
+ CPU time for sorting                             0.14 sec
+ CPU time for fitting                             0.32 sec (36508.1 MFLOP/sec)
+ CPU time for tilde quantities                    0.36 sec (43174.4 MFLOP/sec)
+ CPU time for assembly                            5.49 sec (41253.8 MFLOP/sec)
+ CPU time for tranop_f12                          7.31 sec (41257.4 MFLOP/sec)
+ CPU time for f12 integrals (total)              42.07 sec, Elapsed time:     51.44 sec
+ CPU time for f12 matrices (total)                2.97 sec, Elapsed time:      4.85 sec
+
+ Diagonal F12 approximation with fixed coefficients:  TSING= 0.500,  TTRIP= 0.250 (scaled by -1/beta)
+
+ DF-MP2-F12 energy corrections:
+ ==============================
+ Approx.                                    Singlet             Triplet             Total
+ DF-MP2-F12/3*C(DX,FIX)                -0.069228063438     -0.007803977266     -0.077032040704
+ DF-MP2-F12/3*C(FIX)                   -0.065989070338     -0.007593944296     -0.073583014634
+ DF-MP2-F12/3C(FIX)                    -0.066462544179     -0.007938381221     -0.074400925400
+
+ DF-MP2-F12 correlation energies:
+ ================================
+ Approx.                                    Singlet             Triplet             Ecorr            Total Energy
+ DF-MP2                                -0.564873786501     -0.324096821070     -0.888970607571   -222.172636769666
+ DF-MP2-F12/3*C(DX,FIX)                -0.634101849939     -0.331900798336     -0.966002648275   -222.249668810370
+ DF-MP2-F12/3*C(FIX)                   -0.630862856839     -0.331690765366     -0.962553622205   -222.246219784300
+ DF-MP2-F12/3C(FIX)                    -0.631336330680     -0.332035202291     -0.963371532971   -222.247037695066
+
+ SCS-DF-MP2 energies (F_SING= 1.20000  F_TRIP= 0.62222  F_PARALLEL= 0.33333):
+ ============================================================================
+ SCS-DF-MP2                            -0.879508788022   -222.163174950118
+ SCS-DF-MP2-F12/3*C(DX,FIX)            -0.967438272225   -222.251104434320
+ SCS-DF-MP2-F12/3*C(FIX)               -0.963420793323   -222.247086955419
+ SCS-DF-MP2-F12/3C(FIX)                -0.964203278242   -222.247869440337
+ Symmetry transformation completed.
+
+ Number of N-1 electron functions:              13
+ Number of N-2 electron functions:              91
+ Number of singly external CSFs:              3939
+ Number of doubly external CSFs:           7759830
+ Total number of CSFs:                     7763770
+
+ Length of J-op  integral file:               1.08 GB
+ Length of K-op  integral file:               1.28 GB
+ Length of 3-ext integral record:             0.00 MB
+
+ Memory could be reduced to 451.34 Mwords without degradation in triples
+
+ Integral transformation finished. Total CPU:  72.06 sec, npass=  1  Memory used: 247.74 MW
+
+ Reference energy:                   -221.28366616
+
+ Adding F12 terms to K(Cij), methodcc=4,  factor= 1.0
+
+ ITER.      SQ.NORM     CORR.ENERGY   TOTAL ENERGY   ENERGY CHANGE        DEN1      VAR(S)    VAR(P)  DIIS     TIME  TIME/IT
+   1      1.23872402    -0.89752398  -222.18119014    -0.00841835     0.01307270  0.31D-02  0.38D-02  1  1   215.04    93.78
+   2      1.25299210    -0.89808002  -222.18174619    -0.00055605    -0.01764457  0.75D-04  0.46D-03  2  2   305.12    96.12
+   3      1.25840161    -0.89838460  -222.18205077    -0.00030458    -0.00333380  0.51D-04  0.31D-04  3  3   394.87    95.71
+   4      1.26068520    -0.89846688  -222.18213305    -0.00008228    -0.00126912  0.58D-05  0.38D-05  4  4   484.05    95.50
+   5      1.26131744    -0.89848253  -222.18214869    -0.00001565    -0.00015838  0.18D-05  0.38D-06  5  5   573.50    96.12
+   6      1.26154930    -0.89847406  -222.18214022     0.00000847    -0.00002031  0.23D-06  0.61D-07  6  6   662.67    95.48
+   7      1.26162580    -0.89847043  -222.18213659     0.00000363    -0.00000989  0.22D-07  0.89D-08  6  1   751.94    95.61
+   8      1.26164188    -0.89847050  -222.18213667    -0.00000008    -0.00000024  0.37D-08  0.13D-08  6  3   842.43    95.65
+   9      1.26164958    -0.89847019  -222.18213636     0.00000031    -0.00000163  0.49D-09  0.18D-09  6  2   931.54    95.32
+
+ Norm of t1 vector:      0.07750381      S-energy:     0.00000001      T1 diagnostic:  0.01074784
+                                                                       D1 diagnostic:  0.02651048
+
+
+ Total CPU time for triples:   2144.98 sec
+
+
+ RESULTS
+ =======
+
+  Reference energy                   -221.280956182952
+  F12 singles correction               -0.002709979144
+
+ F12 singles corrections added to reference energy
+
+  New reference energy               -221.283666162095
+
+  F12a singlet correction              -0.065446453167
+  F12a triplet correction              -0.007588360633
+  F12a total correction                -0.073034813801
+
+ F12a corrections for ansatz F12/3C(FIX) added to CCSD energy
+ 
+  CCSD-F12a singlet pair energy        -0.673311737212
+  CCSD-F12a triplet pair energy        -0.298193276026
+  CCSD-F12a correlation energy         -0.971505007094
+
+  Triples (T) contribution             -0.037881976808
+  Total correlation energy             -1.009386983902
+
+  CCSD-F12a total energy             -222.255171169189
+  CCSD[T]-F12a energy                -222.294073492707
+  CCSD-T-F12a energy                 -222.292621039899
+ !CCSD(T)-F12a total energy          -222.293053145997
+
+ Timing summary (sec):
+
+ STEP                 CPU(USER)    SYS     CPU(TOT)    WALL
+ Transformation         72.94      4.34     77.28     77.28
+ CCSD iterations       804.06     22.50    826.56    859.92
+ Triples              2144.98     57.65   2202.63   2202.64
+ MP2-F12                54.60      6.11     60.71     86.83
+
+ Program statistics:
+
+ Available memory in ccsd:              1999998769
+ Min. memory needed in ccsd:              19614516
+ Max. memory used in ccsd:                26641874
+ Max. memory used in cckext:              19531381 ( 9 integral passes)
+
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      20     7092.83       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1300     1700     1380   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER     JKOP   
+
+              2       6        7.06       700     1000      520     2100     7360     7350   
+                                         GEOM     BASIS   MCVARS     RHF    F12ABS    EF12   
+
+ PROGRAMS   *        TOTAL   CCSD(T)        HF       INT
+ CPU TIMES  *      3291.35   3076.63    132.73     81.86
+ REAL TIME  *      3583.99 SEC
+ DISK USED  *        21.33 GB      
+ **********************************************************************************************************************************
+
+ CCSD(T)-F12A/cc-pVTZ-F12 energy=   -222.293053145997
+
+    CCSD(T)-F12A        HF-SCF  
+   -222.29305315   -221.28095618
+ **********************************************************************************************************************************
+ Molpro calculation terminated
+ Variable memory released

--- a/examples/arkane/species/N4H6/input.py
+++ b/examples/arkane/species/N4H6/input.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+title = 'N4H6 thermo'
+
+modelChemistry = "CCSD(T)-F12/cc-pVTZ-f12//B3LYP/6-311+G(3df,2p)"
+
+useHinderedRotors = True
+useBondCorrections = True
+
+species('N4H6','N4H6/N4H6.py')
+
+thermo('N4H6', 'NASA')


### PR DESCRIPTION
### Motivation or Problem
If the user did not specify the frequency scaling factor, Arkane uses the model chemistry to determine it from a dictionary. However, the model chemistry in Arkane currently respesents the sp level, whereas the freq level should have been used instead.

### Description of Changes
Arkane can now process a model chemistry in an sp//freq form, e.g., `CCSD(T)-F12a/aug-cc-pVTZ//B3LYP/6-311++G(3df,3pd)`, and determines the frequency scaling factor from the **freq** level, if available.
Also, if the frequency scaling factor was not specified and could not be determined from the dictionary, we now raise an error instead of setting it to `1` and warn the user. This way, software like ARC could capture the error and attempt to derive the frequency scaling factor by itself.

### Testing
Added an example which also runs in RMG's tests. Also added a unit test for the new `process_model_chemistry` function.

