### PR TITLE
Update constants according to CODATA 2018 recommendations

### DIFF
--- a/arkane/commonTest.py
+++ b/arkane/commonTest.py
@@ -207,10 +207,8 @@ class TestArkaneJob(unittest.TestCase):
         """
         Test the calculation of the high-pressure limit rate coef for one of the kinetics jobs at Tmin and Tmax.
         """
-        self.assertEqual("%0.7f" % self.kineticsjob.reaction.calculateTSTRateCoefficient(self.TminValue),
-                         str(46608.5904933))
-        self.assertEqual("%0.5f" % self.kineticsjob.reaction.calculateTSTRateCoefficient(self.Tmaxvalue),
-                         str(498796.64535))
+        self.assertAlmostEqual(self.kineticsjob.reaction.calculateTSTRateCoefficient(self.TminValue), 46608.257156, 6)
+        self.assertAlmostEqual(self.kineticsjob.reaction.calculateTSTRateCoefficient(self.Tmaxvalue), 498794.081945, 6)
 
     def testTunneling(self):
         """

--- a/arkane/gaussianTest.py
+++ b/arkane/gaussianTest.py
@@ -96,8 +96,8 @@ class GaussianTest(unittest.TestCase):
         rot = [mode for mode in conformer.modes if isinstance(mode, LinearRotor)][0]
         vib = [mode for mode in conformer.modes if isinstance(mode, HarmonicOscillator)][0]
         Tlist = numpy.array([298.15], numpy.float64)
-        self.assertAlmostEqual(trans.getPartitionFunction(Tlist), 7.11169e6, delta=1e1)
-        self.assertAlmostEqual(rot.getPartitionFunction(Tlist), 7.13316e1, delta=1e-4)
+        self.assertAlmostEqual(trans.getPartitionFunction(Tlist), 7.111673e6, delta=1e1)
+        self.assertAlmostEqual(rot.getPartitionFunction(Tlist), 7.13315e1, delta=1e-4)
         self.assertAlmostEqual(vib.getPartitionFunction(Tlist), 1.00037e0, delta=1e-4)
 
         self.assertAlmostEqual(E0 / constants.Na / constants.E_h, -150.3784877, 4)

--- a/arkane/molproTest.py
+++ b/arkane/molproTest.py
@@ -99,8 +99,8 @@ class MolproTest(unittest.TestCase):
         vib = [mode for mode in conformer.modes if isinstance(mode, HarmonicOscillator)][0]
         t_list = numpy.array([298.15], numpy.float64)
 
-        self.assertAlmostEqual(trans.getPartitionFunction(t_list), 9.175364e7, delta=1e1)
-        self.assertAlmostEqual(rot.getPartitionFunction(t_list), 1.00005557e5, delta=1e-2)
+        self.assertAlmostEqual(trans.getPartitionFunction(t_list), 9.1753359e7, delta=1e1)
+        self.assertAlmostEqual(rot.getPartitionFunction(t_list), 1.00005389e5, delta=1e-2)
         self.assertAlmostEqual(vib.getPartitionFunction(t_list), 1.9734989e0, delta=1e-4)
 
         self.assertAlmostEqual(e0 / constants.Na / constants.E_h, -768.275662, 4)
@@ -113,7 +113,7 @@ class MolproTest(unittest.TestCase):
         """
         molpro_log = MolproLog(os.path.join(os.path.dirname(__file__), 'data', 'TS_CCSD(T)_no_F12_sp_molpro.out'))
         e0 = molpro_log.loadEnergy()
-        self.assertAlmostEqual(e0, -301585968.58196217, places=7)
+        self.assertAlmostEqual(e0, -301585943.43928576, places=7)
 
     def test_load_mrci_e0(self):
         """
@@ -123,8 +123,8 @@ class MolproTest(unittest.TestCase):
         mrciq_log = MolproLog(os.path.join(os.path.dirname(__file__), 'data', 'molpro_mrci+q.out'))
         mrci_e0 = mrci_log.loadEnergy()
         mrciq_e0 = mrciq_log.loadEnergy()
-        self.assertAlmostEqual(mrci_e0, -293217091.0381712, places=7)
-        self.assertAlmostEqual(mrciq_e0, -293284017.3925107, places=7)
+        self.assertAlmostEqual(mrci_e0, -293217066.59319293, places=7)
+        self.assertAlmostEqual(mrciq_e0, -293283992.94195294, places=7)
 
     def test_load_negative_frequency(self):
         """

