### PR TITLE
Test that we can make a sample molecule for every atom type.

### DIFF
--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -404,7 +404,7 @@ ATOMTYPES['N3t'] = AtomType('N3t', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5']
 # examples for N3t: N2, N#C, N#[C], N#CC
 ATOMTYPES['N3b'] = AtomType('N3b', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[1], charge=[0])
-# examples for N3b: Oxazole, Pyradine, Pyrazine, 1,3,5-Triazine, Benzimidazole, Purine
+# examples for N3b: Oxazole, Pyridine, Pyrazine, 1,3,5-Triazine, Benzimidazole, Purine
 ATOMTYPES['N5sc'] = AtomType('N5sc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 4-8)
                              single=[0,1,2,3,4], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], benzene=[0], lone_pairs=[0], charge=[+1, +2])
 # examples for N5sc: [NH3+][O-]

--- a/rmgpy/molecule/atomtypeTest.py
+++ b/rmgpy/molecule/atomtypeTest.py
@@ -32,7 +32,7 @@ This module contains unit tests of the rmgpy.molecule.atomtype module.
 """
 
 import unittest
-
+import logging
 import rmgpy.molecule
 from rmgpy.molecule import Molecule
 from rmgpy.molecule.atomtype import get_atomtype
@@ -128,6 +128,22 @@ class TestAtomType(unittest.TestCase):
         self.assertEqual(self.atomtype.increment_radical, other.increment_radical)
         self.assertEqual(self.atomtype.decrement_radical, other.decrement_radical)
 
+
+    def test_make_sample_molecule(self):
+        """
+        Test we can make a sample molecule for every atom type.
+        """
+        failed = []
+        for name, atom_type in rmgpy.molecule.atomtype.ATOMTYPES.items():
+            adjlist = f"1 {name} ux"
+            group = rmgpy.molecule.Group().from_adjacency_list(adjlist)
+            try:
+                result = group.make_sample_molecule()
+                # logging.info(f"For {name} made\n{result.to_adjacency_list()}")
+            except:
+                logging.exception(f"Couldn't make sample molecule for atomType {name}")
+                failed.append(name)
+        self.assertFalse(failed, f"Couldn't make sample molecules for types {', '.join(failed)}")
 
 ################################################################################
 

--- a/rmgpy/molecule/atomtypeTest.py
+++ b/rmgpy/molecule/atomtypeTest.py
@@ -171,6 +171,29 @@ class TestAtomType(unittest.TestCase):
                 logging.exception(f"Couldn't make sample molecule for atomType {name}")
                 failed.append(name)
         self.assertFalse(failed, f"Couldn't make sample molecules for types {', '.join(failed)}")
+
+    @work_in_progress
+    def test_make_sample_molecule_right(self):
+        """
+        Test we can make the correct sample molecule for each atom type.
+        """
+        failed = []
+        for name, atom_type in rmgpy.molecule.atomtype.ATOMTYPES.items():
+            if name in self.EXPECTED_FAILING_ATOMTYPES:
+                continue # These are known to fail. See next WIP test
+            adjlist = f"1 {name} ux"
+            group = rmgpy.molecule.Group().from_adjacency_list(adjlist)
+            try:
+                result = group.make_sample_molecule()
+                if not result.is_subgraph_isomorphic(group):
+                    failed.append(name)
+                    logging.error(f"Sample molecule for {name} is not correct. "
+                                  f"Expected:\n{group.to_adjacency_list().strip()}\n"
+                                  f"Got:\n{result.to_adjacency_list().strip()}")
+            except:
+                logging.exception(f"Couldn't make sample molecule for atomType {name}")
+                failed.append(name)
+        self.assertFalse(failed, f"Couldn't make correct sample molecules for types {', '.join(failed)}")
 ################################################################################
 
 class TestGetAtomType(unittest.TestCase):

--- a/rmgpy/molecule/atomtypeTest.py
+++ b/rmgpy/molecule/atomtypeTest.py
@@ -36,6 +36,7 @@ import logging
 import rmgpy.molecule
 from rmgpy.molecule import Molecule
 from rmgpy.molecule.atomtype import get_atomtype
+from external.wip import work_in_progress
 
 
 ################################################################################
@@ -128,13 +129,23 @@ class TestAtomType(unittest.TestCase):
         self.assertEqual(self.atomtype.increment_radical, other.increment_radical)
         self.assertEqual(self.atomtype.decrement_radical, other.decrement_radical)
 
-
+    """
+    Currently RMG doesn't even detect aromaticity of furan or thiophene, so making
+    them out of atom type group definitions is not an easy fix. Even if we did make a
+    sample molecule out of it, we'd probably not realize it was right. Currently
+    it tries to make a 6-membered ring (not realizing it should be 5-membered)
+    and then gets the wrong number of pi electrons.
+    """
+    EXPECTED_FAILING_ATOMTYPES = ['O4b', 'S4b']
+    
     def test_make_sample_molecule(self):
         """
