### PR TITLE
Scaling zpe

### DIFF
--- a/arkane/gaussian.py
+++ b/arkane/gaussian.py
@@ -45,7 +45,6 @@ from rmgpy.exceptions import InputError
 from arkane.common import check_conformer_energy, get_element_mass
 from arkane.log import Log
 
-
 ################################################################################
 
 
@@ -65,23 +64,20 @@ class GaussianLog(Log):
         Return the number of atoms in the molecular configuration used in
         the Gaussian log file.
         """
-
         Natoms = 0
-        # Open Gaussian log file for parsing
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '' and Natoms == 0:
-            # Automatically determine the number of atoms
-            if 'Input orientation:' in line and Natoms == 0:
-                for i in range(5):
-                    line = f.readline()
-                while '---------------------------------------------------------------------' not in line:
-                    Natoms += 1
-                    line = f.readline()
+
+        with open(self.path, 'r') as f:
             line = f.readline()
-        # Close file when finished
-        f.close()
-        # Return the result
+            while line != '' and Natoms == 0:
+                # Automatically determine the number of atoms
+                if 'Input orientation:' in line and Natoms == 0:
+                    for i in range(5):
+                        line = f.readline()
+                    while '---------------------------------------------------------------------' not in line:
+                        Natoms += 1
+                        line = f.readline()
+                line = f.readline()
+
         return Natoms
 
     def loadForceConstantMatrix(self):
@@ -94,32 +90,29 @@ class GaussianLog(Log):
         are J/m^2. If no force constant matrix can be found in the log file,
         ``None`` is returned.
         """
-
         F = None
 
         Natoms = self.getNumberOfAtoms()
         Nrows = Natoms * 3
 
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-            # Read force constant matrix
-            if 'Force constants in Cartesian coordinates:' in line:
-                F = numpy.zeros((Nrows, Nrows), numpy.float64)
-                for i in range(int(math.ceil(Nrows / 5.0))):
-                    # Header row
-                    line = f.readline()
-                    # Matrix element rows
-                    for j in range(i * 5, Nrows):
-                        data = f.readline().split()
-                        for k in range(len(data) - 1):
-                            F[j, i * 5 + k] = float(data[k + 1].replace('D', 'E'))
-                            F[i * 5 + k, j] = F[j, i * 5 + k]
-                # Convert from atomic units (Hartree/Bohr_radius^2) to J/m^2
-                F *= 4.35974417e-18 / 5.291772108e-11 ** 2
+        with open(self.path, 'r') as f:
             line = f.readline()
-        # Close file when finished
-        f.close()
+            while line != '':
+                # Read force constant matrix
+                if 'Force constants in Cartesian coordinates:' in line:
+                    F = numpy.zeros((Nrows, Nrows), numpy.float64)
+                    for i in range(int(math.ceil(Nrows / 5.0))):
+                        # Header row
+                        line = f.readline()
+                        # Matrix element rows
+                        for j in range(i * 5, Nrows):
+                            data = f.readline().split()
+                            for k in range(len(data) - 1):
+                                F[j, i * 5 + k] = float(data[k + 1].replace('D', 'E'))
+                                F[i * 5 + k, j] = F[j, i * 5 + k]
+                    # Convert from atomic units (Hartree/Bohr_radius^2) to J/m^2
+                    F *= 4.35974417e-18 / 5.291772108e-11 ** 2
+                line = f.readline()
 
         return F
 
@@ -129,25 +122,22 @@ class GaussianLog(Log):
         Gaussian log file. If multiple such geometries are identified, only the
         last is returned.
         """
-
         number, coord, mass = [], [], []
 
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-            # Automatically determine the number of atoms
-            if 'Input orientation:' in line:
-                number, coord = [], []
-                for i in range(5):
-                    line = f.readline()
-                while '---------------------------------------------------------------------' not in line:
-                    data = line.split()
-                    number.append(int(data[1]))
-                    coord.append([float(data[3]), float(data[4]), float(data[5])])
-                    line = f.readline()
+        with open(self.path, 'r') as f:
             line = f.readline()
-        # Close file when finished
-        f.close()
+            while line != '':
+                # Automatically determine the number of atoms
+                if 'Input orientation:' in line:
+                    number, coord = [], []
+                    for i in range(5):
+                        line = f.readline()
+                    while '---------------------------------------------------------------------' not in line:
+                        data = line.split()
+                        number.append(int(data[1]))
+                        coord.append([float(data[3]), float(data[4]), float(data[5])])
+                        line = f.readline()
+                line = f.readline()
 
         # Assign appropriate mass to each atom in the molecule
         mass = []
@@ -175,7 +165,6 @@ class GaussianLog(Log):
         log file with multiple Thermochemistry sections, only the last one will
         be kept.
         """
