### PR TITLE
Python 3 compatibility change to /rmgpy/statmech

### DIFF
--- a/rmgpy/statmech/__init__.py
+++ b/rmgpy/statmech/__init__.py
@@ -28,8 +28,12 @@
 #                                                                             #
 ###############################################################################
 
-from .translation import Translation, IdealGasTranslation
-from .rotation import Rotation, LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor
-from .vibration import Vibration, HarmonicOscillator
-from .torsion import Torsion, HinderedRotor
-from .conformer import Conformer
+"""
+initialize imports
+"""
+
+from rmgpy.statmech.conformer import Conformer
+from rmgpy.statmech.rotation import KRotor, LinearRotor, NonlinearRotor, Rotation, SphericalTopRotor
+from rmgpy.statmech.torsion import HinderedRotor, Torsion
+from rmgpy.statmech.translation import IdealGasTranslation, Translation
+from rmgpy.statmech.vibration import HarmonicOscillator, Vibration

--- a/rmgpy/statmech/conformerTest.py
+++ b/rmgpy/statmech/conformerTest.py
@@ -32,235 +32,245 @@
 This script contains unit tests of the :mod:`rmgpy.statmech.conformer` module.
 """
 
-import unittest
-import numpy
+from __future__ import division
 
-from rmgpy.statmech import Conformer, IdealGasTranslation, NonlinearRotor, HarmonicOscillator, \
-                           LinearRotor, HinderedRotor 
+import unittest
+
+import numpy as np
+
 import rmgpy.constants as constants
+from rmgpy.statmech import Conformer, HarmonicOscillator, HinderedRotor, \
+    IdealGasTranslation, LinearRotor, NonlinearRotor
 
 ################################################################################
+
 
 class TestConformer(unittest.TestCase):
     """
     Contains unit tests of the :class:`Conformer` class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
         """
         self.ethylene = Conformer(
-            E0 = (0.0,"kJ/mol"),
-            modes = [
-                IdealGasTranslation(mass=(28.03,"amu")),
-                NonlinearRotor(inertia=([3.41526,16.6498,20.065],"amu*angstrom^2"), symmetry=4),
-                HarmonicOscillator(frequencies=([828.397,970.652,977.223,1052.93,1233.55,1367.56,1465.09,1672.25,3098.46,3111.7,3165.79,3193.54],"cm^-1")),
+            E0=(0.0, "kJ/mol"),
+            modes=[
+                IdealGasTranslation(mass=(28.03, "amu")),
+                NonlinearRotor(inertia=([3.41526, 16.6498, 20.065], "amu*angstrom^2"), symmetry=4),
+                HarmonicOscillator(frequencies=([828.397, 970.652, 977.223, 1052.93, 1233.55, 1367.56, 1465.09,
+                                                 1672.25, 3098.46, 3111.7, 3165.79, 3193.54], "cm^-1")),
             ],
-            spinMultiplicity = 1,
-            opticalIsomers = 1,
+            spinMultiplicity=1,
+            opticalIsomers=1,
         )
         self.oxygen = Conformer(
-            E0 = (0.0,"kJ/mol"),
-            modes = [
-                IdealGasTranslation(mass=(31.99,"amu")),
-                LinearRotor(inertia=(11.6056,"amu*angstrom^2"), symmetry=2),
-                HarmonicOscillator(frequencies=([1621.54],"cm^-1")),
+            E0=(0.0, "kJ/mol"),
+            modes=[
+                IdealGasTranslation(mass=(31.99, "amu")),
+                LinearRotor(inertia=(11.6056, "amu*angstrom^2"), symmetry=2),
+                HarmonicOscillator(frequencies=([1621.54], "cm^-1")),
             ],
-            spinMultiplicity = 3,
-            opticalIsomers = 1,
+            spinMultiplicity=3,
+            opticalIsomers=1,
         )
-        
+
         # The following data is for ethane at the CBS-QB3 level
-        self.coordinates = numpy.array([
-            [  0.0000,  0.0000,  0.0000],
-            [ -0.0000, -0.0000,  1.0936],
-            [  1.0430, -0.0000, -0.3288],
-            [ -0.4484,  0.9417, -0.3288],
-            [ -0.7609, -1.2051, -0.5580],
-            [ -0.7609, -1.2051, -1.6516],
-            [ -0.3125, -2.1468, -0.2292],
-            [ -1.8039, -1.2051, -0.2293],
+        self.coordinates = np.array([
+            [0.0000,  0.0000,  0.0000],
+            [-0.0000, -0.0000,  1.0936],
+            [1.0430, -0.0000, -0.3288],
+            [-0.4484,  0.9417, -0.3288],
+            [-0.7609, -1.2051, -0.5580],
+            [-0.7609, -1.2051, -1.6516],
+            [-0.3125, -2.1468, -0.2292],
+            [-1.8039, -1.2051, -0.2293],
         ])
-        self.number = numpy.array([6, 1, 1, 1, 6, 1, 1, 1])
-        self.mass = numpy.array([12, 1.007825, 1.007825, 1.007825, 12, 1.007825, 1.007825, 1.007825])
+        self.number = np.array([6, 1, 1, 1, 6, 1, 1, 1])
+        self.mass = np.array([12, 1.007825, 1.007825, 1.007825, 12, 1.007825, 1.007825, 1.007825])
         self.E0 = -93.5097
         self.conformer = Conformer(
-            E0 = (self.E0,"kJ/mol"),
-            modes = [
-                IdealGasTranslation(mass=(30.0469,"amu")),
-                NonlinearRotor(inertia=([6.27071,25.3832,25.3833],"amu*angstrom^2"), symmetry=6),
-                HarmonicOscillator(frequencies=([818.917,819.479,987.099,1206.76,1207.05,1396,1411.35,1489.73,1489.95,1492.49,1492.66,2995.36,2996.06,3040.77,3041,3065.86,3066.02],"cm^-1")),
-                HinderedRotor(inertia=(1.56768,"amu*angstrom^2"), symmetry=3, barrier=(2.69401,"kcal/mol"), quantum=False, semiclassical=False),
+            E0=(self.E0, "kJ/mol"),
+            modes=[
+                IdealGasTranslation(mass=(30.0469, "amu")),
+                NonlinearRotor(inertia=([6.27071, 25.3832, 25.3833], "amu*angstrom^2"), symmetry=6),
+                HarmonicOscillator(frequencies=([818.917, 819.479, 987.099, 1206.76, 1207.05, 1396, 1411.35, 1489.73,
+                                                 1489.95, 1492.49, 1492.66, 2995.36, 2996.06, 3040.77, 3041, 3065.86,
+                                                 3066.02], "cm^-1")),
+                HinderedRotor(inertia=(1.56768, "amu*angstrom^2"), symmetry=3,
+                              barrier=(2.69401, "kcal/mol"), quantum=False, semiclassical=False),
             ],
-            spinMultiplicity = 1,
-            opticalIsomers = 1,
-            coordinates = (self.coordinates,"angstrom"),
-            number = self.number,
-            mass = (self.mass,"amu"),
+            spinMultiplicity=1,
+            opticalIsomers=1,
+            coordinates=(self.coordinates, "angstrom"),
+            number=self.number,
+            mass=(self.mass, "amu"),
         )
-        
-    def test_getPartitionFunction_ethylene(self):
+
+    def test_get_partition_function_ethylene(self):
         """
         Test the StatMech.getPartitionFunction() method for ethylene.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([4.05311e+09, 4.19728e+10, 2.82309e+12, 7.51135e+13, 1.16538e+15])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.ethylene.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([4.05311e+09, 4.19728e+10, 2.82309e+12, 7.51135e+13, 1.16538e+15])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.ethylene.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
 
