### PR TITLE
Check numpy version before passing rcond to numpy.linalg.lstsq

### DIFF
--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -46,6 +46,9 @@ from rmgpy.species import Species
 from rmgpy.quantity import constants
 from rmgpy.exceptions import KineticsError, UndeterminableKineticsError, DatabaseError
 
+# Prior to numpy 1.14, `numpy.linalg.lstsq` does not accept None as a value
+RCOND = -1 if int(numpy.__version__.split('.')[1]) < 14 else None
+
 ################################################################################
 
 class KineticsGroups(Database):
@@ -409,7 +412,7 @@ class KineticsGroups(Database):
             b = numpy.array(b)
             kdata = numpy.array(kdata)
             
-            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
             
             for t, T in enumerate(Tdata):
                 
@@ -513,7 +516,7 @@ class KineticsGroups(Database):
             b = numpy.array(b)
             kdata = numpy.array(kdata)
             
-            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
             
             # Store the results
             self.top[0].data = Arrhenius(
@@ -564,7 +567,7 @@ class KineticsGroups(Database):
             A = numpy.array(A)
             b = numpy.array(b)
             
-            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
             
             # Store the results
             self.top[0].data = Arrhenius(

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -36,6 +36,10 @@ cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 from rmgpy.exceptions import KineticsError
 from rmgpy.kinetics.uncertainies import rank_accuracy_map
+
+# Prior to numpy 1.14, `numpy.linalg.lstsq` does not accept None as a value
+RCOND = -1 if int(numpy.__version__.split('.')[1]) < 14 else None
+
 ################################################################################
 
 cdef class Arrhenius(KineticsModel):
@@ -162,7 +166,7 @@ cdef class Arrhenius(KineticsModel):
             for n in range(b.size):
                 A[n,:] *= weights[n]
                 b[n] *= weights[n]
-        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
 
         # Determine covarianace matrix to obtain parameter uncertainties
         count = klist.size

--- a/rmgpy/kinetics/chebyshev.pyx
+++ b/rmgpy/kinetics/chebyshev.pyx
@@ -34,6 +34,10 @@ cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 import logging
 from rmgpy.exceptions import KineticsError
+
+# Prior to numpy 1.14, `numpy.linalg.lstsq` does not accept None as a value
+RCOND = -1 if int(numpy.__version__.split('.')[1]) < 14 else None
+
 ################################################################################
 
 cdef class Chebyshev(PDepKineticsModel):
@@ -217,7 +221,7 @@ cdef class Chebyshev(PDepKineticsModel):
                 b[p1*nT+t1] = log10(K[t1,p1])
 
         # Do linear least-squares fit to get coefficients
-        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
 
         # Extract coefficients
         coeffs = numpy.zeros((degreeT,degreeP), numpy.float64)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -34,6 +34,9 @@ cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 from rmgpy.exceptions import KineticsError
 
+# Prior to numpy 1.14, `numpy.linalg.lstsq` does not accept None as a value
+RCOND = -1 if int(numpy.__version__.split('.')[1]) < 14 else None
+
 ################################################################################
 
 cdef class StickingCoefficient(KineticsModel):
@@ -157,7 +160,7 @@ cdef class StickingCoefficient(KineticsModel):
             for n in range(b.size):
                 A[n, :] *= weights[n]
                 b[n] *= weights[n]
-        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+        x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
 
         # Determine covarianace matrix to obtain parameter uncertainties
         count = klist.size

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -50,6 +50,9 @@ import rmgpy.statmech.schrodinger as schrodinger
 from rmgpy.exceptions import NegativeBarrierException
 import logging
 
+# Prior to numpy 1.14, `numpy.linalg.lstsq` does not accept None as a value
+RCOND = -1 if int(numpy.__version__.split('.')[1]) < 14 else None
+
 ################################################################################
 
 cdef class Torsion(Mode):
@@ -539,7 +542,7 @@ cdef class HinderedRotor(Torsion):
             # This row forces dV/dangle = 0 at angle = 0
             for m in range(numterms):
                 A[N,m+numterms] = 1
-            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
             fit = numpy.dot(A,x)
             x *= 0.001
             # This checks if there are any negative values in the forier fit.

--- a/rmgpy/thermo/wilhoit.pyx
+++ b/rmgpy/thermo/wilhoit.pyx
@@ -36,6 +36,9 @@ cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 import scipy.linalg
 
+# Prior to numpy 1.14, `numpy.linalg.lstsq` does not accept None as a value
+RCOND = -1 if int(numpy.__version__.split('.')[1]) < 14 else None
+
 ################################################################################
 
 cdef class Wilhoit(HeatCapacityModel):
@@ -277,7 +280,7 @@ cdef class Wilhoit(HeatCapacityModel):
                 for j in range(4):
                     A[i,j] = (y*y*y - y*y) * y**j
                 b[i] = ((Cpdata[i] - Cp0) / (CpInf - Cp0) - y*y)
-            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=None)
+            x, residues, rank, s = numpy.linalg.lstsq(A, b, rcond=RCOND)
             
             self.B = (float(B),"K")
             self.a0 = float(x[0])

--- a/utilities.py
+++ b/utilities.py
@@ -31,6 +31,7 @@
 """
 This module contains utilities related to compilation and code maintenance.
 """
+from __future__ import print_function
 
 import argparse
 import os
@@ -45,14 +46,14 @@ def check_dependencies():
     """
     missing = install_rdkit = False
 
-    print '\nChecking vital dependencies...\n'
-    print '{0:<15}{1:<15}{2}'.format('Package', 'Version', 'Location')
+    print('\nChecking vital dependencies...\n')
+    print('{0:<15}{1:<15}{2}'.format('Package', 'Version', 'Location'))
 
     # Check for symmetry
     try:
         result = subprocess.check_output('symmetry -h', stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError:
-        print '{0:<30}{1}'.format('symmetry', 'Not found. Please install in order to use QM.')
+        print('{0:<30}{1}'.format('symmetry', 'Not found. Please install in order to use QM.'))
         missing = True
     else:
         match = re.search(r'\$Revision: (\S*) \$', result)
@@ -62,15 +63,15 @@ def check_dependencies():
         else:
             location = subprocess.check_output('which symmetry', shell=True)
 
-        print '{0:<15}{1:<15}{2}'.format('symmetry', version, location.strip())
+        print('{0:<15}{1:<15}{2}'.format('symmetry', version, location.strip()))
 
     # Check for RDKit
     try:
         import rdkit
         from rdkit import Chem
     except ImportError:
-        print '{0:<30}{1}'.format('RDKit',
-                                  'Not found. Please install RDKit version 2015.03.1 or later with InChI support.')
+        print('{0:<30}{1}'.format('RDKit',
+                                  'Not found. Please install RDKit version 2015.03.1 or later with InChI support.'))
         missing = install_rdkit = True
     else:
         try:
@@ -81,49 +82,49 @@ def check_dependencies():
         inchi = Chem.inchi.INCHI_AVAILABLE
 
         if version:
-            print '{0:<15}{1:<15}{2}'.format('RDKit', version, location)
+            print('{0:<15}{1:<15}{2}'.format('RDKit', version, location))
             if not inchi:
-                print '    !!! RDKit installed without InChI Support. Please install with InChI.'
+                print('    !!! RDKit installed without InChI Support. Please install with InChI.')
                 missing = install_rdkit = True
         else:
-            print '    !!! RDKit version out of date, please install RDKit version 2015.03.1 or later with InChI support.'
+            print('    !!! RDKit version out of date, please install RDKit version 2015.03.1 or later with InChI support.')
             missing = install_rdkit = True
 
     # Check for OpenBabel
     try:
         import openbabel
     except ImportError:
-        print '{0:<30}{1}'.format('OpenBabel',
-                                  'Not found. Necessary for SMILES/InChI functionality for nitrogen compounds.')
+        print('{0:<30}{1}'.format('OpenBabel',
+                                  'Not found. Necessary for SMILES/InChI functionality for nitrogen compounds.'))
         missing = True
     else:
         version = openbabel.OBReleaseVersion()
         location = openbabel.__file__
-        print '{0:<15}{1:<15}{2}'.format('OpenBabel', version, location)
+        print('{0:<15}{1:<15}{2}'.format('OpenBabel', version, location))
 
     # Check for lpsolve
     try:
         import lpsolve55
     except ImportError:
-        print '{0:<30}{1}'.format('lpsolve55',
-                                  'Not found. Necessary for generating Clar structures for aromatic species.')
+        print('{0:<30}{1}'.format('lpsolve55',
+                                  'Not found. Necessary for generating Clar structures for aromatic species.'))
         missing = True
     else:
         location = lpsolve55.__file__
-        print '{0:<30}{1}'.format('lpsolve55', location)
+        print('{0:<30}{1}'.format('lpsolve55', location))
 
     # Check for pyrdl
     try:
         import py_rdl
     except ImportError:
-        print '{0:<30}{1}'.format('pyrdl', 'Not found. Necessary for ring perception algorithms.')
+        print('{0:<30}{1}'.format('pyrdl', 'Not found. Necessary for ring perception algorithms.'))
         missing = True
     else:
         location = py_rdl.__file__
-        print '{0:<30}{1}'.format('pyrdl', location)
+        print('{0:<30}{1}'.format('pyrdl', location))
 
     if missing:
-        print """
+        print("""
 There are missing dependencies as listed above. Please install them before proceeding.
 
 Using Anaconda, these dependencies can be individually installed from the RMG channel as follows:
@@ -139,11 +140,11 @@ Be sure to activate your conda environment (rmg_env by default) before installin
 RDKit should be installed from the RDKit channel instead:
 
     conda install -c rdkit rdkit
-""" if install_rdkit else '')
+""" if install_rdkit else ''))
     else:
-        print """
+        print("""
 Everything was found :)
-"""
+""")
 
 
 def clean(subdirectory=''):
@@ -204,7 +205,7 @@ def update_headers():
 ###############################################################################
 """
 
-    print header
+    print(header)
 
     def replace_header(oldfile):
         newfile = os.path.join('tmp', 'tempfile')
@@ -263,16 +264,16 @@ def update_headers():
     for root_dir in root_dirs:
         for root, dirs, files in os.walk(root_dir):
             if 'test_data' in root or 'files' in root or '/tools/data' in root or 'arkane/data' in root:
-                print 'Skipping ' + root
+                print('Skipping ' + root)
                 continue
-            print root
+            print(root)
             for f in files:
                 ext = os.path.splitext(f)[1]
                 if ext in ['.py', '.pyx', '.pxd']:
                     filelist.append(os.path.join(root, f))
 
     for f in filelist:
-        print 'Updating {0} ...'.format(f)
+        print('Updating {0} ...'.format(f))
         replace_header(f)
 
     # Remove temporary directory

--- a/utilities.py
+++ b/utilities.py
@@ -43,7 +43,7 @@ def check_dependencies():
     """
     Checks for and locates major dependencies that RMG requires.
     """
-    missing = False
+    missing = install_rdkit = False
 
     print '\nChecking vital dependencies...\n'
     print '{0:<15}{1:<15}{2}'.format('Package', 'Version', 'Location')
@@ -71,7 +71,7 @@ def check_dependencies():
     except ImportError:
         print '{0:<30}{1}'.format('RDKit',
                                   'Not found. Please install RDKit version 2015.03.1 or later with InChI support.')
-        missing = True
+        missing = install_rdkit = True
     else:
         try:
             version = rdkit.__version__
@@ -83,11 +83,11 @@ def check_dependencies():
         if version:
             print '{0:<15}{1:<15}{2}'.format('RDKit', version, location)
             if not inchi:
-                print 'RDKit installed without InChI Support. Please install with InChI.'
-                missing = True
+                print '    !!! RDKit installed without InChI Support. Please install with InChI.'
+                missing = install_rdkit = True
         else:
-            print 'RDKit version out of date, please install RDKit version 2015.03.1 or later with InChI support.'
-            missing = True
+            print '    !!! RDKit version out of date, please install RDKit version 2015.03.1 or later with InChI support.'
+            missing = install_rdkit = True
 
     # Check for OpenBabel
     try:
@@ -129,13 +129,17 @@ There are missing dependencies as listed above. Please install them before proce
 Using Anaconda, these dependencies can be individually installed from the RMG channel as follows:
 
     conda install -c rmg [package name]
-
+{0}
 You can alternatively update your environment and install all missing dependencies as follows:
 
     conda env update -f environment_[linux/mac/windows].yml  # Choose the correct file for your OS
 
 Be sure to activate your conda environment (rmg_env by default) before installing or updating.
-"""
+""".format("""
+RDKit should be installed from the RDKit channel instead:
+
+    conda install -c rdkit rdkit
+""" if install_rdkit else '')
     else:
         print """
 Everything was found :)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
#1659 added the `rcond` argument to calls to `numpy.linalg.lstsq`. A side-effect is that we broke compatibility with numpy versions prior to 1.14.

Original plan was to simply increase our numpy version requirement, but after thinking about it a bit more, this change does not seem like sufficient reason to do so.

### Description of Changes
This PR adds automatic determination of the appropriate value for rcond depending on the numpy version.

It also updates and futurizes `utilities.py`.

### Testing
Will test in an environment with an older version of numpy. Travis should be sufficient to test that it works in newer versions of numpy.
