### PR TITLE
Delete simulation files after unit testing

### DIFF
--- a/rmgpy/tools/simulateTest.py
+++ b/rmgpy/tools/simulateTest.py
@@ -54,6 +54,7 @@ class SimulateTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(sensfile))
         
         shutil.rmtree(os.path.join(folder, 'solver'))
+        os.remove(os.path.join(folder, 'simulate.log'))
 
     def test_liquid(self):
         folder = os.path.join(os.path.dirname(rmgpy.__file__), 'tools/data/sim/liquid')
@@ -71,6 +72,7 @@ class SimulateTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(sensfile))
 
         shutil.rmtree(os.path.join(folder, 'solver'))
+        os.remove(os.path.join(folder, 'simulate.log'))
 
     def tearDown(self):
         import rmgpy.data.rmg


### PR DESCRIPTION
### Motivation or Problem
Whenever the unit test are run, the simulation logs in `rmgpy.tools.simulateTest.py` are created but never deleted (whereas everything else with this test is deleted).

### Description of Changes
Add statements in `rmgpy.tools.simulateTest.py` to remove the log files after the tests have run.

### Testing
Ran the unit tests and everything passed and the logs were deleted