-    def test_getHeatCapacity_ethylene(self):
+    def test_get_heat_capacity_ethylene(self):
         """
         Test the StatMech.getHeatCapacity() method for ethylene.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([5.11186, 7.40447, 11.1659, 13.1221, 14.1617]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.ethylene.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, 3)
-    
-    def test_getEnthalpy_ethylene(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([5.11186, 7.40447, 11.1659, 13.1221, 14.1617]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.ethylene.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, 3)
+
+    def test_get_enthalpy_ethylene(self):
         """
         Test the StatMech.getEnthalpy() method for ethylene.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([4.23129, 5.04826, 7.27337, 8.93167, 10.1223]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.ethylene.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEntropy_ethylene(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([4.23129, 5.04826, 7.27337, 8.93167, 10.1223]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.ethylene.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_entropy_ethylene(self):
         """
         Test the StatMech.getEntropy() method for ethylene.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([26.3540, 29.5085, 35.9422, 40.8817, 44.8142]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.ethylene.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, 3)
-    
-    def test_getSumOfStates_ethylene(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([26.3540, 29.5085, 35.9422, 40.8817, 44.8142]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.ethylene.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, 3)
+
+    def test_get_sum_of_states_ethylene(self):
         """
         Test the StatMech.getSumOfStates() method for ethylene.
         """
-        Elist = numpy.arange(0, 5000*11.96, 2*11.96)
-        sumStates = self.ethylene.getSumOfStates(Elist)
-        densStates = self.ethylene.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n+1]) / sumStates[n] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n+1]), sumStates[n]))
-            
-    def test_getDensityOfStates_ethylene(self):
+        e_list = np.arange(0, 5000 * 11.96, 2 * 11.96)
+        sum_states = self.ethylene.getSumOfStates(e_list)
+        dens_states = self.ethylene.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n + 1]) / sum_states[n] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n + 1]), sum_states[n]))
+
+    def test_get_density_of_states_ethylene(self):
         """
         Test the StatMech.getDensityOfStates() method for ethylene.
         """
-        Elist = numpy.arange(0, 5000*11.96, 2*11.96)
-        densStates = self.ethylene.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.ethylene.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-1*Qexp)
+        e_list = np.arange(0, 5000 * 11.96, 2 * 11.96)
+        dens_states = self.ethylene.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.ethylene.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-1 * q_exp)
 
-    def test_getPartitionFunction_oxygen(self):
+    def test_get_partition_function_oxygen(self):
         """
         Test the StatMech.getPartitionFunction() method for oxygen.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([1.55584e+09, 9.38339e+09, 1.16459e+11, 5.51016e+11, 1.72794e+12])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.oxygen.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1.55584e+09, 9.38339e+09, 1.16459e+11, 5.51016e+11, 1.72794e+12])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.oxygen.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
 
-    def test_getHeatCapacity_oxygen(self):
+    def test_get_heat_capacity_oxygen(self):
         """
         Test the StatMech.getHeatCapacity() method for oxygen.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([3.52538, 3.70877, 4.14751, 4.32063, 4.39392]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.oxygen.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, 3)
-    
-    def test_getEnthalpy_oxygen(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([3.52538, 3.70877, 4.14751, 4.32063, 4.39392]) * constants.R
+        for temperature, Cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.oxygen.getHeatCapacity(temperature)
+            self.assertAlmostEqual(Cv_exp, cv_act, 3)
+
+    def test_get_enthalpy_oxygen(self):
         """
         Test the StatMech.getEnthalpy() method for oxygen.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([3.50326, 3.54432, 3.75062, 3.91623, 4.02765]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.oxygen.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEntropy_oxygen(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([3.50326, 3.54432, 3.75062, 3.91623, 4.02765]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.oxygen.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_entropy_oxygen(self):
         """
         Test the StatMech.getEntropy() method for oxygen.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([24.6685, 26.5065, 29.2314, 30.9513, 32.2056]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.oxygen.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, 3)
-    
-    def test_getSumOfStates_oxygen(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([24.6685, 26.5065, 29.2314, 30.9513, 32.2056]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.oxygen.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, 3)
+
+    def test_get_sum_of_states_oxygen(self):
         """
         Test the StatMech.getSumOfStates() method for oxygen.
         """
-        Elist = numpy.arange(0, 5000*11.96, 2*11.96)
-        sumStates = self.oxygen.getSumOfStates(Elist)
-        densStates = self.oxygen.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n+1]) / sumStates[n] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n+1]), sumStates[n]))
-            
-    def test_getDensityOfStates_oxygen(self):
+        e_list = np.arange(0, 5000 * 11.96, 2 * 11.96)
+        sum_states = self.oxygen.getSumOfStates(e_list)
+        dens_states = self.oxygen.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n + 1]) / sum_states[n] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n + 1]), sum_states[n]))
+
+    def test_get_density_of_states_oxygen(self):
         """
         Test the StatMech.getDensityOfStates() method for oxygen.
         """
-        Elist = numpy.arange(0, 5000*11.96, 2*11.96)
-        densStates = self.oxygen.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.oxygen.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-1*Qexp)
+        e_list = np.arange(0, 5000 * 11.96, 2 * 11.96)
+        dens_states = self.oxygen.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.oxygen.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-1 * q_exp)
 
-    def test_getTotalMass(self):
+    def test_get_total_mass(self):
         """
         Test the Conformer.getTotalMass() method.
         """
-        self.assertAlmostEqual(self.conformer.getTotalMass()*constants.Na*1000., numpy.sum(self.mass), 6)
+        self.assertAlmostEqual(self.conformer.getTotalMass() * constants.Na * 1000.,
+                               np.sum(self.mass), 6)
 
-    def test_getCenterOfMass(self):
+    def test_get_center_of_mass(self):
         """
         Test the Conformer.getCenterOfMass() method.
         """
         cm = self.conformer.getCenterOfMass()
-        self.assertAlmostEqual(cm[0]*1e10, -0.38045, 4)
-        self.assertAlmostEqual(cm[1]*1e10, -0.60255, 4)
-        self.assertAlmostEqual(cm[2]*1e10, -0.27900, 4)
+        self.assertAlmostEqual(cm[0] * 1e10, -0.38045, 4)
+        self.assertAlmostEqual(cm[1] * 1e10, -0.60255, 4)
+        self.assertAlmostEqual(cm[2] * 1e10, -0.27900, 4)
 
-    def test_getMomentOfInertiaTensor(self):
+    def test_get_moment_of_inertia_tensor(self):
         """
         Test the Conformer.getMomentOfInertiaTensor() method.
         """
-        I = self.conformer.getMomentOfInertiaTensor()
-        self.assertAlmostEqual(I[0,0]*constants.Na*1e23, 20.65968, 4)
-        self.assertAlmostEqual(I[0,1]*constants.Na*1e23, -7.48115, 4)
-        self.assertAlmostEqual(I[0,2]*constants.Na*1e23, -3.46416, 4)
-        self.assertAlmostEqual(I[1,0]*constants.Na*1e23, -7.48115, 4)
-        self.assertAlmostEqual(I[1,1]*constants.Na*1e23, 13.53472, 4)
-        self.assertAlmostEqual(I[1,2]*constants.Na*1e23, -5.48630, 4)
-        self.assertAlmostEqual(I[2,0]*constants.Na*1e23, -3.46416, 4)
-        self.assertAlmostEqual(I[2,1]*constants.Na*1e23, -5.48630, 4)
-        self.assertAlmostEqual(I[2,2]*constants.Na*1e23, 22.84296, 4)
+        inertia = self.conformer.getMomentOfInertiaTensor()
+        self.assertAlmostEqual(inertia[0, 0] * constants.Na * 1e23, 20.65968, 4)
+        self.assertAlmostEqual(inertia[0, 1] * constants.Na * 1e23, -7.48115, 4)
+        self.assertAlmostEqual(inertia[0, 2] * constants.Na * 1e23, -3.46416, 4)
+        self.assertAlmostEqual(inertia[1, 0] * constants.Na * 1e23, -7.48115, 4)
+        self.assertAlmostEqual(inertia[1, 1] * constants.Na * 1e23, 13.53472, 4)
+        self.assertAlmostEqual(inertia[1, 2] * constants.Na * 1e23, -5.48630, 4)
+        self.assertAlmostEqual(inertia[2, 0] * constants.Na * 1e23, -3.46416, 4)
+        self.assertAlmostEqual(inertia[2, 1] * constants.Na * 1e23, -5.48630, 4)
+        self.assertAlmostEqual(inertia[2, 2] * constants.Na * 1e23, 22.84296, 4)
 
-    def test_getPrincipalMomentsOfInertia(self):
+    def test_get_principal_moments_of_inertia(self):
         """
         Test the Conformer.getPrincipalMomentsOfInertia() method.
         """
-        I, V = self.conformer.getPrincipalMomentsOfInertia()
-        self.assertAlmostEqual(I[0]*constants.Na*1e23,  6.27074, 4)
-        self.assertAlmostEqual(I[1]*constants.Na*1e23, 25.38321, 3)
-        self.assertAlmostEqual(I[2]*constants.Na*1e23, 25.38341, 3)
-        #print V
+        inertia, axes = self.conformer.getPrincipalMomentsOfInertia()
+        self.assertAlmostEqual(inertia[0] * constants.Na * 1e23,  6.27074, 4)
+        self.assertAlmostEqual(inertia[1] * constants.Na * 1e23, 25.38321, 3)
+        self.assertAlmostEqual(inertia[2] * constants.Na * 1e23, 25.38341, 3)
         # For some reason the axes seem to jump around (positioning and signs change)
         # but the absolute values should be the same as we expect
         expected = sorted([0.497140,
@@ -272,32 +282,32 @@ class TestConformer(unittest.TestCase):
                            0.364578,
                            0.792099,
                            0.489554])
-        result = sorted(abs(V).flat)
-        for i,j in zip(expected, result):
+        result = sorted(abs(axes).flat)
+        for i, j in zip(expected, result):
             self.assertAlmostEqual(i, j, 4)
         return
 
-    def test_getInternalReducedMomentOfInertia(self):
+    def test_get_internal_reduced_moment_of_inertia(self):
         """
         Test the Conformer.getInternalReducedMomentOfInertia() method.
         """
-        I = self.conformer.getInternalReducedMomentOfInertia(pivots=[1,5], top1=[1,2,3,4])
-        self.assertAlmostEqual(I*constants.Na*1e23, 1.56768, 4)
+        inertia = self.conformer.getInternalReducedMomentOfInertia(pivots=[1, 5], top1=[1, 2, 3, 4])
+        self.assertAlmostEqual(inertia * constants.Na * 1e23, 1.56768, 4)
 
-    def test_getNumberDegreesOfFreedom(self):
+    def test_get_number_degrees_of_freedom(self):
         """
         Test the Conformer.getNumberDegreesOfFreedom() method.
         """
-        #this is for ethane:
-        numberDegreesOfFreedom = self.conformer.getNumberDegreesOfFreedom()
-        self.assertEqual(numberDegreesOfFreedom, 24)
+        # this is for ethane:
+        number_degrees_of_freedom = self.conformer.getNumberDegreesOfFreedom()
+        self.assertEqual(number_degrees_of_freedom, 24)
 
-        #this is for ethylene:
-        # It doesn't check aganist 3*Natoms, because Natoms is not declared.
-        numberDegreesOfFreedom = self.ethylene.getNumberDegreesOfFreedom()
-        self.assertEqual(numberDegreesOfFreedom, 18)
+        # this is for ethylene:
+        # It doesn't check against 3 * n_atoms, because n_atoms is not declared.
+        number_degrees_of_freedom = self.ethylene.getNumberDegreesOfFreedom()
+        self.assertEqual(number_degrees_of_freedom, 18)
 
-        #this is for CO
-        # It doesn't check aganist 3*Natoms, because Natoms is not declared.
-        numberDegreesOfFreedom = self.oxygen.getNumberDegreesOfFreedom()
-        self.assertEqual(numberDegreesOfFreedom, 6)
+        # this is for CO
+        # It doesn't check against 3 * n_atoms, because n_atoms is not declared.
+        number_degrees_of_freedom = self.oxygen.getNumberDegreesOfFreedom()
+        self.assertEqual(number_degrees_of_freedom, 6)

--- a/rmgpy/statmech/rotationTest.py
+++ b/rmgpy/statmech/rotationTest.py
@@ -32,19 +32,23 @@
 This script contains unit tests of the :mod:`rmgpy.statmech.rotation` module.
 """
 
-import unittest
-import numpy
+from __future__ import division
 
-from rmgpy.statmech.rotation import LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor
+import unittest
+
+import numpy as np
+
 import rmgpy.constants as constants
+from rmgpy.statmech.rotation import KRotor, LinearRotor, NonlinearRotor, SphericalTopRotor
 
 ################################################################################
+
 
 class TestLinearRotor(unittest.TestCase):
     """
     Contains unit tests of the LinearRotor class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
@@ -53,191 +57,191 @@ class TestLinearRotor(unittest.TestCase):
         self.symmetry = 2
         self.quantum = False
         self.mode = LinearRotor(
-            inertia = (self.inertia,"amu*angstrom^2"), 
-            symmetry = self.symmetry, 
-            quantum = self.quantum,
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
+            quantum=self.quantum,
         )
-        
-    def test_getRotationalConstant(self):
+
+    def test_get_rotational_constant(self):
         """
         Test getting the LinearRotor.rotationalConstant property.
         """
-        Bexp = 1.434692
-        Bact = self.mode.rotationalConstant.value_si
-        self.assertAlmostEqual(Bexp, Bact, 4)
-        
-    def test_setRotationalConstant(self):
+        b_exp = 1.434692
+        b_act = self.mode.rotationalConstant.value_si
+        self.assertAlmostEqual(b_exp, b_act, 4)
+
+    def test_set_rotational_constant(self):
         """
         Test setting the LinearRotor.rotationalConstant property.
         """
-        B = self.mode.rotationalConstant
-        B.value_si *= 2
-        self.mode.rotationalConstant = B
-        Iexp = 0.5 * self.inertia
-        Iact = self.mode.inertia.value_si * constants.Na * 1e23
-        self.assertAlmostEqual(Iexp, Iact, 4)
-        
-    def test_getLevelEnergy(self):
+        rotational_constant = self.mode.rotationalConstant
+        rotational_constant.value_si *= 2
+        self.mode.rotationalConstant = rotational_constant
+        i_exp = 0.5 * self.inertia
+        i_act = self.mode.inertia.value_si * constants.Na * 1e23
+        self.assertAlmostEqual(i_exp, i_act, 4)
+
+    def test_get_level_energy(self):
         """
         Test the LinearRotor.getLevelEnergy() method.
         """
-        B = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100.
-        B *= constants.Na
-        for J in range(0, 100):
-            Eexp = B * J * (J + 1)
-            Eact = self.mode.getLevelEnergy(J)
-            if J == 0:
-                self.assertEqual(Eact, 0)
+        rotational_constant = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100.
+        rotational_constant *= constants.Na
+        for j in range(0, 100):
+            e_exp = rotational_constant * j * (j + 1)
+            e_act = self.mode.getLevelEnergy(j)
+            if j == 0:
+                self.assertEqual(e_act, 0)
             else:
-                self.assertAlmostEqual(Eexp, Eact, delta=1e-4*Eexp)
-    
-    def test_getLevelDegeneracy(self):
+                self.assertAlmostEqual(e_exp, e_act, delta=1e-4 * e_exp)
+
+    def test_get_level_degeneracy(self):
         """
         Test the LinearRotor.getLevelDegeneracy() method.
         """
-        for J in range(0, 100):
-            gexp = 2 * J + 1
-            gact = self.mode.getLevelDegeneracy(J)
-            self.assertEqual(gexp, gact)
-    
-    def test_getPartitionFunction_classical(self):
+        for j in range(0, 100):
+            g_exp = 2 * j + 1
+            g_act = self.mode.getLevelDegeneracy(j)
+            self.assertEqual(g_exp, g_act)
+
+    def test_get_partition_function_classical(self):
         """
         Test the LinearRotor.getPartitionFunction() method for a classical
         rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([72.6691, 121.115, 242.230, 363.346, 484.461])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([72.6691, 121.115, 242.230, 363.346, 484.461])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_quantum(self):
         """
         Test the LinearRotor.getPartitionFunction() method for a quantum
         rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([72.8360, 121.282, 242.391, 363.512, 484.627])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getHeatCapacity_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([72.8360, 121.282, 242.391, 363.512, 484.627])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_heat_capacity_classical(self):
         """
         Test the LinearRotor.getHeatCapacity() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1, 1, 1, 1, 1]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-            
-    def test_getHeatCapacity_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1, 1, 1, 1, 1]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_quantum(self):
         """
         Test the LinearRotor.getHeatCapacity() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1, 1, 1, 1, 1]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-       
-    def test_getEnthalpy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1, 1, 1, 1, 1]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_enthalpy_classical(self):
         """
         Test the LinearRotor.getEnthalpy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([1, 1, 1, 1, 1]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEnthalpy_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1, 1, 1, 1, 1]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_quantum(self):
         """
         Test the LinearRotor.getEnthalpy() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.997705, 0.998624, 0.999312, 0.999541, 0.999656]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array(
+            [0.997705, 0.998624, 0.999312, 0.999541, 0.999656]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
 
-    def test_getEntropy_classical(self):
+    def test_get_entropy_classical(self):
         """
         Test the LinearRotor.getEntropy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([5.28592, 5.79674, 6.48989, 6.89535, 7.18304]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-    
-    def test_getEntropy_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([5.28592, 5.79674, 6.48989, 6.89535, 7.18304]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_entropy_quantum(self):
         """
         Test the LinearRotor.getEntropy() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([5.28592, 5.79674, 6.48989, 6.89535, 7.18304]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([5.28592, 5.79674, 6.48989, 6.89535, 7.18304]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
 
-    def test_getSumOfStates_classical(self):
+    def test_get_sum_of_states_classical(self):
         """
         Test the LinearRotor.getSumOfStates() method using a classical rotor.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 2000*11.96, 1.0*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        sumStates = self.mode.getSumOfStates(Elist)
-        for n in range(1, len(Elist)):
-            self.assertAlmostEqual(numpy.sum(densStates[0:n]) / sumStates[n], 1.0, 3)
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        sum_states = self.mode.getSumOfStates(e_list)
+        for n in range(1, len(e_list)):
+            self.assertAlmostEqual(np.sum(dens_states[0:n]) / sum_states[n], 1.0, 3)
 
-    def test_getSumOfStates_quantum(self):
+    def test_get_sum_of_states_quantum(self):
         """
         Test the LinearRotor.getSumOfStates() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 4000.*11.96, 2.0*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        sumStates = self.mode.getSumOfStates(Elist)
-        for n in range(1, len(Elist)):
-            self.assertAlmostEqual(numpy.sum(densStates[0:n+1]) / sumStates[n], 1.0, 3)
+        e_list = np.arange(0, 4000. * 11.96, 2.0 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        sum_states = self.mode.getSumOfStates(e_list)
+        for n in range(1, len(e_list)):
+            self.assertAlmostEqual(np.sum(dens_states[0:n + 1]) / sum_states[n], 1.0, 3)
 
-    def test_getDensityOfStates_classical(self):
+    def test_get_dsensity_of_states_classical(self):
         """
-        Test the LinearRotor.getDensityOfStates() method using a classical
-        rotor.
+        Test the LinearRotor.getDensityOfStates() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,400,500])
-        Elist = numpy.arange(0, 4000.*11.96, 1.0*11.96)
-        for T in Tlist:
-            densStates = self.mode.getDensityOfStates(Elist)
-            Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-            Qexp = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        t_list = np.array([300, 400, 500])
+        e_list = np.arange(0, 4000. * 11.96, 1.0 * 11.96)
+        for temperature in t_list:
+            dens_states = self.mode.getDensityOfStates(e_list)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+            q_exp = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
-    def test_getDensityOfStates_quantum(self):
+    def test_get_dsensity_of_states_quantum(self):
         """
         Test the LinearRotor.getDensityOfStates() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,400,500])
-        Elist = numpy.arange(0, 4000.*11.96, 2.0*11.96)
-        for T in Tlist:
-            densStates = self.mode.getDensityOfStates(Elist)
-            Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-            Qexp = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        t_list = np.array([300, 400, 500])
+        e_list = np.arange(0, 4000. * 11.96, 2.0 * 11.96)
+        for temperature in t_list:
+            dens_states = self.mode.getDensityOfStates(e_list)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+            q_exp = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
     def test_repr(self):
         """
@@ -250,14 +254,14 @@ class TestLinearRotor(unittest.TestCase):
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a LinearRotor object can be pickled and unpickled with no
         loss of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertAlmostEqual(self.mode.inertia.value, mode.inertia.value, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
@@ -265,114 +269,116 @@ class TestLinearRotor(unittest.TestCase):
 
 ################################################################################
 
+
 class TestNonlinearRotor(unittest.TestCase):
     """
     Contains unit tests of the NonlinearRotor class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
         """
-        self.inertia = numpy.array([3.415, 16.65, 20.07])
+        self.inertia = np.array([3.415, 16.65, 20.07])
         self.symmetry = 4
         self.quantum = False
         self.mode = NonlinearRotor(
-            inertia = (self.inertia,"amu*angstrom^2"), 
-            symmetry = self.symmetry, 
-            quantum = self.quantum,
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
+            quantum=self.quantum,
         )
-        
-    def test_getRotationalConstant(self):
+
+    def test_get_rotational_constant(self):
         """
         Test getting the NonlinearRotor.rotationalConstant property.
         """
-        Bexp = numpy.array([4.93635, 1.0125, 0.839942])
-        Bact = self.mode.rotationalConstant.value_si
-        for B0, B in zip(Bexp, Bact):
-            self.assertAlmostEqual(B0, B, 4)
-        
-    def test_setRotationalConstant(self):
+        b_exp = np.array([4.93635, 1.0125, 0.839942])
+        b_act = self.mode.rotationalConstant.value_si
+        for rotational_constant0, rotational_constant in zip(b_exp, b_act):
+            self.assertAlmostEqual(rotational_constant0, rotational_constant, 4)
+
+    def test_set_rotational_constant(self):
         """
         Test setting the NonlinearRotor.rotationalConstant property.
         """
-        B = self.mode.rotationalConstant
-        B.value_si *= 2
-        self.mode.rotationalConstant = B
-        Iexp = 0.5 * self.inertia
-        Iact = self.mode.inertia.value_si * constants.Na * 1e23
-        for I0, I in zip(Iexp, Iact):
-            self.assertAlmostEqual(I0, I, 4)
-        
-    def test_getPartitionFunction_classical(self):
+        rotational_constant = self.mode.rotationalConstant
+        rotational_constant.value_si *= 2
+        self.mode.rotationalConstant = rotational_constant
+        i_exp = 0.5 * self.inertia
+        i_act = self.mode.inertia.value_si * constants.Na * 1e23
+        for inertia0, inertia in zip(i_exp, i_act):
+            self.assertAlmostEqual(inertia0, inertia, 4)
+
+    def test_get_partition_function_classical(self):
         """
         Test the NonlinearRotor.getPartitionFunction() method for a classical
         rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([651.162, 1401.08, 3962.84, 7280.21, 11208.6])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getHeatCapacity_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([651.162, 1401.08, 3962.84, 7280.21, 11208.6])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_heat_capacity_classical(self):
         """
         Test the NonlinearRotor.getHeatCapacity() method using a classical
         rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-    
-    def test_getEnthalpy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_enthalpy_classical(self):
         """
         Test the NonlinearRotor.getEnthalpy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-   
-    def test_getEntropy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_entropy_classical(self):
         """
         Test the NonlinearRotor.getEntropy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([7.97876, 8.74500, 9.78472, 10.3929, 10.8244]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-    
-    def test_getSumOfStates_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([7.97876, 8.74500, 9.78472, 10.3929, 10.8244]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_sum_of_states_classical(self):
         """
         Test the NonlinearRotor.getSumOfStates() method using a classical rotor.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 1000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
+        e_list = np.arange(0, 1000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
 
-    def test_getDensityOfStates_classical(self):
+    def test_get_sensity_of_states_classical(self):
         """
         Test the NonlinearRotor.getDensityOfStates() method using a classical
         rotor.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 1000*11.96, 1*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        e_list = np.arange(0, 1000 * 11.96, 1 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
     def test_repr(self):
         """
@@ -382,33 +388,34 @@ class TestNonlinearRotor(unittest.TestCase):
         mode = None
         exec('mode = {0!r}'.format(self.mode))
         self.assertEqual(self.mode.inertia.value.shape, mode.inertia.value.shape)
-        for I0, I in zip(self.mode.inertia.value, mode.inertia.value):
-            self.assertAlmostEqual(I0, I, 6)
+        for inertia_0, inertia in zip(self.mode.inertia.value, mode.inertia.value):
+            self.assertAlmostEqual(inertia_0, inertia, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a NonlinearRotor object can be pickled and unpickled with
         no loss of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertEqual(self.mode.inertia.value.shape, mode.inertia.value.shape)
-        for I0, I in zip(self.mode.inertia.value, mode.inertia.value):
-            self.assertAlmostEqual(I0, I, 6)
+        for inertia_0, inertia in zip(self.mode.inertia.value, mode.inertia.value):
+            self.assertAlmostEqual(inertia_0, inertia, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
 
 ################################################################################
 
+
 class TestKRotor(unittest.TestCase):
     """
     Contains unit tests of the KRotor class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
@@ -417,189 +424,191 @@ class TestKRotor(unittest.TestCase):
         self.symmetry = 2
         self.quantum = False
         self.mode = KRotor(
-            inertia = (self.inertia,"amu*angstrom^2"),
-            symmetry = self.symmetry, 
-            quantum = self.quantum,
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
+            quantum=self.quantum,
         )
-        
-    def test_getRotationalConstant(self):
+
+    def test_get_rotational_constant(self):
         """
         Test getting the KRotor.rotationalConstant property.
         """
-        Bexp = 1.434692
-        Bact = self.mode.rotationalConstant.value_si
-        self.assertAlmostEqual(Bexp, Bact, 4)
-        
-    def test_setRotationalConstant(self):
+        b_exp = 1.434692
+        b_act = self.mode.rotationalConstant.value_si
+        self.assertAlmostEqual(b_exp, b_act, 4)
+
+    def test_set_rotational_constant(self):
         """
         Test setting the KRotor.rotationalConstant property.
         """
-        B = self.mode.rotationalConstant
-        B.value_si *= 2
-        self.mode.rotationalConstant = B
-        Iexp = 0.5 * self.inertia
-        Iact = self.mode.inertia.value_si * constants.Na * 1e23
-        self.assertAlmostEqual(Iexp, Iact, 4)
-        
-    def test_getLevelEnergy(self):
+        rotational_constant = self.mode.rotationalConstant
+        rotational_constant.value_si *= 2
+        self.mode.rotationalConstant = rotational_constant
+        i_exp = 0.5 * self.inertia
+        i_act = self.mode.inertia.value_si * constants.Na * 1e23
+        self.assertAlmostEqual(i_exp, i_act, 4)
+
+    def test_get_level_energy(self):
         """
         Test the KRotor.getLevelEnergy() method.
         """
-        B = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100.
-        B *= constants.Na
-        for J in range(0, 100):
-            Eexp = float(B * J * J)
-            Eact = float(self.mode.getLevelEnergy(J))
-            if J == 0:
-                self.assertEqual(Eact, 0)
+        rotational_constant = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100.
+        rotational_constant *= constants.Na
+        for j in range(0, 100):
+            e_exp = float(rotational_constant * j * j)
+            e_act = float(self.mode.getLevelEnergy(j))
+            if j == 0:
+                self.assertEqual(e_act, 0)
             else:
-                self.assertAlmostEqual(Eexp, Eact, delta=1e-4*Eexp)
-    
-    def test_getLevelDegeneracy(self):
+                self.assertAlmostEqual(e_exp, e_act, delta=1e-4 * e_exp)
+
+    def test_get_level_degeneracy(self):
         """
         Test the KRotor.getLevelDegeneracy() method.
         """
-        for J in range(0, 100):
-            gexp = 1 if J == 0 else 2
-            gact = self.mode.getLevelDegeneracy(J)
-            self.assertEqual(gexp, gact, '{0} != {1}'.format(gact, gexp))
-    
-    def test_getPartitionFunction_classical(self):
+        for j in range(0, 100):
+            g_exp = 1 if j == 0 else 2
+            g_act = self.mode.getLevelDegeneracy(j)
+            self.assertEqual(g_exp, g_act, '{0} != {1}'.format(g_act, g_exp))
+
+    def test_get_partition_function_classical(self):
         """
         Test the KRotor.getPartitionFunction() method for a classical
         rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([10.6839, 13.7929, 19.5060, 23.8899, 27.5857])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([10.6839, 13.7929, 19.5060, 23.8899, 27.5857])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_quantum(self):
         """
         Test the KRotor.getPartitionFunction() method for a quantum
         rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([10.6839, 13.7929, 19.5060, 23.8899, 27.5857])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getHeatCapacity_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([10.6839, 13.7929, 19.5060, 23.8899, 27.5857])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_heat_capacity_classical(self):
         """
         Test the KRotor.getHeatCapacity() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-    
-    def test_getHeatCapacity_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_quantum(self):
         """
         Test the KRotor.getHeatCapacity() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-       
-    def test_getEnthalpy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_enthalpy_classical(self):
         """
         Test the KRotor.getEnthalpy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEnthalpy_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_quantum(self):
         """
         Test the KRotor.getEnthalpy() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([0.5, 0.5, 0.5, 0.5, 0.5]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
 
-    def test_getEntropy_classical(self):
+    def test_get_entropy_classical(self):
         """
         Test the KRotor.getEntropy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([2.86874, 3.12415, 3.47072, 3.67346, 3.81730]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-    
-    def test_getEntropy_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([2.86874, 3.12415, 3.47072, 3.67346, 3.81730]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_entropy_quantum(self):
         """
         Test the KRotor.getEntropy() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([2.86874, 3.12415, 3.47072, 3.67346, 3.81730]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([2.86874, 3.12415, 3.47072, 3.67346, 3.81730]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
 
-    def test_getSumOfStates_classical(self):
+    def test_get_sum_of_states_classical(self):
         """
         Test the KRotor.getSumOfStates() method using a classical rotor.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 1000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.75 < numpy.sum(densStates[0:n+1]) / sumStates[n] < 1.3333, '{0} != {1}'.format(numpy.sum(densStates[0:n+1]), sumStates[n]))
+        e_list = np.arange(0, 1000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.75 < np.sum(dens_states[0:n + 1]) / sum_states[n] < 1.3333,
+                            '{0} != {1}'.format(np.sum(dens_states[0:n + 1]), sum_states[n]))
 
-    def test_getSumOfStates_quantum(self):
+    def test_get_sum_of_states_quantum(self):
         """
         Test the KRotor.getSumOfStates() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 1000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n+1]) / sumStates[n] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n+1]), sumStates[n]))
+        e_list = np.arange(0, 1000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n + 1]) / sum_states[n] < 1.25,
+                            '{0} != {1}'.format(np.sum(dens_states[0:n + 1]), sum_states[n]))
 
-    def test_getDensityOfStates_classical(self):
+    def test_get_density_of_states_classical(self):
         """
         Test the KRotor.getDensityOfStates() method using a classical
         rotor.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 3000*11.96, 0.05*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 500
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        e_list = np.arange(0, 3000 * 11.96, 0.05 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 500
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
-    def test_getDensityOfStates_quantum(self):
+    def test_get_density_of_states_quantum(self):
         """
         Test the KRotor.getDensityOfStates() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 4000*11.96, 2*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 500
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        e_list = np.arange(0, 4000 * 11.96, 2 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 500
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
     def test_repr(self):
         """
@@ -612,14 +621,14 @@ class TestKRotor(unittest.TestCase):
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a KRotor object can be pickled and unpickled with no loss
         of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertAlmostEqual(self.mode.inertia.value, mode.inertia.value, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
@@ -627,11 +636,12 @@ class TestKRotor(unittest.TestCase):
 
 ################################################################################
 
+
 class TestSphericalTopRotor(unittest.TestCase):
     """
     Contains unit tests of the SphericalTopRotor class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
@@ -640,191 +650,191 @@ class TestSphericalTopRotor(unittest.TestCase):
         self.symmetry = 2
         self.quantum = False
         self.mode = SphericalTopRotor(
-            inertia = (self.inertia,"amu*angstrom^2"), 
-            symmetry = self.symmetry, 
-            quantum = self.quantum,
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
+            quantum=self.quantum,
         )
-        
-    def test_getRotationalConstant(self):
+
+    def test_get_rotational_constant(self):
         """
         Test getting the SphericalTopRotor.rotationalConstant property.
         """
-        Bexp = 1.434692
-        Bact = self.mode.rotationalConstant.value_si
-        self.assertAlmostEqual(Bexp, Bact, 4)
-        
-    def test_setRotationalConstant(self):
+        b_exp = 1.434692
+        b_act = self.mode.rotationalConstant.value_si
+        self.assertAlmostEqual(b_exp, b_act, 4)
+
+    def test_set_rotational_constant(self):
         """
         Test setting the SphericalTopRotor.rotationalConstant property.
         """
-        B = self.mode.rotationalConstant
-        B.value_si *= 2
-        self.mode.rotationalConstant = B
-        Iexp = 0.5 * self.inertia
-        Iact = self.mode.inertia.value_si * constants.Na * 1e23
-        self.assertAlmostEqual(Iexp, Iact, 4)
-        
-    def test_getLevelEnergy(self):
+        rotational_constant = self.mode.rotationalConstant
+        rotational_constant.value_si *= 2
+        self.mode.rotationalConstant = rotational_constant
+        i_exp = 0.5 * self.inertia
+        i_act = self.mode.inertia.value_si * constants.Na * 1e23
+        self.assertAlmostEqual(i_exp, i_act, 4)
+
+    def test_get_level_energy(self):
         """
         Test the SphericalTopRotor.getLevelEnergy() method.
         """
-        B = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100.
-        B *= constants.Na
-        for J in range(0, 100):
-            Eexp = B * J * (J + 1)
-            Eact = self.mode.getLevelEnergy(J)
-            if J == 0:
-                self.assertEqual(Eact, 0)
+        rotational_constant = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100.
+        rotational_constant *= constants.Na
+        for j in range(0, 100):
+            e_exp = rotational_constant * j * (j + 1)
+            e_act = self.mode.getLevelEnergy(j)
+            if j == 0:
+                self.assertEqual(e_act, 0)
             else:
-                self.assertAlmostEqual(Eexp, Eact, delta=1e-4*Eexp)
-    
-    def test_getLevelDegeneracy(self):
+                self.assertAlmostEqual(e_exp, e_act, delta=1e-4 * e_exp)
+
+    def test_get_level_degeneracy(self):
         """
         Test the SphericalTopRotor.getLevelDegeneracy() method.
         """
-        for J in range(0, 100):
-            gexp = (2 * J + 1)**2
-            gact = self.mode.getLevelDegeneracy(J)
-            self.assertEqual(gexp, gact, '{0} != {1}'.format(gact, gexp))
-    
-    def test_getPartitionFunction_classical(self):
+        for j in range(0, 100):
+            g_exp = (2 * j + 1)**2
+            g_act = self.mode.getLevelDegeneracy(j)
+            self.assertEqual(g_exp, g_act)
+
+    def test_get_partition_function_classical(self):
         """
         Test the SphericalTopRotor.getPartitionFunction() method for a classical
         rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([1552.74, 3340.97, 9449.69, 17360.2, 26727.8])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1552.74, 3340.97, 9449.69, 17360.2, 26727.8])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_quantum(self):
         """
         Test the SphericalTopRotor.getPartitionFunction() method for a quantum
         rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([1555.42, 3344.42, 9454.57, 17366.2, 26734.7])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getHeatCapacity_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1555.42, 3344.42, 9454.57, 17366.2, 26734.7])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_heat_capacity_classical(self):
         """
         Test the SphericalTopRotor.getHeatCapacity() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-    
-    def test_getHeatCapacity_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_quantum(self):
         """
         Test the SphericalTopRotor.getHeatCapacity() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-       
