### PR TITLE
Small catalysis related fixes for website operation

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1169,9 +1169,12 @@ class KineticsFamily(Database):
                     quantumMechanics.runJobs(item.reactants+item.products, procnum=procnum)
 
             for reactant in item.reactants:
+                # Clear atom labels to avoid effects on thermo generation, ok because this is a deepcopy
+                reactant.molecule[0].clearLabeledAtoms()
                 reactant.generate_resonance_structures()
                 reactant.thermo = thermoDatabase.getThermoData(reactant, trainingSet=True)
             for product in item.products:
+                product.molecule[0].clearLabeledAtoms()
                 product.generate_resonance_structures()
                 product.thermo = thermoDatabase.getThermoData(product,trainingSet=True)
             # Now that we have the thermo, we can get the reverse k(T)

--- a/rmgpy/kinetics/surface.pxd
+++ b/rmgpy/kinetics/surface.pxd
@@ -44,6 +44,8 @@ cdef class StickingCoefficient(KineticsModel):
 
     cpdef changeT0(self, double T0)
 
+    cpdef fitToData(self, numpy.ndarray Tlist, numpy.ndarray klist, str kunits, double T0=?, numpy.ndarray weights=?, bint threeParams=?)
+
     cpdef bint isIdenticalTo(self, KineticsModel otherKinetics) except -2
     
     cpdef changeRate(self, double factor)

--- a/rmgpy/molecule/util.py
+++ b/rmgpy/molecule/util.py
@@ -52,6 +52,12 @@ def retrieveElementCount(obj):
                     element_count[element] += int(count)
                 else:
                     element_count[element] = int(count)
+
+        # For surface species, replace Pt with X again
+        if 'Pt' in element_count:
+            element_count['X'] = element_count['Pt']
+            del element_count['Pt']
+
         return element_count
     
     elif isinstance(obj, Molecule):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
In order to get the RMG-website working with latest version of RMG. May add additional commits if new issues are discovered.

### Description of Changes
- Set default values for deltaAtomicAdsorptionEnergy when loading the thermo database. Somewhat addresses cfgoldsmith/RMG-Py#76
- Clear atom labels before getting thermo when adding training reactions. Somehow this is only an issue when using `getThermoDataForSurfaceSpecies`. This is likely the problem we were encountering during the catmerge hackathon.
- Add `StickingCoefficient.fitToData` method which is used by the results page of kinetics search. Simply a copy of `Arrhenius.fitToData`.
- Convert Pt back to X when getting element counts from InChI for validating InChI generation.

### Testing
Suggestions for cat examples to run would be appreciated. Also, it would be a good idea to identify a cat example which could be added to RMG-tests (main requirement is completing in less than 4.5 min).

### Reviewer Tips
Make sure tests pass. Should run a catalysis job to make sure functionality is unchanged.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
