### PR TITLE
Fix a few bugs and add tests: KineticsModel and uncertainty handling.

### DIFF
--- a/rmgpy/kinetics/model.pyx
+++ b/rmgpy/kinetics/model.pyx
@@ -227,15 +227,15 @@ cdef class KineticsModel:
         Returns ``True`` if Tmin, Tmax for both objects match.
         Otherwise returns ``False``
         """
-        if self.Tmin is not None and otherKinetics.Tmin is not None and not self.Tmin.equals(otherKinetics.Tmin):
-            return False
+        if self.Tmin is not None and otherKinetics.Tmin is not None and self.Tmin.equals(otherKinetics.Tmin):
+            pass
         elif self.Tmin is None and otherKinetics.Tmin is None:
             pass
         else:
             return False
 
-        if self.Tmax is not None and otherKinetics.Tmax is not None and not self.Tmax.equals(otherKinetics.Tmax):
-            return False
+        if self.Tmax is not None and otherKinetics.Tmax is not None and self.Tmax.equals(otherKinetics.Tmax):
+            pass
         elif self.Tmax is None and otherKinetics.Tmax is None:
             pass
         else:

--- a/rmgpy/kinetics/model.pyx
+++ b/rmgpy/kinetics/model.pyx
@@ -120,7 +120,7 @@ cdef class KineticsModel:
         Return a string representation that can be used to reconstruct the
         KineticsModel object.
         """
-        return 'KineticsModel(Tmin={0!r}, Tmax={1!r}, Pmin={0!r}, Pmax={1!r}, comment="""{2}""")'.format(self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.uncertainty, self.comment)
+        return 'KineticsModel(Tmin={0!r}, Tmax={1!r}, Pmin={2!r}, Pmax={3!r}, uncertainty={4!r}, comment="""{5}""")'.format(self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.uncertainty, self.comment)
 
     def __reduce__(self):
         """

--- a/rmgpy/kinetics/modelTest.py
+++ b/rmgpy/kinetics/modelTest.py
@@ -35,10 +35,77 @@ This script contains unit tests of the :mod:`rmgpy.kinetics.model` module.
 import unittest
 
 from rmgpy.kinetics.model import getReactionOrderFromRateCoefficientUnits, \
-                                 getRateCoefficientUnitsFromReactionOrder
+                                 getRateCoefficientUnitsFromReactionOrder, \
+                                 KineticsModel
+
+from rmgpy.kinetics.uncertainties import RateUncertainty
+
+
+class TestKineticsModel(unittest.TestCase):
+    """
+    Contains unit tests of the KineticsModel class
+    """
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        self.Tmin = 300.
+        self.Tmax = 3000.
+        self.Pmin = 0.1
+        self.Pmax = 100.
+        self.comment = 'foo bar'
+        self.uncertainty = RateUncertainty(mu=0.3,var=0.6,Tref=1000.0,N=1,correlation="ab")
+        self.km = KineticsModel(
+            Tmin = (self.Tmin,"K"),
+            Tmax = (self.Tmax,"K"),
+            Pmin = (self.Pmin,"bar"),
+            Pmax = (self.Pmax,"bar"),
+            uncertainty = self.uncertainty,
+            comment = self.comment,
+        )
+
+    def test_isIdenticalTo(self):
+        """
+        Test that the KineticsModel.isIdenticalTo method works on itself.
+
+        This just checks the Temperature range
+        """
+        self.assertTrue(self.km.isIdenticalTo(self.km))
+
+        import copy
+        km = copy.deepcopy(self.km)
+        self.assertTrue(self.km.isIdenticalTo(self.km))
+
+        km.Tmax = (self.Tmax - 50, 'K') # discrepancy must be more than 1%!
+        self.assertFalse(self.km.isIdenticalTo(km))
+
+    def test_repr(self):
+        """
+        Test that an KineticsModel object can be reconstructed from its repr()
+        output with no loss of information.
+        """
+        km = None
+        exec('km = {0!r}'.format(self.km))
+        self.assertTrue(self.km.isIdenticalTo(km))
+        self.assertEqual(dir(self.km), dir(km))
+        for att in 'Tmax Tmin Pmax Pmin comment uncertainty'.split():
+            self.assertEqual(repr(getattr(self.km, att)), repr(getattr(km, att)))
+
+    def test_pickle(self):
+        """
+        Test that an KineticsModel object can be pickled and unpickled
+        with no loss of information.
+        """
+        import cPickle
+        km = cPickle.loads(cPickle.dumps(self.km,-1))
+        self.assertTrue(self.km.isIdenticalTo(km))
+        self.assertEqual(dir(self.km), dir(km))
+        for att in 'Tmax Tmin Pmax Pmin comment uncertainty'.split():
+            self.assertEqual(repr(getattr(self.km, att)), repr(getattr(km, att)))
+
+
 
 ################################################################################
-
 class TestOrder(unittest.TestCase):
     """
     Contains unit tests of the functions for converting rate coefficient units

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -390,6 +390,7 @@ cdef class SurfaceArrhenius(Arrhenius):
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `uncertainty`   Uncertainty information
     `comment`       Information about the model (e.g. its source)
     =============== =============================================================
     """
@@ -412,6 +413,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
+        if self.uncertainty is not None: string += ', uncertainty={0!r}'.format(self.uncertainty)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -420,7 +422,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         """
         A helper function used when pickling a SurfaceArrhenius object.
         """
-        return (SurfaceArrhenius, (self.A, self.n, self.Ea, self.T0, self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.comment))
+        return (SurfaceArrhenius, (self.A, self.n, self.Ea, self.T0, self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.uncertainty, self.comment))
 
 
 ################################################################################
@@ -447,6 +449,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `uncertainty`   Uncertainty information
     `comment`       Information about the model (e.g. its source)
     =============== =============================================================
     
@@ -470,6 +473,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
+        if self.uncertainty is not None: string += ', uncertainty={0!r}'.format(self.uncertainty)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -478,7 +482,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         """
         A helper function used when pickling an SurfaceArrheniusBEP object.
         """
-        return (SurfaceArrheniusBEP, (self.A, self.n, self.alpha, self.E0, self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.comment))
+        return (SurfaceArrheniusBEP, (self.A, self.n, self.alpha, self.E0, self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.uncertainty, self.comment))
     
     cpdef SurfaceArrhenius toArrhenius(self, double dHrxn):
         """
