### PR TITLE
Update environment files, including RDKit and Cantera versions

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -2,47 +2,44 @@ name: rmg_env
 channels:
   - defaults
   - rmg
+  - rdkit
 dependencies:
-  - libgcc # [unix]
-  - python
-  - numpy >=1.10.0
-  - cantera >=2.3.0a3
-  - coolprop
-  - cython >=0.25.2
-  - matplotlib >=1.5
-  - rdkit >=2015.09.2
-  - pydas >=1.0.1
-  - pydqed >=1.0.0
-  - lpsolve55
-  - quantities
-  - scipy
-  - xlwt
-  - markupsafe
-  - jinja2
-  #- argparse # [py26]
-  - pyparsing
-  - pydot ==1.2.2
-  - pyrdl
-  - nose
-  - coverage
-  - gprof2dot
   - cairo
   - cairocffi
+  - cantera >=2.3.0
+  - coolprop
+  - coverage
+  - cython >=0.25.2
+  - dde
+  - ffmpeg
+  - gprof2dot
+  - graphviz
+  - jinja2
+  - jupyter
+  - lpsolve55
+  - markupsafe
+  - matplotlib >=1.5
+  - mock
+  - mopac
+  - mpmath
+  - muq
+  - networkx
+  - nose
+  - numpy >=1.10.0
   - openbabel
   - psutil
-  - symmetry
-  - mopac
-  - graphviz
-  - scoop
-  - libgfortran >=1.0 # You may need to comment this out for mac osx
-  - ffmpeg
-  - jupyter
-  - networkx
-  - mock
-  - muq
+  - pydas >=1.0.1
+  - pydot ==1.2.2
+  - pydqed >=1.0.0
   - pymongo
-  - mpmath
-  - dde
+  - pyparsing
+  - pyrdl
+  - python >=2.7
   - pyyaml
-  - textgenrnn
+  - quantities
+  - rdkit >=2018
   - scikit-learn
+  - scipy
+  - symmetry
+  - textgenrnn
+  - xlwt

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - rmg
   - rdkit
+  - cantera
 dependencies:
   - cairo
   - cairocffi

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -2,46 +2,44 @@ name: rmg_env
 channels:
   - defaults
   - rmg
+  - rdkit
 dependencies:
-  - libgcc # [unix]
-  - python
-  - numpy >=1.10.0
-  - cantera >=2.3.0a3
-  - coolprop
-  - cython >=0.25.2
-  - matplotlib >=1.5
-  - rdkit >=2015.09.2
-  - pydas >=1.0.1
-  - pydqed >=1.0.0
-  - lpsolve55
-  - quantities
-  - scipy
-  - xlwt
-  - markupsafe
-  - jinja2
-  #- argparse # [py26]
-  - pyparsing
-  - pydot ==1.2.2
-  - pyrdl
-  - nose
-  - coverage
-  - gprof2dot
   - cairo
   - cairocffi
+  - cantera >=2.3.0
+  - coolprop
+  - coverage
+  - cython >=0.25.2
+  - dde
+  - ffmpeg
+  - gprof2dot
+  - graphviz
+  - jinja2
+  - jupyter
+  - lpsolve55
+  - markupsafe
+  - matplotlib >=1.5
+  - mock
+  - mopac
+  - mpmath
+#  - muq
+  - networkx
+  - nose
+  - numpy >=1.10.0
   - openbabel
   - psutil
-  - symmetry
-  - mopac
-  - graphviz
-  - scoop
-  - ffmpeg
-  - jupyter
-  - networkx
-  - mock
-  # - muq
+  - pydas >=1.0.1
+  - pydot ==1.2.2
+  - pydqed >=1.0.0
   - pymongo
-  - mpmath
-  - dde
+  - pyparsing
+  - pyrdl
+  - python >=2.7
   - pyyaml
-  - textgenrnn
+  - quantities
+  - rdkit >=2018
   - scikit-learn
+  - scipy
+  - symmetry
+  - textgenrnn
+  - xlwt

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - rmg
   - rdkit
+  - cantera
 dependencies:
   - cairo
   - cairocffi

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -1,46 +1,46 @@
 name: rmg_env
 channels:
-  - rmg
   - defaults
+  - rmg
+  - rdkit
 dependencies:
-  - mingwpy
-  - python
-  - numpy >=1.10.0
-  - cantera >=2.3.0a3
-  - coolprop
-  - cython >=0.25.2
-  - matplotlib >=1.5
-  - rdkit >=2015.09.2
-  - lpsolve55
-  - quantities
-  - scipy
-  - xlwt
-  - markupsafe
-  - jinja2
-  - pyparsing
-  - pydas
-  - pydot ==1.2.2
-  - pydqed
-  - pyrdl
-  - nose
-  - coverage
-  - gprof2dot
   - cairo
   - cairocffi
+  - cantera >=2.3.0
+  - coolprop
+  - coverage
+  - cython >=0.25.2
+  - dde
+  - ffmpeg
+  - gprof2dot
+  - graphviz
+  - jinja2
+  - jupyter
+  - lpsolve55
+  - markupsafe
+  - matplotlib >=1.5
+  - mingwpy
+  - mock
+  - mopac
+  - mpmath
+#  - muq
+  - networkx
+  - nose
+  - numpy >=1.10.0
   - openbabel
   - psutil
-  - symmetry
-  - mopac
-  - graphviz
-  - scoop
-  - ffmpeg
-  - jupyter
-  - networkx
-  - mock
-  # - muq
+  - pydas >=1.0.1
+  - pydot ==1.2.2
+  - pydqed >=1.0.0
   - pymongo
-  - mpmath
-  - dde
+  - pyparsing
+  - pyrdl
+  - python >=2.7
   - pyyaml
-  - textgenrnn
+  - quantities
+  - rdkit >=2018
   - scikit-learn
+  - scipy
+  - symmetry
+  - textgenrnn
+  - xlwt

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - rmg
   - rdkit
