### PR TITLE
Debug travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ stages:
 
 before_install:
   - cd ..
+  # Display CPU and memory information on the Linux builds
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then lscpu; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then free -m; fi
   # Install miniconda
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh; fi

--- a/rmgpy/rmg/reactTest.py
+++ b/rmgpy/rmg/reactTest.py
@@ -99,6 +99,9 @@ class TestReact(unittest.TestCase):
         self.assertEqual(len(reaction_list), 3)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in reaction_list]))
 
+        # Reset module level maxproc back to default
+        rmgpy.rmg.main.maxproc = 1
+
     def testReactAll(self):
         """
         Test that the ``react_all`` function works in serial
@@ -146,6 +149,9 @@ class TestReact(unittest.TestCase):
         flat_rxn_list = list(itertools.chain.from_iterable(reaction_list))
         self.assertEqual(len(flat_rxn_list), 44)
         self.assertTrue(all([isinstance(rxn, TemplateReaction) for rxn in flat_rxn_list]))
+
+        # Reset module level maxproc back to default
+        rmgpy.rmg.main.maxproc = 1
 
     def tearDown(self):
         """


### PR DESCRIPTION
### Motivation or Problem
A bug (well, at least we hope it is a bug and not a new feature) in Travis Worker 6.2.1 means that these builds only run with 1 CPU instead of the expected two. This made us realize that we have a bug in one of our unit tests that does not check the number of CPUs properly (fixed by this PR). We also want to display CPU and memory information in the Travis build log so that we can debug errors like this in the future.

While this PR will not fix Travis builds completely for 6.2.1 (there is no work around for insufficient memory) it fixes everything that we can right now, and we have opened up issues with Travis.

### Description of Changes

- Reset module level rmgpy.rmg.main.maxproc back to the default of 1 at the end of individual tests
- Print CPU and memory info in the Travis logs.

### Testing
I have already tested that our bug fixes work in Travis Worker 6.2.1, so we just need this to build in Travis Worker 6.2.0 so that we can merge this PR.