-
         modes = []
         unscaled_frequencies = []
         E0 = 0.0
@@ -185,83 +174,81 @@ class GaussianLog(Log):
                 opticalIsomers = _opticalIsomers
             if symmetry is None:
                 symmetry = _symmetry
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-
-            # Read the spin multiplicity if not explicitly given
-            if spinMultiplicity == 0 and 'Multiplicity =' in line:
-                spinMultiplicity = int(line.split()[-1])
-                logging.debug('Conformer {0} is assigned a spin multiplicity of {1}'.format(label, spinMultiplicity))
-
-            # The data we want is in the Thermochemistry section of the output
-            if '- Thermochemistry -' in line:
-                modes = []
-                inPartitionFunctions = False
-                line = f.readline()
-                while line != '':
-
-                    # This marks the end of the thermochemistry section
-                    if '-------------------------------------------------------------------' in line:
-                        break
-
-                    # Read molecular mass for external translational modes
-                    elif 'Molecular mass:' in line:
-                        mass = float(line.split()[2])
-                        translation = IdealGasTranslation(mass=(mass, "amu"))
-                        modes.append(translation)
-
-                    # Read moments of inertia for external rotational modes
-                    elif 'Rotational constants (GHZ):' in line:
-                        inertia = [float(d) for d in line.split()[-3:]]
-                        for i in range(3):
-                            inertia[i] = constants.h / (8 * constants.pi * constants.pi * inertia[i] * 1e9)\
-                                         * constants.Na * 1e23
-                        rotation = NonlinearRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
-                        modes.append(rotation)
-                    elif 'Rotational constant (GHZ):' in line:
-                        inertia = [float(line.split()[3])]
-                        inertia[0] = constants.h / (8 * constants.pi * constants.pi * inertia[0] * 1e9)\
-                                     * constants.Na * 1e23
-                        rotation = LinearRotor(inertia=(inertia[0], "amu*angstrom^2"), symmetry=symmetry)
-                        modes.append(rotation)
-
-                    # Read vibrational modes
-                    elif 'Vibrational temperatures:' in line:
-                        frequencies = []
-                        frequencies.extend([float(d) for d in line.split()[2:]])
-                        line = f.readline()
-                        frequencies.extend([float(d) for d in line.split()[1:]])
-                        line = f.readline()
-                        while line.strip() != '':
-                            frequencies.extend([float(d) for d in line.split()])
-                            line = f.readline()
-                        # Convert from K to cm^-1
-                        if len(frequencies) > 0:
-                            frequencies = [freq * 0.695039 for freq in frequencies]  # kB = 0.695039 cm^-1/K
-                            unscaled_frequencies = frequencies
-                            vibration = HarmonicOscillator(frequencies=(frequencies, "cm^-1"))
-                            modes.append(vibration)
-
-                    # Read ground-state energy
-                    elif 'Sum of electronic and zero-point Energies=' in line:
-                        E0 = float(line.split()[6]) * 4.35974394e-18 * constants.Na
-
-                    # Read spin multiplicity if above method was unsuccessful
-                    elif 'Electronic' in line and inPartitionFunctions and spinMultiplicity == 0:
-                        spinMultiplicity = int(float(line.split()[1].replace('D', 'E')))
-
-                    elif 'Log10(Q)' in line:
-                        inPartitionFunctions = True
-
-                    # Read the next line in the file
-                    line = f.readline()
-
-            # Read the next line in the file
+        with open(self.path, 'r') as f:
             line = f.readline()
+            while line != '':
 
