### PR TITLE
Move parse_command_line_arguments to util.py

### DIFF
--- a/rmg.py
+++ b/rmg.py
@@ -34,7 +34,6 @@ RMG is an automatic chemical mechanism generator. It is awesomely awesome.
 from __future__ import print_function
 
 import os.path
-import argparse
 import logging
 
 # Before importing any RMG modules, check Python version
@@ -43,90 +42,9 @@ utilities.check_python()
 
 import rmgpy
 from rmgpy.rmg.main import RMG, initialize_log, process_profile_stats, make_profile_graph
-
+from rmgpy.util import parse_command_line_arguments
 
 ################################################################################
-
-
-def parse_command_line_arguments(command_line_args=None):
-    """
-    Parse the command-line arguments being passed to RMG Py. This uses the
-    :mod:`argparse` module, which ensures that the command-line arguments are
-    sensible, parses them, and returns them.
-    """
-
-    parser = argparse.ArgumentParser(description='Reaction Mechanism Generator (RMG) is an automatic chemical reaction '
-                                                 'mechanism generator that constructs kinetic models composed of '
-                                                 'elementary chemical reaction steps using a general understanding of '
-                                                 'how molecules react.')
-
-    parser.add_argument('file', metavar='FILE', type=str, nargs=1,
-                        help='a file describing the job to execute')
-
-    # Options for controlling the amount of information printed to the console
-    # By default a moderate level of information is printed; you can either
-    # ask for less (quiet), more (verbose), or much more (debug)
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('-q', '--quiet', action='store_true', help='only print warnings and errors')
-    group.add_argument('-v', '--verbose', action='store_true', help='print more verbose output')
-    group.add_argument('-d', '--debug', action='store_true', help='print debug information')
-
-    # Add options for controlling what directories files are written to
-    parser.add_argument('-o', '--output-directory', type=str, nargs=1, default='',
-                        metavar='DIR', help='use DIR as output directory')
-
-    # Add restart option
-    parser.add_argument('-r', '--restart', type=str, nargs=1, metavar='path/to/seed/', help='restart RMG from a seed',
-                        default='')
-
-    parser.add_argument('-p', '--profile', action='store_true',
-                        help='run under cProfile to gather profiling statistics, and postprocess them if job completes')
-    parser.add_argument('-P', '--postprocess', action='store_true',
-                        help='postprocess profiling statistics from previous [failed] run; does not run the simulation')
-
-    parser.add_argument('-t', '--walltime', type=str, nargs=1, default='00:00:00:00',
-                        metavar='DD:HH:MM:SS', help='set the maximum execution time')
-
-    # Add option to select max number of processes for reaction generation
-    parser.add_argument('-n', '--maxproc', type=int, nargs=1, default=1,
-                        help='max number of processes used during reaction generation')
-
-    # Add option to output a folder that stores the details of each kinetic database entry source
-    parser.add_argument('-k', '--kineticsdatastore', action='store_true',
-                        help='output a folder, kinetics_database, that contains a .txt file for each reaction family '
-                             'listing the source(s) for each entry')
-
-    args = parser.parse_args(command_line_args)
-
-    # Process args to set correct default values and format
-
-    # For output and scratch directories, if they are empty strings, set them
-    # to match the input file location
-    args.file = args.file[0]
-
-    # If walltime was specified, retrieve this string from the element 1 list
-    if args.walltime != '00:00:00:00':
-        args.walltime = args.walltime[0]
-
-    if args.restart:
-        args.restart = args.restart[0]
-
-    if args.maxproc != 1:
-        args.maxproc = args.maxproc[0]
-
-    # Set directories
-    input_directory = os.path.abspath(os.path.dirname(args.file))
-
-    if args.output_directory == '':
-        args.output_directory = input_directory
-    # If output directory was specified, retrieve this string from the element 1 list
-    else:
-        args.output_directory = args.output_directory[0]
-
-    if args.postprocess:
-        args.profile = True
-
-    return args
 
 
 def main():

--- a/rmgpy/rmg/rmgTest.py
+++ b/rmgpy/rmg/rmgTest.py
@@ -32,7 +32,6 @@ import os
 import unittest
 
 from external.wip import work_in_progress
-from rmg import parse_command_line_arguments
 from rmgpy import settings
 from rmgpy.data.base import ForbiddenStructures
 from rmgpy.data.rmg import RMGDatabase
@@ -41,6 +40,7 @@ from rmgpy.rmg.react import react_species
 from rmgpy.rmg.main import RMG
 from rmgpy.rmg.model import CoreEdgeReactionModel
 from rmgpy.species import Species