-    def test_getEnthalpy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_enthalpy_classical(self):
         """
         Test the SphericalTopRotor.getEnthalpy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEnthalpy_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_quantum(self):
         """
         Test the SphericalTopRotor.getEnthalpy() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([1.49828, 1.49897, 1.49948, 1.49966, 1.49974]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1.49828, 1.49897, 1.49948, 1.49966, 1.49974]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
 
-    def test_getEntropy_classical(self):
+    def test_get_entropy_classical(self):
         """
         Test the SphericalTopRotor.getEntropy() method using a classical rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([8.84778, 9.61402, 10.6537, 11.2619, 11.6935]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-    
-    def test_getEntropy_quantum(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([8.84778, 9.61402, 10.6537, 11.2619, 11.6935]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_entropy_quantum(self):
         """
         Test the SphericalTopRotor.getEntropy() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([8.84778, 9.61402, 10.6537, 11.2619, 11.6935]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([8.84778, 9.61402, 10.6537, 11.2619, 11.6935]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
 
-    def test_getSumOfStates_classical(self):
+    def test_get_sum_of_states_classical(self):
         """
         Test the SphericalTopRotor.getSumOfStates() method using a classical rotor.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 2000*11.96, 1.0*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        sumStates = self.mode.getSumOfStates(Elist)
-        for n in range(20, len(Elist)):
-            self.assertAlmostEqual(numpy.sum(densStates[0:n+1]) / sumStates[n], 1.0, 1)
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        sum_states = self.mode.getSumOfStates(e_list)
+        for n in range(20, len(e_list)):
+            self.assertAlmostEqual(np.sum(dens_states[0:n + 1]) / sum_states[n], 1.0, 1)
 
-    def test_getSumOfStates_quantum(self):
+    def test_get_sum_of_states_quantum(self):
         """
         Test the SphericalTopRotor.getSumOfStates() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 2000*11.96, 1.0*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        sumStates = self.mode.getSumOfStates(Elist)
-        for n in range(1, len(Elist)):
-            self.assertAlmostEqual(numpy.sum(densStates[0:n+1]) / sumStates[n], 1.0, 3)
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        sum_states = self.mode.getSumOfStates(e_list)
+        for n in range(1, len(e_list)):
+            self.assertAlmostEqual(np.sum(dens_states[0:n + 1]) / sum_states[n], 1.0, 3)
 
-    def test_getDensityOfStates_classical(self):
+    def test_get_density_of_states_classical(self):
         """
         Test the SphericalTopRotor.getDensityOfStates() method using a classical
         rotor.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,400,500])
-        Elist = numpy.arange(0, 2000*11.96, 1.0*11.96)
-        for T in Tlist:
-            densStates = self.mode.getDensityOfStates(Elist)
-            Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-            Qexp = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        t_list = np.array([300, 400, 500])
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        for temperature in t_list:
+            dens_states = self.mode.getDensityOfStates(e_list)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+            q_exp = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
-    def test_getDensityOfStates_quantum(self):
+    def test_get_density_of_states_quantum(self):
         """
         Test the SphericalTopRotor.getDensityOfStates() method using a quantum rotor.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,400,500])