-        # Close file when finished
-        f.close()
+                # Read the spin multiplicity if not explicitly given
+                if spinMultiplicity == 0 and 'Multiplicity =' in line:
+                    spinMultiplicity = int(line.split()[-1])
+                    logging.debug('Conformer {0} is assigned a spin multiplicity of {1}'.format(label, spinMultiplicity))
+
+                # The data we want is in the Thermochemistry section of the output
+                if '- Thermochemistry -' in line:
+                    modes = []
+                    inPartitionFunctions = False
+                    line = f.readline()
+                    while line != '':
+
+                        # This marks the end of the thermochemistry section
+                        if '-------------------------------------------------------------------' in line:
+                            break
+
+                        # Read molecular mass for external translational modes
+                        elif 'Molecular mass:' in line:
+                            mass = float(line.split()[2])
+                            translation = IdealGasTranslation(mass=(mass, "amu"))
+                            modes.append(translation)
+
+                        # Read moments of inertia for external rotational modes
+                        elif 'Rotational constants (GHZ):' in line:
+                            inertia = [float(d) for d in line.split()[-3:]]
+                            for i in range(3):
+                                inertia[i] = constants.h / (8 * constants.pi * constants.pi * inertia[i] * 1e9)\
+                                             * constants.Na * 1e23
+                            rotation = NonlinearRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
+                            modes.append(rotation)
+                        elif 'Rotational constant (GHZ):' in line:
+                            inertia = [float(line.split()[3])]
+                            inertia[0] = constants.h / (8 * constants.pi * constants.pi * inertia[0] * 1e9)\
+                                         * constants.Na * 1e23
+                            rotation = LinearRotor(inertia=(inertia[0], "amu*angstrom^2"), symmetry=symmetry)
+                            modes.append(rotation)
+
+                        # Read vibrational modes
+                        elif 'Vibrational temperatures:' in line:
+                            frequencies = []
+                            frequencies.extend([float(d) for d in line.split()[2:]])
+                            line = f.readline()
+                            frequencies.extend([float(d) for d in line.split()[1:]])
+                            line = f.readline()
+                            while line.strip() != '':
+                                frequencies.extend([float(d) for d in line.split()])
+                                line = f.readline()
+                            # Convert from K to cm^-1
+                            if len(frequencies) > 0:
+                                frequencies = [freq * 0.695039 for freq in frequencies]  # kB = 0.695039 cm^-1/K
+                                unscaled_frequencies = frequencies
+                                vibration = HarmonicOscillator(frequencies=(frequencies, "cm^-1"))
+                                modes.append(vibration)
+
+                        # Read ground-state energy
+                        elif 'Sum of electronic and zero-point Energies=' in line:
+                            E0 = float(line.split()[6]) * 4.35974394e-18 * constants.Na
+
+                        # Read spin multiplicity if above method was unsuccessful
+                        elif 'Electronic' in line and inPartitionFunctions and spinMultiplicity == 0:
+                            spinMultiplicity = int(float(line.split()[1].replace('D', 'E')))
+
+                        elif 'Log10(Q)' in line:
+                            inPartitionFunctions = True
+
+                        # Read the next line in the file
+                        line = f.readline()
+
+                # Read the next line in the file
+                line = f.readline()
+
         return Conformer(E0=(E0 * 0.001, "kJ/mol"), modes=modes, spinMultiplicity=spinMultiplicity,
                          opticalIsomers=opticalIsomers), unscaled_frequencies
 
