### PR TITLE
Do not deploy RMG-tests for master and stable branches

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,31 +2,24 @@
 
 set -e # exit with nonzero exit code if anything fails
 
-echo 'Travis Build Dir: '$TRAVIS_BUILD_DIR
-
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  DEPLOY_BRANCH=$TRAVIS_PULL_REQUEST
+  echo "RMG-tests should not deploy from pull requests"
+  exit 0
+elif [ "$TRAVIS_BRANCH" == "master" ]; then
+  echo "RMG-tests should not deploy from the master branch"
+  exit 0
+elif [ "$TRAVIS_BRANCH" == "stable" ]; then
+  echo "RMG-tests should not deploy from the stable branch"
+  exit 0
 else
   DEPLOY_BRANCH=$TRAVIS_BRANCH
 fi
 
-# Deploy built site to this branch
+echo "TRAVIS_BUILD_DIR: $TRAVIS_BUILD_DIR"
 echo "DEPLOY_BRANCH: $DEPLOY_BRANCH"
 
 # URL for the official RMG-tests repository
 REPO=https://${GH_TOKEN}@github.com/ReactionMechanismGenerator/RMG-tests.git
-
-if [ -n "$TRAVIS_BUILD_ID" ]; then
-
-  if [ "$TRAVIS_BRANCH" != "$DEPLOY_BRANCH" ]; then
-    echo "Travis should only deploy from the DEPLOY_BRANCH ($DEPLOY_BRANCH) branch"
-    exit 0
-  elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    echo "Travis should not deploy from pull requests"
-    exit 0
-  fi
-
-fi
 
 # create a temporary folder:
 REPO_NAME=$(basename $REPO)


### PR DESCRIPTION
Simplify logic to deploy only from feature branches
Changes behavior to not deploy from master or stable branches

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Running RMG-tests is relatively expensive since it consumes at most 3 Travis builds and takes over an hour to complete. Since the goal of RMG-tests is to compare models between feature branches and master, it seems unnecessary to test on the master and stable branches.

### Description of Changes
Effective change is to prevent builds on master and stable. Also cleaned up the logic a bit in the deploy script.

### Testing
It's a bit hard to test, but we should see an RMG-tests build triggered by the push build for this branch. We should confirm that the correct message is displayed for the PR build. However, we'll only be able to confirm that it doesn't build on master after merging.

### Reviewer Tips
Double-check that the bash code is correct.