### PR TITLE
Don't hard-code for CBS-QB3-Paraskevas in process_model_chemistry

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -703,7 +703,4 @@ def process_model_chemistry(model_chemistry):
         # assume the sp and freq levels are the same, assign the model chemistry to both
         # (this could also be a composite method, and we'll expect the same behavior)
         sp_level = freq_level = model_chemistry
-        if model_chemistry.startswith('cbs-qb3'):
-            # hard code for CBS-QB3-Paraskevas which has the same frequency scaling factor as CBS-QB3
-            freq_level = 'cbs-qb3'
     return sp_level, freq_level

--- a/arkane/inputTest.py
+++ b/arkane/inputTest.py
@@ -207,9 +207,9 @@ class InputTest(unittest.TestCase):
         self.assertEqual(sp, 'wb97x-d3/def2-tzvp')
         self.assertEqual(freq, 'wb97x-d3/def2-tzvp')
 
-        mc = 'cbs-qb3-paraskevas'
+        mc = 'cbs-qb3'
         sp, freq = process_model_chemistry(mc)
-        self.assertEqual(sp, 'cbs-qb3-paraskevas')
+        self.assertEqual(sp, 'cbs-qb3')
         self.assertEqual(freq, 'cbs-qb3')
 
         with self.assertRaises(InputError):


### PR DESCRIPTION
It already has a frequency scaling factor under Arkane statmech assign_frequency_scale_factor()

I chose to remove the newly added hard-coding instead of the table entry to leave the code generic, assuming that the scaling factor dictionary is more likely to change soon anyway (e.g., if we fit our own BACs).

Thanks, @mliu49, for spotting this duplicity.