### PR TITLE
Run database tests in Travis after testing RMG-Py code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 
 stages:
   - test
+  - check
   - name: documentation
     if: branch = master AND type = push
   - name: deploy
@@ -48,6 +49,20 @@ jobs:
       script:
         - make test-unittests
         - make test-functional
+    - stage: check
+      install:
+        # Clone RMG-database
+        - git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
+        - cd RMG-Py
+        - conda env create -q -f environment_linux.yml
+        - source activate rmg_env
+        # Install codecov for coverage report
+        - conda install -y -c conda-forge codecov
+        - conda list
+        # Setup MOPAC license key
+        - yes 'Yes' | $HOME/miniconda/envs/rmg_env/bin/mopac $MOPACKEY > /dev/null
+        - make
+      script:
         - make test-database
       after_success:
         - codecov


### PR DESCRIPTION
### Motivation or Problem
We are starting to run out of time to complete the database checks if the filter thresholds are to be tested every time as in #1577 . This draft PR explores the idea of running the database test in a separate stage after the unit and functional tests have been run.