-        Elist = numpy.arange(0, 4000*11.96, 2.0*11.96)
-        for T in Tlist:
-            densStates = self.mode.getDensityOfStates(Elist)
-            Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-            Qexp = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        t_list = np.array([300, 400, 500])
+        e_list = np.arange(0, 4000 * 11.96, 2.0 * 11.96)
+        for temperature in t_list:
+            dens_states = self.mode.getDensityOfStates(e_list)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+            q_exp = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
     def test_repr(self):
         """
@@ -837,14 +847,14 @@ class TestSphericalTopRotor(unittest.TestCase):
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a SphericalTopRotor object can be pickled and unpickled
         with no loss of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertAlmostEqual(self.mode.inertia.value, mode.inertia.value, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)

--- a/rmgpy/statmech/schrodingerTest.py
+++ b/rmgpy/statmech/schrodingerTest.py
@@ -29,17 +29,22 @@
 ###############################################################################
 
 """
-This script contains unit tests of the :mod:`rmgpy.statmech.schrodinger` 
+This script contains unit tests of the :mod:`rmgpy.statmech.schrodinger`
 module.
 """
 
+from __future__ import division
+
 import unittest
 
-import numpy
-from rmgpy.statmech.schrodinger import getPartitionFunction, getHeatCapacity, getEnthalpy, getEntropy, getDensityOfStates
+import numpy as np
+
 import rmgpy.constants as constants
+from rmgpy.statmech.schrodinger import getDensityOfStates, getEnthalpy, getEntropy, \
+    getHeatCapacity, getPartitionFunction
 
 ################################################################################
+
 
 class TestSchrodinger(unittest.TestCase):
     """
