### PR TITLE
Support reversing PDepArrhenius objects containing MultiArrhenius rates

### DIFF
--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -409,7 +409,7 @@ class KineticsGroups(Database):
             b = numpy.array(b)
             kdata = numpy.array(kdata)
             
-            x, residues, rank, s = numpy.linalg.lstsq(A, b)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
             
             for t, T in enumerate(Tdata):
                 
@@ -513,7 +513,7 @@ class KineticsGroups(Database):
             b = numpy.array(b)
             kdata = numpy.array(kdata)
             
-            x, residues, rank, s = numpy.linalg.lstsq(A, b)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
             
             # Store the results
             self.top[0].data = Arrhenius(
@@ -564,7 +564,7 @@ class KineticsGroups(Database):
             A = numpy.array(A)
             b = numpy.array(b)
             
-            x, residues, rank, s = numpy.linalg.lstsq(A, b)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
             
             # Store the results
             self.top[0].data = Arrhenius(

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -162,7 +162,7 @@ cdef class Arrhenius(KineticsModel):
             for n in range(b.size):
                 A[n,:] *= weights[n]
                 b[n] *= weights[n]
-        x, residues, rank, s = numpy.linalg.lstsq(A,b)
+        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
 
         # Determine covarianace matrix to obtain parameter uncertainties
         count = klist.size

--- a/rmgpy/kinetics/chebyshev.pyx
+++ b/rmgpy/kinetics/chebyshev.pyx
@@ -217,7 +217,7 @@ cdef class Chebyshev(PDepKineticsModel):
                 b[p1*nT+t1] = log10(K[t1,p1])
 
         # Do linear least-squares fit to get coefficients
-        x, residues, rank, s = numpy.linalg.lstsq(A, b)
+        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
 
         # Extract coefficients
         coeffs = numpy.zeros((degreeT,degreeP), numpy.float64)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -157,7 +157,7 @@ cdef class StickingCoefficient(KineticsModel):
             for n in range(b.size):
                 A[n, :] *= weights[n]
                 b[n] *= weights[n]
-        x, residues, rank, s = numpy.linalg.lstsq(A, b)
+        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
 
         # Determine covarianace matrix to obtain parameter uncertainties
         count = klist.size

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -99,9 +99,9 @@ cdef class Reaction:
 
     cpdef fixBarrierHeight(self, bint forcePositive=?)
 
-    cpdef reverseThisArrheniusRate(self, Arrhenius kForward, str reverseUnits)
+    cpdef reverseThisArrheniusRate(self, Arrhenius kForward, str reverseUnits, Tmin=?, Tmax=?)
 
-    cpdef generateReverseRateCoefficient(self, bint network_kinetics=?)
+    cpdef generateReverseRateCoefficient(self, bint network_kinetics=?, Tmin=?, Tmax=?)
 
     cpdef numpy.ndarray calculateTSTRateCoefficients(self, numpy.ndarray Tlist)
 

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -32,25 +32,26 @@
 This module contains unit tests of the rmgpy.reaction module.
 """
 
-import numpy
 import unittest
+
+import cantera as ct
+import numpy
 from external.wip import work_in_progress
 
-from rmgpy.quantity import Quantity
-from rmgpy.species import Species, TransitionState
-from rmgpy.molecule import Molecule
-from rmgpy.reaction import Reaction
-from rmgpy.quantity import Quantity
-from rmgpy.statmech.translation import Translation, IdealGasTranslation
-from rmgpy.statmech.rotation import Rotation, LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor
-from rmgpy.statmech.vibration import Vibration, HarmonicOscillator
-from rmgpy.statmech.torsion import Torsion, HinderedRotor
-from rmgpy.statmech.conformer import Conformer
-from rmgpy.kinetics import Arrhenius, ArrheniusEP, MultiArrhenius, \
-                           PDepArrhenius, MultiPDepArrhenius, \
-                           SurfaceArrhenius, StickingCoefficient
-from rmgpy.thermo import Wilhoit, ThermoData, NASA, NASAPolynomial
 import rmgpy.constants as constants
+from rmgpy.kinetics import Arrhenius, ArrheniusEP, MultiArrhenius, PDepArrhenius, MultiPDepArrhenius, \
+                           ThirdBody, Troe, Lindemann, Chebyshev, SurfaceArrhenius, StickingCoefficient
+from rmgpy.molecule import Molecule
+from rmgpy.quantity import Quantity
+from rmgpy.reaction import Reaction
+from rmgpy.species import Species, TransitionState
+from rmgpy.statmech.conformer import Conformer
+from rmgpy.statmech.rotation import NonlinearRotor
+from rmgpy.statmech.torsion import HinderedRotor
+from rmgpy.statmech.translation import IdealGasTranslation
+from rmgpy.statmech.vibration import HarmonicOscillator
+from rmgpy.thermo import Wilhoit, ThermoData, NASA, NASAPolynomial
+
 
 ################################################################################
 
@@ -961,8 +962,6 @@ class TestReaction(unittest.TestCase):
         Test the Reaction.generateReverseRateCoefficient() method works for the ThirdBody format.
         """
 
-        from rmgpy.kinetics import ThirdBody
-
         arrheniusLow = Arrhenius(
             A = (2.62e+33,"cm^6/(mol^2*s)"), 
             n = -4.76, 
@@ -1008,8 +1007,6 @@ class TestReaction(unittest.TestCase):
         """
         Test the Reaction.generateReverseRateCoefficient() method works for the Lindemann format.
         """
-
-        from rmgpy.kinetics import Lindemann
 
         arrheniusHigh = Arrhenius(
             A = (1.39e+16,"cm^3/(mol*s)"), 
@@ -1064,8 +1061,6 @@ class TestReaction(unittest.TestCase):
         """
         Test the Reaction.generateReverseRateCoefficient() method works for the Troe format.
         """
-
-        from rmgpy.kinetics import Troe
 
         arrheniusHigh = Arrhenius(
             A = (1.39e+16,"cm^3/(mol*s)"), 
@@ -1238,11 +1233,6 @@ class TestReactionToCantera(unittest.TestCase):
         """
         A method that is called prior to each unit test in this class.
         """
-        from rmgpy.kinetics import Arrhenius, MultiArrhenius, PDepArrhenius, MultiPDepArrhenius, ThirdBody, Troe, Lindemann, Chebyshev
-        from rmgpy.molecule import Molecule
-        from rmgpy.thermo import NASA, NASAPolynomial
-        import cantera as ct
-        
         # define some species:
         ch3 = Species(index=13, label="CH3", thermo=NASA(polynomials=[NASAPolynomial(coeffs=[3.91547,0.00184154,3.48744e-06,-3.3275e-09,8.49964e-13,16285.6,0.351739], Tmin=(100,'K'), Tmax=(1337.62,'K')), NASAPolynomial(coeffs=[3.54145,0.00476788,-1.82149e-06,3.28878e-10,-2.22547e-14,16224,1.6604], Tmin=(1337.62,'K'), Tmax=(5000,'K'))], Tmin=(100,'K'), Tmax=(5000,'K'), comment="""
 Thermo library: primaryThermoLibrary + radical(CH3)

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -594,10 +594,9 @@ class TestEnlarge(unittest.TestCase):
         A method that is run ONCE before all unit tests in this class.
         """
         cls.dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), 'temp'))
-        print cls.dirname
         os.makedirs(os.path.join(cls.dirname, 'pdep'))
 
-        TESTFAMILY = 'R_Recombination'
+        test_family = 'R_Recombination'
 
         cls.rmg = RMG()
 
@@ -620,7 +619,7 @@ class TestEnlarge(unittest.TestCase):
         cls.rmg.database.load(
             path=settings['database.directory'],
             thermoLibraries=['primaryThermoLibrary'],
-            kineticsFamilies=[TESTFAMILY],
+            kineticsFamilies=[test_family],
             reactionLibraries=[],
         )
 

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -539,7 +539,7 @@ cdef class HinderedRotor(Torsion):
             # This row forces dV/dangle = 0 at angle = 0
             for m in range(numterms):
                 A[N,m+numterms] = 1
-            x, residues, rank, s = numpy.linalg.lstsq(A, b)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
             fit = numpy.dot(A,x)
             x *= 0.001
             # This checks if there are any negative values in the forier fit.

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -277,7 +277,7 @@ cdef class Wilhoit(HeatCapacityModel):
                 for j in range(4):
                     A[i,j] = (y*y*y - y*y) * y**j
                 b[i] = ((Cpdata[i] - Cp0) / (CpInf - Cp0) - y*y)
-            x, residues, rank, s = numpy.linalg.lstsq(A, b)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
             
             self.B = (float(B),"K")
             self.a0 = float(x[0])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This really should have been fixed a long time ago, but better late than never.

#329 implemented the capability for the PDepArrhenius class to hold MultiArrhenius rates instead of just Arrhenius rates. This is commonly seen in literature rates, especially from MESS calculations, e.g.
```
C2H3+O2=CH2CHOO                                    4.07E+27       -4.67    5222.0
  PLOG/1.000E-02    1.55E+24       -5.45    9662.0/
  PLOG/1.000E-02    1.78E-09        4.15    -4707.0/                            ! fit btw. 400 and 1250 K with MAE of 0.4%, 1.2%
  PLOG/1.000E-01    3.48E+56      -15.01    19160.0/
  PLOG/1.000E-01    2.36E+22       -4.52    2839.0/                             ! fit btw. 400 and 1350 K with MAE of 0.2%, 0.5%
  PLOG/3.160E-01    1.25E+64      -16.97    21290.0/
  PLOG/3.160E-01    2.00E+26       -5.43    2725.0/                             ! fit btw. 400 and 1450 K with MAE of 0.2%, 0.6%
  PLOG/1.000E+00    3.34E+61      -15.79    20150.0/
  PLOG/1.000E+00    6.13E+28       -5.89    3154.0/                             ! fit btw. 400 and 1550 K with MAE of 0.2%, 1.1%
  PLOG/3.160E+00    7.34E+53      -13.11    17300.0/
  PLOG/3.160E+00    2.14E+29       -5.80    3520.0/                             ! fit btw. 400 and 1650 K with MAE of 0.3%, 1.5%
  PLOG/1.000E+01    4.16E+48      -11.21    16000.0/
  PLOG/1.000E+01    3.48E+28       -5.37    3636.0/                             ! fit btw. 400 and 1750 K with MAE of 0.4%, 1.9%
  PLOG/3.160E+01    2.33E+43       -9.38    14810.0/
  PLOG/3.160E+01    3.32E+27       -4.95    3610.0/                             ! fit btw. 400 and 1900 K with MAE of 0.6%, 2.5%
  PLOG/1.000E+02    3.41E+39       -8.04    14360.0/
  PLOG/1.000E+02    1.03E+27       -4.72    3680.0/                             ! fit btw. 400 and 2100 K with MAE of 0.9%, 3.1%
```

As noted in #797, RMG could not reverse these rates and would print the following error:
```
AttributeError: 'rmgpy.kinetics.arrhenius.MultiArrhenius' object has no attribute 'T0'
```

### Description of Changes
This PR adds the ability to reverse such rates along with a unit test. Since RMG can reverse MultiArrhenius rates, this simply reverses the MultiArrhenius rate associated with each pressure.

This also adds `rcond=None` to all calls to `numpy.linalg.lstsq`. In numpy 1.14, the default behavior for the `rcond` parameter changed. Passing `rcond=None` silences the warnings printed by numpy and accepts the new default behavior.

https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.lstsq.html

### Testing
Check that tests pass. Jobs containing such rates (e.g. from the Klippenstein_Glarborg2016 kinetics library) will crash during the check collision limit violators step, which is another way to test.