@@ -496,6 +500,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
             T0 = (1,"K"),
             Tmin = self.Tmin,
             Tmax = self.Tmax,
+            uncertainty = self.uncertainty,
             comment = self.comment,
         )
 

--- a/rmgpy/kinetics/surfaceTest.py
+++ b/rmgpy/kinetics/surfaceTest.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This script contains unit tests of the :mod:`rmgpy.kinetics.surface` module.
+"""
+
+import unittest
+import math
+import numpy
+
+from rmgpy.kinetics.surface import StickingCoefficient, StickingCoefficientBEP, SurfaceArrhenius, SurfaceArrheniusBEP
+import rmgpy.constants as constants
+
+################################################################################
+
+class TestStickingCoefficient(unittest.TestCase):
+    """
+    Contains unit tests of the :class:`StickingCoefficient` class.
+    """
+    
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        self.A = 4.3e-2
+        self.n = -0.21
+        self.Ea = 1.2
+        self.T0 = 1.
+        self.Tmin = 300.
+        self.Tmax = 3000.
+        self.comment = 'O2 dissociative'
+        self.stick = StickingCoefficient(
+            A = self.A,
+            n = self.n,
+            Ea = (self.Ea,"kJ/mol"),
+            T0 = (self.T0,"K"),
+            Tmin = (self.Tmin,"K"),
+            Tmax = (self.Tmax,"K"),
+            comment = self.comment,
+        )
+    
+    def test_A(self):
+        """
+        Test that the StickingCoefficient A property was properly set.
+        """
+        self.assertAlmostEqual(self.stick.A.value_si, self.A, delta=1e0)
+        
+    def test_n(self):
+        """
+        Test that the StickingCoefficient n property was properly set.
+        """
+        self.assertAlmostEqual(self.stick.n.value_si, self.n, 6)
+        
+    def test_Ea(self):
+        """
+        Test that the StickingCoefficient Ea property was properly set.
+        """
+        self.assertAlmostEqual(self.stick.Ea.value_si * 0.001, self.Ea, 6)
+        
+    def test_T0(self):
+        """
+        Test that the StickingCoefficient T0 property was properly set.
+        """
+        self.assertAlmostEqual(self.stick.T0.value_si, self.T0, 6)
+        
+    def test_Tmin(self):
+        """
+        Test that the StickingCoefficient Tmin property was properly set.
+        """
+        self.assertAlmostEqual(self.stick.Tmin.value_si, self.Tmin, 6)
+        
+    def test_Tmax(self):
+        """
+        Test that the StickingCoefficient Tmax property was properly set.
+        """
+        self.assertAlmostEqual(self.stick.Tmax.value_si, self.Tmax, 6)
+        
+    def test_comment(self):
+        """
+        Test that the StickingCoefficient comment property was properly set.
+        """
+        self.assertEqual(self.stick.comment, self.comment)
+        
+    def test_isTemperatureValid(self):
+        """
+        Test the StickingCoefficient.isTemperatureValid() method.
+        """
+        Tdata = numpy.array([200,400,600,800,1000,1200,1400,1600,1800,4000])
+        validdata = numpy.array([False,True,True,True,True,True,True,True,True,False], numpy.bool)
+        for T, valid in zip(Tdata, validdata):
+            valid0 = self.stick.isTemperatureValid(T)
+            self.assertEqual(valid0, valid)
+    
+    def test_pickle(self):
+        """
+        Test that an StickingCoefficient object can be pickled and unpickled with no loss
+        of information.
+        """
+        import cPickle
+        stick = cPickle.loads(cPickle.dumps(self.stick,-1))
+        self.assertAlmostEqual(self.stick.A.value, stick.A.value, delta=1e0)
+        self.assertEqual(self.stick.A.units, stick.A.units)
+        self.assertAlmostEqual(self.stick.n.value, stick.n.value, 4)
+        self.assertAlmostEqual(self.stick.Ea.value, stick.Ea.value, 4)
+        self.assertEqual(self.stick.Ea.units, stick.Ea.units)
+        self.assertAlmostEqual(self.stick.T0.value, stick.T0.value, 4)
+        self.assertEqual(self.stick.T0.units, stick.T0.units)
+        self.assertAlmostEqual(self.stick.Tmin.value, stick.Tmin.value, 4)
+        self.assertEqual(self.stick.Tmin.units, stick.Tmin.units)
+        self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
+        self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
+        self.assertEqual(self.stick.comment, stick.comment)
+        self.assertEqual(dir(self.stick), dir(stick))
+    
+    def test_repr(self):
+        """
+        Test that an StickingCoefficient object can be reconstructed from its repr()
+        output with no loss of information.
+        """
+        stick = None
+        exec('stick = {0!r}'.format(self.stick))
+        self.assertAlmostEqual(self.stick.A.value, stick.A.value, delta=1e0)
+        self.assertEqual(self.stick.A.units, stick.A.units)
+        self.assertAlmostEqual(self.stick.n.value, stick.n.value, 4)
+        self.assertAlmostEqual(self.stick.Ea.value, stick.Ea.value, 4)
+        self.assertEqual(self.stick.Ea.units, stick.Ea.units)
+        self.assertAlmostEqual(self.stick.T0.value, stick.T0.value, 4)
+        self.assertEqual(self.stick.T0.units, stick.T0.units)
+        self.assertAlmostEqual(self.stick.Tmin.value, stick.Tmin.value, 4)
+        self.assertEqual(self.stick.Tmin.units, stick.Tmin.units)
+        self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
+        self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
+        self.assertEqual(self.stick.comment, stick.comment)
+        self.assertEqual(dir(self.stick), dir(stick))
+    
+    def test_copy(self):
+        """
+        Test that an StickingCoefficient object can be copied with deepcopy
+        with no loss of information.
+        """
+        import copy
+        stick = copy.deepcopy(self.stick)
+        self.assertAlmostEqual(self.stick.A.value, stick.A.value, delta=1e0)
+        self.assertEqual(self.stick.A.units, stick.A.units)
+        self.assertAlmostEqual(self.stick.n.value, stick.n.value, 4)
+        self.assertAlmostEqual(self.stick.Ea.value, stick.Ea.value, 4)
+        self.assertEqual(self.stick.Ea.units, stick.Ea.units)
+        self.assertAlmostEqual(self.stick.T0.value, stick.T0.value, 4)
+        self.assertEqual(self.stick.T0.units, stick.T0.units)
+        self.assertAlmostEqual(self.stick.Tmin.value, stick.Tmin.value, 4)
+        self.assertEqual(self.stick.Tmin.units, stick.Tmin.units)
+        self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
+        self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
+        self.assertEqual(self.stick.comment, stick.comment)
+        self.assertEqual(dir(self.stick), dir(stick))
+
+    def test_isIdenticalTo(self):
+        """
+        Test that the StickingCoefficient.isIdenticalTo method works on itself
+        """
+        self.assertTrue(self.stick.isIdenticalTo(self.stick))
+     
+################################################################################
+
+
+class TestSurfaceArrhenius(unittest.TestCase):
+    """
+    Contains unit tests of the :class:`SurfaceArrhenius` class.
+    """
+    
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        self.A = 1.44e18
+        self.n = -0.087
+        self.Ea = 63.4
+        self.T0 = 1.
+        self.Tmin = 300.
+        self.Tmax = 3000.
+        self.comment = 'CH3x + Hx <=> CH4 + x + x'
+        self.surfarr = SurfaceArrhenius(
+            A = (self.A, 'm^2/(mol*s)'),
+            n = self.n,
+            Ea = (self.Ea,"kJ/mol"),
+            T0 = (self.T0,"K"),
+            Tmin = (self.Tmin,"K"),
+            Tmax = (self.Tmax,"K"),
+            comment = self.comment,
+        )
+    
+    def test_A(self):
+        """
+        Test that the SurfaceArrhenius A property was properly set.
+        """
+        self.assertAlmostEqual(self.surfarr.A.value_si, self.A, delta=1e0)
+        
+    def test_n(self):
+        """
+        Test that the SurfaceArrhenius n property was properly set.
+        """
+        self.assertAlmostEqual(self.surfarr.n.value_si, self.n, 6)
+        
+    def test_Ea(self):
+        """
+        Test that the SurfaceArrhenius Ea property was properly set.
+        """
+        self.assertAlmostEqual(self.surfarr.Ea.value_si * 0.001, self.Ea, 6)
+        
+    def test_T0(self):
+        """
+        Test that the SurfaceArrhenius T0 property was properly set.
+        """
+        self.assertAlmostEqual(self.surfarr.T0.value_si, self.T0, 6)
+        
+    def test_Tmin(self):
+        """
+        Test that the SurfaceArrhenius Tmin property was properly set.
+        """
+        self.assertAlmostEqual(self.surfarr.Tmin.value_si, self.Tmin, 6)
+        
+    def test_Tmax(self):
+        """
+        Test that the SurfaceArrhenius Tmax property was properly set.
+        """
+        self.assertAlmostEqual(self.surfarr.Tmax.value_si, self.Tmax, 6)
+        
+    def test_comment(self):
+        """
+        Test that the SurfaceArrhenius comment property was properly set.
+        """
+        self.assertEqual(self.surfarr.comment, self.comment)
+        
+    def test_isTemperatureValid(self):
+        """
+        Test the SurfaceArrhenius.isTemperatureValid() method.
+        """
+        Tdata = numpy.array([200,400,600,800,1000,1200,1400,1600,1800,4000])
+        validdata = numpy.array([False,True,True,True,True,True,True,True,True,False], numpy.bool)
+        for T, valid in zip(Tdata, validdata):
+            valid0 = self.surfarr.isTemperatureValid(T)
+            self.assertEqual(valid0, valid)
+    
+    def test_pickle(self):
+        """
+        Test that an SurfaceArrhenius object can be pickled and unpickled with no loss
+        of information.
+        """
+        import cPickle
+        surfarr = cPickle.loads(cPickle.dumps(self.surfarr,-1))
+        self.assertAlmostEqual(self.surfarr.A.value, surfarr.A.value, delta=1e0)
+        self.assertEqual(self.surfarr.A.units, surfarr.A.units)
+        self.assertAlmostEqual(self.surfarr.n.value, surfarr.n.value, 4)
+        self.assertAlmostEqual(self.surfarr.Ea.value, surfarr.Ea.value, 4)
+        self.assertEqual(self.surfarr.Ea.units, surfarr.Ea.units)
+        self.assertAlmostEqual(self.surfarr.T0.value, surfarr.T0.value, 4)
+        self.assertEqual(self.surfarr.T0.units, surfarr.T0.units)
+        self.assertAlmostEqual(self.surfarr.Tmin.value, surfarr.Tmin.value, 4)
+        self.assertEqual(self.surfarr.Tmin.units, surfarr.Tmin.units)
+        self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
+        self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
+        self.assertEqual(self.surfarr.comment, surfarr.comment)
+        self.assertEqual(dir(self.surfarr), dir(surfarr))
+    
+    def test_repr(self):
+        """
+        Test that an SurfaceArrhenius object can be reconstructed from its repr()
+        output with no loss of information.
+        """
+        surfarr = None
+        exec('surfarr = {0!r}'.format(self.surfarr))
+        self.assertAlmostEqual(self.surfarr.A.value, surfarr.A.value, delta=1e0)
+        self.assertEqual(self.surfarr.A.units, surfarr.A.units)
+        self.assertAlmostEqual(self.surfarr.n.value, surfarr.n.value, 4)
+        self.assertAlmostEqual(self.surfarr.Ea.value, surfarr.Ea.value, 4)
+        self.assertEqual(self.surfarr.Ea.units, surfarr.Ea.units)
+        self.assertAlmostEqual(self.surfarr.T0.value, surfarr.T0.value, 4)
+        self.assertEqual(self.surfarr.T0.units, surfarr.T0.units)
+        self.assertAlmostEqual(self.surfarr.Tmin.value, surfarr.Tmin.value, 4)
+        self.assertEqual(self.surfarr.Tmin.units, surfarr.Tmin.units)
+        self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
+        self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
+        self.assertEqual(self.surfarr.comment, surfarr.comment)
+        self.assertEqual(dir(self.surfarr), dir(surfarr))
+    
+    def test_copy(self):
+        """
+        Test that an SurfaceArrhenius object can be copied with deepcopy
+        with no loss of information.
+        """
+        import copy
+        surfarr = copy.deepcopy(self.surfarr)
+        self.assertAlmostEqual(self.surfarr.A.value, surfarr.A.value, delta=1e0)
+        self.assertEqual(self.surfarr.A.units, surfarr.A.units)
+        self.assertAlmostEqual(self.surfarr.n.value, surfarr.n.value, 4)
+        self.assertAlmostEqual(self.surfarr.Ea.value, surfarr.Ea.value, 4)
+        self.assertEqual(self.surfarr.Ea.units, surfarr.Ea.units)
+        self.assertAlmostEqual(self.surfarr.T0.value, surfarr.T0.value, 4)
+        self.assertEqual(self.surfarr.T0.units, surfarr.T0.units)
+        self.assertAlmostEqual(self.surfarr.Tmin.value, surfarr.Tmin.value, 4)
+        self.assertEqual(self.surfarr.Tmin.units, surfarr.Tmin.units)
+        self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
+        self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
+        self.assertEqual(self.surfarr.comment, surfarr.comment)
+        self.assertEqual(dir(self.surfarr), dir(surfarr))
+
+    def test_isIdenticalTo(self):
+        """
+        Test that the SurfaceArrhenius.isIdenticalTo method works on itself
+        """
+        self.assertTrue(self.surfarr.isIdenticalTo(self.surfarr))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Issue #1703 describes a problem whereby `SurfaceArrhenius` objects can't be copied with `deepcopy` (meaning they can't be loaded in a kinetics family, or pretty much used for anything).
It was due to the new `uncertainty` attribute being left out of the `__repr__` or `__reduce__` methods.
While fixing and debugging, and adding unit tests, I caught some other bugs.
The `KineticsModel` had some errors, also in the `__repr__` method, and the logic behind the isIdenticalTo() was broken and it'd return False when it should be True (which was causing the new unit tests I wrote for the surface kinetics module to fail).

### Description of Changes
Added some unit tests that initially failed, and then fixed the bugs that they demonstrated.

### Testing
It was test-driven development. A test I wrote to isolate one bug in fact led to finding two more.
Tested locally. Running Travis now. Test coverage around these modules is still pretty low, and even when lines of code are executed, the logic is not always being tested that the lines of code do the right thing. But improving that situation should wait until after Py3!


<!--
### Reviewer Tips


Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
