### PR TITLE
Bugfix nasa as dict

### DIFF
--- a/rmgpy/thermo/nasa.pyx
+++ b/rmgpy/thermo/nasa.pyx
@@ -256,11 +256,16 @@ cdef class NASA(HeatCapacityModel):
                     poly_dict[key]['coeffs'] = poly.coeffs.tolist()
             i = i + 1
         output_dict['polynomials'] = poly_dict
-        output_dict['Tmin'] = self.Tmin.as_dict()
-        output_dict['Tmax'] = self.Tmax.as_dict()
-        output_dict['E0'] = self.E0.as_dict()
-        output_dict['Cp0'] = self.Cp0.as_dict()
-        output_dict['CpInf'] = self.CpInf.as_dict()
+        if self.Tmin:
+            output_dict['Tmin'] = self.Tmin.as_dict()
+        if self.Tmax:
+            output_dict['Tmax'] = self.Tmax.as_dict()
+        if self.E0:
+            output_dict['E0'] = self.E0.as_dict()
+        if self.Cp0:
+            output_dict['Cp0'] = self.Cp0.as_dict()
+        if self.CpInf:
+            output_dict['CpInf'] = self.CpInf.as_dict()
         if self.label != '':
             output_dict['label'] = self.label
         if self.comment != '':

--- a/rmgpy/thermo/nasaTest.py
+++ b/rmgpy/thermo/nasaTest.py
@@ -285,3 +285,33 @@ class TestNASA(unittest.TestCase):
         self.assertEqual(wilhoit.comment,nasa.comment)
 
         # nasa to wilhoi performed in wilhoitTest
+
+    def test_nasa_as_dict_full(self):
+        """
+        Test that NASA.as_dict functions properly with all attributes
+        """
+        nasa_dict = self.nasa.as_dict()
+        self.assertEqual(nasa_dict['E0']['value'], self.E0)
+        self.assertEqual(nasa_dict['Tmin']['value'], self.Tmin)
+        self.assertEqual(nasa_dict['Tmax']['value'], self.Tmax)
+        self.assertEqual(nasa_dict['comment'], self.comment)
+        self.assertTupleEqual(tuple(nasa_dict['polynomials']['polynomial1']['coeffs']), tuple(self.coeffs_low))
+        self.assertTupleEqual(tuple(nasa_dict['polynomials']['polynomial2']['coeffs']), tuple(self.coeffs_high))
+        self.assertEqual(nasa_dict['polynomials']['polynomial1']['Tmin']['value'], self.Tmin)
+        self.assertEqual(nasa_dict['polynomials']['polynomial1']['Tmax']['value'], self.Tint)
+        self.assertEqual(nasa_dict['polynomials']['polynomial2']['Tmin']['value'], self.Tint)
+        self.assertEqual(nasa_dict['polynomials']['polynomial2']['Tmax']['value'], self.Tmax)
+
+    def test_nasa_as_dict_minimal(self):
+        """
+        Test that NASA.as_dict does not contain empty, optional attributes
+        """
+        nasa_dict = NASA().as_dict()
+        keys = nasa_dict.keys()
+        self.assertNotIn('Tmin', keys)
+        self.assertNotIn('Tmax', keys)
+        self.assertNotIn('E0', keys)
+        self.assertNotIn('Cp0', keys)
+        self.assertNotIn('CpInf', keys)
+        self.assertNotIn('label', keys)
+        self.assertNotIn('comment', keys)


### PR DESCRIPTION
### Motivation or Problem
NASA polynomials would throw an error when calling the `as_dict` method when optional variables like `Tmin` are not set.

### Description of Changes
Added an if statement to the `as_dict` method to only add attributes which are set.

### Testing
RMG tests should be sufficient

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