-        Test we can make a sample molecule for every atom type.
+        Test we can make a sample molecule for most atom type without crashing.
         """
         failed = []
         for name, atom_type in rmgpy.molecule.atomtype.ATOMTYPES.items():
+            if name in self.EXPECTED_FAILING_ATOMTYPES:
+                continue # These are known to fail. See next WIP test
             adjlist = f"1 {name} ux"
             group = rmgpy.molecule.Group().from_adjacency_list(adjlist)
             try:
@@ -145,6 +156,21 @@ class TestAtomType(unittest.TestCase):
                 failed.append(name)
         self.assertFalse(failed, f"Couldn't make sample molecules for types {', '.join(failed)}")
 
+    @work_in_progress
+    def test_make_sample_molecule_wip(self):
+        """
+        Test we can make a sample molecule for some failing atom types.
+        """
+        failed = []
+        for name in self.EXPECTED_FAILING_ATOMTYPES:
+            adjlist = f"1 {name} ux"
+            group = rmgpy.molecule.Group().from_adjacency_list(adjlist)
+            try:
+                result = group.make_sample_molecule()
+            except:
+                logging.exception(f"Couldn't make sample molecule for atomType {name}")
+                failed.append(name)
+        self.assertFalse(failed, f"Couldn't make sample molecules for types {', '.join(failed)}")
 ################################################################################
 
 class TestGetAtomType(unittest.TestCase):

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2727,28 +2727,16 @@ class Group(Graph):
 
         # Check that the charge of atoms is expected
         for atom in new_molecule.atoms:
-            if abs(atom.charge) > 0:
+            if atom.charge != 0:
                 if atom in mol_to_group:
                     group_atom = mol_to_group[atom]
                 else:
                     raise UnexpectedChargeError(graph=new_molecule)
-                # check hardcoded atomtypes
-                positive_charged = ['Csc', 'Cdc', 'Ctc',
-                                    'N3sc', 'N5sc', 'N5dc', 'N5ddc', 'N5tc', 'N5b',
-                                    'O2sc', 'O4sc', 'O4dc', 'O4tc',
-                                    'P5sc', 'P5dc', 'P5ddc', 'P5tc', 'P5b',
-                                    'S2sc', 'S4sc', 'S4dc', 'S4tdc', 'S6sc', 'S6dc', 'S6tdc']
-                negative_charged = ['C2sc', 'C2dc', 'C2tc',
-                                    'N0sc', 'N1sc', 'N1dc', 'N5dddc',
-                                    'O0sc',
-                                    'P0sc', 'P1sc', 'P1dc', 'P5sc',
-                                    'S0sc', 'S2sc', 'S2dc', 'S2tc', 'S4sc', 'S4dc', 'S4tdc', 'S6sc', 'S6dc', 'S6tdc']
-                if group_atom.atomtype[0] in [ATOMTYPES[x] for x in positive_charged] and atom.charge > 0:
+                if atom.charge in group_atom.atomtype[0].charge:
+                    # declared charge in atomtype is same as new charge
                     pass
-                elif group_atom.atomtype[0] in [ATOMTYPES[x] for x in negative_charged] and atom.charge < 0:
-                    pass
-                # declared charge in original group is not same as new charge
                 elif atom.charge in group_atom.charge:
+                    # declared charge in original group is same as new charge
                     pass
                 else:
                     raise UnexpectedChargeError(graph=new_molecule)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2219,12 +2219,12 @@ class Group(Graph):
         # Only want to work with benzene bonds on carbon
         labels_of_carbon_atom_types = [x.label for x in ATOMTYPES['C'].specific] + ['C']
         # Also allow with R!H and some nitrogen groups
-        labels_of_carbon_atom_types.extend(['R!H', 'N5b', 'N3b'])
+        labels_of_carbon_atom_types.extend(['R!H', 'N5b', 'N3b', 'N5bd'])
 
         for atom in self.atoms:
             if atom.atomtype[0].label not in labels_of_carbon_atom_types:
                 continue
-            elif atom.atomtype[0].label in ['Cb', 'N5b', 'N3b']:  # Make Cb and N3b into normal cb atoms
+            elif atom.atomtype[0].label in ['Cb', 'N5b', 'N3b', 'N5bd']:  # Make Cb and N3b into normal cb atoms
                 cb_atom_list.append(atom)
             elif atom.atomtype[0].label == 'Cbf':
                 cbf_atom_list.append(atom)
@@ -2755,13 +2755,13 @@ class Group(Graph):
         # classify atoms
         cb_atom_list = []
 
-        # only want to work with carbon atoms
-        labels_of_carbon_atom_types = [x.label for x in ATOMTYPES['C'].specific] + ['C', 'N3b', 'N5b']
+        # only want to work with carbon atoms (and some others)
+        labels_of_carbon_atom_types = [x.label for x in ATOMTYPES['C'].specific] + ['C', 'N3b', 'N5b', 'N5bd']
 
         for atom in self.atoms:
             if atom.atomtype[0].label not in labels_of_carbon_atom_types:
                 continue
-            elif atom.atomtype[0].label in ['Cb', 'Cbf', 'N3b', 'N5b']:  # Make Cb and N3b into normal cb atoms
+            elif atom.atomtype[0].label in ['Cb', 'Cbf', 'N3b', 'N5b', 'N5bd']:  # Make Cb and N3b into normal cb atoms
                 cb_atom_list.append(atom)
             else:
                 benzene_bonds = 0

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2205,7 +2205,10 @@ class Group(Graph):
             group: :class:Group with atoms to classify
             partners: dictionary of partnered up atoms, which must be a cbf atom
 
-        Returns: tuple with lists of each atom classification
+        Some non-carbon 'benzene' type atoms (eg. N3b) are included and classified.
+
+        Returns: tuple with lists of each atom classification:
+        cb_atom_list, cbf_atom_list, cbf_atom_list1, cbf_atom_list2, connected_cbfs
         """
         if not partners:
             partners = {}
