### PR TITLE
Calculate the translational mode if doesn't exist

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -365,12 +365,19 @@ class StatMechJob(object):
                                                                     spinMultiplicity=spinMultiplicity,
                                                                     opticalIsomers=opticalIsomers,
                                                                     label=self.species.label)
+        translational_mode_exists = False
         for mode in conformer.modes:
             if isinstance(mode, (LinearRotor, NonlinearRotor)):
                 self.supporting_info.append(mode)
                 break
+            if isinstance(mode, (Translation, IdealGasTranslation)):
+                translational_mode_exists = True
         if unscaled_frequencies:
             self.supporting_info.append(unscaled_frequencies)
+
+        if not translational_mode_exists:
+            # Sometimes the translational mode is not appended to modes for monoatomic species
+            conformer.modes.append(IdealGasTranslation(mass=self.species.molecularWeight))
 
         if conformer.spinMultiplicity == 0:
             raise ValueError("Could not read spin multiplicity from log file {0},\n"


### PR DESCRIPTION
### Motivation or Problem
Arkane determines poor entropies for atoms. The reason is that it appends a translational partition function to modes only if it finds, e.g., 'Molecular mass:' in a Gaussian input file, but that line appears in a freq calculation, not in an sp calculation log file (atoms only have the latter, which is passed to Arkane as the frequency log file as well).
As a result, we get great H298's, but poor S298's:
![image](https://user-images.githubusercontent.com/16158262/59141173-3c295a00-8976-11e9-9a91-b112d360bcb5.png)
![image](https://user-images.githubusercontent.com/16158262/59141176-464b5880-8976-11e9-8905-a2009c628ebb.png)


### Description of Changes
Detect if the translational mode was not appended to the conformer modes, and if so determine it from the mass and append it.
This results in improved S298:
![image](https://user-images.githubusercontent.com/16158262/59141215-cec9f900-8976-11e9-80cc-f0c8930e41ed.png)
![image](https://user-images.githubusercontent.com/16158262/59141188-772b8d80-8976-11e9-905b-f04e2551ba7c.png)
Much, much better, but could still be improved for O and S (I don't know what the source for the deviation is).