### PR TITLE
Molecular weight growth

### DIFF
--- a/examples/rmg/polyethylene/input.py
+++ b/examples/rmg/polyethylene/input.py
@@ -1,0 +1,63 @@
+"""
+This example is for demonstrating the use of RMG for molecular growth
+We use mass weighted fluxes to bias the algorithm toward adding larger species
+"""
+database(
+    thermoLibraries = ['Klippenstein_Glarborg2016','BurkeH2O2','primaryThermoLibrary','thermo_DFT_CCSDTF12_BAC','CBS_QB3_1dHR','DFT_QCI_thermo'],
+    reactionLibraries = ['Klippenstein_Glarborg2016','BurkeH2O2inN2'],
+    seedMechanisms = [],
+    kineticsDepositories = 'default', 
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+
+species(
+    label='butadiene',
+    reactive=True,	
+    structure=SMILES("C=CC=C"),
+)
+
+
+simpleReactor(
+    temperature=(700,'K'),
+    pressure=(10.0,'bar'),
+    initialMoleFractions={
+        "butadiene": 1,
+    },
+
+    terminationTime=(1e5,'s'),
+    terminationAvgMW=150.0, #terminate simulation when the average molecule weight reaches terminationAvgMW amu
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceMoveToCore=1.0,
+    toleranceInterruptSimulation=1.0,
+    maxNumObjsPerIter=1,
+    fluxBasis='mass', #use mass weighting
+    massIndex=2.0,    #weight fluxes by mass to the power of massIndex
+    terminateAtMaxObjects=True,
+    filterReactions=True,
+)
+
+options(
+    units='si',
+    generateSeedEachIteration=False,
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveSimulationProfiles=False,
+    verboseComments=False,
+    saveEdgeSpecies=False,
+    keepIrreversible=False,
+)
+
+generatedSpeciesConstraints(
+    allowed=['input species','seed mechanisms','reaction libraries'],
+    maximumRadicalElectrons=2,
+    maximumHeavyAtoms=15,
+)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -558,12 +558,10 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=np.inf, tole
           toleranceMoveEdgeReactionToSurface=np.inf, toleranceMoveSurfaceSpeciesToCore=np.inf,
           toleranceMoveSurfaceReactionToCore=np.inf,
           toleranceMoveEdgeReactionToSurfaceInterrupt=None,
-          toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50,
-          minSpeciesExistIterationsForPrune=2, filterReactions=False, filterThreshold=1e8,
-          ignoreOverallFluxCriterion=False,
-          maxNumSpecies=None, maxNumObjsPerIter=1, terminateAtMaxObjects=False,
-          toleranceThermoKeepSpeciesInEdge=np.inf, dynamicsTimeScale=(0.0, 'sec'),
-          toleranceBranchReactionToCore=0.0, branchingIndex=0.5, branchingRatioMax=1.0):
+          toleranceMoveEdgeReactionToCoreInterrupt=None, maximumEdgeSpecies=1000000, minCoreSizeForPrune=50, 
+          minSpeciesExistIterationsForPrune=2, filterReactions=False, filterThreshold=1e8, ignoreOverallFluxCriterion=False,
+          maxNumSpecies=None, maxNumObjsPerIter=1, terminateAtMaxObjects=False, toleranceThermoKeepSpeciesInEdge=np.inf, dynamicsTimeScale=(0.0, 'sec'),
+          toleranceBranchReactionToCore=0.0, branchingIndex=0.5, branchingRatioMax=1.0, fluxBasis='mole', massIndex=1.0):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -604,6 +602,8 @@ def model(toleranceMoveToCore=None, toleranceMoveEdgeReactionToCore=np.inf, tole
             tol_branch_rxn_to_core=toleranceBranchReactionToCore,
             branching_index=branchingIndex,
             branching_ratio_max=branchingRatioMax,
+            flux_basis=fluxBasis,
+            mass_index=massIndex,
         )
     )
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -39,7 +39,7 @@ from rmgpy.molecule import Molecule
 from rmgpy.quantity import Quantity, Energy, RateCoefficient, SurfaceConcentration
 from rmgpy.rmg.model import CoreEdgeReactionModel
 from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
-from rmgpy.solver.base import TerminationTime, TerminationConversion, TerminationRateRatio
+from rmgpy.solver.base import TerminationTime, TerminationConversion, TerminationRateRatio, TerminationNumberAvgMW, TerminationWeightAvgMW
 from rmgpy.solver.liquid import LiquidReactor
 from rmgpy.solver.mbSampled import MBSampledReactor
 from rmgpy.solver.simple import SimpleReactor
@@ -183,6 +183,8 @@ def simple_reactor(temperature,
                    terminationConversion=None,
                    terminationTime=None,
                    terminationRateRatio=None,
+                   terminationNumberAvgMW=None,
+                   terminationWeightAvgMW=None,
                    balanceSpecies=None,
                    sensitivity=None,
                    sensitivityThreshold=1e-3,
@@ -251,6 +253,10 @@ def simple_reactor(temperature,
         termination.append(TerminationTime(Quantity(terminationTime)))
     if terminationRateRatio is not None:
         termination.append(TerminationRateRatio(terminationRateRatio))
+    if terminationNumberAvgMW is not None:
+        termination.append(TerminationNumberAvgMW(terminationNumberAvgMW))
+        if terminationWeightAvgMW is not None:
+            termination.append(TerminationWeightAvgMW(terminationWeightAvgMW))
     if len(termination) == 0:
         raise InputError('No termination conditions specified for reaction system #{0}.'.format(len(rmg.reaction_systems) + 2))
 
@@ -314,6 +320,8 @@ def liquid_reactor(temperature,
                    nSims=4,
                    terminationTime=None,
                    terminationRateRatio=None,
+                   terminationNumberAvgMW=None,
+                   terminationWeightAvgMW=None,
                    sensitivity=None,
                    sensitivityThreshold=1e-3,
                    sensitivityTemperature=None,
@@ -352,6 +360,10 @@ def liquid_reactor(temperature,
         termination.append(TerminationTime(Quantity(terminationTime)))
     if terminationRateRatio is not None:
         termination.append(TerminationRateRatio(terminationRateRatio))
+    if terminationNumberAvgMW is not None:
+        termination.append(TerminationNumberAvgMW(terminationNumberAvgMW))
+    if terminationWeightAvgMW is not None:
+        termination.append(TerminationWeightAvgMW(terminationWeightAvgMW))
     if len(termination) == 0:
         raise InputError('No termination conditions specified for reaction system #{0}.'.format(len(rmg.reaction_systems) + 2))
 

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -73,7 +73,7 @@ class ModelSettings(object):
                  ignore_overall_flux_criterion=False, max_num_species=None, max_num_objects_per_iter=1,
                  terminate_at_max_objects=False, thermo_tol_keep_spc_in_edge=np.inf,
                  dynamics_time_scale=Quantity((0.0, 'sec')),
-                 tol_branch_rxn_to_core=0.0, branching_index=0.5, branching_ratio_max=1.0):
+                 tol_branch_rxn_to_core=0.0, branching_index=0.5, branching_ratio_max=1.0, flux_basis='mole', mass_index=1.0):
 
         self.tol_keep_in_edge = tol_keep_in_edge
         self.tol_move_to_core = tol_move_to_core
@@ -95,6 +95,7 @@ class ModelSettings(object):
         self.branching_index = branching_index
         self.branching_ratio_max = branching_ratio_max
 
+        self.mass_index = mass_index
         if tol_interrupt_simulation:
             self.tol_interrupt_simulation = tol_interrupt_simulation
         else:
@@ -120,6 +121,10 @@ class ModelSettings(object):
         else:
             self.max_num_objects_per_iter = max_num_objects_per_iter
 
+        if flux_basis in ['mole', 'mass']:
+            self.flux_basis = flux_basis
+        else:
+            raise ValueError("flux_basis must either be 'mole' or 'mass' not '{}'".format(flux_basis))
 
 class SimulatorSettings(object):
     """

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -63,6 +63,9 @@ cdef class ReactionSystem(DASx):
     cdef public np.ndarray Keq  # equilibrium constants
     cdef public np.ndarray network_leak_coefficients
     cdef public np.ndarray jacobian_matrix
+    cdef public np.ndarray mw
+    cdef public np.ndarray mww #molecular weight based weights of species
+    cdef public np.ndarray mww_network #molecular weight based weights of pdep networks
 
     cdef public np.ndarray core_species_concentrations
     

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -1009,6 +1009,7 @@ cdef class ReactionSystem(DASx):
                                  ''.format(len(self.surface_species_indices), len(self.surface_reaction_indices)))
 
             if filter_reactions:
+                mww = self.mww
                 # Calculate thresholds for reactions
                 (unimolecular_threshold_rate_constant,
                  bimolecular_threshold_rate_constant,
@@ -1019,19 +1020,20 @@ cdef class ReactionSystem(DASx):
                 for i in range(num_core_species):
                     if not unimolecular_threshold[i]:
                         # Check if core species concentration has gone above threshold for unimolecular reaction
-                        if core_species_concentrations[i] > unimolecular_threshold_val:
+                        if (flux_basis == 'mass' and core_species_concentrations[i]*mww[i] > unimolecular_threshold_val) or core_species_concentrations[i] > unimolecular_threshold_val:
                             unimolecular_threshold[i] = True
                 for i in range(num_core_species):
                     for j in range(i, num_core_species):
                         if not bimolecular_threshold[i, j]:
-                            if core_species_concentrations[i] * core_species_concentrations[j] > bimolecular_threshold_val:
+                            if (flux_basis == 'mass' and core_species_concentrations[i]*core_species_concentrations[j]*(mww[i]+mww[j]) > bimolecular_threshold_val) or core_species_concentrations[i] * core_species_concentrations[j] > bimolecular_threshold_val:
                                 bimolecular_threshold[i, j] = True
                 if self.trimolecular:
                     for i in range(num_core_species):
                         for j in range(i, num_core_species):
                             for k in range(j, num_core_species):
                                 if not trimolecular_threshold[i, j, k]:
-                                    if (core_species_concentrations[i] *
+                                    if (flux_basis == 'mass' and (core_species_concentrations[i]*core_species_concentrations[j]*core_species_concentrations[k]*
+                                        (mww[i]+mww[j]+mww[k])> trimolecular_threshold_val)) or (core_species_concentrations[i] *
                                             core_species_concentrations[j] *
                                             core_species_concentrations[k]
                                             > trimolecular_threshold_val):

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -1258,7 +1258,21 @@ cdef class ReactionSystem(DASx):
                         logging.info('At time {0:10.4e} s, reached target termination RateRatio: '
                                      '{1}'.format(self.t,char_rate/max_char_rate))
                         self.log_conversions(species_index, y0)
-
+                        
+                elif isinstance(term, TerminationNumberAvgMW):
+                    avg_MW = np.dot(self.y[:num_core_species],self.mw[:num_core_species])*constants.Na*1000.0/self.y[:num_core_species].sum()
+                    if avg_MW > term.avg_MW:
+                        terminated = True
+                        logging.info('At time {0:10.4e} s, reached target termination Number Averaged MW: {1}'.format(self.t,avg_MW))
+                        self.logConversions(species_index, y0)
+                        
+                elif isinstance(term, TerminationWeightAvgMW):
+                    avg_MW = np.dot(self.y[:num_core_species],self.mw[:num_core_species]**2)*constants.Na*1000.0/self.y[:num_core_species].dot(self.mw[:num_core_species])
+                    if avg_MW > term.avg_MW:
+                        terminated = True
+                        logging.info('At time {0:10.4e} s, reached target termination Weight Averaged MW: {1}'.format(self.t,avg_MW))
+                        self.logConversions(species_index, y0)
+                        
             # Increment destination step time if necessary
             if self.t >= 0.9999 * step_time:
                 step_time *= 10.0
@@ -1455,3 +1469,21 @@ class TerminationRateRatio:
 
     def __init__(self, ratio=0.01):
         self.ratio = ratio
+        
+class TerminationNumberAvgMW:
+    """
+    Represent an number averaged MW in amu at which a simulation
+    should be terminated. This class has one attribute the average
+    molecular weight.  Useful for molecular growth situations.
+    """
+    def __init__(self, avg_MW=50.0):
+        self.avg_MW = avg_MW
+
+class TerminationWeightAvgMW:
+    """
+    Represent an weight averaged MW in amu at which a simulation
+    should be terminated. This class has one attribute the average
+    molecular weight.  Useful for molecular growth situations.
+    """
+    def __init__(self, avg_MW=50.0):
+        self.avg_MW = avg_MW


### PR DESCRIPTION
This adds features that greatly improve RMG's capacity to model molecular weight growth problems:  

-Mass flux based flux algorithm
   -Includes a mass index for adjusting the bias toward weight (molar flux * MW**massIndex) = "flux"

-Average MW termination criterion
   -Most of the old criteria other than time are difficult to use because in many polymerization cases          
             RMG doesn't generate important reactions unless you simulate out much farther than 
             conversion and rate ratio terminations allow you to
   -Time has to be set out very far to make this work, which make it ineffective after initial key    
             reactions have been generated
   -Average MW along with time (as an initial stop) provides good control over how far out the 
             model should be simulated
   