@@ -2214,17 +2217,19 @@ class Group(Graph):
         cbf_atom_list = []  # All Cbf Atoms
         cbf_atom_list1 = []  # Cbf Atoms that are bonded to exactly one other Cbf (part of 2 rings)
         cbf_atom_list2 = []  # Cbf that are sandwiched between two other Cbf (part of 2 rings)
-        connected_cbfs = {}  # dictionary of connections to other cbfAtoms
+        connected_cbfs = {}  # dictionary of connections to other cbf Atoms
 
         # Only want to work with benzene bonds on carbon
         labels_of_carbon_atom_types = [x.label for x in ATOMTYPES['C'].specific] + ['C']
-        # Also allow with R!H and some nitrogen groups
-        labels_of_carbon_atom_types.extend(['R!H', 'N5b', 'N3b', 'N5bd'])
+        # Also allow with R!H and some other aromatic groups
+        labels_of_carbon_atom_types.extend(['R!H', 'N5b', 'N3b', 'N5bd', 'O4b', 'P3b', 'P5b', 'P5bd', 'S4b'])
+        # Why are Sib and Sibf missing?
 
         for atom in self.atoms:
+            atomtype = atom.atomtype[0]
             if atom.atomtype[0].label not in labels_of_carbon_atom_types:
                 continue
-            elif atom.atomtype[0].label in ['Cb', 'N5b', 'N3b', 'N5bd']:  # Make Cb and N3b into normal cb atoms
+            elif atom.atomtype[0].label in ['Cb', 'N5b', 'N3b', 'N5bd', 'O4b', 'P3b', 'P5b', 'P5bd', 'S4b']:  # Make Cb and N3b into normal cb atoms
                 cb_atom_list.append(atom)
             elif atom.atomtype[0].label == 'Cbf':
                 cbf_atom_list.append(atom)
