### PR TITLE
In training notebook, save once per family instead of per reaction

### DIFF
--- a/ipython/kinetics_library_to_training.ipynb
+++ b/ipython/kinetics_library_to_training.ipynb
@@ -175,6 +175,11 @@
     "\n",
     "        print('Training depository previously had {} rxns. Now adding {} new rxn(s).'.format(len(depository.entries), len(reaction_list)))\n",
     "\n",
+    "        ref_list = []\n",
+    "        type_list = []\n",
+    "        short_list = []\n",
+    "        long_list = []\n",
+    "        \n",
     "        for reaction in reaction_list:\n",
     "            # Get the original entry to retrieve metadata\n",
     "            orig_entry = library.entries[reaction.index]\n",
@@ -183,13 +188,18 @@
     "            if orig_entry.longDesc:\n",
     "                longDesc += '\\n' + orig_entry.longDesc\n",
     "            \n",
-    "            family.saveTrainingReactions(\n",
-    "                [reaction],\n",
-    "                reference=orig_entry.reference,\n",
-    "                referenceType=orig_entry.referenceType,\n",
-    "                shortDesc=shortDesc,\n",
-    "                longDesc=longDesc,\n",
-    "            )"
+    "            ref_list.append(orig_entry.reference)\n",
+    "            type_list.append(orig_entry.referenceType)\n",
+    "            short_list.append(shortDesc)\n",
+    "            long_list.append(longDesc)\n",
+    "            \n",
+    "        family.saveTrainingReactions(\n",
+    "            reaction_list,\n",
+    "            reference=ref_list,\n",
+    "            referenceType=type_list,\n",
+    "            shortDesc=short_list,\n",
+    "            longDesc=long_list,\n",
+    "        )"
    ]
   },
   {
@@ -217,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Now that saveTrainingReactions supports lists for metadata, this approach is much faster.
