### PR TITLE
Element count from conformer

### DIFF
--- a/arkane/commonTest.py
+++ b/arkane/commonTest.py
@@ -249,9 +249,9 @@ class TestArkaneInput(unittest.TestCase):
         job.includeHinderedRotors = self.useHinderedRotors
         job.applyBondEnergyCorrections = self.useBondCorrections
         job.load()
-        self.assertTrue(isinstance(job.species.props['elementCounts'], dict))
-        self.assertEqual(job.species.props['elementCounts']['C'], 2)
-        self.assertEqual(job.species.props['elementCounts']['H'], 4)
+        self.assertTrue(isinstance(job.species.props['element_counts'], dict))
+        self.assertEqual(job.species.props['element_counts']['C'], 2)
+        self.assertEqual(job.species.props['element_counts']['H'], 4)
 
     def testSpeciesThermo(self):
         """Test thermo job execution for species from separate input file."""

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -399,7 +399,7 @@ class StatMechJob(object):
 
         # Save atoms for use in writing thermo output
         if isinstance(self.species, Species):
-            self.species.props['elementCounts'] = atoms
+            self.species.props['element_counts'] = atoms
 
         conformer.coordinates = (coordinates, "angstroms")
         conformer.number = number

--- a/arkane/thermoTest.py
+++ b/arkane/thermoTest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This script contains unit tests of the :mod:`arkane.thermo` module.
+"""
+
+import unittest
+import os
+
+from rmgpy.species import Species
+
+from arkane.gaussian import GaussianLog
+from arkane.thermo import ThermoJob
+
+################################################################################
+
+
+class TestThermo(unittest.TestCase):
+    """
+    Contains unit tests of the ThermoJob class.
+    """
+    @classmethod
+    def setUp(cls):
+        """A method that is run before each unit test in this class"""
+        spc = Species().fromSMILES('CCO')
+        log = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'ethylene.log'))
+        spc.conformer = log.loadConformer()[0]
+        coords, numbers, masses = log.loadGeometry()
+        spc.conformer.coordinates = coords, 'angstroms'
+        spc.conformer.number = numbers
+        spc.conformer.mass = masses, 'amu'
+        cls.thermo_job = ThermoJob(species=spc, thermoClass='NASA')
+
+    def test_element_count_from_conformer(self):
+        """Test Getting an element count dictionary from the species.conformer attribute"""
+        element_count = self.thermo_job.element_count_from_conformer()
+        self.assertEqual(element_count, {'H': 4, 'C': 2})
+
+
+
+################################################################################
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
### Motivation or Problem
Previously thermo blocks in Chemkin files outputted by Arkane did not have an element count if the molecular structure wasn't specified by the user.

### Description of Changes
Now we use the xyz information Arkane has for each species (specifically the species.conformer.number attribute) to determine the element count.

Additional minor modifications:
- replaced file `open()` `close()` with `with open()`
- don't append a species adjList dictionary to the species dictionary file if the species is already there

### Testing
Added a thermoTest for the new element_count_from_conformer() method.

### Reviewer Tips
Try running a ThermoJob without specifying a structure and look at the Chemkin output
