### PR TITLE
Expand species length

### DIFF
--- a/arkane/main.py
+++ b/arkane/main.py
@@ -257,7 +257,12 @@ class Arkane:
             # write each species in species block
             for job in self.jobList:
                 if isinstance(job, ThermoJob):
-                    f.write(job.species.toChemkin())
+                    f.write(job.species.label)
+                    if len(job.species.label) > 16:
+                        f.write('   ! species label is longer than chemkin supports. Consider shortening it.')
+                        logging.warning('Species {} has a label {} char longer '\
+                                        'than chemkin supports. Consider '\
+                                        'shortening it.'.format(job.species.label, len(job.species.label) - 16))
                     f.write('\n')
 
             f.write('\nEND\n\n\n\n')

--- a/arkane/pdep.py
+++ b/arkane/pdep.py
@@ -505,7 +505,7 @@ class PressureDependenceJob(object):
                     duplicate = True
 
                 # write chemkin output.
-                string = writeKineticsEntry(reaction, speciesList=None, verbose=False, commented=duplicate)
+                string = writeKineticsEntry(reaction, speciesList=None, verbose=False, commented=duplicate, use_label=True)
                 f_chemkin.write('{0}\n'.format(string))
 
                 # write to 'output.py'

--- a/arkane/thermo.py
+++ b/arkane/thermo.py
@@ -193,7 +193,7 @@ class ThermoJob(object):
                     elementCounts = {'C': 0, 'H': 0}
         else:
             elementCounts = {'C': 0, 'H': 0}
-        chemkin_thermo_string = writeThermoEntry(species, elementCounts=elementCounts, verbose=True)
+        chemkin_thermo_string = writeThermoEntry(species, elementCounts=elementCounts, verbose=True, use_label=True)
         f.write('{0}\n'.format(chemkin_thermo_string))
         f.close()
 

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1526,7 +1526,7 @@ def writeReactionString(reaction, javaLibrary=False, use_label=False):
             reaction_string = ' + '.join([reactant.label for reactant in reaction.reactants])
         else:
             reaction_string = ' + '.join([getSpeciesIdentifier(reactant) for reactant in reaction.reactants])
-        reaction_string += ' => ' if not reaction.reversible else ' = '
+        reaction_string += ' <=> ' if reaction.reversible else '=>'
         if use_label:
             reaction_string += ' + '.join([product.label for product in reaction.products])
         else:
@@ -1576,7 +1576,7 @@ def writeReactionString(reaction, javaLibrary=False, use_label=False):
         else:
             reaction_string = ' + '.join([getSpeciesIdentifier(reactant) for reactant in reaction.reactants])
         reaction_string += thirdBody
-        reaction_string += '=' if reaction.reversible else '=>'
+        reaction_string += ' <=> ' if reaction.reversible else ' => '
         if use_label:
             reaction_string += ' + '.join([product.label for product in reaction.products])
         else:

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -73,10 +73,10 @@ def readThermoEntry(entry, Tmin=0, Tint=0, Tmax=0):
     the label of the species and the thermodynamics model as a :class:`NASA`
     object.
     
-    Format specification at http://www2.galcit.caltech.edu/EDL/public/formats/chemkin.html
+    For format specification, see the Chemkin Input Manual
     """
     lines = entry.splitlines()
-    species = str(lines[0][0:18].split()[0].strip())
+    species = str(lines[0][0:24].split()[0].strip())
     
     comment = lines[0][len(species):24].strip()
     formula = {}
@@ -1466,7 +1466,7 @@ def writeThermoEntry(species, elementCounts=None, verbose=True):
                     string += "! {0}\n".format(line) 
 
     # Line 1
-    string += '{0:<16}        '.format(getSpeciesIdentifier(species))
+    string += '{0:<24}'.format(getSpeciesIdentifier(species))
     if len(elementCounts) <= 4:
         # Use the original Chemkin syntax for the element counts
         for key, count in elementCounts.iteritems():
@@ -1948,9 +1948,9 @@ def saveChemkinFile(path, species, reactions, verbose = True, checkForDuplicates
     for spec in sorted_species:
         label = getSpeciesIdentifier(spec)
         if verbose:
-            f.write('    {0!s:<16}    ! {1}\n'.format(label, str(spec)))
+            f.write('    {0!s:<24}  ! {1}\n'.format(label, str(spec)))
         else:
-            f.write('    {0!s:<16}\n'.format(label))
+            f.write('    {0!s:<24}\n'.format(label))
     f.write('END\n\n\n\n')
 
     # Thermodynamics section

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1683,8 +1683,7 @@ def writeKineticsEntry(reaction, speciesList, verbose=True, javaLibrary=False, c
     
     kinetics = reaction.kinetics
     numReactants = len(reaction.reactants)
-    reaction_string = writeReactionString(reaction, javaLibrary, use_label = use_label)
-    
+    reaction_string = writeReactionString(reaction, javaLibrary, use_label=use_label)
     string += '{0!s:<51} '.format(reaction_string)
 
     if isinstance(kinetics, _kinetics.StickingCoefficient):

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1430,11 +1430,14 @@ def getSpeciesIdentifier(species):
 
 ################################################################################
 
-def writeThermoEntry(species, elementCounts=None, verbose=True):
+def writeThermoEntry(species, elementCounts=None, verbose=True, use_label=False):
     """
     Return a string representation of the NASA model readable by Chemkin.
     To use this method you must have exactly two NASA polynomials in your
     model, and you must use the seven-coefficient forms for each.
