### PR TITLE
Prevent file locking for HDF5 files

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -84,6 +84,11 @@ from rmgpy.tools.uncertainty import Uncertainty, process_local_results
 
 ################################################################################
 
+# This module uses the HDF5 data format, which can cause problems on files systems that use NFS (common for network
+# mounted file systems. The following sets an environment variable that prevents file locking that would otherwise
+# cause a problem for NFS.
+os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
+
 solvent = None
 
 # Maximum number of user defined processors


### PR DESCRIPTION
### Motivation or Problem
There appears to be an issue with saving HDF5 files, which we now use to save the filter tensors (thanks to @mjohnson541 for discovering this). On remote servers, it is possible to get the following error on current master:

```
Making seed mechanism...
Traceback (most recent call last):
 File “RMG-Py/rmg.py”, line 185, in <module>
   main()
 File “RMG-Py/rmg.py”, line 179, in main
   rmg.execute(**kwargs)
 File “RMG-Py/rmgpy/rmg/main.py”, line 711, in execute
   self.makeSeedMech(firstTime=True)
 File “RMG-Py/rmgpy/rmg/main.py”, line 1350, in makeSeedMech
   raise e
IOError: Unable to create file (unable to lock file, errno = 37, error message = ‘No locks available’)
dbolsm(). more than (i1)=itmax iterations solving bounded least squares problem.
error number =    22, message level =     1
i1 =      110
/var/spool/slurm/spool/jobxxxx/slurm_script: line 33: deactivate: No such file or directory
```

I found this [issue](https://github.com/h5py/h5py/issues/1082) on the h5py Github, which suggests that this is a problem with the code trying to lock the file when writing, which causes problems for NFS mounted file systems (i.e. most network mounted drives on servers). The only suggested fix is to export and environment variable with `export HDF5_USE_FILE_LOCKING=FALSE`, though this fix does not appear to work for everyone.

### Description of Changes
Use `os.environ` to set this environment variable whenever `rmgpy.rmg.main` is imported, which contains the code that saves the filter tensors as HDF5 files. This way, we do not have to tell people to add this on to their job submission scripts.

### Testing
@mjohnson541 has confirmed that this fix removed this issue for him
