### PR TITLE
Make page titles contain current release number instead of 2.1.0

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -137,10 +137,10 @@ html_style = 'custom.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'RMG-Py 2.1.0 Documentation'
+html_title = 'RMG-Py {} Documentation'.format(release)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = '2.1.0 Documentation'
+html_short_title = '{} Documentation'.format(release)
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.


### PR DESCRIPTION
Pages currently have a title that's something like
`<title>Arkane (arkane) &#8212; RMG-Py 2.1.0 Documentation</title>`
which clearly we forget to update with new version numbers.
This should automatically update it with the release version.
The titles are not prominent in some browsers, but are very obvious in google search results etc.