--- a/arkane/qchemTest.py
+++ b/arkane/qchemTest.py
@@ -62,11 +62,11 @@ class QChemTest(unittest.TestCase):
         molecular energies can be properly read.
         """
         log = QChemLog(os.path.join(os.path.dirname(__file__), 'data', 'npropyl.out'))
-        self.assertAlmostEqual(log.loadEnergy(), -310896203.5432524, delta=1e-5)
+        self.assertAlmostEqual(log.loadEnergy(), -310896177.6243986, delta=1e-5)
         log = QChemLog(os.path.join(os.path.dirname(__file__), 'data', 'co.out'))
-        self.assertAlmostEqual(log.loadEnergy(), -297402545.0217114, delta=1e-5)
+        self.assertAlmostEqual(log.loadEnergy(), -297402520.22779953, delta=1e-5)
         log = QChemLog(os.path.join(os.path.dirname(__file__), 'data', 'CH4_sp_qchem.out'))
-        self.assertAlmostEqual(log.loadEnergy(), -106356735.53661588, delta=1e-5)
+        self.assertAlmostEqual(log.loadEnergy(), -106356726.66984732, delta=1e-5)
 
     def testLoadVibrationsFromQChemLog(self):
         """

--- a/rmgpy/constants.py
+++ b/rmgpy/constants.py
@@ -41,28 +41,27 @@ The constants defined in this module are listed in the table below:
 
 .. table:: Physical constants defined in the :mod:`rmgpy.constants` module
     
-    ======================= =================== =========================================================== ============================================================
-    Symbol                  Constant            Value                                                       Description
-    ======================= =================== =========================================================== ============================================================
-    :math:`E_\mathrm{h}`    :data:`E_h`         :math:`4.35974434 \times 10^{-18} \ \mathrm{J}`             Hartree energy
-    :math:`F`               :data:`F`           :math:`96485.3365 \ \mathrm{C/mol}`                         Faraday constant
-    :math:`G`               :data:`G`           :math:`6.67384 \times 10^{-11} \ \mathrm{m^3/kg \cdot s^2}` Newtonian gravitational constant
-    :math:`N_\mathrm{A}`    :data:`Na`          :math:`6.02214179 \times 10^{23} \ \mathrm{mol^{-1}}`       Avogadro constant
-    :math:`R`               :data:`R`           :math:`8.314472 \ \mathrm{J/mol \cdot K}`                   gas law constant
-    :math:`a_0`             :data:`a0`          :math:`5.2917721092 \times 10^{-11} \ \mathrm{m}`           Bohr radius
-    :math:`c`               :data:`c`           :math:`299792458 \ \mathrm{m/s}`                            speed of light in a vacuum
-    :math:`e`               :data:`e`           :math:`1.602176565 \times 10^{-19} \ \mathrm{C}`            elementary charge
-    :math:`g`               :data:`g`           :math:`9.80665 \ \mathrm{m/s^2}`                            standard acceleration due to gravity
-    :math:`h`               :data:`h`           :math:`6.62606896 \times 10^{-34} \ \mathrm{J \cdot s}`     Planck constant
-    :math:`\hbar`           :data:`hbar`        :math:`1.054571726 \times 10^{-34} \ \mathrm{J \cdot s}`    reduced Planck constant
-    :math:`k_\mathrm{B}`    :data:`kB`          :math:`1.3806504 \times 10^{-23} \ \mathrm{J/K}`            Boltzmann constant
-    :math:`m_\mathrm{e}`    :data:`m_e`         :math:`9.10938291 \times 10^{-31} \ \mathrm{kg}`            electron rest mass
-    :math:`m_\mathrm{n}`    :data:`m_n`         :math:`1.674927351 \times 10^{-27} \ \mathrm{kg}`           neutron rest mass
-    :math:`m_\mathrm{p}`    :data:`m_p`         :math:`1.672621777 \times 10^{-27} \ \mathrm{kg}`           proton rest mass
-    :math:`m_\mathrm{u}`    :data:`amu`         :math:`1.660538921 \times 10^{-27} \ \mathrm{kg}`           atomic mass unit
-    :math:`\pi`             :data:`pi`          :math:`3.14159 \ldots`      
-    ======================= =================== =========================================================== ============================================================
+    ==================== ============ ======================================================== ========================
+    Symbol               Constant     Value                                                    Description
+    ==================== ============ ======================================================== ========================
+    :math:`E_\mathrm{h}` :data:`E_h`  :math:`4.3597447222071 \times 10^{-18} \ \mathrm{J}`     Hartree energy
+    :math:`N_\mathrm{A}` :data:`Na`   :math:`6.02214076 \times 10^{23} \ \mathrm{mol^{-1}}`    Avogadro constant
+    :math:`R`            :data:`R`    :math:`8.314462618 \ \mathrm{J/mol \cdot K}`             molar gas constant
+    :math:`a_0`          :data:`a0`   :math:`5.29177210903 \times 10^{-11} \ \mathrm{m}`       Bohr radius
+    :math:`c`            :data:`c`    :math:`299792458 \ \mathrm{m/s}`                         speed of light in vacuum
+    :math:`e`            :data:`e`    :math:`1.602176634 \times 10^{-19} \ \mathrm{C}`         elementary charge
+    :math:`h`            :data:`h`    :math:`6.62607015 \times 10^{-34} \ \mathrm{J \cdot s}`  Planck constant
+    :math:`\hbar`        :data:`hbar` :math:`1.054571817 \times 10^{-34} \ \mathrm{J \cdot s}` reduced Planck constant
+    :math:`k_\mathrm{B}` :data:`kB`   :math:`1.380649 \times 10^{-23} \ \mathrm{J/K}`          Boltzmann constant
+    :math:`m_\mathrm{e}` :data:`m_e`  :math:`9.1093837015 \times 10^{-31} \ \mathrm{kg}`       electron rest mass
+    :math:`m_\mathrm{n}` :data:`m_n`  :math:`1.67492749804 \times 10^{-27} \ \mathrm{kg}`      neutron rest mass
+    :math:`m_\mathrm{p}` :data:`m_p`  :math:`1.67262192369 \times 10^{-27} \ \mathrm{kg}`      proton rest mass
+    :math:`m_\mathrm{u}` :data:`amu`  :math:`1.66053906660 \times 10^{-27} \ \mathrm{kg}`      atomic mass unit
+    :math:`\pi`          :data:`pi`   :math:`3.14159 \ldots`
+    ==================== ============ ======================================================== ========================
 