+  - cantera
 dependencies:
   - cairo
   - cairocffi

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1351,72 +1351,74 @@ multiplicity 2
         The first two are different Kekule forms of the same thing.
         """
         test_cases = {
-                    "CC1C=CC=CC=1O":"""
-                        1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
-                        2 C u0 p0 c0 {1,S} {3,D} {4,S}
-                        3 C u0 p0 c0 {2,D} {5,S} {8,S}
-                        4 C u0 p0 c0 {2,S} {7,D} {12,S}
-                        5 C u0 p0 c0 {3,S} {6,D} {13,S}
-                        6 C u0 p0 c0 {5,D} {7,S} {14,S}
-                        7 C u0 p0 c0 {4,D} {6,S} {15,S}
-                        8 O u0 p2 c0 {3,S} {16,S}
-                        9 H u0 p0 c0 {1,S}
-                        10 H u0 p0 c0 {1,S}
-                        11 H u0 p0 c0 {1,S}
-                        12 H u0 p0 c0 {4,S}
-                        13 H u0 p0 c0 {5,S}
-                        14 H u0 p0 c0 {6,S}
-                        15 H u0 p0 c0 {7,S}
-                        16 H u0 p0 c0 {8,S}""",
-                    "CC1=CC=CC=C1O":"""
-                        1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
-                        2 C u0 p0 c0 {1,S} {3,S} {4,D}
-                        3 C u0 p0 c0 {2,S} {5,D} {8,S}
-                        4 C u0 p0 c0 {2,D} {7,S} {15,S}
-                        5 C u0 p0 c0 {3,D} {6,S} {12,S}
-                        6 C u0 p0 c0 {5,S} {7,D} {13,S}
-                        7 C u0 p0 c0 {4,S} {6,D} {14,S}
-                        8 O u0 p2 c0 {3,S} {16,S}
-                        9 H u0 p0 c0 {1,S}
-                        10 H u0 p0 c0 {1,S}
-                        11 H u0 p0 c0 {1,S}
-                        12 H u0 p0 c0 {5,S}
-                        13 H u0 p0 c0 {6,S}
-                        14 H u0 p0 c0 {7,S}
-                        15 H u0 p0 c0 {4,S}
-                        16 H u0 p0 c0 {8,S}""",
-                    "CC1C=CC=CC=1":"""
-                        1  C u0 p0 c0 {2,D} {6,S} {7,S}
-                        2  C u0 p0 c0 {1,D} {3,S} {8,S}
-                        3  C u0 p0 c0 {2,S} {4,D} {9,S}
-                        4  C u0 p0 c0 {3,D} {5,S} {10,S}
-                        5  C u0 p0 c0 {4,S} {6,D} {11,S}
-                        6  C u0 p0 c0 {1,S} {5,D} {12,S}
-                        7  C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
-                        8  H u0 p0 c0 {2,S}
-                        9  H u0 p0 c0 {3,S}
-                        10 H u0 p0 c0 {4,S}
-                        11 H u0 p0 c0 {5,S}
-                        12 H u0 p0 c0 {6,S}
-                        13 H u0 p0 c0 {7,S}
-                        14 H u0 p0 c0 {7,S}
-                        15 H u0 p0 c0 {7,S}"""
-                    }
+            "CC1=C(O)C=CC=C1": """
+1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 C u0 p0 c0 {2,D} {5,S} {8,S}
+4 C u0 p0 c0 {2,S} {7,D} {12,S}
+5 C u0 p0 c0 {3,S} {6,D} {13,S}
+6 C u0 p0 c0 {5,D} {7,S} {14,S}
+7 C u0 p0 c0 {4,D} {6,S} {15,S}
+8 O u0 p2 c0 {3,S} {16,S}
+9 H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {1,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {5,S}
+14 H u0 p0 c0 {6,S}
+15 H u0 p0 c0 {7,S}
+16 H u0 p0 c0 {8,S}
+""",
+            "CC1=CC=CC=C1O": """
+1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,D}
+3 C u0 p0 c0 {2,S} {5,D} {8,S}
+4 C u0 p0 c0 {2,D} {7,S} {15,S}
+5 C u0 p0 c0 {3,D} {6,S} {12,S}
+6 C u0 p0 c0 {5,S} {7,D} {13,S}
+7 C u0 p0 c0 {4,S} {6,D} {14,S}
+8 O u0 p2 c0 {3,S} {16,S}
+9 H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {1,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {6,S}
+14 H u0 p0 c0 {7,S}
+15 H u0 p0 c0 {4,S}
+16 H u0 p0 c0 {8,S}
+""",
+            "CC1=CC=CC=C1": """
+1  C u0 p0 c0 {2,D} {6,S} {7,S}
+2  C u0 p0 c0 {1,D} {3,S} {8,S}
+3  C u0 p0 c0 {2,S} {4,D} {9,S}
+4  C u0 p0 c0 {3,D} {5,S} {10,S}
+5  C u0 p0 c0 {4,S} {6,D} {11,S}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {7,S}
+14 H u0 p0 c0 {7,S}
+15 H u0 p0 c0 {7,S}
+""",
+        }
         for smiles, adjlist in test_cases.iteritems():
             m = Molecule().fromAdjacencyList(adjlist)
             s = m.toSMILES()
             self.assertEqual(s, smiles, "Generated SMILES string {0} instead of {1}".format(s, smiles))
-        
 
     def testKekuleRoundTripSMILES(self):
         """
         Test that we can round-trip SMILES strings of Kekulized aromatics
         """
-        import rmgpy.molecule
         test_strings = [
-                       'CC1=CC=CC=C1O', 'CC1C=CC=CC=1O',
-                       # 'Cc1ccccc1O', # this will fail because it is Kekulized during fromSMILES()
-                       ]
+            'CC1=CC=CC=C1O',
+            'CC1=C(O)C=CC=C1',
+            # 'Cc1ccccc1O',  # this will fail because it is Kekulized during fromSMILES()
+        ]
         for s in test_strings:
             molecule = Molecule(SMILES=s)
             self.assertEqual(s, molecule.toSMILES(), "Started with {0} but ended with {1}".format(s, molecule.toSMILES()))

--- a/rmgpy/tools/canteraModel.py
+++ b/rmgpy/tools/canteraModel.py
@@ -422,7 +422,7 @@ class Cantera:
             while canteraSimulation.time<condition.reactionTime.value_si:
 
                 # Advance the state of the reactor network in time from the current time to time t [s], taking as many integrator timesteps as necessary.
-                canteraSimulation.step(condition.reactionTime.value_si)
+                canteraSimulation.step()
                 times.append(canteraSimulation.time)
                 temperature.append(canteraReactor.T)
                 pressure.append(canteraReactor.thermo.P)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
We were artificially limiting our RDKit version, so this removes that limitation.

### Description of Changes
Major changes:
- Add RDKit and Cantera channels to defaults so we can directly get their packages
- Require RDKit > 2018, mainly so we don't pull from the RMG channel which has higher priority but older versions

Minor changes:
- Update unit tests broken by RDKit changes
- Remove argument to Cantera ReactorNet.step which no longer exists
- Alphabetize environment files
- Remove libgcc and libgfortran because they should be dependencies of packages that use them
- Remove scoop because it's no longer functioning
- Comment out muq and textgenrnn for MacOS and Windows because they don't work

### Testing
Haven't done any real testing. Seems like this should be safe as long as all of the tests pass.

Not sure if we want to include this in the release. Comments welcome.