@@ -47,79 +52,80 @@ class TestSchrodinger(unittest.TestCase):
     module. The solution to the Schrodinger equation used for these tests is
     that of a linear rigid rotor with a rotational constant of 1 cm^-1.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
         """
         self.B = 1.0 * 11.96
-        self.energy = lambda J: self.B * J * (J + 1)
-        self.degeneracy = lambda J: 2 * J + 1
+        self.energy = lambda j: self.B * j * (j + 1)
+        self.degeneracy = lambda j: 2 * j + 1
         self.n0 = 0
-        
-    def test_getPartitionFunction(self):
+
+    def test_get_partition_function(self):
         """
         Test the getPartitionFunction() method.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([208.8907, 347.9285, 695.5234, 1043.118, 1390.713])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = getPartitionFunction(T, self.energy, self.degeneracy, self.n0)
-            self.assertAlmostEqual(Qexp / Qact, 1.0, 4, '{0} != {1} within 4 figures'.format(Qexp, Qact))
-            
-    def test_getHeatCapacity(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([208.8907, 347.9285, 695.5234, 1043.118, 1390.713])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = getPartitionFunction(temperature, self.energy, self.degeneracy, self.n0)
+            self.assertAlmostEqual(q_exp / q_act, 1.0, 4)
+
+    def test_get_heat_capacity(self):
         """
         Test the getHeatCapacity() method.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1, 1, 1, 1, 1])
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = getHeatCapacity(T, self.energy, self.degeneracy, self.n0)
-            self.assertAlmostEqual(Cvexp / Cvact, 1.0, 4, '{0} != {1} within 4 figures'.format(Cvexp, Cvact))
-       
-    def test_getEnthalpy(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1, 1, 1, 1, 1])
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = getHeatCapacity(temperature, self.energy, self.degeneracy, self.n0)
+            self.assertAlmostEqual(cv_exp / cv_act, 1.0, 4)
+
+    def test_get_enthalpy(self):
         """
         Test the getEnthalpy() method.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.9984012, 0.9990409, 0.9995205, 0.9996803, 0.9997603])
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = getEnthalpy(T, self.energy, self.degeneracy, self.n0)
-            self.assertAlmostEqual(Hexp / Hact, 1.0, 4, '{0} != {1} within 4 figures'.format(Hexp, Hact))
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([0.9984012, 0.9990409, 0.9995205, 0.9996803, 0.9997603])
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = getEnthalpy(temperature, self.energy, self.degeneracy, self.n0)
+            self.assertAlmostEqual(h_exp / h_act, 1.0, 4)
 
-    def test_getEntropy(self):
+    def test_get_entropy(self):
         """
         Test the getEntropy() method.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([6.340212, 6.851038, 7.544185, 7.949650, 8.237332])
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = getEntropy(T, self.energy, self.degeneracy, self.n0)
-            self.assertAlmostEqual(Sexp / Sact, 1.0, 4, '{0} != {1} within 4 figures'.format(Sexp, Sact))
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([6.340212, 6.851038, 7.544185, 7.949650, 8.237332])
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = getEntropy(temperature, self.energy, self.degeneracy, self.n0)
+            self.assertAlmostEqual(s_exp / s_act, 1.0, 4)
 
-#    def test_getSumOfStates(self):
+#    def test_get_sum_of_states(self):
 #        """
 #        Test the getSumOfStates() method.
 #        """
-#        Elist = numpy.arange(0, 10., 0.01)
-#        densStates = getDensityOfStates(Elist, self.energy, self.degeneracy, self.n0)
-#        sumStates = getSumOfStates(Elist, self.energy, self.degeneracy, self.n0)
-#        for n in range(1, len(Elist)):
-#            self.assertAlmostEqual(numpy.sum(densStates[0:n+1]) / sumStates[n], 1.0, 3)
+#        e_list = np.arange(0, 10., 0.01)
+#        dens_states = getDensityOfStates(e_list, self.energy, self.degeneracy, self.n0)
+#        sum_states = getSumOfStates(e_list, self.energy, self.degeneracy, self.n0)
+#        for n in range(1, len(e_list)):
+#            self.assertAlmostEqual(np.sum(dens_states[0:n + 1]) / sum_states[n], 1.0, 3)
 
