### PR TITLE
Revert Fix Travis builds by adding in missing miniconda dependencies

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -4,7 +4,6 @@ channels:
   - rmg
   - rdkit
   - cantera
-  - anaconda
 dependencies:
   - cairo
   - cairocffi
@@ -32,9 +31,7 @@ dependencies:
   - psutil
   - pydas >=1.0.1
   - pydot ==1.2.2
-  - pydot-ng
   - pydqed >=1.0.0
-  - pygpu
   - pymongo
   - pyparsing
   - pyrdl

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -4,7 +4,6 @@ channels:
   - rmg
   - rdkit
   - cantera
-  - anaconda
 dependencies:
   - cairo
   - cairocffi
@@ -32,9 +31,7 @@ dependencies:
   - psutil
   - pydas >=1.0.1
   - pydot ==1.2.2
-  - pydot-ng
   - pydqed >=1.0.0
-  - pygpu
   - pymongo
   - pyparsing
   - pyrdl

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -4,7 +4,6 @@ channels:
   - rmg
   - rdkit
   - cantera
-  - anaconda
 dependencies:
   - cairo
   - cairocffi
@@ -33,9 +32,7 @@ dependencies:
   - psutil
   - pydas >=1.0.1
   - pydot ==1.2.2
-  - pydot-ng
   - pydqed >=1.0.0
-  - pygpu
   - pymongo
   - pyparsing
   - pyrdl


### PR DESCRIPTION
Packages requiring libgcc have been rebuilt to require libgcc-ng instead. With this the conda solver can resolve the environment without needing pydot-ng and pygpu to be given explicitly

### Motivation or Problem
In #1644 we added some packages explicitly to the environment files to fix failing Travis builds. It has since been determined that all that was necessary was to add in the anaconda channel so that `pydot-ng`, `pygpu`, and `libgpuarray` could be found (these packages were previously taken from the Free channel, but this was removed as a default channel in conda 4.7). The only packages that need these dependencies are DDE and anything that depends on theano, which we are about to update/get rid of. When this happens, we should get rid of these dependencies from our environment files, as they will no longer be needed.

### Description of Changes

1. Removed the anaconda channel
2. Removed pydot-ng
3. Removed pygpu

### Testing
Note that the Travis builds for this PR will fail until DDE/Theano are dealt with, which must happen before the transition to python 3.
