### PR TITLE
Fix Travis builds by adding in missing miniconda dependencies

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -4,6 +4,7 @@ channels:
   - rmg
   - rdkit
   - cantera
+  - anaconda
 dependencies:
   - cairo
   - cairocffi
@@ -31,7 +32,9 @@ dependencies:
   - psutil
   - pydas >=1.0.1
   - pydot ==1.2.2
+  - pydot-ng
   - pydqed >=1.0.0
+  - pygpu
   - pymongo
   - pyparsing
   - pyrdl

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -4,6 +4,7 @@ channels:
   - rmg
   - rdkit
   - cantera
+  - anaconda
 dependencies:
   - cairo
   - cairocffi
@@ -31,7 +32,9 @@ dependencies:
   - psutil
   - pydas >=1.0.1
   - pydot ==1.2.2
+  - pydot-ng
   - pydqed >=1.0.0
+  - pygpu
   - pymongo
   - pyparsing
   - pyrdl

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -4,6 +4,7 @@ channels:
   - rmg
   - rdkit
   - cantera
+  - anaconda
 dependencies:
   - cairo
   - cairocffi
@@ -32,7 +33,9 @@ dependencies:
   - psutil
   - pydas >=1.0.1
   - pydot ==1.2.2
+  - pydot-ng
   - pydqed >=1.0.0
+  - pygpu
   - pymongo
   - pyparsing
   - pyrdl


### PR DESCRIPTION
### Motivation or Problem
Lately, every Travis build has been failing during the stage where the conda environment is created, with the following error message:

```
ResolvePackageNotFound: 
  - dde -> pydot-ng
  - dde -> theano=0.9.0 -> pygpu[version='>=0.6.5,<0.7']
  - textgenrnn -> theano=0.9.0 -> pygpu[version='>=0.6.5,<0.7']

```

Interestingly, the conda environment builds just fine from a clean install of anaconda on the current master branch. However, after looking at how we have setup our Travis builds, I saw that we use miniconda on Travis. It appears that miniconda needs the dependencies of pydot-ng and pygpu to be explicitly given.

### Description of Changes
Added pydot-ng and pygpu to the conda environment files.

### Testing
On a clean Ubuntu machine, I first tried creating a fresh anaconda install, and creating the conda environment did not cause any problems. After cleaning this anaconda install, I then followed the travis.yml file instructions as closely as I could and used miniconda. This replicated the error on Travis. Finally, I updated the environment files, and again tried to install the environment from miniconda. This seemed to solve the issue

### Reviewer Note
We will see for certain in a few minutes, but I believe this commit will solve the current Travis issue. Whether this is the best way to solve the issue or whether adding pydot-ng or pygpu will cause issues is something I am not sure about currently. 