@@ -273,40 +260,36 @@ class GaussianLog(Log):
         energy is *not* included in the returned value; it is removed from the
         CBS-QB3 value.
         """
-
         E0 = None
         E0_cbs = None
         scaledZPE = None
 
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-
-            if 'SCF Done:' in line:
-                E0 = float(line.split()[4]) * constants.E_h * constants.Na
-            elif 'CBS-QB3 (0 K)' in line:
-                E0_cbs = float(line.split()[3]) * constants.E_h * constants.Na
-            elif 'G3(0 K)' in line:
-                E0_cbs = float(line.split()[2]) * constants.E_h * constants.Na
-
-            # Read the ZPE from the "E(ZPE)=" line, as this is the scaled version.
-            # Gaussian defines the following as
-            # E (0 K) = Elec + E(ZPE), 
-            # The ZPE is the scaled ZPE given by E(ZPE) in the log file, 
-            # hence to get the correct Elec from E (0 K) we need to subtract the scaled ZPE
-
-            elif 'E(ZPE)' in line:
-                scaledZPE = float(line.split()[1]) * constants.E_h * constants.Na
-            elif '\\ZeroPoint=' in line:
-                line = line.strip() + f.readline().strip()
-                start = line.find('\\ZeroPoint=') + 11
-                end = line.find('\\', start)
-                scaledZPE = float(line[start:end]) * constants.E_h * constants.Na * frequencyScaleFactor
-            # Read the next line in the file
+        with open(self.path, 'r') as f:
             line = f.readline()
+            while line != '':
 
-        # Close file when finished
-        f.close()
+                if 'SCF Done:' in line:
+                    E0 = float(line.split()[4]) * constants.E_h * constants.Na
+                elif 'CBS-QB3 (0 K)' in line:
+                    E0_cbs = float(line.split()[3]) * constants.E_h * constants.Na
+                elif 'G3(0 K)' in line:
+                    E0_cbs = float(line.split()[2]) * constants.E_h * constants.Na
+
+                # Read the ZPE from the "E(ZPE)=" line, as this is the scaled version.
+                # Gaussian defines the following as
+                # E (0 K) = Elec + E(ZPE),
+                # The ZPE is the scaled ZPE given by E(ZPE) in the log file,
+                # hence to get the correct Elec from E (0 K) we need to subtract the scaled ZPE
+
+                elif 'E(ZPE)' in line:
+                    scaledZPE = float(line.split()[1]) * constants.E_h * constants.Na
+                elif '\\ZeroPoint=' in line:
+                    line = line.strip() + f.readline().strip()
+                    start = line.find('\\ZeroPoint=') + 11
+                    end = line.find('\\', start)
+                    scaledZPE = float(line[start:end]) * constants.E_h * constants.Na * frequencyScaleFactor
+                # Read the next line in the file
+                line = f.readline()
 
         if E0_cbs is not None:
             if scaledZPE is None:
@@ -321,28 +304,23 @@ class GaussianLog(Log):
         """
         Load the unscaled zero-point energy in J/mol from a Gaussian log file.
         """
-
         ZPE = None
 
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-
-            # Do NOT read the ZPE from the "E(ZPE)=" line, as this is the scaled version!
-            # We will read in the unscaled ZPE and later multiply the scaling factor
-            # from the input file
-            if 'Zero-point correction=' in line:
-                ZPE = float(line.split()[2]) * constants.E_h * constants.Na
-            elif '\\ZeroPoint=' in line:
-                line = line.strip() + f.readline().strip()
-                start = line.find('\\ZeroPoint=') + 11
-                end = line.find('\\', start)
-                ZPE = float(line[start:end]) * constants.E_h * constants.Na
-            # Read the next line in the file
+        with open(self.path, 'r') as f:
             line = f.readline()
+            while line != '':
 
-        # Close file when finished
-        f.close()
+                # Do NOT read the ZPE from the "E(ZPE)=" line, as this is the scaled version!
+                # We will read in the unscaled ZPE and later multiply the scaling factor
+                # from the input file
+                if 'Zero-point correction=' in line:
+                    ZPE = float(line.split()[2]) * constants.E_h * constants.Na
+                elif '\\ZeroPoint=' in line:
+                    line = line.strip() + f.readline().strip()
+                    start = line.find('\\ZeroPoint=') + 11
+                    end = line.find('\\', start)
+                    ZPE = float(line[start:end]) * constants.E_h * constants.Na
+                line = f.readline()
 
         if ZPE is not None:
             return ZPE
@@ -354,40 +332,36 @@ class GaussianLog(Log):
         Extract the optimized energies in J/mol from a log file, e.g. the 
         result of a Gaussian "Scan" quantum chemistry calculation.
         """
-
         optfreq = False
         rigidScan = False
 
-        # The array of potentials at each scan angle
-        Vlist = []
+        Vlist = []  # The array of potentials at each scan angle
 
         # Parse the Gaussian log file, extracting the energies of each
         # optimized conformer in the scan
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-            # If the job contains a "freq" then we want to ignore the last energy
-            if ' freq ' in line:
-                optfreq = True
-            # if # scan is keyword instead of # opt, then this is a rigid scan job
-            # and parsing the energies is done a little differently
-            if '# scan' in line:
-                rigidScan = True
-            # The lines containing "SCF Done" give the energy at each
-            # iteration (even the intermediate ones)
-            if 'SCF Done:' in line:
-                E = float(line.split()[4])
-                # rigid scans will only not optimize, so just append every time it finds an energy.
-                if rigidScan:
-                    Vlist.append(E)
-            # We want to keep the values of E that come most recently before
-            # the line containing "Optimization completed", since it refers
-            # to the optimized geometry
-            if 'Optimization completed' in line:
-                Vlist.append(E)
+        with open(self.path, 'r') as f:
             line = f.readline()