+These values have been updated following CODATA 2018 recommendations.
+https://physics.nist.gov/cuu/Constants/Table/allascii.txt
 """
 
 import math
@@ -70,45 +69,45 @@ import math
 ################################################################################
 
 #: The Hartree energy :math:`E_\mathrm{h}` in :math:`\mathrm{J}`
-E_h = 4.35974434e-18
+E_h = 4.3597447222071e-18
 
-#: The Avogadro constant :math:`N_\mathrm{A}` in :math:`\mathrm{mol^{-1}}`       
-Na = 6.02214179e23
+#: The Avogadro constant :math:`N_\mathrm{A}` in :math:`\mathrm{mol^{-1}}`
+Na = 6.02214076e23
 
 #: The gas law constant :math:`R` in :math:`\mathrm{J/mol \cdot K}`
-R = 8.314472
+R = 8.314462618
 
 #: The Bohr radius :math:`a_0` in :math:`\mathrm{m}`
-a0 = 5.2917721092e-11
+a0 = 5.29177210903e-11
 
 #: The atomic mass unit in :math:`\mathrm{kg}`
-amu = 1.660538921e-27
+amu = 1.66053906660e-27
 
 #: The speed of light in a vacuum :math:`c` in :math:`\mathrm{m/s}`
-c = 299792458
+c = 299792458.
 
 #: The elementary charge :math:`e` in :math:`\mathrm{C}`
-e = 1.602176565e-19
+e = 1.602176634e-19
 
 #: The Planck constant :math:`h` in :math:`\mathrm{J \cdot s}`
-h = 6.62606896e-34
+h = 6.62607015e-34
 
 #: The reduced Planck constant :math:`\hbar` in :math:`\mathrm{J \cdot s}`
-hbar = 1.054571726e-34
+hbar = 1.054571817e-34
 
 #: The Boltzmann constant :math:`k_\mathrm{B}` in :math:`\mathrm{J/K}`
-kB = 1.3806504e-23
+kB = 1.380649e-23
 
 #: The mass of an electron :math:`m_\mathrm{e}` in :math:`\mathrm{kg}`
-m_e = 9.10938291e-31
+m_e = 9.1093837015e-31
 
 #: The mass of a neutron :math:`m_\mathrm{n}` in :math:`\mathrm{kg}`
-m_n = 1.674927351e-27
+m_n = 1.67492749804e-27
 
 #: The mass of a proton :math:`m_\mathrm{p}` in :math:`\mathrm{kg}`
-m_p = 1.672621777e-27
+m_p = 1.67262192369e-27
 
-#: :math:`\pi = 3.14159 \ldots`      
+#: :math:`\pi = 3.14159 \ldots`
 pi = float(math.pi)
 
 ################################################################################

--- a/rmgpy/constantsTest.py
+++ b/rmgpy/constantsTest.py
@@ -50,42 +50,42 @@ class TestConstants(unittest.TestCase):
         """
         Test the value of the Avogadro constant.
         """
-        Na = 6.02214179e23
+        Na = 6.02214076e23
         self.assertAlmostEqual(constants.Na / Na, 1.0, 6, '{0} != {1}'.format(constants.Na, Na))
 
     def test_boltzmannConstant(self):
         """
         Test the value of the Boltzmann constant.
         """
-        kB = 1.3806504e-23
+        kB = 1.380649e-23
         self.assertAlmostEqual(constants.kB / kB, 1.0, 6, '{0} != {1}'.format(constants.kB, kB))
     
     def test_elementaryCharge(self):
         """
         Test the value of the elementary charge constant.
         """
-        e = 1.602176565e-19
+        e = 1.602176634e-19
         self.assertAlmostEqual(constants.e / e, 1.0, 6, '{0} != {1}'.format(constants.e, e))
     
     def test_gasLawConstant(self):
         """
         Test the value of the gas law constant.
         """
-        R = 8.314472
-        self.assertAlmostEqual(constants.R / R, 1.0, 6, '{0} != {1}'.format(constants.R, R))
+        R = 8.314462618
+        self.assertEqual(constants.R, R)
     
     def test_planckConstant(self):
         """
         Test the value of the Planck constant.
         """
-        h = 6.62606896e-34
+        h = 6.62607015e-34
         self.assertAlmostEqual(constants.h / h, 1.0, 6, '{0} != {1}'.format(constants.h, h))
     
     def test_reducedPlanckConstant(self):
         """
         Test the value of the reduced Planck constant.
         """
-        hbar = 1.054571726e-34
+        hbar = 1.054571817e-34
         self.assertAlmostEqual(constants.hbar / hbar, 1.0, 6, '{0} != {1}'.format(constants.hbar, hbar))
     
     def test_pi(self):
@@ -98,49 +98,49 @@ class TestConstants(unittest.TestCase):
         """
         Test the value of the speed of light in a vacuum.
         """
-        c = 299792458
+        c = 299792458.
         self.assertEqual(constants.c, c)
 
     def test_electronMass(self):
         """
         Test the value of the electron rest mass.
         """
-        m_e = 9.10938291e-31
+        m_e = 9.1093837015e-31
         self.assertAlmostEqual(constants.m_e / m_e, 1.0, 6, '{0} != {1}'.format(constants.m_e, m_e))
 
     def test_protonMass(self):
         """
         Test the value of the proton rest mass.
         """
-        m_p = 1.672621777e-27
+        m_p = 1.67262192369e-27
         self.assertAlmostEqual(constants.m_p / m_p, 1.0, 6, '{0} != {1}'.format(constants.m_p, m_p))
 
     def test_neutronMass(self):
         """
         Test the value of the neutron rest mass.
         """
-        m_n = 1.674927351e-27
+        m_n = 1.67492749804e-27
         self.assertAlmostEqual(constants.m_n / m_n, 1.0, 6, '{0} != {1}'.format(constants.m_n, m_n))
 
     def test_atomicMassUnit(self):
         """
         Test the value of the atomic mass unit.
         """
-        amu = 1.660538921e-27
+        amu = 1.66053906660e-27
         self.assertAlmostEqual(constants.amu / amu, 1.0, 6, '{0} != {1}'.format(constants.amu, amu))
 
     def test_bohrRadius(self):
         """
         Test the value of the Bohr radius.
         """
-        a0 = 5.2917721092e-11
+        a0 = 5.29177210903e-11
         self.assertAlmostEqual(constants.a0 / a0, 1.0, 6, '{0} != {1}'.format(constants.a0, a0))
 
     def test_hartreeEnergy(self):
         """
         Test the value of the Hartree energy.
         """
-        E_h = 4.35974434e-18
+        E_h = 4.3597447222071e-18
         self.assertAlmostEqual(constants.E_h / E_h, 1.0, 6, '{0} != {1}'.format(constants.E_h, E_h))
 
 ################################################################################

--- a/rmgpy/quantityTest.py
+++ b/rmgpy/quantityTest.py
@@ -211,7 +211,7 @@ class TestEnergy(unittest.TestCase):
         Test the creation of an energy quantity with units of K (not really an energy!).
         """
         q = quantity.Energy(10.0,"K")
