### PR TITLE
Reduce the amount of logging messages that get too frequently printed during debug

### DIFF
--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -90,7 +90,7 @@ def fails_species_constraints(species):
 
     max_radicals = species_constraints.get('maximumRadicalElectrons', -1)
     if max_radicals != -1:
-        if (struct.get_radical_count() > max_radicals):
+        if struct.get_radical_count() > max_radicals:
             return True
 
     max_carbenes = species_constraints.get('maximumSingletCarbenes', 1)

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -968,10 +968,9 @@ class Database(object):
                             return False
                     elif group.has_bond(center, atom1):  # but structure doesn't
                         return False
-                    # but we don't mind if...
                     elif structure.has_bond(atom, atom2):  # but group doesn't
-                        logging.debug("We don't mind that structure " + str(structure) +
-                                      " has bond but group {0} doesn't".format(node))
+                        # We don't mind that the structure has bond but the group doesn't
+                        pass
                 # Passed semantic checks, so add to maps of already-matched atoms
                 if not (isinstance(center, list) or isinstance(atom, list)):
                     initial_map[atom] = center

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -199,7 +199,6 @@ def ensure_independent_atom_ids(input_species, resonance=True):
 
     # If they are not all different, reassign ids and remake resonance structures
     if not independent_ids():
-        logging.debug('identical atom ids found between species. regenerating')
         for species in input_species:
             unreactive_mol_list = [mol for mol in species.molecule if not mol.reactive]
             mol = [mol for mol in species.molecule if mol.reactive][0]  # Choose first reactive molecule

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1002,26 +1002,19 @@ class KineticsFamily(Database):
         # First, generate a list of reactant structures that are actual
         # structures, rather than unions
         reactant_structures = []
-        logging.log(1, "Generating template for products.")
         for reactant in reactants0:
             if isinstance(reactant, list):
                 reactants = [reactant[0]]
             else:
                 reactants = [reactant]
 
-            logging.log(1, "Reactants: {0}".format(reactants))
             for s in reactants:
-                logging.log(1, "Reactant {0}".format(s))
                 struct = s.item
                 if isinstance(struct, LogicNode):
                     all_structures = struct.get_possible_structures(self.groups.entries)
-                    logging.log(1, 'Expanding logic node {0} to {1}'.format(s, all_structures))
                     reactant_structures.append(all_structures)
-                    for p in all_structures:
-                        logging.log(1, p.to_adjacency_list())
                 else:
                     reactant_structures.append([struct])
-                    logging.log(1, struct.to_adjacency_list())
 
         # Second, get all possible combinations of reactant structures
         reactant_structures = get_all_combinations(reactant_structures)
@@ -1048,10 +1041,6 @@ class KineticsFamily(Database):
                         raise
                 else:
                     product_structure_list[i].append(struct)
-
-        logging.log(1, "Unique generated product structures:")
-        logging.log(1, "\n".join([p[0].to_adjacency_list() for p in product_structures]))
-
         # Fifth, associate structures with product template
         product_set = []
         for index, products in enumerate(product_structure_list):

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -196,22 +196,6 @@ class KineticsGroups(Database):
             msg = 'Unable to find matching template for reaction {0} in reaction family {1}.'.format(str(reaction),
                                                                                                      str(self))
             msg += 'Trying to match {0} but matched {1}'.format(str(forward_template), str(template))
-            logging.debug('len(template): {0}'.format(len(template)))
-            logging.debug('len(forward_template): {0}'.format(len(forward_template)))
-            logging.debug('reactants:')
-            for reactant in reaction.reactants:
-                if isinstance(reactant, Species):
-                    for mol in reactant.molecule:
-                        logging.debug(mol.to_adjacency_list())
-                else:
-                    logging.debug(reactant.to_adjacency_list())
-            logging.debug('products:')
-            for product in reaction.products:
-                if isinstance(product, Species):
-                    for mol in product.molecule:
-                        logging.debug(mol.to_adjacency_list())
-                else:
-                    logging.debug(product.to_adjacency_list())
             raise UndeterminableKineticsError(reaction, message=msg)
 
         return template

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1191,7 +1191,6 @@ class ThermoDatabase(object):
         thermo0 = self.get_thermo_data_from_libraries(species)
 
         if thermo0 is not None:
-            logging.debug("Found thermo for {0} in {1}".format(species.label, thermo0[0].comment.lower()))
             if len(thermo0) != 3:
                 raise RuntimeError("thermo0 should be a tuple (thermo_data, library, entry), not {0}".format(thermo0))
             thermo0 = thermo0[0]


### PR DESCRIPTION
### Motivation or Problem
When debugging RMG or a software that depends on RMG the amount of debugging statements that get printed jam the buffer, not allowing the developer to conveniently see the actual original error massage.

### Description of Changes
Some logging statements, most of which are debugging level, were commented out. I only marked those which get printed too frequently in my experience. The purpose here was to flag them in the code for a discussion of how to best deal with them - leave commented out (so can be conveniently brought back to life if needed) or completely deleting them.
I think we can start the discussion even though we won't merge until the Py3 transition, since the same logging statements will be relevant after transitioning.