-        # Close file when finished
-        f.close()
+            while line != '':
+                # If the job contains a "freq" then we want to ignore the last energy
+                if ' freq ' in line:
+                    optfreq = True
+                # if # scan is keyword instead of # opt, then this is a rigid scan job
+                # and parsing the energies is done a little differently
+                if '# scan' in line:
+                    rigidScan = True
+                # The lines containing "SCF Done" give the energy at each
+                # iteration (even the intermediate ones)
+                if 'SCF Done:' in line:
+                    E = float(line.split()[4])
+                    # rigid scans will only not optimize, so just append every time it finds an energy.
+                    if rigidScan:
+                        Vlist.append(E)
+                # We want to keep the values of E that come most recently before
+                # the line containing "Optimization completed", since it refers
+                # to the optimized geometry
+                if 'Optimization completed' in line:
+                    Vlist.append(E)
+                line = f.readline()
 
         # give warning in case this assumption is not true
         if rigidScan:
@@ -420,15 +394,13 @@ class GaussianLog(Log):
         """
         frequency = None
         frequencies = []
-        f = open(self.path, 'r')
-        line = f.readline()
-        while line != '':
-            # Read vibrational frequencies
-            if 'Frequencies --' in line:
-                frequencies.extend(line.split()[2:])
+        with open(self.path, 'r') as f:
             line = f.readline()
-        # Close file when finished
-        f.close()
+            while line != '':
+                # Read vibrational frequencies
+                if 'Frequencies --' in line:
+                    frequencies.extend(line.split()[2:])
+                line = f.readline()
 
         frequencies = [float(freq) for freq in frequencies]
         frequencies.sort()

--- a/arkane/log.py
+++ b/arkane/log.py
@@ -86,7 +86,7 @@ class Log(object):
         raise NotImplementedError("loadConformer is not implemented for the Log class. "
                                   "This method should be implemented by a subclass.")
 
-    def loadEnergy(self, frequencyScaleFactor=1.):
+    def loadEnergy(self, zpe_scale_factor=1.):
         """
         Load the energy in J/mol from a QChem log file. Only the last energy
         in the file is returned. The zero-point energy is *not* included in

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1227,79 +1227,79 @@ def projectRotors(conformer, F, rotors, linear, is_ts, label):
     return np.sqrt(eig[-Nvib:]) / (2 * math.pi * constants.c * 100)
 
 
-def assign_frequency_scale_factor(model_chemistry):
+def assign_frequency_scale_factor(freq_level):
     """
     Assign the frequency scaling factor according to the model chemistry.
     Refer to https://comp.chem.umn.edu/freqscale/index.html for future updates of these factors
 
+    Sources:
+        [1] I.M. Alecu, J. Zheng, Y. Zhao, D.G. Truhlar, J. Chem. Theory Comput. 2010, 6, 2872, DOI: 10.1021/ct100326h
+        [2] http://cccbdb.nist.gov/vibscalejust.asp
+        [3] http://comp.chem.umn.edu/freqscale/190107_Database_of_Freq_Scale_Factors_v4.pdf
+        [4] Calculated as described in 10.1021/ct100326h
+        [5] J.A. Montgomery, M.J. Frisch, J. Chem. Phys. 1999, 110, 2822–2827, DOI: 10.1063/1.477924
+
     Args:
-        model_chemistry (str, unicode): The frequency level of theory.
+        freq_level (str, unicode): The frequency level of theory.
 
     Returns:
         float: The frequency scaling factor (1 by default).
     """