-    def test_getDensityOfStates(self):
+    def test_get_density_of_states(self):
         """
         Test the getDensityOfStates() method.
         """
-        Tlist = numpy.array([300,400,500,600])
-        Elist = numpy.arange(0, 40000., 20.)
-        for T in Tlist:
-            densStates = getDensityOfStates(Elist, self.energy, self.degeneracy, self.n0)
-            Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-            Qexp = getPartitionFunction(T, self.energy, self.degeneracy, self.n0)
-            self.assertAlmostEqual(Qexp / Qact, 1.0, 2, '{0} != {1} within 2 figures'.format(Qexp, Qact))
-            
+        t_list = np.array([300, 400, 500, 600])
+        e_list = np.arange(0, 40000., 20.)
+        for temperature in t_list:
+            dens_states = getDensityOfStates(e_list, self.energy, self.degeneracy, self.n0)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+            q_exp = getPartitionFunction(temperature, self.energy, self.degeneracy, self.n0)
+            self.assertAlmostEqual(q_exp / q_act, 1.0, 2)
+
 ################################################################################
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/statmech/torsionTest.py
+++ b/rmgpy/statmech/torsionTest.py
@@ -32,426 +32,433 @@
 This script contains unit tests of the :mod:`rmgpy.statmech.torsion` module.
 """
 
-import unittest
-import math
-import numpy
+from __future__ import division
 
-from rmgpy.statmech.torsion import HinderedRotor, FreeRotor
+import unittest
+import numpy as np
+
 import rmgpy.constants as constants
+from rmgpy.statmech.torsion import FreeRotor, HinderedRotor
 
 ################################################################################
+
 
 class TestHinderedRotor(unittest.TestCase):
     """
     Contains unit tests of the HinderedRotor class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
         """
         self.inertia = 1.56764
         self.symmetry = 3
-        self.barrier = 11.373 
+        self.barrier = 11.373
         self.quantum = True
         self.mode = HinderedRotor(
-            inertia = (self.inertia,"amu*angstrom^2"), 
-            symmetry = self.symmetry,
-            barrier = (self.barrier,"kJ/mol"),
-            fourier = ([ [4.58375, 0.841648, -5702.71, 6.02657, 4.7446], [0.726951, -0.677255, 0.207032, 0.553307, -0.503303] ],"J/mol"),
-            quantum = self.quantum,
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
+            barrier=(self.barrier, "kJ/mol"),
+            fourier=([[4.58375, 0.841648, -5702.71, 6.02657, 4.7446],
+                      [0.726951, -0.677255, 0.207032, 0.553307, -0.503303]], "J/mol"),
+            quantum=self.quantum,
         )
         self.freemode = FreeRotor(
-            inertia = (self.inertia,"amu*angstrom^2"), 
-            symmetry = self.symmetry,
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
         )
-        
-    def test_getRotationalConstant(self):
+
+    def test_get_rotational_constant(self):
         """
         Test getting the HinderedRotor.rotationalConstant property.
         """
-        Bexp = 10.7535
-        Bact = self.mode.rotationalConstant.value_si
-        self.assertAlmostEqual(Bexp, Bact, 4)
-        Bact2 = self.freemode.rotationalConstant.value_si
-        self.assertAlmostEqual(Bexp,Bact2,4)
-        
-    def test_setRotationalConstant(self):
+        b_exp = 10.7535
+        b_act = self.mode.rotationalConstant.value_si
+        self.assertAlmostEqual(b_exp, b_act, 4)
+        b_act2 = self.freemode.rotationalConstant.value_si
+        self.assertAlmostEqual(b_exp, b_act2, 4)
+
+    def test_set_rotational_constant(self):
         """
         Test setting the HinderedRotor.rotationalConstant property.
         """
-        B = self.mode.rotationalConstant
-        B.value_si *= 2
-        self.mode.rotationalConstant = B
-        self.freemode.rotationalConstant = B
-        Iexp = 0.5 * self.inertia
-        Iact = self.mode.inertia.value_si * constants.Na * 1e23
-        Iact2 = self.freemode.inertia.value_si * constants.Na * 1e23
-        self.assertAlmostEqual(Iexp, Iact, 4)
-        self.assertAlmostEqual(Iexp, Iact2, 4)
-    
-    def test_getPotential_cosine(self):
+        rotational_constant = self.mode.rotationalConstant
+        rotational_constant.value_si *= 2
+        self.mode.rotationalConstant = rotational_constant
+        self.freemode.rotationalConstant = rotational_constant
+        i_exp = 0.5 * self.inertia
+        i_act = self.mode.inertia.value_si * constants.Na * 1e23
+        i_act2 = self.freemode.inertia.value_si * constants.Na * 1e23
+        self.assertAlmostEqual(i_exp, i_act, 4)
+        self.assertAlmostEqual(i_exp, i_act2, 4)
+
+    def test_get_potential_cosine(self):
         """
         Test the HinderedRotor.getPotential() method for a cosine potential.
         """
         self.mode.fourier = None
-        phi = numpy.arange(0.0, 2 * constants.pi + 0.0001, constants.pi / 24.)
-        V = numpy.zeros_like(phi)
+        phi = np.arange(0.0, 2 * constants.pi + 0.0001, constants.pi / 24.)
+        potential = np.zeros_like(phi)
         for i in range(phi.shape[0]):
-            V[i] = self.mode.getPotential(phi[i])
-    
-    def test_getPotential_fourier(self):
+            potential[i] = self.mode.getPotential(phi[i])
+
+    def test_get_potential_fourier(self):
         """
         Test the HinderedRotor.getPotential() method for a Fourier series
         potential.
         """
-        phi = numpy.arange(0.0, 2 * constants.pi + 0.0001, constants.pi / 24.)
-        V = numpy.zeros_like(phi)
+        phi = np.arange(0.0, 2 * constants.pi + 0.0001, constants.pi / 24.)
+        potential = np.zeros_like(phi)
         for i in range(phi.shape[0]):
-            V[i] = self.mode.getPotential(phi[i])
-    
-    def test_getPartitionFunction_free(self):
+            potential[i] = self.mode.getPotential(phi[i])
+
+    def test_get_partition_function_free(self):
         """
-        Test the FreeRotor.getPartitionFunction() method 
+        Test the FreeRotor.getPartitionFunction() method
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.sqrt(8*numpy.pi**3*constants.kB*Tlist*self.freemode.inertia.value_si)/(self.symmetry*constants.h)
-        for T, Qexp in zip(Tlist,Qexplist):
-            Qact = self.freemode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp,Qact,delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_classical_cosine(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.sqrt(8 * np.pi**3 * constants.kB * t_list
+                             * self.freemode.inertia.value_si) / (self.symmetry * constants.h)
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.freemode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_classical_cosine(self):
         """
         Test the HinderedRotor.getPartitionFunction() method for a cosine
         potential in the classical limit.
         """
         self.mode.quantum = False
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([0.741953, 1.30465, 2.68553, 3.88146, 4.91235])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_classical_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([0.741953, 1.30465, 2.68553, 3.88146, 4.91235])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_classical_fourier(self):
         """
         Test the HinderedRotor.getPartitionFunction() method for a Fourier
         series potential in the classical limit.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([0.745526, 1.30751, 2.68722, 3.88258, 4.91315])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_quantum_cosine(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([0.745526, 1.30751, 2.68722, 3.88258, 4.91315])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_quantum_cosine(self):
         """
         Test the HinderedRotor.getPartitionFunction() method for a cosine
         potential in the quantum limit.
         """
         self.mode.quantum = True
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([1.39947, 1.94793, 3.30171, 4.45856, 5.45188])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getPartitionFunction_quantum_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1.39947, 1.94793, 3.30171, 4.45856, 5.45188])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_quantum_fourier(self):
         """
         Test the HinderedRotor.getPartitionFunction() method for a Fourier
         series potential in the quantum limit.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([1.39364, 1.94182, 3.29509, 4.45205, 5.44563])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=5e-4*Qexp)
-    
-    def test_getHeatCapacity_free(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1.39364, 1.94182, 3.29509, 4.45205, 5.44563])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=5e-4 * q_exp)
+
+    def test_get_heat_capacity_free(self):
         """
-        Test the FreeRotor.getHeatCapacity() method 
+        Test the FreeRotor.getHeatCapacity() method
         """
-        Cvexp = constants.R/2.0
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        for T in Tlist:
-            Cvact = self.freemode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp,Cvact,delta=1e-4*Cvexp)
-            
-    def test_getHeatCapacity_classical_cosine(self):
+        cv_exp = constants.R/2.0
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        for temperature in t_list:
+            cv_act = self.freemode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_classical_cosine(self):
         """
         Test the HinderedRotor.getHeatCapacity() method using a cosine
         potential in the classical limit.
         """
         self.mode.quantum = False
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.01741, 0.951141, 0.681919, 0.589263, 0.552028]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-    
-    def test_getHeatCapacity_classical_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.01741, 0.951141, 0.681919, 0.589263, 0.552028]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_classical_fourier(self):
         """
         Test the HinderedRotor.getHeatCapacity() method using a Fourier series
         potential in the classical limit.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.17682, 1.01369, 0.698588, 0.596797, 0.556293]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-        
-    def test_getHeatCapacity_quantum_cosine(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.17682, 1.01369, 0.698588, 0.596797, 0.556293]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_quantum_cosine(self):
         """
         Test the HinderedRotor.getHeatCapacity() method using a cosine
         potential in the quantum limit.
         """
         self.mode.quantum = True
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.01271, 0.945341, 0.684451, 0.591949, 0.554087]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-     
-    def test_getHeatCapacity_quantum_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.01271, 0.945341, 0.684451, 0.591949, 0.554087]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_quantum_fourier(self):
         """
         Test the HinderedRotor.getHeatCapacity() method using a Fourier series
         potential in the quantum limit.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([1.01263, 0.946618, 0.685345, 0.592427, 0.554374]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-3*Cvexp)
- 
-    def test_getEnthalpy_free(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.01263, 0.946618, 0.685345, 0.592427, 0.554374]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-3 * cv_exp)
+
+    def test_get_enthalpy_free(self):
         """
         Test the FreeRotor.getEnthalpy() method
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = constants.R*Tlist/2.0
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.freemode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-            
-    def test_getEnthalpy_classical_cosine(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = constants.R * t_list / 2.0
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.freemode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_classical_cosine(self):
         """
         Test the HinderedRotor.getEnthalpy() method using a cosine potential
         in the classical limit.
         """
         self.mode.quantum = False
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([1.09556, 1.09949, 0.962738, 0.854617, 0.784333]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-     
-    def test_getEnthalpy_classical_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1.09556, 1.09949, 0.962738, 0.854617, 0.784333]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_classical_fourier(self):
         """
