### PR TITLE
generateChemkinHTML documentation editted

### DIFF
--- a/documentation/source/users/rmg/modules/generateChemkinHTML.rst
+++ b/documentation/source/users/rmg/modules/generateChemkinHTML.rst
@@ -16,7 +16,7 @@ for generating the HTML file after job completion.
 To use this script, you need a Chemkin input file and an RMG species dictionary.
 The syntax is as follows::
 
-    python importChemkinLibrary.py [-h, -f] CHEMKIN DICTIONARY [OUTPUT]
+    python generateChemkinHTML.py [-h, -f] CHEMKIN DICTIONARY [OUTPUT]
 
 Positional arguments::
 


### PR DESCRIPTION

### Motivation or Problem
The documentation suggested to use `importChemkinLibrary.py`. It shoult be `generateChemkinHTML.py`.

### Description of Changes
Change from `importChemkinLibrary.py` to `generateChemkinHTML.py`