+
+    Use `use_label=True` to force use of the default RMG species label instead
+    of a Chemkin compatible species identifier in the reaction string.
     """
 
     thermo = species.getThermoData()
@@ -1466,7 +1469,10 @@ def writeThermoEntry(species, elementCounts=None, verbose=True):
                     string += "! {0}\n".format(line) 
 
     # Line 1
-    string += '{0:<24}'.format(getSpeciesIdentifier(species))
+    if use_label:
+        string += '{0:<24}'.format(species.label)
+    else:
+        string += '{0:<24}'.format(getSpeciesIdentifier(species))
     if len(elementCounts) <= 4:
         # Use the original Chemkin syntax for the element counts
         for key, count in elementCounts.iteritems():
@@ -1506,16 +1512,25 @@ def writeThermoEntry(species, elementCounts=None, verbose=True):
 
 ################################################################################
 
-def writeReactionString(reaction, javaLibrary = False):
+def writeReactionString(reaction, javaLibrary=False, use_label=False):
     """
     Return a reaction string in chemkin format.
+
+    Use `use_label=True` to force use of the default RMG species label instead
+    of a Chemkin compatible species identifier in the reaction string.
     """
     kinetics = reaction.kinetics
     
     if kinetics is None:
-        reaction_string = ' + '.join([getSpeciesIdentifier(reactant) for reactant in reaction.reactants])
+        if use_label:
+            reaction_string = ' + '.join([reactant.label for reactant in reaction.reactants])
+        else:
+            reaction_string = ' + '.join([getSpeciesIdentifier(reactant) for reactant in reaction.reactants])
         reaction_string += ' => ' if not reaction.reversible else ' = '
-        reaction_string += ' + '.join([getSpeciesIdentifier(product) for product in reaction.products])
+        if use_label:
+            reaction_string += ' + '.join([product.label for product in reaction.products])
+        else:
+            reaction_string += ' + '.join([getSpeciesIdentifier(product) for product in reaction.products])
         return reaction_string
 
     if reaction.specificCollider is not None:
@@ -1555,11 +1570,17 @@ def writeReactionString(reaction, javaLibrary = False):
                 thirdBody = ''
             else:
                 thirdBody = ('(+' + getSpeciesIdentifier(reaction.specificCollider) + ')') if reaction.specificCollider else '(+M)'
-        
-        reaction_string = '+'.join([getSpeciesIdentifier(reactant) for reactant in reaction.reactants])
+
+        if use_label:
+            reaction_string = ' + '.join([reactant.label for reactant in reaction.reactants])
+        else:
+            reaction_string = ' + '.join([getSpeciesIdentifier(reactant) for reactant in reaction.reactants])
         reaction_string += thirdBody
         reaction_string += '=' if reaction.reversible else '=>'
-        reaction_string += '+'.join([getSpeciesIdentifier(product) for product in reaction.products])
+        if use_label:
+            reaction_string += ' + '.join([product.label for product in reaction.products])
+        else:
+            reaction_string += ' + '.join([getSpeciesIdentifier(product) for product in reaction.products])
         reaction_string += thirdBody
 
     if len(reaction_string) > 52:
@@ -1568,13 +1589,16 @@ def writeReactionString(reaction, javaLibrary = False):
     
 ################################################################################
 
-def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = False, commented=False):
+def writeKineticsEntry(reaction, speciesList, verbose=True, javaLibrary=False, commented=False, use_label=False):
     """
     Return a string representation of the reaction as used in a Chemkin
     file. Use `verbose = True` to turn on kinetics comments.
     Use `commented = True` to comment out the entire reaction.
     Use javaLibrary = True in order to generate a kinetics entry suitable
     for an RMG-Java kinetics library.
