### PR TITLE
Fix frequencyScaleFactor in Arkane examples

### DIFF
--- a/arkane/commonTest.py
+++ b/arkane/commonTest.py
@@ -358,7 +358,7 @@ class TestArkaneSpecies(unittest.TestCase):
         self.assertEqual(arkane_spc.smiles, 'CC')
         self.assertTrue('8 H u0 p0 c0 {2,S}' in arkane_spc.adjacency_list)
         self.assertEqual(arkane_spc.label, 'C2H6')
-        self.assertEqual(arkane_spc.frequency_scale_factor, 1.00386)  # checks float conversion
+        self.assertEqual(arkane_spc.frequency_scale_factor, 0.99*1.014)  # checks float conversion
         self.assertFalse(arkane_spc.use_bond_corrections)
         self.assertAlmostEqual(arkane_spc.conformer.modes[2].frequencies.value_si[0], 830.38202, 4)  # HarmonicOsc.
         self.assertIsInstance(arkane_spc.energy_transfer_model, SingleExponentialDown)

--- a/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy.py
+++ b/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy.py
@@ -16,8 +16,6 @@ energy = {
 geometry = Log('dimetpropoxy.out')
 frequencies = Log('dimetpropoxy.out')
 
-frequencyScaleFactor = 0.983
-
 """pivot are the two atoms that are attached to the rotor                                                                                      
 top contains the atoms that are being rotated including one of the atoms from pivots                                                           
 symmetry is the symmetry number of the scan                                                                                                    

--- a/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
+++ b/examples/arkane/reactions/23dimethylpropoxy/dimetpropoxy_betasci.py
@@ -16,8 +16,6 @@ energy = {
 geometry = Log('dimetpropoxy_betasci.out')
 frequencies = Log('dimetpropoxy_betasci.out')
 
-frequencyScaleFactor = 0.983
-
 """pivot are the two atoms that are attached to the rotor                                                                                      
 top contains the atoms that are being rotated including one of the atoms from pivots                                                           
 symmetry is the symmetry number of the scan                                                                                                    

--- a/examples/arkane/species/C2H6/C2H6.py
+++ b/examples/arkane/species/C2H6/C2H6.py
@@ -23,8 +23,6 @@ geometry = Log('ethane_cbsqb3.log')
 
 frequencies = Log('ethane_cbsqb3.log')
 
-frequencyScaleFactor = 0.99
-
 """pivot are the two atoms that are attached to the rotor
 top contains the atoms that are being rotated including one of the atoms from pivots
 symmetry is the symmetry number of the scan

--- a/examples/arkane/species/C2H6/input.py
+++ b/examples/arkane/species/C2H6/input.py
@@ -11,6 +11,10 @@ modelChemistry = "CBS-QB3"
 useHinderedRotors = True
 useBondCorrections = False
 author = 'I.B. Modeling'
+# Example of how to manually set the frequencyScaleFactor
+# Factor of 0.99 for CBS-QB3 ZPE scaling (dx.doi.org/10.1063/1.477924)
+# Factor of 1.014 for converting between ZPE and frequency scaling factors (dx.doi.org/10.1021/ct100326h)
+frequencyScaleFactor = 0.99*1.014
 
 species('C2H6', 'C2H6.py',
         structure=SMILES('CC'))


### PR DESCRIPTION
### Motivation or Problem
Setting `frequencyScaleFactor` in an species file instead of an Arkane input file does nothing. Therefore, we should not define this in our example files. See #1655 

### Reviewer Note
~~Must be merged after #1643~~ (Update: This PR can now be reviewed and merged when ready)