-        self.assertAlmostEqual(q.value, 10*8.314472, delta=1e-6)
+        self.assertAlmostEqual(q.value, 10 * constants.R, delta=1e-6)
         self.assertEqual(q.units, "J/mol")
 
 ################################################################################

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -510,7 +510,9 @@ class TestReaction(unittest.TestCase):
         Test the Reaction.getEquilibriumConstant() method.
         """
         Tlist = numpy.arange(200.0, 2001.0, 200.0, numpy.float64)
-        Kalist0 = [float(v) for v in ['8.75951e+29', '7.1843e+10', '34272.7', '26.1877', '0.378696', '0.0235579', '0.00334673', '0.000792389', '0.000262777', '0.000110053']]
+        Kalist0 = [8.75880596e+29, 7.18388385e+10, 3.42710001e+04, 2.61864574e+01,
+                   3.78679351e-01, 2.35568712e-02, 3.34658978e-03, 7.92357444e-04,
+                   2.62766697e-04, 1.10048401e-04]
         Kalist = self.reaction2.getEquilibriumConstants(Tlist, type='Ka')
         for i in range(len(Tlist)):
             self.assertAlmostEqual(Kalist[i] / Kalist0[i], 1.0, 4)
@@ -520,7 +522,9 @@ class TestReaction(unittest.TestCase):
         Test the Reaction.getEquilibriumConstant() method.
         """
         Tlist = numpy.arange(200.0, 2001.0, 200.0, numpy.float64)