-    freq_dict = {'cbs-qb3': 0.99,  # J. Chem. Phys. 1999, 110, 2822–2827
-                 'cbs-qb3-paraskevas': 0.99,
-                 # 'g3': ,
-                 'm08so/mg3s*': 0.983,  # DOI: 10.1021/ct100326h, taken as 'M08-SO/MG3S'
-                 'm06-2x/cc-pvtz': 0.955,  # http://cccbdb.nist.gov/vibscalejust.asp
-                 # 'klip_1': ,
-                 # 'klip_2': ,
-                 # 'klip_3': ,
-                 # 'klip_2_cc': ,
-                 # 'ccsd(t)-f12/cc-pvdz-f12_h-tz': ,
-                 # 'ccsd(t)-f12/cc-pvdz-f12_h-qz': ,
-                 'ccsd(t)-f12/cc-pvdz-f12': 0.979,
-                 # http://cccbdb.nist.gov/vibscalejust.asp, taken as 'ccsd(t)/cc-pvdz'
-                 'ccsd(t)-f12/cc-pvtz-f12': 0.984,
-                 # Taken from https://comp.chem.umn.edu/freqscale/version3b2.htm as CCSD(T)-F12a/cc-pVTZ-F12
-                 'ccsd(t)-f12/cc-pvqz-f12': 0.970,
-                 # http://cccbdb.nist.gov/vibscalejust.asp, taken as 'ccsd(t)/cc-pvqz'
-                 'ccsd(t)-f12/cc-pcvdz-f12': 0.971,
-                 # http://cccbdb.nist.gov/vibscalejust.asp, taken as 'ccsd(t)/cc-pcvdz'
-                 'ccsd(t)-f12/cc-pcvtz-f12': 0.966,
-                 # 'ccsd(t)-f12/cc-pcvqz-f12': ,
-                 # 'ccsd(t)-f12/cc-pvtz-f12(-pp)': ,
-                 # 'ccsd(t)/aug-cc-pvtz(-pp)': ,
-                 'ccsd(t)-f12/aug-cc-pvdz': 0.963,
-                 # http://cccbdb.nist.gov/vibscalejust.asp, taken as 'ccsd(t)/aug-cc-pvdz'
-                 'ccsd(t)-f12/aug-cc-pvtz': 0.970,
-                 # http://cccbdb.nist.gov/vibscalejust.asp, taken as 'ccsd(t)/aug-cc-pvtz'
-                 'ccsd(t)-f12/aug-cc-pvqz': 0.975,
-                 # http://cccbdb.nist.gov/vibscalejust.asp, taken as 'ccsd(t)/aug-cc-pvqz'
-                 # 'b-ccsd(t)-f12/cc-pvdz-f12': ,
-                 # 'b-ccsd(t)-f12/cc-pvtz-f12': ,
-                 # 'b-ccsd(t)-f12/cc-pvqz-f12': ,
-                 # 'b-ccsd(t)-f12/cc-pcvdz-f12': ,
-                 # 'b-ccsd(t)-f12/cc-pcvtz-f12': ,
-                 # 'b-ccsd(t)-f12/cc-pcvqz-f12': ,
-                 # 'b-ccsd(t)-f12/aug-cc-pvdz': ,
-                 # 'b-ccsd(t)-f12/aug-cc-pvtz': ,
-                 # 'b-ccsd(t)-f12/aug-cc-pvqz': ,
-                 'mp2_rmp2_pvdz': 0.953,  # http://cccbdb.nist.gov/vibscalejust.asp, taken as ',p2/cc-pvdz'
-                 'mp2_rmp2_pvtz': 0.950,  # http://cccbdb.nist.gov/vibscalejust.asp, taken as ',p2/cc-pvdz'
-                 'mp2_rmp2_pvqz': 0.962,  # http://cccbdb.nist.gov/vibscalejust.asp, taken as ',p2/cc-pvdz'
-                 'ccsd-f12/cc-pvdz-f12': 0.947,  # http://cccbdb.nist.gov/vibscalejust.asp, taken as ccsd/cc-pvdz
-                 # 'ccsd(t)-f12/cc-pvdz-f12_noscale': ,
-                 # 'g03_pbepbe_6-311++g_d_p': ,
-                 # 'fci/cc-pvdz': ,
-                 # 'fci/cc-pvtz': ,
-                 # 'fci/cc-pvqz': ,
-                 # 'bmk/cbsb7': ,
-                 # 'bmk/6-311g(2d,d,p)': ,
-                 'b3lyp/6-31g**': 0.961,  # http://cccbdb.nist.gov/vibscalejust.asp
-                 'b3lyp/6-311+g(3df,2p)': 0.967,  # http://cccbdb.nist.gov/vibscalejust.asp
-                 'wb97x-d/aug-cc-pvtz': 0.974,
-                 # Taken from https://comp.chem.umn.edu/freqscale/version3b2.htm as ωB97X-D/maug-cc-pVTZ
+    freq_dict = {'hf/sto-3g': 0.817,  # [2]
+                 'hf/6-31g': 0.903,  # [2]
+                 'hf/6-31g(d)': 0.899,  # [2]
+                 'hf/6-31g(d,p)': 0.903,  # [2]
+                 'hf/6-31g+(d,p)': 0.904,  # [2]
+                 'hf/6-31+g(d,p)': 0.915 * 1.014,  # [1] Table 7
+                 'pm3': 0.940 * 1.014,  # [1] Table 7, the 0.940 value is the ZPE scale factor
+                 'pm6': 1.078 * 1.014,  # [1] Table 7, the 1.078 value is the ZPE scale factor
+                 'b3lyp/6-31g(d,p)': 0.961,  # [2]
+                 'b3lyp/6-311g(d,p)': 0.967,  # [2]
+                 'b3lyp/6-311+g(3df,2p)': 0.967,  # [2]
+                 'b3lyp/6-311+g(3df,2pd)': 0.970,  # [2]
+                 'm06-2x/6-31g(d,p)': 0.952,  # [2]
+                 'm06-2x/6-31+g(d,p)': 0.979,  # [3]
+                 'm06-2x/6-311+g(d,p)': 0.983,  # [3]
+                 'm06-2x/6-311++g(d,p)': 0.983,  # [3]
+                 'm06-2x/cc-pvtz': 0.955,  # [2]
+                 'm06-2x/aug-cc-pvdz': 0.993,  # [3]
+                 'm06-2x/aug-cc-pvtz': 0.985,  # [1] Table 3, [3]
+                 'm06-2x/def2-tzvp': 0.984,  # [3]
+                 'm06-2x/def2-qzvp': 0.983,  # [3]
+                 'm06-2x/def2-tzvpp': 0.983,  # [1] Table 3, [3]
+                 'm08so/mg3s*': 0.995,  # [1] Table 3, taken as 'M08-SO/MG3S'
+                 'wb97x-d/aug-cc-pvtz': 0.988,  # [3], taken as 'ωB97X-D/maug-cc-pVTZ'
+                 'wb97xd/6-311++g(d,p)': 0.988,  # [4]
+                 'mp2_rmp2_pvdz': 0.953,  # [2], taken as 'MP2/cc-pVDZ'
+                 'mp2_rmp2_pvtz': 0.950,  # [2], taken as 'MP2/cc-pVTZ'
+                 'mp2_rmp2_pvqz': 0.962,  # [2], taken as 'MP2/cc-pVQZ'
+                 'cbs-qb3': 0.99 * 1.014,  # [5], the 0.99 value is the ZPE scale factor of CBS-QB3
+                 'cbs-qb3-paraskevas': 0.99 * 1.014,  # [5], the 0.99 value is the ZPE scale factor of CBS-QB3
+                 'ccsd-f12/cc-pvdz-f12': 0.947,  # [2], taken as 'CCSD/cc-pVDZ'
+                 'ccsd(t)/cc-pvdz': 0.979,  # [2]
+                 'ccsd(t)/cc-pvtz': 0.975,  # [2]
+                 'ccsd(t)/cc-pvqz': 0.970,  # [2]
+                 'ccsd(t)/aug-cc-pvdz': 0.963,  # [2]
+                 'ccsd(t)/aug-cc-pvtz': 1.001,  # [3]
+                 'ccsd(t)/aug-cc-pvqz': 0.975,  # [2]
+                 'ccsd(t)/cc-pv(t+d)z': 0.965,  # [2]
+                 'ccsd(t)-f12/cc-pvdz-f12': 0.997,  # [3], taken as 'CCSD(T)-F12a/cc-pVDZ-F12'
+                 'ccsd(t)-f12/cc-pvtz-f12': 0.998,  # [3], taken as 'CCSD(T)-F12a/cc-pVTZ-F12'
+                 'ccsd(t)-f12/cc-pvqz-f12': 0.998,  # [3], taken as 'CCSD(T)-F12b/VQZF12//CCSD(T)-F12a/TZF'
+                 'ccsd(t)-f12/cc-pcvdz-f12': 0.997,  # [3], taken as 'CCSD(T)-F12a/cc-pVDZ-F12'
+                 'ccsd(t)-f12/cc-pcvtz-f12': 0.998,  # [3], taken as 'CCSD(T)-F12a/cc-pVTZ-F12'
+                 'ccsd(t)-f12/aug-cc-pvdz': 0.997,  # [3], taken as 'CCSD(T)/cc-pVDZ'
+                 'ccsd(t)-f12/aug-cc-pvtz': 0.998,  # [3], taken as CCSD(T)-F12a/cc-pVTZ-F12
+                 'ccsd(t)-f12/aug-cc-pvqz': 0.998,  # [3], taken as 'CCSD(T)-F12b/VQZF12//CCSD(T)-F12a/TZF'
                  }
-    scaling_factor = freq_dict.get(model_chemistry.lower(), 1)
+    scaling_factor = freq_dict.get(freq_level.lower(), 1)
     if scaling_factor == 1:
         logging.warning('No frequency scaling factor found for model chemistry {0}. Assuming a value of unity. '
                         'This will affect the partition function and all quantities derived from it '
-                        '(thermo quantities and rate coefficients).'.format(model_chemistry))
+                        '(thermo quantities and rate coefficients).'.format(freq_level))
     else:
-        logging.info('Assigned a frequency scale factor of {0} for model chemistry {1}'.format(
-            scaling_factor, model_chemistry))
+        logging.info('Assigned a frequency scale factor of {0} for the frequency level of theory {1}'.format(
+            scaling_factor, freq_level))
     return scaling_factor
 
 

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -517,19 +517,18 @@ states, intermediates and products are reported relative to that.
 Also note that the value of ``E0`` provided here will be used directly, i.e., no atom or bond corrections will be applied.
 
 If you want Arkane to correct for zero point energy, you can either just place
-the raw units in Hartree (as if it were read directly from quantum):
+the raw units in Hartree (as if it were read directly from quantum): ::
 
     E0 = 547.6789753223456
 
 Or you can add a third argument to the Quantity specified whether zero-point
-energy is included or not:
+energy is included or not: ::
 
-    E0 = (95.1, 'kJ/mol', 'E0') # when ZPE is not included
-    E0 = (95.1, 'kJ/mol', 'E0-ZPE') # when ZPE is already included
+    E0 = (95.1, 'kJ/mol', 'e_electronic')  # when zero point energy (ZPE) is not included - Arkane will add it
+    E0 = (95.1, 'kJ/mol', 'E0')  # when ZPE is already included - Arkane will not add it
 
-When specifying the ``modes`` parameter, define a list
-with the following types of degrees of freedom.  To understand how to define these
-degrees of freedom, please click on the links below:
+When specifying the ``modes`` parameter, define a list with the following types of degrees of freedom.
+To understand how to define these degrees of freedom, please click on the links below:
 
 **Translational degrees of freedom**
 


### PR DESCRIPTION
### Motivation or Problem
Previously we used the __frequency__ scaling factor to also scale the zero point energy correction in Arkane. Principally, these should be two different factors. Luckily, there's a simple ratio between them, a factor of 1.014 (+/- 0.002, see https://pubs.acs.org/doi/10.1021/ct100326h section 3.1.3) - largely independent of the model chemistry. So only of the factors one should be known, the second can be easily determined. **This erroneous behaviour causes a systematic error of about 1.5 kJ/mol(!) - or 0.35 kcal/mol - to H298** (see below).

Thanks @dranasinghe for helping me understand what I'm doing :)

### Description of Changes
Dividing the freq scaling factor by 1.014 to obtain the ZPEC scaling factor when scaling the __ZPEC__.

Here are some species I ran (purposely selected ones with no torsions) prior and after this change at ccsd(t)-f12/cc-pvtz-f12//wb97xd/6-311++g(d,p), energies are in kJ/mol:

| Species | H298, master | H298, this branch | H298, ATcT |
| ------------- | ------------- | ------------- | ------------- |
| CH4 | -71.95 | -73.56 | -74.525 +/- 0.056 |
| NH3 | -41.81 | -43.06 | -45.558 +/- 0.030 |
| CO2 | -385.07 | -385.49 | -393.475 +/- 0.015 |
| C2H4 | 55.97 | 54.13 | 52.39 +/- 0.12 |
| C2H2 | 232.61 | 231.63 | 228.27 +/- 0.13 |

Before the changes we had an average deviation from ATcT values of 4.5 kJ/mol (for these species at this level), now it is 3.3 kJ/mol (not accounting for CO2, the deviation went down from 3.6 kJ/mol to 2.1 kJ/mol). If these species could be representative, the implication is that **we're improving Arkane's H298 by about 1.2 to 1.5 kJ/mol**, at least for this level.