### PR TITLE
onlyHeterocyclics option for Machine Leaning Estimator Settings

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -640,6 +640,7 @@ The available options with their default values are ::
         minNitrogenAtoms=0,
         maxNitrogenAtoms=None,
         onlyCyclics=False,
+        onlyHeterocyclics=False,
         minCycleOverlap=0,
         H298UncertaintyCutoff=(3.0, 'kcal/mol'),
         S298UncertaintyCutoff=(2.0, 'cal/(mol*K)'),
@@ -648,11 +649,18 @@ The available options with their default values are ::
 
 ``name`` is the name of the folder containing the machine learning model architecture and parameters in the RMG
 database. The next several options allow setting limits on the numbers of atoms. ``onlyCyclics`` means that only cyclic
-species will be estimated. ``minCycleOverlap`` specified the minimum number of atoms that must be shared between any
-two cycles. For example, if there are only disparate monocycles or no cycles in a species, the overlap is zero;
-"spiro" cycles have an overlap of one; "fused" cycles have an overlap of two; and "bridged" cycles have an overlap of
-at least three. Note that specifying any value greater than zero will automatically restrict the machine learning
-estimator to only consider cyclic species regardless of the ``onlyCyclics`` setting.
+species will be estimated. ``onlyHeterocyclics`` means that only heterocyclic species will be estimated. Note that
+if ``onlyHeterocyclics`` setting is set to True, the machine learning estimator will be restricted to heterocyclic
+species regardless of the ``onlyCyclics`` setting. If ``onlyCyclics`` is False and ``onlyHeterocyclics`` is True,
+RMG will log a warning that ``onlyCyclics`` should also be True and the machine learning estimator will be
+restricted to heterocyclic species because they are a subset of cyclics.
+``minCycleOverlap`` specifies the minimum number of atoms that must be shared between any two cycles. For example,
+if there are only disparate monocycles or no cycles in a species, the overlap is zero; "spiro" cycles have an overlap
+of one; "fused" cycles have an overlap of two; and "bridged" cycles have an overlap of at least three. Note that
+specifying any value greater than zero will automatically restrict the machine learning estimator to only consider
+cyclic species regardless of the ``onlyCyclics`` setting. If ``onlyCyclics`` is False and ``minCycleOverlap`` is greater
+than zero, RMG will log a warning that ``onlyCyclics`` should also be True and the machine learning estimator will be
+restricted to only cyclic species with the specified minimum cycle overlap.
 
 If the estimated uncertainty of the thermo prediction is greater than any of the ``UncertaintyCutoff`` values, then
 machine learning estimation is not used for that species.

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -274,7 +274,13 @@ generatedSpeciesConstraints(
 #     maxNitrogenAtoms=None,
 #     # Limits on cycles
 #     onlyCyclics=False,
-#     minCycleOverlap=0,  # specifies the minimum number of atoms that must be shared between any two cycles
+#     onlyHeterocyclics=False, # If onlyHeterocyclics is True, the machine learning estimator is restricted to only
+#                                heterocyclics species regardless of onlyCyclics setting.
+#                                But onlyCyclics should also be True if onlyHeterocyclics is True.
+#     minCycleOverlap=0,  # specifies the minimum number of atoms that must be shared between any two cycles.
+#                           If minCycleOverlap is greater than zero, the machine learning estimator is restricted to
+#                           only cyclic species with the specified minimum cyclic overlap regardless of onlyCyclics
+#                           setting.
 #     # If the estimated uncertainty of the thermo prediction is greater than
 #     # any of these values, then don't use the ML estimate
 #     H298UncertaintyCutoff=(3.0, 'kcal/mol'),

--- a/examples/thermoEstimator/input_ml.py
+++ b/examples/thermoEstimator/input_ml.py
@@ -17,7 +17,13 @@ mlEstimator(
     maxNitrogenAtoms=None,
     # Limits on cycles
     onlyCyclics=False,
+    onlyHeterocyclics=False,    # If onlyHeterocyclics is True, the machine learning estimator is restricted to only
+                                # heterocyclics species regardless of onlyCyclics setting.
+                                # But onlyCyclics should also be True if onlyHeterocyclics is True.
     minCycleOverlap=0,  # specifies the minimum number of atoms that must be shared between any two cycles
+                        # If minCycleOverlap is greater than zero, the machine learning estimator is restricted to
+                        # only cyclic species with the specified minimum cyclic overlap regardless of onlyCyclics
+                        # setting.
     # If the estimated uncertainty of the thermo prediction is greater than
     # any of these values, then don't use the ML estimate
     H298UncertaintyCutoff=(3.0, 'kcal/mol'),

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1662,7 +1662,8 @@ class ThermoDatabase(object):
             return None
         if not(min_nitrogen <= element_count.get('N', 0) <= max_nitrogen):
             return None
-
+        if ml_settings['only_heterocyclics'] and not molecule.isHeterocyclic():
+            return None
         if ml_settings['only_cyclics'] and not molecule.isCyclic():
             return None
         min_cycle_overlap = ml_settings['min_cycle_overlap']

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -319,6 +319,7 @@ multiplicity 2
             min_nitrogen_atoms=0,
             max_nitrogen_atoms=None,
             only_cyclics=False,
+            only_heterocyclics=False,
             min_cycle_overlap=0,
         )
 
@@ -368,6 +369,7 @@ multiplicity 2
             min_nitrogen_atoms=0,
             max_nitrogen_atoms=None,
             only_cyclics=False,
+            only_heterocyclics=False,
             min_cycle_overlap=0,
             uncertainty_cutoffs=dict(
                 H298=Quantity(1e8, 'kcal/mol'),
@@ -393,7 +395,28 @@ multiplicity 2
         thermo = self.database.get_thermo_data_from_ml(spec2, self.ml_estimator, ml_settings)
         self.assertIsNone(thermo)
 
+        # Test cyclic species whether it outputs None when_both onlycyclics and heterocyclics are both True.
+        ml_settings['only_heterocyclics'] = True
+        thermo = self.database.get_thermo_data_from_ml(spec3, self.ml_estimator, ml_settings)
+        self.assertIsNone(thermo)
+
+        # Test heterocyclic species when both onlycyclics and heterocyclics are both True.
+        thermo = self.database.get_thermo_data_from_ml(spec4, self.ml_estimator, ml_settings)
+        self.assertIsInstance(thermo, ThermoData)
+        self.assertTrue('ML Estimation' in thermo.comment, 'Thermo not from ML estimation, test purpose not fulfilled')
+
+        # Test cyclic species whether it outputs None when_only heterocyclics is True
+        ml_settings['only_cyclics'] = False
+        thermo = self.database.get_thermo_data_from_ml(spec3, self.ml_estimator, ml_settings)
+        self.assertIsNone(thermo)
+
+        # Test heterocyclic species when_only heterocyclics is True
+        thermo = self.database.get_thermo_data_from_ml(spec4, self.ml_estimator, ml_settings)
+        self.assertIsInstance(thermo, ThermoData)
+        self.assertTrue('ML Estimation' in thermo.comment, 'Thermo not from ML estimation, test purpose not fulfilled')
+
         # Test spiro species
+        ml_settings['only_heterocyclics'] = False
         ml_settings['min_cycle_overlap'] = 1
         thermo = self.database.get_thermo_data_from_ml(spec3, self.ml_estimator, ml_settings)
         self.assertIsInstance(thermo, ThermoData)

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -228,6 +228,8 @@ cdef class Molecule(Graph):
 
     cpdef bint isLinear(self) except -2
 
+    cpdef bint isHeterocyclic(self) except -2
+
     cpdef int countInternalRotors(self) except -2
 
     cpdef double calculateCp0(self) except -1

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1846,6 +1846,16 @@ class Molecule(Graph):
                         return True    
         return False
 
+    def isHeterocyclic(self):
+        """
+        Returns ``True`` if the molecule is heterocyclic, or ``False`` if not.
+        """
+        if self.isCyclic():
+            for atom in self.atoms:
+                if atom.isNonHydrogen() and not atom.isCarbon() and self.isVertexInCycle(atom):
+                    return True
+        return False
+
     def countInternalRotors(self):
         """
         Determine the number of internal rotors in the structure. Any single

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1530,7 +1530,25 @@ multiplicity 2
         m = Molecule().fromSMILES('C1CCCCC1')
         isomers = m.generate_resonance_structures()
         self.assertFalse(any(isomer.isAromatic() for isomer in isomers))
-         
+
+    def testHeterocyclicCyclohexanol(self):
+        """
+        Test the Molecule.isHeterocyclic() method for Cyclohexanol.
+        """
+        self.assertFalse(Molecule().fromSMILES('OC1CCCCC1').isHeterocyclic())
+
+    def testHeterocyclicFuran(self):
+        """
+        Test the Molecule.isHeterocyclic() method for Furan.
+        """
+        self.assertTrue(Molecule().fromSMILES('C1C=COC=1').isHeterocyclic())
+
+    def testHeterocyclicPyridine(self):
+        """
+        Test the Molecule.isHeterocyclic() method for Pyridine.
+        """
+        self.assertTrue(Molecule().fromSMILES('c1cccnc1').isHeterocyclic())
+
     def testCountInternalRotorsEthane(self):
         """
         Test the Molecule.countInternalRotors() method.

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -532,6 +532,7 @@ def mlEstimator(thermo=True,
                 minNitrogenAtoms=0,
                 maxNitrogenAtoms=None,
                 onlyCyclics=False,
+                onlyHeterocyclics=False,
                 minCycleOverlap=0,
                 H298UncertaintyCutoff=(3.0, 'kcal/mol'),
                 S298UncertaintyCutoff=(2.0, 'cal/(mol*K)'),
@@ -563,10 +564,21 @@ def mlEstimator(thermo=True,
             min_nitrogen_atoms=minNitrogenAtoms,
             max_nitrogen_atoms=maxNitrogenAtoms,
             only_cyclics=onlyCyclics,
+            only_heterocyclics=onlyHeterocyclics,
             min_cycle_overlap=minCycleOverlap,
             uncertainty_cutoffs=uncertainty_cutoffs,
         )
-                    
+
+    # Shows warning when onlyCyclics is False and onlyHeterocyclics is True
+    if minCycleOverlap > 0 and not onlyCyclics and not onlyHeterocyclics:
+        logging.warning('"onlyCyclics" should be True when "minCycleOverlap" is greater than zero.'
+                        ' Machine learning estimator is restricted to only cyclic species thermo with the specified minimum cycle overlap')
+    elif minCycleOverlap > 0 and not onlyCyclics and onlyHeterocyclics:
+        logging.warning('"onlyCyclics" should be True when "onlyHeterocyclics" is True and "minCycleOverlap" is greater than zero.'
+                        ' Machine learning estimator is restricted to only heterocyclic species thermo with the specified minimum cycle overlap')
+    elif onlyHeterocyclics and not onlyCyclics:
+        logging.warning('"onlyCyclics" should be True when "onlyHeterocyclics" is True.'
+                        ' Machine learning estimator is restricted to only heterocyclic species thermo')
 
 def pressureDependence(
                        method,


### PR DESCRIPTION
### Motivation or Problem
Adds one more option for Machine Learning Estimator settings to allow one to use machine learning for only heterocyclic species and group additivity for the rest

### Description of Changes
`onlyHeterocyclics` option is added to Machine `rmgpy.rmg.input.mlEstimator`, and a new method `isHeterocyclic` is added to `rmgpy.molecule.molecule.py`. Relevant changes are made in other rmg files including the documentation. 
If both `onlyCyclics` and `onlyHeterocyclics` options are True, then `onlyCyclics` option overrides, and all cyclic species thermo will be estimated by machine learning.

### Testing
3 unit tests are added to `rmgpy.molecule.moleculeTest.py` to check that species can be correctly identified as heterocyclic or not by `isHeterocyclic` method.
3 unit tests are added to `rmgpy.data.thermoTest.py` to check that mlEstimator is applied for heterocyclic species for appropriate mlEstimator settings.

### Reviewer Tips
Check unit tests and run simple mlEstimators examples with heterocyclic settings turned on and off