+
+    Use `use_label=True` to force use of the default RMG species label instead
+    of a Chemkin compatible species identifier in the reaction string.
     """
     string = ""
     
@@ -1659,7 +1683,7 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
     
     kinetics = reaction.kinetics
     numReactants = len(reaction.reactants)
-    reaction_string = writeReactionString(reaction, javaLibrary)    
+    reaction_string = writeReactionString(reaction, javaLibrary, use_label = use_label)
     
     string += '{0!s:<51} '.format(reaction_string)
 

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -315,13 +315,14 @@ def _readKineticsReaction(line, speciesDict, Aunits, Eunits):
     
     # Split the reaction equation into reactants and products
     reversible = True
-    reactants, products = reaction.split('=')
     if '<=>' in reaction:
-        reactants = reactants[:-1]
-        products = products[1:]
+        reactants, products = reaction.split('<=>')
     elif '=>' in reaction:
-        products = products[1:]
+        reactants, products = reaction.split('=>')
         reversible = False
+    else:
+        reactants, products = reaction.split('=')
+
     specificCollider = None
     # search for a third body collider, e.g., '(+M)', '(+m)', or a specific species like '(+N2)', matching `(+anythingOtherThanEndingParenthesis)`:
     collider = re.search('\(\+[^\)]+\)',reactants)

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1382,13 +1382,10 @@ def getSpeciesIdentifier(species):
         # No index present -- probably not in RMG job
         # In this case just return the label (if the right size)
         if len(label) > 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#]+', label):
-            if len(label) <= 10:
+            if len(label) <= 16:
                 return label
-            elif len(label) <= 15:
-                #logging.warning('Species label {0} is longer than 10 characters and may exceed chemkin string limit'.format(label))
-                return label            
             else:
-                logging.warning('Species label is longer than 15 characters and will break CHEMKIN 2.0')
+                logging.warning('Species label is longer than 16 characters and will break CHEMKIN 2.0')
                 return label
         else:
             # try the chemical formula if the species label is not present
@@ -1404,14 +1401,14 @@ def getSpeciesIdentifier(species):
         # The label can only contain alphanumeric characters, and -()*#_,
         if len(label) > 0 and species.index >= 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#]+', label):
             name = '{0}({1:d})'.format(label, species.index)
-            if len(name) <= 10:
+            if len(name) <= 16:
                 return name
     
         # Next try the chemical formula
         if len(species.molecule) > 0:
             # Try the chemical formula
             name = '{0}({1:d})'.format(species.molecule[0].getFormula(), species.index)
-            if len(name) <= 10:
+            if len(name) <= 16:
                 return name
     
         # As a last resort, just use the index
@@ -1421,7 +1418,7 @@ def getSpeciesIdentifier(species):
                 name = 'SX({0:d})'.format(species.index)
             else:
                 name = 'S({0:d})'.format(species.index)
-            if len(name) <= 10:
+            if len(name) <= 16:
                 return name
 
     # If we're here then we just can't come up with a valid Chemkin name
@@ -1582,9 +1579,6 @@ def writeReactionString(reaction, javaLibrary=False, use_label=False):
         else:
             reaction_string += ' + '.join([getSpeciesIdentifier(product) for product in reaction.products])
         reaction_string += thirdBody
-
-    if len(reaction_string) > 52:
-        logging.warning("Chemkin reaction string {0!r} is too long for Chemkin 2!".format(reaction_string))
     return reaction_string
     
 ################################################################################


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Anyone who uses RMG likely has encountered the frustrating `S(14567)` species label. 

### Description of Changes
This commit tries to make species labels more readable and intuitive. It does this in Arkane by using the species label given in the input file for the species. In RMG it expands the species length from 10 characters to 16 characters, almost entirely eliminating the dreaded `S` label.

This PR is compatible with the cantera and modern versions of chemkin. Unmodified versions of chemkin 2 will not be able to run some models because of a limitation on the length of reaction. chemkin 2, however, can be modified by the users to be compatible with the more widely used chemkin specifications. 

The commits in this PR were moved from #1607 since they appear to pertain to different problems. They have already been code reviewed in that commit. The main question holding this PR back is whether we should eliminate the ambiguous species label `S` or stay completely compatible with unmodified versions of chemkin 2. 
