### PR TITLE
Corrected the instructions for running in parallel

### DIFF
--- a/documentation/source/users/rmg/running.rst
+++ b/documentation/source/users/rmg/running.rst
@@ -53,7 +53,7 @@ Make sure that:
 
     source activate rmg_env
 
-    python  -n $Processes $RMG_WS/RMG-Py/rmg.py input.py
+    python $RMG_WS/RMG-Py/rmg.py -n $Processes input.py
 
     source deactivate
 
@@ -89,7 +89,7 @@ Make sure that:
 
     source activate rmg_env
 
-    python -n $Processes $RMG_WS/RMG-Py/rmg.py input.py
+    python $RMG_WS/RMG-Py/rmg.py -n $Processes input.py
 
     source deactivate
 


### PR DESCRIPTION
The option `-n $Processes` is an argument to `rmg.py` not to `python`.

### Motivation or Problem
The documentation suggested `python -n $Processes  path/to/rmg.py path/to/input.py` 

### Description of Changes
It now says `python path/to/rmg.py -n $Processes path/to/input.py` 