-        Test the HinderedRotor.getEnthalpy() method using a Fourier series 
+        Test the HinderedRotor.getEnthalpy() method using a Fourier series
         potential in the classical limit.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([1.08882, 1.09584, 0.961543, 0.854054, 0.784009]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1.08882, 1.09584, 0.961543, 0.854054, 0.784009]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
 
-    def test_getEnthalpy_quantum_cosine(self):
+    def test_get_enthalpy_quantum_cosine(self):
         """
         Test the HinderedRotor.getEnthalpy() method using a cosine potential
         in the quantum limit.
         """
         self.mode.quantum = True
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.545814, 0.727200, 0.760918, 0.717496, 0.680767]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEnthalpy_quantum_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([0.545814, 0.727200, 0.760918, 0.717496, 0.680767]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_quantum_fourier(self):
         """
-        Test the HinderedRotor.getEnthalpy() method using a Fourier series 
+        Test the HinderedRotor.getEnthalpy() method using a Fourier series
         potential in the quantum limit.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.548251, 0.728974, 0.762396, 0.718702, 0.681764]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-3*Hexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([0.548251, 0.728974, 0.762396, 0.718702, 0.681764]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-3 * h_exp)
 
-    def test_getEntropy_free(self):
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Q = numpy.array([self.freemode.getPartitionFunction(T) for T in Tlist])
-        Sexplist = constants.R*(numpy.log(Q)+.5)
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.freemode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-            
-    def test_getEntropy_classical_cosine(self):
+    def test_get_entropy_free(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        pf = np.array([self.freemode.getPartitionFunction(temperature) for temperature in t_list])
+        s_exp_list = constants.R * (np.log(pf) + .5)
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.freemode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_entropy_classical_cosine(self):
         """
         Test the HinderedRotor.getEntropy() method using a cosine potential
         in the classical limit.
         """
         self.mode.quantum = False
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([0.797089, 1.36543, 1.95062, 2.21083, 2.37608]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([0.797089, 1.36543, 1.95062, 2.21083, 2.37608]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
 
-    def test_getEntropy_classical_fourier(self):
+    def test_get_entropy_classical_fourier(self):
         """
-        Test the HinderedRotor.getEntropy() method using a Fourier series 
+        Test the HinderedRotor.getEntropy() method using a Fourier series
         potential in the classical limit.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([0.795154, 1.36396, 1.95005, 2.21055, 2.37592]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([0.795154, 1.36396, 1.95005, 2.21055, 2.37592]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
 
-    def test_getEntropy_quantum_cosine(self):
+    def test_get_entropy_quantum_cosine(self):
         """
         Test the HinderedRotor.getEntropy() method using a cosine potential
         in the quantum limit.
         """
         self.mode.quantum = True
         self.mode.fourier = None
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([0.881906, 1.39397, 1.95536, 2.21232, 2.37673]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-    
-    def test_getEntropy_quantum_fourier(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([0.881906, 1.39397, 1.95536, 2.21232, 2.37673]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_entropy_quantum_fourier(self):
         """
-        Test the HinderedRotor.getEntropy() method using a Fourier series 
+        Test the HinderedRotor.getEntropy() method using a Fourier series
         potential in the quantum limit.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([0.880170, 1.39260, 1.95483, 2.21207, 2.37658]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-3*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([0.880170, 1.39260, 1.95483, 2.21207, 2.37658]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-3 * s_exp)
 
-    def test_getSumOfStates_classical_cosine(self):
+    def test_get_sum_of_states_classical_cosine(self):
         """
         Test the HinderedRotor.getSumOfStates() method using a cosine potential
         in the classical limit.
         """
         self.mode.quantum = False
         self.mode.fourier = None
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n-1] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n - 1] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
 
-    def test_getSumOfStates_classical_fourier(self):
+    def test_get_sum_of_states_classical_fourier(self):
         """
         Test the HinderedRotor.getSumOfStates() method using a Fourier series
         potential in the classical limit.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
         try:
-            sumStates = self.mode.getSumOfStates(Elist)
+            sum_states = self.mode.getSumOfStates(e_list)
             self.fail('NotImplementedError not raised by HinderedRotor.getSumOfStates()')
         except NotImplementedError:
             pass
-        
-    def test_getSumOfStates_quantum_cosine(self):
+
+    def test_get_sum_of_states_quantum_cosine(self):
         """
         Test the HinderedRotor.getSumOfStates() method using a cosine potential
         in the quantum limit.
         """
         self.mode.quantum = True
         self.mode.fourier = None
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n-1] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n - 1] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
 
-    def test_getSumOfStates_quantum_fourier(self):
+    def test_get_sum_of_states_quantum_fourier(self):
         """
         Test the HinderedRotor.getSumOfStates() method using a Fourier series
         potential in the quantum limit.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n-1] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
-        
-    def test_getDensityOfStates_classical_cosine(self):
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n - 1] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
+
+    def test_get_density_of_states_classical_cosine(self):
         """
         Test the HinderedRotor.getDensityOfStates() method using a classical
         potential in the classical limit.
         """
         self.mode.quantum = False
         self.mode.fourier = None
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
-    def test_getDensityOfStates_classical_fourier(self):
+    def test_get_density_of_states_classical_fourier(self):
         """
-        Test the HinderedRotor.getDensityOfStates() method using a Fourier 
+        Test the HinderedRotor.getDensityOfStates() method using a Fourier
         series potential in the classical limit.
         """
         self.mode.quantum = False
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
         try:
-            densStates = self.mode.getDensityOfStates(Elist)
+            dens_states = self.mode.getDensityOfStates(e_list)
             self.fail('NotImplementedError not raised by HinderedRotor.getDensityOfStates()')
         except NotImplementedError:
             pass
-        
-    def test_getDensityOfStates_quantum_cosine(self):
+
+    def test_get_density_of_states_quantum_cosine(self):
         """
         Test the HinderedRotor.getDensityOfStates() method using a classical
         potential in the quantum limit.
         """
         self.mode.quantum = True
         self.mode.fourier = None
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
-    def test_getDensityOfStates_quantum_fourier(self):
+    def test_get_density_of_states_quantum_fourier(self):
         """
-        Test the HinderedRotor.getDensityOfStates() method using a Fourier 
+        Test the HinderedRotor.getDensityOfStates() method using a Fourier
         series potential in the quantum limit.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-2*Qexp)
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
 
     def test_repr(self):
         """
@@ -470,14 +477,14 @@ class TestHinderedRotor(unittest.TestCase):
         self.assertEqual(self.mode.barrier.units, mode.barrier.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a HinderedRotor object can be pickled and unpickled with no
         loss of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertAlmostEqual(self.mode.inertia.value, mode.inertia.value, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units, 6)
         self.assertEqual(self.mode.fourier.value.shape, mode.fourier.value.shape)
@@ -488,8 +495,9 @@ class TestHinderedRotor(unittest.TestCase):
         self.assertEqual(self.mode.barrier.units, mode.barrier.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
 ################################################################################
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/statmech/translationTest.py
+++ b/rmgpy/statmech/translationTest.py
@@ -32,19 +32,23 @@
 This script contains unit tests of the :mod:`rmgpy.statmech.translation` module.
 """
 
-import unittest
-import numpy
+from __future__ import division
 
-from rmgpy.statmech.translation import IdealGasTranslation
+import unittest
+
+import numpy as np
+
 import rmgpy.constants as constants
+from rmgpy.statmech.translation import IdealGasTranslation
 
 ################################################################################
+
 
 class TestIdealGasTranslation(unittest.TestCase):
     """
     Contains unit tests of the IdealGasTranslation class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
@@ -52,76 +56,77 @@ class TestIdealGasTranslation(unittest.TestCase):
         self.mass = 32.0
         self.quantum = False
         self.mode = IdealGasTranslation(
-            mass = (self.mass,"amu"), 
-            quantum = self.quantum, 
+            mass=(self.mass, "amu"),
+            quantum=self.quantum,
         )
-        
-    def test_getPartitionFunction_classical(self):
+
+    def test_get_partition_function_classical(self):
         """
         Test the IdealGasTranslation.getPartitionFunction() method for a
         classical translator.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([7.22597e+06, 2.59130e+07, 1.46586e+08, 4.03944e+08, 8.29217e+08])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
-    def test_getHeatCapacity_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([7.22597e+06, 2.59130e+07, 1.46586e+08, 4.03944e+08, 8.29217e+08])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_heat_capacity_classical(self):
         """
         Test the IdealGasTranslation.getHeatCapacity() method using a classical
         translator.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([2.5, 2.5, 2.5, 2.5, 2.5]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-    
-    def test_getEnthalpy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([2.5, 2.5, 2.5, 2.5, 2.5]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_enthalpy_classical(self):
         """
         Test the IdealGasTranslation.getEnthalpy() method using a classical
         translator.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([2.5, 2.5, 2.5, 2.5, 2.5]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
-    def test_getEntropy_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([2.5, 2.5, 2.5, 2.5, 2.5]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_entropy_classical(self):
         """
         Test the IdealGasTranslation.getEntropy() method using a classical
         translator.
         """
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([18.2932, 19.5703, 21.3031, 22.3168, 23.0360]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
-    
-    def test_getSumOfStates_classical(self):
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([18.2932, 19.5703, 21.3031, 22.3168, 23.0360]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_sum_of_states_classical(self):
         """
         Test the IdealGasTranslation.getSumOfStates() method using a classical
         translator.
         """
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n-1] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n - 1] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
 
-    def test_getDensityOfStates_classical(self):
+    def test_get_density_of_states_classical(self):
         """
-        Test the IdealGasTranslation.getDensityOfStates() method using a 
+        Test the IdealGasTranslation.getDensityOfStates() method using a
         classical translator.
         """
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-6*Qexp)
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-6 * q_exp)
 
     def test_repr(self):
         """
@@ -133,14 +138,14 @@ class TestIdealGasTranslation(unittest.TestCase):
         self.assertAlmostEqual(self.mode.mass.value, mode.mass.value, 6)
         self.assertEqual(self.mode.mass.units, mode.mass.units)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a IdealGasTranslation object can be pickled and unpickled
         with no loss of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertAlmostEqual(self.mode.mass.value, mode.mass.value, 6)
         self.assertEqual(self.mode.mass.units, mode.mass.units)
         self.assertEqual(self.mode.quantum, mode.quantum)

--- a/rmgpy/statmech/vibrationTest.py
+++ b/rmgpy/statmech/vibrationTest.py
@@ -32,102 +32,105 @@
 This script contains unit tests of the :mod:`rmgpy.statmech.vibration` module.
 """
 
-import unittest
-import math
-import numpy
+from __future__ import division
 
-from rmgpy.statmech.vibration import HarmonicOscillator
+import unittest
+
+import numpy as np
+
 import rmgpy.constants as constants
+from rmgpy.statmech.vibration import HarmonicOscillator
 
 ################################################################################
+
 
 class TestHarmonicOscillator(unittest.TestCase):
     """
     Contains unit tests of the HarmonicOscillator class.
     """
-    
+
     def setUp(self):
         """
         A function run before each unit test in this class.
         """
-        self.frequencies = numpy.array([500, 1000, 2000])
+        self.frequencies = np.array([500, 1000, 2000])
         self.quantum = True
         self.mode = HarmonicOscillator(
-            frequencies = (self.frequencies,"cm^-1"),
-            quantum = self.quantum,
+            frequencies=(self.frequencies, 'cm^-1'),
+            quantum=self.quantum,
         )
-        
+
     def test_getPartitionFunction_classical(self):
         """
         Test the HarmonicOscillator.getPartitionFunction() method for a set of
         classical oscillators.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([0.00906536, 0.04196925, 0.335754, 1.13316978, 2.68603])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([0.00906536, 0.04196925, 0.335754, 1.13316978, 2.68603])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
     def test_getPartitionFunction_quantum(self):
         """
         Test the HarmonicOscillator.getPartitionFunction() method for a set of
         quantum oscillators.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Qexplist = numpy.array([1.10923, 1.39358, 2.70819, 4.98825, 8.459780])
-        for T, Qexp in zip(Tlist, Qexplist):
-            Qact = self.mode.getPartitionFunction(T)
-            self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
-            
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1.10923, 1.39358, 2.70819, 4.98825, 8.459780])
+        for temperature, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.getPartitionFunction(temperature)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
     def test_getHeatCapacity_classical(self):
         """
         Test the HarmonicOscillator.getHeatCapacity() method using a set of
         classical oscillators.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([3, 3, 3, 3, 3]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-    
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([3, 3, 3, 3, 3]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
     def test_getHeatCapacity_quantum(self):
         """
         Test the HarmonicOscillator.getHeatCapacity() method using a set of
         quantum oscillators.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Cvexplist = numpy.array([0.832004, 1.47271, 2.32513, 2.65024, 2.79124]) * constants.R
-        for T, Cvexp in zip(Tlist, Cvexplist):
-            Cvact = self.mode.getHeatCapacity(T)
-            self.assertAlmostEqual(Cvexp, Cvact, delta=1e-4*Cvexp)
-       
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([0.832004, 1.47271, 2.32513, 2.65024, 2.79124]) * constants.R
+        for temperature, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.getHeatCapacity(temperature)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
     def test_getEnthalpy_classical(self):
         """
         Test the HarmonicOscillator.getEnthalpy() method using a set of
         classical oscillators.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([3, 3, 3, 3, 3]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
-    
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([3, 3, 3, 3, 3]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
     def test_getEnthalpy_quantum(self):
         """
         Test the HarmonicOscillator.getEnthalpy() method using a set of quantum
         oscillators.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Hexplist = numpy.array([0.280395, 0.637310, 1.30209, 1.70542, 1.96142]) * constants.R * Tlist
-        for T, Hexp in zip(Tlist, Hexplist):
-            Hact = self.mode.getEnthalpy(T)
-            self.assertAlmostEqual(Hexp, Hact, delta=1e-4*Hexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([0.280395, 0.637310, 1.30209, 1.70542, 1.96142]) * constants.R * t_list
+        for temperature, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.getEnthalpy(temperature)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
 
     def test_getEntropy_classical(self):
         """
@@ -135,80 +138,82 @@ class TestHarmonicOscillator(unittest.TestCase):
         classical oscillators.
         """
         self.mode.quantum = False
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([-1.70329, -0.170818, 1.90862, 3.12502, 3.98807]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*abs(Sexp))
-        
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([-1.70329, -0.170818, 1.90862, 3.12502, 3.98807]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * abs(s_exp))
+
     def test_getEntropy_quantum(self):
         """
         Test the HarmonicOscillator.getEntropy() method using a set of quantum
         oscillators.
         """
         self.mode.quantum = True
-        Tlist = numpy.array([300,500,1000,1500,2000])
-        Sexplist = numpy.array([0.384065, 0.969182, 2.29837, 3.31251, 4.09675]) * constants.R
-        for T, Sexp in zip(Tlist, Sexplist):
-            Sact = self.mode.getEntropy(T)
-            self.assertAlmostEqual(Sexp, Sact, delta=1e-4*Sexp)
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([0.384065, 0.969182, 2.29837, 3.31251, 4.09675]) * constants.R
+        for temperature, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.getEntropy(temperature)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
 
     def test_getSumOfStates_classical(self):
         """
-        Test the HarmonicOscillator.getSumOfStates() method using a set of 
+        Test the HarmonicOscillator.getSumOfStates() method using a set of
         classical oscillators.
         """
         self.mode.quantum = False
-        self.mode.frequencies = ([500, 1000],"cm^-1")
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(10, len(Elist)):
-            self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
-        
+        self.mode.frequencies = ([500, 1000], 'cm^-1')
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(10, len(e_list)):
+            self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n] < 1.25,
+                             '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
+
     def test_getSumOfStates_quantum(self):
         """
-        Test the HarmonicOscillator.getSumOfStates() method using a set of 
+        Test the HarmonicOscillator.getSumOfStates() method using a set of
         quantum oscillators.
         """
         self.mode.quantum = True
-        Elist = numpy.arange(0, 10000*11.96, 1*11.96)
-        sumStates = self.mode.getSumOfStates(Elist)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(1, len(Elist)):
-            if sumStates[n-1] == 0:
-                self.assertTrue(numpy.sum(densStates[0:n]) == 0, '{0} != {1}'.format(numpy.sum(densStates[0:n]), 0))
+        e_list = np.arange(0, 10000 * 11.96, 1 * 11.96)
+        sum_states = self.mode.getSumOfStates(e_list)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(1, len(e_list)):
+            if sum_states[n - 1] == 0:
+                self.assertEqual(np.sum(dens_states[0:n]), 0)
             else:
-                self.assertTrue(0.8 < numpy.sum(densStates[0:n]) / sumStates[n-1] < 1.25, '{0} != {1}'.format(numpy.sum(densStates[0:n]), sumStates[n]))
+                self.assertTrue(0.8 < np.sum(dens_states[0:n]) / sum_states[n - 1] < 1.25,
+                                 '{0} != {1}'.format(np.sum(dens_states[0:n]), sum_states[n]))
 
     def test_getDensityOfStates_classical(self):
         """
-        Test the HarmonicOscillator.getDensityOfStates() method using a set of 
+        Test the HarmonicOscillator.getDensityOfStates() method using a set of
         classical oscillators.
         """
         self.mode.quantum = False
-        factor = constants.h * constants.c * 100. * constants.Na # cm^-1 to J/mol
-        Elist = numpy.arange(0, 10000*factor, 1*factor)
-        densStates = self.mode.getDensityOfStates(Elist)
-        T = 100
-        Qact = numpy.sum(densStates * numpy.exp(-Elist / constants.R / T))
-        Qexp = self.mode.getPartitionFunction(T)
-        self.assertAlmostEqual(Qexp, Qact, delta=1e-4*Qexp)
+        factor = constants.h * constants.c * 100. * constants.Na  # cm^-1 to J/mol
+        e_list = np.arange(0, 10000 * factor, 1 * factor)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        temperature = 100
+        q_act = np.sum(dens_states * np.exp(-e_list / constants.R / temperature))
+        q_exp = self.mode.getPartitionFunction(temperature)
+        self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
 
     def test_getDensityOfStates_quantum(self):
         """
-        Test the HarmonicOscillator.getDensityOfStates() method using a set of 
+        Test the HarmonicOscillator.getDensityOfStates() method using a set of
         quantum oscillators.
         """
         self.mode.quantum = True
-        factor = constants.h * constants.c * 100. * constants.Na # cm^-1 to J/mol
-        Elist = numpy.arange(0, 10000*factor, 1*factor)
-        densStates = self.mode.getDensityOfStates(Elist)
-        for n in range(len(Elist)):
-            if densStates[n] != 0:
+        factor = constants.h * constants.c * 100. * constants.Na  # cm^-1 to J/mol
+        e_list = np.arange(0, 10000 * factor, 1 * factor)
+        dens_states = self.mode.getDensityOfStates(e_list)
+        for n in range(len(e_list)):
+            if dens_states[n] != 0:
                 # The peaks should occur near a multiple of 500 cm^-1
-                E = float(Elist[n]) / factor
-                self.assertTrue(E % 500 < 5 or E % 500 > 495)
+                energy = float(e_list[n]) / factor
+                self.assertTrue(energy % 500 < 5 or energy % 500 > 495)
 
     def test_repr(self):
         """
@@ -222,14 +227,14 @@ class TestHarmonicOscillator(unittest.TestCase):
             self.assertAlmostEqual(freq0, freq, 6)
         self.assertEqual(self.mode.frequencies.units, mode.frequencies.units)
         self.assertEqual(self.mode.quantum, mode.quantum)
-        
+
     def test_pickle(self):
         """
         Test that a HarmonicOscillator object can be pickled and unpickled
         with no loss of information.
         """
-        import cPickle
-        mode = cPickle.loads(cPickle.dumps(self.mode,-1))
+        import pickle
+        mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertEqual(self.mode.frequencies.value.shape, mode.frequencies.value.shape)
         for freq0, freq in zip(self.mode.frequencies.value, mode.frequencies.value):
             self.assertAlmostEqual(freq0, freq, 6)
@@ -237,6 +242,7 @@ class TestHarmonicOscillator(unittest.TestCase):
         self.assertEqual(self.mode.quantum, mode.quantum)
 
 ################################################################################
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
This PR include python 3 compatibility changes to 
```
/rmgpy/statmech/
- __init__.py
- conformerTest.py
- rotationTest.py
- schrodingerTest.py
- torsionTest.py
- translationTest.py
- vibrationTest.py
```
including: 
- PEP-8 reformatting
- PEP-8 renaming of internal variables
- Futurize files
- Replace relative imports (`__init__.py`)
- remove unused `math` module