### PR TITLE
Remove unnecessary zip folder unpacking in arkane/mainTest.py

### DIFF
--- a/arkane/mainTest.py
+++ b/arkane/mainTest.py
@@ -59,11 +59,6 @@ class TestArkaneExamples(unittest.TestCase):
         cls.base_path = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)), 'examples', 'arkane')
         cls.failed = []
         cls.example_types = ['species', 'reactions', 'explorer', 'networks']
-        ch2ooh_path = os.path.join(cls.base_path, 'species', 'CH2CHOOH', 'CH2CHOOHscans')
-        if not os.path.exists(ch2ooh_path):
-            ch2ooh_path = os.path.join(cls.base_path, 'species', 'CH2CHOOH', 'CH2CHOOHscans.zip')
-            zip_ref = zipfile.ZipFile(ch2ooh_path, 'r')
-            zip_ref.extractall()
 
     def test_arkane_examples(self):
         for example_type in self.example_types:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
CH2CHOOHscans was previously being unpacked into the current working directory and was not being cleaned up.

### Description of Changes
- Add some variables to improve readability of path generation
- Specify the directory to which CH2CHOOHscans should be unpacked
- Check whether q2dtor is installed before unpacking scans and running the q2dtor example

### Testing
Should be sufficient for Travis to pass.

### Reviewer Question
While I was testing this, I discovered that this test doesn't seem to actually run q2dtor. My guess is that it's because the `r0.pes` file exists (since that's the only difference between this example and the test in ndTorsionsTest).

Was this intentional? If so, I will remove the changes that check that q2dtor is installed. If not, we should fix the example.