-        Kclist0 = [float(v) for v in ['1.45661e+28', '2.38935e+09', '1709.76', '1.74189', '0.0314866', '0.00235045', '0.000389568', '0.000105413', '3.93273e-05', '1.83006e-05']]
+        Kclist0 = [1.45649529e+28, 2.38920535e+09, 1.70966970e+03, 1.74181057e+00,
+                   3.14851531e-02, 2.35035270e-03, 3.89551339e-04, 1.05408422e-04,
+                   3.93257498e-05, 1.82998663e-05]
         Kclist = self.reaction2.getEquilibriumConstants(Tlist, type='Kc')
         for i in range(len(Tlist)):
             self.assertAlmostEqual(Kclist[i] / Kclist0[i], 1.0, 4)
@@ -530,7 +534,9 @@ class TestReaction(unittest.TestCase):
         Test the Reaction.getEquilibriumConstant() method.
         """
         Tlist = numpy.arange(200.0, 2001.0, 200.0, numpy.float64)
-        Kplist0 = [float(v) for v in ['8.75951e+24', '718430', '0.342727', '0.000261877', '3.78696e-06', '2.35579e-07', '3.34673e-08', '7.92389e-09', '2.62777e-09', '1.10053e-09']]
+        Kplist0 = [8.75880596e+24, 7.18388385e+05, 3.42710001e-01, 2.61864574e-04,
+                   3.78679351e-06, 2.35568712e-07, 3.34658978e-08, 7.92357444e-09,
+                   2.62766697e-09, 1.10048401e-09]
         Kplist = self.reaction2.getEquilibriumConstants(Tlist, type='Kp')
         for i in range(len(Tlist)):
             self.assertAlmostEqual(Kplist[i] / Kplist0[i], 1.0, 4)

--- a/rmgpy/thermo/wilhoitTest.py
+++ b/rmgpy/thermo/wilhoitTest.py
@@ -58,8 +58,8 @@ class TestWilhoit(unittest.TestCase):
         self.a2 = 26.2524
         self.a3 = -12.6785
         self.B = 1068.68
-        self.H0 = -94088. # -782.292 kJ/mol / constants.R
-        self.S0 = -118.46 # -984.932 J/mol*K / constants.R
+        self.H0 = -1000 * 782.292 / constants.R  # -782.292 kJ/mol / constants.R
+        self.S0 = -984.932 / constants.R  # -984.932 J/mol*K / constants.R
         self.Tmin = 300.
         self.Tmax = 3000.
         self.comment = 'C2H6'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem

> Sufficient progress towards redefining the International System of Units (SI) in terms of exact values of fundamental constants has been achieved. Exact values of the Planck constant h, elementary charge e, Boltzmann constant k, and Avogadro constant N A from the CODATA 2017 Special Adjustment of the Fundamental Constants are presented here. These values are recommended to the 26th General Conference on Weights and Measures to form the foundation of the revised SI.

https://iopscience.iop.org/article/10.1088/1681-7575/aa950a

### Description of Changes
Update values in the `constants` module based on the new recommended values, as obtained from https://pml.nist.gov/cuu/Constants/.

Also update the module docstring to reflect the constants that are actually included.

### Testing
This should have almost no effect on any results. It's more of a formality. :smiley:
