### PR TITLE
Recursive as dictionary

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -209,7 +209,7 @@ class StatMechJob(object):
         is_ts = isinstance(self.species, TransitionState)
         _, file_extension = os.path.splitext(path)
         if file_extension in ['.yml', '.yaml']:
-            self.arkane_species.load_yaml(path=path, species=self.species, pdep=pdep)
+            self.arkane_species.load_yaml(path=path, label=self.species.label, pdep=pdep)
             self.species.conformer = self.arkane_species.conformer
             if is_ts:
                 self.species.frequency = self.arkane_species.imaginary_frequency

--- a/rmgpy/quantity.pxd
+++ b/rmgpy/quantity.pxd
@@ -29,9 +29,11 @@ cimport numpy
 
 cpdef list NOT_IMPLEMENTED_UNITS
 
+from rmgpy.rmgobject cimport RMGObject
+
 ################################################################################
 
-cdef class Units(object):
+cdef class Units(RMGObject):
 
     cdef public str units
 
@@ -51,8 +53,6 @@ cdef class ScalarQuantity(Units):
 
     cpdef dict as_dict(self)
 
-    cpdef make_object(self, dict data, dict class_dict)
-
     cpdef str getUncertaintyType(self)
     cpdef     setUncertaintyType(self, str v)
     
@@ -71,8 +71,6 @@ cdef class ArrayQuantity(Units):
     cdef public numpy.ndarray uncertainty_si
 
     cpdef dict as_dict(self)
-
-    cpdef make_object(self, dict data, dict class_dict)
 
     cpdef str getUncertaintyType(self)
     cpdef     setUncertaintyType(self, str v)

--- a/rmgpy/quantity.py
+++ b/rmgpy/quantity.py
@@ -41,6 +41,7 @@ import re
 
 import rmgpy.constants as constants
 from rmgpy.exceptions import QuantityError
+from rmgpy.rmgobject import RMGObject, expand_to_dict
 
 ################################################################################
 
@@ -70,7 +71,7 @@ NOT_IMPLEMENTED_UNITS = [
 
 ################################################################################
 
-class Units(object):
+class Units(RMGObject):
     """
     The :class:`Units` class provides a representation of the units of a
     physical quantity. The attributes are:
@@ -227,19 +228,6 @@ class ScalarQuantity(Units):
             output_dict['uncertainty'] = self.uncertainty
             output_dict['uncertaintyType'] = self.uncertaintyType
         return output_dict
-
-    def make_object(self, data, class_dict):
-        """
-        A helper function for YAML parsing
-        """
-        # the `class_dict` parameter isn't used here, it is passed by default when calling the `make_object()` methods
-        if 'units' in data:
-            self.units = data['units']
-        self.value = data['value']
-        if 'uncertaintyType' in data:
-            self.uncertaintyType = data['uncertaintyType']
-        if 'uncertainty' in data:
-            self.uncertainty = data['uncertainty']
     
     def copy(self):
         """
@@ -461,28 +449,15 @@ class ArrayQuantity(Units):
         """
         output_dict = dict()
         output_dict['class'] = self.__class__.__name__
-        output_dict['value'] = self.value.tolist()
+        output_dict['value'] = expand_to_dict(self.value)
         if self.units != '':
             output_dict['units'] = self.units
         if self.uncertainty is not None and any([val != 0.0 for val in numpy.nditer(self.uncertainty)]):
             logging.info(self.uncertainty)
             logging.info(type(self.uncertainty))
-            output_dict['uncertainty'] = self.uncertainty.tolist()
+            output_dict['uncertainty'] = expand_to_dict(self.uncertainty)
             output_dict['uncertaintyType'] = self.uncertaintyType
         return output_dict
-
-    def make_object(self, data, class_dict):
-        """
-        A helper function for YAML parsing
-        """
-        # the `class_dict` parameter isn't used here, it is passed by default when calling the `make_object()` methods
-        if 'units' in data:
-            self.units = data['units']
-        self.value = data['value']
-        if 'uncertaintyType' in data:
-            self.uncertaintyType = data['uncertaintyType']
-        if 'uncertainty' in data:
-            self.uncertainty = data['uncertainty']
 
     def copy(self):
         """

--- a/rmgpy/quantityTest.py
+++ b/rmgpy/quantityTest.py
@@ -1053,4 +1053,160 @@ class TestQuantity(unittest.TestCase):
         self.assertEqual(repr(self.v),repr(self.v_array))
 
 
+class TestQuantityDictionaryConversion(unittest.TestCase):
+    """
+    Test that Scalar and Array Quantity objects can be represented and reconstructed from dictionaries
+    """
+    def setUp(self):
+        """
+        Initialize necessary variables for the TestQuantityDictionaryConversion unit test
+        """
+        self.class_dict = {'ScalarQuantity': quantity.ScalarQuantity,
+                           'ArrayQuantity': quantity.ArrayQuantity,
+                           'np_array': numpy.array
+                           }
 
+        self.empty_scalar = quantity.ScalarQuantity()
+        self.minimal_scalar = quantity.ScalarQuantity(value=5)
+        self.know_scalar = quantity.ScalarQuantity(value=2.4, units='kcal/mol')
+        self.uncertain_scalar = quantity.ScalarQuantity(value=3, uncertainty=0.2)
+
+        self.empty_array = quantity.ArrayQuantity()
+        self.minimal_array = quantity.ArrayQuantity(value=numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
+        self.known_array = quantity.ArrayQuantity(value=numpy.array([[1.2, 2.4, 3.4], [4.8, 5.0, 6.0], [7.4, 8.6, 9]]),
+                                                  units='kcal/mol')
+        self.uncertain_array = quantity.ArrayQuantity(value=numpy.array([[1.2, 2.4, 3.4],
+                                                                         [4.8, 5.0, 6.0],
+                                                                         [7.4, 8.6, 9.0]]
+                                                                        ),
+                                                      uncertainty=numpy.array([[0.2, 0.4, 0.6],
+                                                                               [0.6, 0.4, 0.2],
+                                                                               [0.8, 0.2, 0.4]])
+                                                      )
+
+    def test_scalar_as_dict(self):
+        """
+        Test the `as_dict` method of ScalarQuantity objects
+        """
+        self.assertEqual(self.empty_scalar.as_dict(), {'class': 'ScalarQuantity', 'value': 0.0})
+        self.assertEqual(self.minimal_scalar.as_dict(), {'class': 'ScalarQuantity', 'value': 5})
+        self.assertEqual(self.know_scalar.as_dict(), {'class': 'ScalarQuantity', 'value': 2.4, 'units': 'kcal/mol'})
+        self.assertEqual(self.uncertain_scalar.as_dict(), {'class': 'ScalarQuantity', 'value': 3,
+                                                           'uncertainty': 0.2, 'uncertaintyType': '+|-'}
+                         )
+
+    def test_scalar_make_object(self):
+        """
+        Test the `make_object` method of ScalarQuantity objects
+        """
+        empty_scalar = quantity.ScalarQuantity()
+        minimal_scalar = quantity.ScalarQuantity()
+        known_scalar = quantity.ScalarQuantity()
+        uncertain_scalar = quantity.ScalarQuantity()
+
+        empty_scalar.make_object({}, self.class_dict)
+        minimal_scalar.make_object({'value': 5}, self.class_dict)
+        known_scalar.make_object({'value': 2.4, 'units': 'kcal/mol'}, self.class_dict)
+        uncertain_scalar.make_object({'class': 'ScalarQuantity', 'value': 3, 'uncertainty': 0.2,
+                                      'uncertaintyType': '+|-'
+                                      },
+                                     self.class_dict
+                                     )
+
+        self.assertEqual(empty_scalar.as_dict(), self.empty_scalar.as_dict())
+        self.assertEqual(minimal_scalar.as_dict(), self.minimal_scalar.as_dict())
+        self.assertEqual(known_scalar.as_dict(), self.know_scalar.as_dict())
+        self.assertEqual(uncertain_scalar.as_dict(), self.uncertain_scalar.as_dict())
+
+    def test_array_as_dict(self):
+        """
+        Test the `as_dict` method of ArrayQuantity objects
+        """
+        self.assertEqual(self.empty_array.as_dict(), {'class': 'ArrayQuantity',
+                                                      'value': {'class': 'np_array', 'object': [0.0]}
+                                                      }
+                         )
+
+        self.assertEqual(self.minimal_array.as_dict(), {'class': 'ArrayQuantity',
+                                                        'value': {'class': 'np_array', 'object': [[1, 2, 3],
+                                                                                                  [4, 5, 6],
+                                                                                                  [7, 8, 9]]
+                                                                  }
+                                                        }
+                         )
+
+        self.assertEqual(self.known_array.as_dict(), {'class': 'ArrayQuantity',
+                                                      'value': {'class': 'np_array', 'object': [[1.2, 2.4, 3.4],
+                                                                                                [4.8, 5.0, 6.0],
+                                                                                                [7.4, 8.6, 9]]
+                                                                },
+                                                      'units': 'kcal/mol'
+                                                      }
+                         )
+
+        self.assertEqual(self.uncertain_array.as_dict(), {'class': 'ArrayQuantity',
+                                                          'value': {'class': 'np_array', 'object': [[1.2, 2.4, 3.4],
+                                                                                                    [4.8, 5.0, 6.0],
+                                                                                                    [7.4, 8.6, 9.0]]
+                                                                    },
+                                                          'uncertainty': {'class': 'np_array',
+                                                                          'object': [[0.2, 0.4, 0.6],
+                                                                                     [0.6, 0.4, 0.2],
+                                                                                     [0.8, 0.2, 0.4]]
+                                                                          },
+                                                          'uncertaintyType': '+|-'
+                                                          }
+                         )
+
+    def test_array_make_object(self):
+        """
+        Test the `make_object` method of ArrayQuantity objects
+        """
+        empty_array = quantity.ArrayQuantity()
+        minimal_array = quantity.ArrayQuantity()
+        known_array = quantity.ArrayQuantity()
+        uncertain_array = quantity.ArrayQuantity()
+
+        minimal_dict = {'class': 'ArrayQuantity', 'value': {'class': 'np_array', 'object': [[1, 2, 3],
+                                                                                            [4, 5, 6],
+                                                                                            [7, 8, 9]]
+                                                            }
+                        }
+
+        known_dict = {'class': 'ArrayQuantity',
+                      'value': {'class': 'np_array', 'object': [[1.2, 2.4, 3.4],
+                                                                [4.8, 5.0, 6.0],
+                                                                [7.4, 8.6, 9]]
+                                },
+                      'units': 'kcal/mol'
+                      }
+
+        uncertain_dict = {'class': 'ArrayQuantity',
+                          'value': {'class': 'np_array', 'object': [[1.2, 2.4, 3.4],
+                                                                    [4.8, 5.0, 6.0],
+                                                                    [7.4, 8.6, 9.0]]
+                                    },
+                          'uncertainty': {'class': 'np_array',
+                                          'object': [[0.2, 0.4, 0.6],
+                                                     [0.6, 0.4, 0.2],
+                                                     [0.8, 0.2, 0.4]]
+                                          },
+                          'uncertaintyType': '+|-'
+                          }
+
+        empty_array.make_object({}, self.class_dict)
+        minimal_array.make_object(minimal_dict, self.class_dict)
+        known_array.make_object(known_dict, self.class_dict)
+        uncertain_array.make_object(uncertain_dict, self.class_dict)
+
+        self.assertEqual(empty_array.as_dict(), self.empty_array.as_dict())
+        self.assertEqual(minimal_array.as_dict(), self.minimal_array.as_dict())
+        self.assertEqual(known_array.as_dict(), self.known_array.as_dict())
+        self.assertEqual(uncertain_array.as_dict(), self.uncertain_array.as_dict())
+
+
+################################################################################
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/rmgobject.pxd
+++ b/rmgpy/rmgobject.pxd
@@ -33,3 +33,5 @@ cdef class RMGObject(object):
     cpdef make_object(self, dict data, dict class_dict)
 
 cpdef expand_to_dict(obj)
+
+cpdef recursive_make_object(obj, class_dictionary)

--- a/rmgpy/rmgobject.pxd
+++ b/rmgpy/rmgobject.pxd
@@ -31,3 +31,5 @@ cdef class RMGObject(object):
     cpdef dict as_dict(self)
 
     cpdef make_object(self, dict data, dict class_dict)
+
+cpdef expand_to_dict(obj)

--- a/rmgpy/rmgobjectTest.py
+++ b/rmgpy/rmgobjectTest.py
@@ -36,9 +36,11 @@ import unittest
 
 import numpy as np
 
-from rmgpy.rmgobject import RMGObject
+from rmgpy.quantity import ScalarQuantity, ArrayQuantity
+from rmgpy.rmgobject import RMGObject, expand_to_dict, recursive_make_object
 
 ################################################################################
+
 
 class PseudoRMGObject(RMGObject):
     """
@@ -46,6 +48,7 @@ class PseudoRMGObject(RMGObject):
     """
 
     def __init__(self, a=None, b=None, c=None, d=None):
+        super(PseudoRMGObject, self).__init__()
         self.a = a
         self.b = b
         self.c = c
@@ -252,7 +255,154 @@ class TestRMGObject(unittest.TestCase):
         self.assertEqual(obj.a[1].c, 5.0)
         self.assertEqual(obj.b, [])
 
+
+class TestExpandAndMakeFromDictionaries(unittest.TestCase):
+    """
+    Contains unit tests for the expand_to_dict and recursive_make_object function utilized by RMGObjects
+    """
+
+    def setUp(self):
+        self.np_array = np.array([[1, 2], [3, 4]])
+        self.np_dict = {'class': 'np_array', 'object': [[1, 2], [3, 4]]}
+
+        self.array_quantity = ArrayQuantity(value=self.np_array, units='kJ/mol')
+        self.array_dict = {'class': 'ArrayQuantity', 'value': self.np_dict, 'units': 'kJ/mol'}
+
+        self.scalar_quantity = ScalarQuantity(value=500.0, units='K')
+        self.scalar_dict = {'class': 'ScalarQuantity', 'value': 500.0, 'units': 'K'}
+
+        # Abbreviate name
+        PRO = PseudoRMGObject
+
+        self.highly_nested_object = PRO(a=PRO(a=PRO(b=self.np_array,
+                                                    c=PRO(c=self.array_quantity,
+                                                          d=PRO(a=self.scalar_quantity,
+                                                                b=PRO()
+                                                                )
+                                                          )
+                                                    )
+                                              ),
+                                        b=6
+                                        )
+        self.highly_nest_dictionary = {'class': 'PseudoRMGObject',
+                                       'a': {'class': 'PseudoRMGObject',
+                                             'a': {'class': 'PseudoRMGObject',
+                                                   'b': self.np_dict,
+                                                   'c': {'class': 'PseudoRMGObject',
+                                                         'c': self.array_dict,
+                                                         'd': {'class': 'PseudoRMGObject',
+                                                               'a': self.scalar_dict,
+                                                               'b': {'class': 'PseudoRMGObject'}
+                                                               }
+                                                         }
+                                                   }
+                                             },
+                                       'b': 6
+                                       }
+
+        self.list_of_objects = [1, 2.0, 'abc', self.np_array, self.array_quantity, self.scalar_quantity,
+                                self.highly_nested_object]
+        self.list_dict = [1, 2.0, 'abc', self.np_dict, self.array_dict, self.scalar_dict, self.highly_nest_dictionary]
+
+        self.dictionary_of_objects = {'test_int': 1,
+                                      'test_float': 2.0,
+                                      'test_np': self.np_array,
+                                      'test_array': self.array_quantity,
+                                      'test_scalar': self.scalar_quantity,
+                                      'test_nested': self.highly_nested_object}
+        self.objects_dict = {'test_int': 1,
+                             'test_float': 2.0,
+                             'test_np': self.np_dict,
+                             'test_array': self.array_dict,
+                             'test_scalar': self.scalar_dict,
+                             'test_nested': self.highly_nest_dictionary}
+
+        self.input_dict = {'class': 'PseudoRMGObject', 'a': {'class': 'PseudoRMGObject', 'b': self.np_dict}}
+        self.final_obj_dict = {'a': PseudoRMGObject(b=self.np_array)}
+
+        self.class_dictionary = {'np_array': np.array,
+                                 'ScalarQuantity': ScalarQuantity,
+                                 'ArrayQuantity': ArrayQuantity,
+                                 'PseudoRMGObject': PseudoRMGObject}
+
+    def test_expanding_list_to_dict(self):
+        """
+        Test that objects nested inside of lists can be expanded
+        """
+        self.assertEqual(expand_to_dict(self.list_of_objects), self.list_dict)
+
+    def test_expanding_objects_in_dictionary(self):
+        """
+        Test that objects nested inside of dictionaries can be expanded
+        """
+        self.assertEqual(expand_to_dict(self.dictionary_of_objects), self.objects_dict)
+
+    def test_expanding_np_arrays(self):
+        """
+        Test that np_arrays are expanded properly
+        """
+        self.assertEqual(expand_to_dict(self.np_array), self.np_dict)
+
+    def test_expanding_RMGObjects(self):
+        """
+        Test that RMGObjects (even when nested) can be expanded using the as_dict method
+        """
+        self.assertEqual(expand_to_dict(self.highly_nested_object), self.highly_nest_dictionary)
+        self.assertEqual(self.highly_nested_object.as_dict(), self.highly_nest_dictionary)
+
+    def test_make_object_from_dict(self):
+        """
+        Test that RMGObjects can be recreated from their dictionary representation
+        """
+        created_from_function = recursive_make_object(self.highly_nest_dictionary, self.class_dictionary)
+        created_from_object = PseudoRMGObject.__new__(PseudoRMGObject)
+        created_from_object.make_object(self.highly_nest_dictionary, self.class_dictionary)
+        orig_obj = self.highly_nested_object
+
+        for obj in (created_from_function, created_from_object):
+            self.assertEqual(orig_obj.b, obj.b)
+            self.assertEqual(type(orig_obj.a), type(obj.a))
+            self.assertEqual(type(orig_obj.a.a), type(obj.a.a))
+            self.assertTrue(np.array_equal(orig_obj.a.a.b, obj.a.a.b))
+            self.assertEqual(type(orig_obj.a.a.c), type(obj.a.a.c))
+            self.assertEqual(orig_obj.a.a.c.c.units, obj.a.a.c.c.units)
+            self.assertTrue(np.array_equal(orig_obj.a.a.c.c.value, obj.a.a.c.c.value))
+            self.assertEqual(type(orig_obj.a.a.c.d), type(obj.a.a.c.d))
+            self.assertEqual(orig_obj.a.a.c.d.a.units, obj.a.a.c.d.a.units)
+            self.assertTrue(orig_obj.a.a.c.d.a.value, obj.a.a.c.d.a.value)
+            self.assertEqual(type(orig_obj.a.a.c.d.b), type(orig_obj.a.a.c.d.b))
+
+    def test_make_all_but_final_object_from_dict(self):
+        """
+        Test the `make_final_object=False` option for the recursive_make_object function
+        """
+        final_obj_dict = recursive_make_object(self.input_dict, self.class_dictionary, make_final_object=False)
+        self.assertTrue(np.array_equal(final_obj_dict['a'].b, self.final_obj_dict['a'].b))
+
+    def test_float_creation(self):
+        """
+        Test that strings of floats are recreated as floats
+        """
+        obj = recursive_make_object('5.0', self.class_dictionary)
+        self.assertEqual(obj, 5.0)
+        self.assertEqual(type(obj), float)
+
+    def test_int_creation(self):
+        """
+        Test that strings of ints are recreated as ints
+        """
+        obj = recursive_make_object('5', self.class_dictionary)
+        self.assertEqual(obj, 5)
+        self.assertEqual(type(obj), int)
+
+    def test_np_array_creation(self):
+        """
+        Test that numpy arrays can be recreated from their dictionary representation
+        """
+        self.assertTrue(np.array_equal(recursive_make_object(self.np_dict, self.class_dictionary), self.np_array))
+
 ################################################################################
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/rmgobjectTest.py
+++ b/rmgpy/rmgobjectTest.py
@@ -177,7 +177,7 @@ class TestRMGObject(unittest.TestCase):
         obj = PseudoRMGObject(a=np.array([1.0, 2.0, 3.0]))
         result = obj.as_dict()
 
-        expected = {'class': 'PseudoRMGObject', 'a': [1.0, 2.0, 3.0]}
+        expected = {'class': 'PseudoRMGObject', 'a': {'object': [1.0, 2.0, 3.0], 'class': 'np_array'}}
 
         self.assertEqual(result, expected)
 

--- a/rmgpy/statmech/rotation.pyx
+++ b/rmgpy/statmech/rotation.pyx
@@ -42,6 +42,7 @@ cimport rmgpy.constants as constants
 import rmgpy.statmech.schrodinger as schrodinger 
 cimport rmgpy.statmech.schrodinger as schrodinger 
 import rmgpy.quantity as quantity
+from rmgpy.rmgobject import recursive_make_object
 
 ################################################################################
 
@@ -82,6 +83,12 @@ cdef class Rotation(Mode):
         A helper function used when pickling a Rotation object.
         """
         return (Rotation, (self.symmetry, self.quantum))
+
+    def make_object(self, data, class_dict):
+        kwargs = recursive_make_object(data, class_dict, make_final_object=False)
+        if ('inertia' in kwargs) and ('rotationalConstant' in kwargs):  # Only one of these can be specified
+            kwargs = {key: kwargs[key] for key in kwargs.iterkeys() if key != 'inertia'}
+        self.__init__(**kwargs)
 
 ################################################################################
 

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -44,6 +44,7 @@ from libc.math cimport log, exp, sqrt, sin, cos
 
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
+from rmgpy.rmgobject import recursive_make_object
 cimport rmgpy.statmech.schrodinger as schrodinger 
 import rmgpy.statmech.schrodinger as schrodinger 
 from rmgpy.exceptions import NegativeBarrierException
@@ -87,6 +88,12 @@ cdef class Torsion(Mode):
         A helper function used when pickling a Rotation object.
         """
         return (Torsion, (self.symmetry, self.quantum))
+
+    def make_object(self, data, class_dict):
+        kwargs = recursive_make_object(data, class_dict, make_final_object=False)
+        if ('inertia' in kwargs) and ('rotationalConstant' in kwargs):  # Only one of these can be specified
+            kwargs = {key: kwargs[key] for key in kwargs.iterkeys() if key != 'inertia'}
+        self.__init__(**kwargs)
 
 ################################################################################
 

--- a/rmgpy/statmech/translation.pyx
+++ b/rmgpy/statmech/translation.pyx
@@ -107,7 +107,10 @@ cdef class IdealGasTranslation(Translation):
         def __get__(self):
             return self._mass
         def __set__(self, value):
-            self._mass = quantity.Mass(value)
+            if isinstance(value, quantity.ScalarQuantity):
+                self._mass = value
+            else:
+                self._mass = quantity.Mass(value)
     
     cpdef double getPartitionFunction(self, double T) except -1:
         """

--- a/rmgpy/thermo/model.pxd
+++ b/rmgpy/thermo/model.pxd
@@ -26,8 +26,9 @@
 ###############################################################################
 
 from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
+from rmgpy.rmgobject cimport RMGObject
 
-cdef class HeatCapacityModel:
+cdef class HeatCapacityModel(RMGObject):
     
     cdef public ScalarQuantity _Tmin, _Tmax, _E0, _Cp0, _CpInf
     cdef public str comment,label

--- a/rmgpy/thermo/model.pyx
+++ b/rmgpy/thermo/model.pyx
@@ -28,6 +28,7 @@
 ###############################################################################
 
 import rmgpy.quantity as quantity
+from rmgpy.rmgobject cimport RMGObject
 
 """
 This module contains base classes that represent various thermodynamic
@@ -37,7 +38,7 @@ property calculation methods.
 
 ################################################################################
 
-cdef class HeatCapacityModel:
+cdef class HeatCapacityModel(RMGObject):
     """
     A base class for heat capacity models, containing several attributes
     common to all models:

--- a/rmgpy/thermo/nasa.pxd
+++ b/rmgpy/thermo/nasa.pxd
@@ -61,8 +61,6 @@ cdef class NASA(HeatCapacityModel):
 
     cpdef dict as_dict(self)
 
-    cpdef make_object(self, dict data, dict class_dict)
-
     cpdef double getHeatCapacity(self, double T) except -1000000000
 
     cpdef double getEnthalpy(self, double T) except 1000000000

--- a/rmgpy/thermo/nasaTest.py
+++ b/rmgpy/thermo/nasaTest.py
@@ -37,6 +37,7 @@ import numpy
 import os.path
 
 from rmgpy.thermo.nasa import NASA, NASAPolynomial
+from rmgpy.quantity import ScalarQuantity
 import rmgpy.constants as constants
 
 ################################################################################
@@ -295,8 +296,8 @@ class TestNASA(unittest.TestCase):
         self.assertEqual(nasa_dict['Tmin']['value'], self.Tmin)
         self.assertEqual(nasa_dict['Tmax']['value'], self.Tmax)
         self.assertEqual(nasa_dict['comment'], self.comment)
-        self.assertTupleEqual(tuple(nasa_dict['polynomials']['polynomial1']['coeffs']), tuple(self.coeffs_low))
-        self.assertTupleEqual(tuple(nasa_dict['polynomials']['polynomial2']['coeffs']), tuple(self.coeffs_high))
+        self.assertTupleEqual(tuple(nasa_dict['polynomials']['polynomial1']['coeffs']['object']), tuple(self.coeffs_low))
+        self.assertTupleEqual(tuple(nasa_dict['polynomials']['polynomial2']['coeffs']['object']), tuple(self.coeffs_high))
         self.assertEqual(nasa_dict['polynomials']['polynomial1']['Tmin']['value'], self.Tmin)
         self.assertEqual(nasa_dict['polynomials']['polynomial1']['Tmax']['value'], self.Tint)
         self.assertEqual(nasa_dict['polynomials']['polynomial2']['Tmin']['value'], self.Tint)
@@ -315,3 +316,36 @@ class TestNASA(unittest.TestCase):
         self.assertNotIn('CpInf', keys)
         self.assertNotIn('label', keys)
         self.assertNotIn('comment', keys)
+
+    def test_nasa_polynomial_as_dict(self):
+        """
+        Test that NASAPolynomial.as_dict returns all non-empty, non-redundant attributes properly.
+        """
+        nasa_poly_dict = self.nasa.polynomials[0].as_dict()
+        self.assertEqual(nasa_poly_dict, {'coeffs': {'object': [4.03055, -0.00214171, 4.90611e-05, -5.99027e-08,
+                                                                2.38945e-11, -11257.6, 3.5613],
+                                                     'class': 'np_array'},
+                                          'Tmax': {'units': 'K', 'class': 'ScalarQuantity', 'value': 650.73},
+                                          'Tmin': {'units': 'K', 'class': 'ScalarQuantity', 'value': 300.0},
+                                          'class': 'NASAPolynomial'}
+                         )
+
+    def test_make_nasa(self):
+        """
+        Test that a NASA object can be reconstructed from a dictionary (also test NASAPolynomial by extension)
+        """
+        nasa_dict = self.nasa.as_dict()
+        new_nasa = NASA.__new__(NASA)
+        class_dictionary = {'ScalarQuantity': ScalarQuantity,
+                            'np_array': numpy.array,
+                            'NASA': NASA,
+                            'NASAPolynomial': NASAPolynomial,
+                            }
+
+        new_nasa.make_object(nasa_dict, class_dictionary)
+
+################################################################################
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -93,52 +93,12 @@ cdef class Wilhoit(HeatCapacityModel):
         """
         A helper function for YAML parsing
         """
-        output_dict = dict()
-        output_dict['class'] = self.__class__.__name__
-        if self.Tmin is not None:
-            output_dict['Tmin'] = self.Tmin.as_dict()
-        if self.Tmax is not None:
-            output_dict['Tmax'] = self.Tmax.as_dict()
-        if self.E0 is not None:
-            output_dict['E0'] = self.E0.as_dict()
-        if self.Cp0 is not None:
-            output_dict['Cp0'] = self.Cp0.as_dict()
-        if self.CpInf is not None:
-            output_dict['CpInf'] = self.CpInf.as_dict()
-        if self.label != '':
-            output_dict['label'] = self.label
-        if self.comment != '':
-            output_dict['comment'] = self.comment
-        output_dict['B'] = self.B.as_dict()
-        output_dict['E0'] = self.E0.as_dict()
-        output_dict['H0'] = self.H0.as_dict()
-        output_dict['S0'] = self.S0.as_dict()
-        output_dict['a0'] = self.a0
-        output_dict['a1'] = self.a1
-        output_dict['a2'] = self.a2
-        output_dict['a3'] = self.a3
-        return output_dict
+        output_dict = super(Wilhoit, self).as_dict()
 
-    cpdef make_object(self, dict data, dict class_dict):
-        """
-        A helper function for YAML parsing
-        """
-        try:
-            data['Tmin'] = quantity.ScalarQuantity().make_object(data['Tmin'], class_dict)
-            data['Tmax'] = quantity.ScalarQuantity().make_object(data['Tmax'], class_dict)
-        except KeyError:
-            pass
-        data['B'] = quantity.ScalarQuantity().make_object(data['B'], class_dict)
-        data['Cp0'] = quantity.ScalarQuantity().make_object(data['Cp0'], class_dict)
-        data['CpInf'] = quantity.ScalarQuantity().make_object(data['CpInf'], class_dict)
-        data['H0'] = quantity.ScalarQuantity().make_object(data['H0'], class_dict)
-        data['S0'] = quantity.ScalarQuantity().make_object(data['S0'], class_dict)
-        data['a0'] = float(data['a0'])
-        data['a1'] = float(data['a1'])
-        data['a2'] = float(data['a2'])
-        data['a3'] = float(data['a3'])
-        del data['E0']
-        self.__init__(**data)
+        # Remove E0 from the attributes, as this should not be set
+        output_dict = {key: output_dict[key] for key in output_dict if key != 'E0'}
+
+        return output_dict
 
     property B:
         """The Wilhoit scaled temperature coefficient."""

--- a/rmgpy/thermo/wilhoitTest.py
+++ b/rmgpy/thermo/wilhoitTest.py
@@ -38,6 +38,7 @@ import os.path
 import logging
 
 from rmgpy.thermo.wilhoit import Wilhoit
+from rmgpy.quantity import ScalarQuantity
 import rmgpy.constants as constants
 
 ################################################################################
@@ -360,3 +361,42 @@ class TestWilhoit(unittest.TestCase):
 
         self.assertAlmostEqual(Std, Swh, -1)
         self.assertEqual(td.comment,wilhoit.comment)
+
+    def testWilhoitAsDict(self):
+        """
+        Test that a Wilhoit object can be converted to a dictionary representation properly
+        """
+        wilhoit_dict = self.wilhoit.as_dict()
+        self.assertEqual(wilhoit_dict, {'comment': 'C2H6',
+                                        'B': {'units': 'K', 'class': 'ScalarQuantity', 'value': 1068.68},
+                                        'Tmin': {'units': 'K', 'class': 'ScalarQuantity', 'value': 300.0},
+                                        'H0': {'units': 'kJ/mol', 'class': 'ScalarQuantity', 'value': -782.292041536},
+                                        'Tmax': {'units': 'K', 'class': 'ScalarQuantity', 'value': 3000.0},
+                                        'S0': {'units': 'J/(mol*K)', 'class': 'ScalarQuantity', 'value': -984.93235312},
+                                        'a1': -16.3067,
+                                        'a0': 0.0977518,
+                                        'a3': -12.6785,
+                                        'a2': 26.2524,
+                                        'Cp0': {'units': 'J/(mol*K)', 'class': 'ScalarQuantity', 'value': 33.257888},
+                                        'CpInf': {'units': 'J/(mol*K)', 'class': 'ScalarQuantity',
+                                                  'value': 178.76114800000002},
+                                        'class': 'Wilhoit'}
+                         )
+
+    def testMakeWilhoit(self):
+        """
+        Test that a Wilhoit object can be created from a dictionary representation
+        """
+        wilhoit_dict = self.wilhoit.as_dict()
+        new_wilhoit = Wilhoit.__new__(Wilhoit)
+        class_dictionary = {'ScalarQuantity': ScalarQuantity,
+                            'Wilhoit': Wilhoit}
+
+        new_wilhoit.make_object(wilhoit_dict, class_dictionary)
+
+################################################################################
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))
+


### PR DESCRIPTION
### Motivation or Problem
The methods `as_dict` and `make_object` allow for any object that inherits from RMGObject to be easily saved to a yaml file and reconstructed from a yaml file, respectively. However, as currently written is RMG there is a limited recursion depth to how many objects, dictionaries, and lists can be nested inside of each other.

For example, consider an object that has an attribute that is a dictionary which itself contains another object. The desired affect of `as_dict` would be for the object nested inside of this dictionary to be expanded to a dictionary (i.e. for `as_dict` to be called on this object as well). However, the current implementation will return for this attribute a dictionary that contains the object itself rather than the expanded object.

Furthermore, many objects have to rewrite their `as_dict` and `make_objects` to function properly, even if they inherit from RMGObject. Ideally, newly created objects that inherit from RMGObject should have working `as_dict` and `make_object` methods without needing to overwrite these methods (at least more times than not).

### Description of Changes
Inside the file where we define the RMGObject I have created method for recursively calling `as_dict` for all objects inside of a dictionary or list. I have also created a method for recursively calling `make_object` for all objects inside of a dictionary. Becasue these functions are recursive by calling themselves, the recursion limit for nested objects and iterables should be whatever the recursion stack limit of python is (very large). 

While these functions can be called as standalone functions (potentially useful for scripting), I have used these functions to help re-write the `as_dict` and `make_object` methods of the RMGObject class.

With this, I have also cleaned-up the affected code, and made it so that the `as_dict` and `make_object` methods are only re-written when absolutely necessary (for example, see statmech rotations and torsions), which thanks to the new functions require very little code even when necessary. Note that this is usually necessary whenever passing all attributes to the __init__ method causes issues.

### Testing
I have ran the unit tests, and even successfully recreated an ArkaneSpecies object from a YAML file, but it is likely that there are affected classes that weren't properly unit tested. I am specifically concerned about the Wilhoit class, and the NASA class can probably be cleaned up further.

### Reviewer Note
Because we have a few pull requests open or about to be opened that define new objects that will be saved to a YAML file, these PRs will require these changes, and thus this PR needs to be merged in first. For example, this affects #1577, #1641, and #1561