+from rmgpy.util import parse_command_line_arguments
 
 
 ###################################################

--- a/rmgpy/tools/generate_reactions.py
+++ b/rmgpy/tools/generate_reactions.py
@@ -39,10 +39,10 @@ The input file is a subset of that used with regular RMG jobs.
 import logging
 import os.path
 
-from rmg import parse_command_line_arguments
 from rmgpy.chemkin import ChemkinWriter
 from rmgpy.rmg.main import initialize_log, RMG
 from rmgpy.rmg.output import OutputHTMLWriter
+from rmgpy.util import parse_command_line_arguments
 
 
 def main():

--- a/rmgpy/util.py
+++ b/rmgpy/util.py
@@ -28,6 +28,7 @@
 #                                                                             #
 ###############################################################################
 
+import argparse
 import logging
 import os.path
 import shutil
@@ -135,6 +136,87 @@ def timefn(fn):
         return result
 
     return measure_time
+
+
+def parse_command_line_arguments(command_line_args=None):
+    """
+    Parse the command-line arguments being passed to RMG Py. This uses the
+    :mod:`argparse` module, which ensures that the command-line arguments are
+    sensible, parses them, and returns them.
+    """
+
+    parser = argparse.ArgumentParser(description='Reaction Mechanism Generator (RMG) is an automatic chemical reaction '
+                                                 'mechanism generator that constructs kinetic models composed of '
+                                                 'elementary chemical reaction steps using a general understanding of '
+                                                 'how molecules react.')
+
+    parser.add_argument('file', metavar='FILE', type=str, nargs=1,
+                        help='a file describing the job to execute')
+
+    # Options for controlling the amount of information printed to the console
+    # By default a moderate level of information is printed; you can either
+    # ask for less (quiet), more (verbose), or much more (debug)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-q', '--quiet', action='store_true', help='only print warnings and errors')
+    group.add_argument('-v', '--verbose', action='store_true', help='print more verbose output')
+    group.add_argument('-d', '--debug', action='store_true', help='print debug information')
+
+    # Add options for controlling what directories files are written to
+    parser.add_argument('-o', '--output-directory', type=str, nargs=1, default='',
+                        metavar='DIR', help='use DIR as output directory')
+
+    # Add restart option
+    parser.add_argument('-r', '--restart', type=str, nargs=1, metavar='path/to/seed/', help='restart RMG from a seed',
+                        default='')
+
+    parser.add_argument('-p', '--profile', action='store_true',
+                        help='run under cProfile to gather profiling statistics, and postprocess them if job completes')
+    parser.add_argument('-P', '--postprocess', action='store_true',
+                        help='postprocess profiling statistics from previous [failed] run; does not run the simulation')
+
+    parser.add_argument('-t', '--walltime', type=str, nargs=1, default='00:00:00:00',
+                        metavar='DD:HH:MM:SS', help='set the maximum execution time')
+
+    # Add option to select max number of processes for reaction generation
+    parser.add_argument('-n', '--maxproc', type=int, nargs=1, default=1,
+                        help='max number of processes used during reaction generation')
+
+    # Add option to output a folder that stores the details of each kinetic database entry source
+    parser.add_argument('-k', '--kineticsdatastore', action='store_true',
+                        help='output a folder, kinetics_database, that contains a .txt file for each reaction family '
+                             'listing the source(s) for each entry')
+
+    args = parser.parse_args(command_line_args)
+
+    # Process args to set correct default values and format
+
+    # For output and scratch directories, if they are empty strings, set them
+    # to match the input file location
+    args.file = args.file[0]
+
+    # If walltime was specified, retrieve this string from the element 1 list
+    if args.walltime != '00:00:00:00':
+        args.walltime = args.walltime[0]
+
+    if args.restart:
+        args.restart = args.restart[0]
+
+    if args.maxproc != 1:
+        args.maxproc = args.maxproc[0]
+
+    # Set directories
+    input_directory = os.path.abspath(os.path.dirname(args.file))
+
+    if args.output_directory == '':
+        args.output_directory = input_directory
+    # If output directory was specified, retrieve this string from the element 1 list
+    else:
+        args.output_directory = args.output_directory[0]
+
+    if args.postprocess:
+        args.profile = True
+
+    return args
 
 
 def as_list(item, default=None):


### PR DESCRIPTION
rmg.py is not installed as a module in the conda binary, so we cannot import this function

### Motivation or Problem
Fixes #1716 

### Description of Changes
Move `parse_commnad_line_arguments` inside of rmgpy.util where it can be imported for binary installations