@@ -2277,8 +2282,12 @@ class Group(Graph):
         are many dangling Cb or Cbf atoms not in a ring, it is likely fail. In the database test
         (the only use thus far), we will require that any group with more than 3 Cbfs have
         complete rings. This is much stricter than this method can handle, but right now
-        this method cannot handle very general cases, so it is better to be conservative. 
+        this method cannot handle very general cases, so it is better to be conservative.
+
+        Note that it also works on other aromatic atomtypes like N5bd etc.
         """
+        # Note that atomtypes like N5bd are mostly referred to as Cb in this code,
+        # which was first written for just carbon.
 
         # First define some helper functions
         def check_set(super_list, sub_list):

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2746,28 +2746,22 @@ class Group(Graph):
     def is_benzene_explicit(self):
         """
 
-        Returns: 'True' if all Cb, Cbf atoms are in completely explicitly stated benzene rings.
+        Returns: 'True' if all Cb, Cbf (and other 'b' atoms)
+        are in completely explicitly stated benzene rings.
 
         Otherwise return 'False'
 
         """
-
         # classify atoms
         cb_atom_list = []
-
-        # only want to work with carbon atoms (and some others)
-        labels_of_carbon_atom_types = [x.label for x in ATOMTYPES['C'].specific] + ['C', 'N3b', 'N5b', 'N5bd']
-
         for atom in self.atoms:
-            if atom.atomtype[0].label not in labels_of_carbon_atom_types:
-                continue
-            elif atom.atomtype[0].label in ['Cb', 'Cbf', 'N3b', 'N5b', 'N5bd']:  # Make Cb and N3b into normal cb atoms
+            if sum(atom.atomtype[0].benzene): # atomtype has at least one benzene bond
                 cb_atom_list.append(atom)
-            else:
-                benzene_bonds = 0
+            else: # there may be some undeclared (eg. a generic C atomtype, with a benzene bond)
                 for atom2, bond12 in atom.bonds.items():
-                    if bond12.is_benzene(): benzene_bonds += 1
-                if benzene_bonds > 0: cb_atom_list.append(atom)
+                    if bond12.is_benzene():
+                        cb_atom_list.append(atom)
+                        break # can stop checking bonds for this atom
 
         # get all explicit benzene rings
         rings = [cycle for cycle in self.get_all_cycles_of_size(6) if Group(atoms=cycle).is_aromatic_ring()]

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2733,7 +2733,7 @@ class Group(Graph):
                 else:
                     raise UnexpectedChargeError(graph=new_molecule)
                 # check hardcoded atomtypes
-                positive_charged = ['Csc', 'Cdc',
+                positive_charged = ['Csc', 'Cdc', 'Ctc',
                                     'N3sc', 'N5sc', 'N5dc', 'N5ddc', 'N5tc', 'N5b',
                                     'O2sc', 'O4sc', 'O4dc', 'O4tc',
                                     'P5sc', 'P5dc', 'P5ddc', 'P5tc', 'P5b',


### PR DESCRIPTION
### Motivation or Problem
This unit test at the start of this PR was inspired by efforts to debug something in some changes to the database (https://github.com/ReactionMechanismGenerator/RMG-database/pull/317) , which caused a segfault when running the database Tests, but was in fact caused by an undetected bug in RMG (https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1656) not a problem in the database.  I felt there ought to have been a unit test to prevent the bug.

### Description of Changes
The goal is to make a group definition out of each atom type, and then make a sample molecule for each group definition. This should test the group definition and the `make_sample_molecule` method.

At first, the test failed, and that was either because of 
1) bug(s) in the way the test is currently written, or 
2) bug(s) in our atom type definitions 
3) bug(s) in our `make_sample_molecule` method.

I then fixed several of the bugs - mostly in the algorithm to make aromatic rings for sample molecules.
The remaining bugs I split into a "work in progress" unit test - they involve aromatic O and S atoms (['O4b', 'S4b'] ) which seem to be poorly supported currently.

I then made a more stringent test  - that not only do we generate sample molecules without crashing, but that they're correct. This test is also currently marked a "work in progress". The list of problems is Xo, Cq, Sib, Sibf, Siq. Fixing those can be a separate issue.