### PR TITLE
Reduce species copying and resonance structure generation when reacting

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -198,7 +198,7 @@ def ensure_independent_atom_ids(input_species, resonance=True):
     Modifies the list in place (replacing :class:`Molecule` with :class:`Species`).
     Returns None.
     """
-    ensure_species(input_species, resonance=resonance, keep_isomorphic=True)
+    ensure_species(input_species)  # do not generate resonance structures since we do so below
     # Method to check that all species' atom ids are different
     def independent_ids():
         num_atoms = 0

--- a/rmgpy/rmg/react.py
+++ b/rmgpy/rmg/react.py
@@ -91,9 +91,6 @@ def react_species(species_tuple, only_families=None):
     Returns:
         list of generated reactions
     """
-
-    species_tuple = tuple([spc.copy(deep=True) for spc in species_tuple])
-
     reactions = getDB('kinetics').generate_reactions_from_families(species_tuple, only_families=only_families)
 
     return reactions


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Two performance related changes, cherry-picked from #1577.

### Description of Changes
1. Do not make deep copies of species in `react_species` ([reasoning](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1577#issuecomment-519315774))
2. Remove a redundant resonance structure generation step

### Testing
Tested with the liquid oxidation test from RMG-tests, but on the FilterCritPerReactFamily branch.

Should confirm that RMG-tests show no differences in models except for runtime.