### PR TITLE
Improve group additivity ranking for aromatic species

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1797,17 +1797,17 @@ class ThermoDatabase(object):
                     # Group values are generally fitted to the most aromatic resonance structure
                     num_arom_rings = species.molecule[i].count_aromatic_rings()
 
-                    entries.append((thermo, sum_rank, -num_arom_rings))
+                    entries.append((i, thermo, sum_rank, -num_arom_rings))
 
                 # Sort first by number of aromatic rings, then rank, then by enthalpy at 298 K
-                entries = sorted(entries, key=lambda entry: (entry[2], entry[1], entry[0].get_enthalpy(298.)))
-                indices = [thermo_data_list.index(entry[0]) for entry in entries]
+                entries.sort(key=lambda entry: (entry[3], entry[2], entry[1].get_enthalpy(298.)))
+                indices = [entry[0] for entry in entries]
             else:
                 # For noncyclics, default to original algorithm of ordering thermo based on the most stable enthalpy
                 H298 = np.array([t.get_enthalpy(298.) for t in thermo_data_list])
-                indices = H298.argsort()
-            indices = np.array([i for i in indices if species.molecule[i].reactive] +
-                               [i for i in indices if not species.molecule[i].reactive])
+                indices = H298.argsort().tolist()
+            # Sort indices again by the Molecule.reactive flag
+            indices.sort(key=lambda index: species.molecule[index].reactive, reverse=True)
         else:
             indices = [0]
         return indices

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1785,17 +1785,22 @@ class ThermoDatabase(object):
             if species.molecule[0].is_cyclic():
                 # Special treatment for cyclic compounds
                 entries = []
-                for thermo in thermo_data_list:
+                for i, thermo in enumerate(thermo_data_list):
                     ring_groups, polycyclic_groups = self.get_ring_groups_from_comments(thermo)
 
                     # Use rank as a metric for prioritizing thermo. 
                     # The smaller the rank, the better.
                     sum_rank = np.sum(
                         [3 if entry.rank is None else entry.rank for entry in ring_groups + polycyclic_groups])
-                    entries.append((thermo, sum_rank))
 
-                # Sort first by rank, then by enthalpy at 298 K
-                entries = sorted(entries, key=lambda entry: (entry[1], entry[0].get_enthalpy(298.)))
+                    # Also use number of aromatic rings as a metric, more aromatic rings is better
+                    # Group values are generally fitted to the most aromatic resonance structure
+                    num_arom_rings = species.molecule[i].count_aromatic_rings()
+
+                    entries.append((thermo, sum_rank, -num_arom_rings))
+
+                # Sort first by number of aromatic rings, then rank, then by enthalpy at 298 K
+                entries = sorted(entries, key=lambda entry: (entry[2], entry[1], entry[0].get_enthalpy(298.)))
                 indices = [thermo_data_list.index(entry[0]) for entry in entries]
             else:
                 # For noncyclics, default to original algorithm of ordering thermo based on the most stable enthalpy

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -585,6 +585,15 @@ multiplicity 2
         self.assertTrue(thermo_gav2.get_enthalpy(298) > thermo_gav1.get_enthalpy(298),
                         msg="Did not select the reactive molecule for thermo")
 
+    def test_thermo_for_aromatic_radicals(self):
+        """Test that we use the most aromatic resonance structure for thermo estimation"""
+        spec = Species(smiles='C=[C]c1ccc2ccccc2c1')  # vinylnaphthalene radical
+        spec.generate_resonance_structures()
+        thermo_gav = self.database.get_thermo_data_from_groups(spec)
+        self.assertAlmostEqual(thermo_gav.H298.value_si / 4184, 107, delta=1)
+        self.assertIn('group additivity', thermo_gav.comment, 'Thermo not found from GAV, test purpose not fulfilled.')
+        self.assertIn('polycyclic(s2_6_6_naphthalene)', thermo_gav.comment)
+
 
 class TestThermoAccuracy(unittest.TestCase):
     """

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -248,6 +248,8 @@ cdef class Molecule(Graph):
 
     cpdef identify_ring_membership(self)
 
+    cpdef int count_aromatic_rings(self)
+
     cpdef tuple get_aromatic_rings(self, list rings=?)
 
     cpdef list get_deterministic_sssr(self)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2218,6 +2218,27 @@ class Molecule(Graph):
                     atom.props['inRing'] = True
                     break
 
+    def count_aromatic_rings(self):
+        """
+        Count the number of aromatic rings in the current molecule, as determined by the benzene bond type.
+        This is purely dependent on representation and is unrelated to the actual aromaticity of the molecule.
+
+        Returns an integer corresponding to the number or aromatic rings.
+        """
+        cython.declare(rings=list, count=int, ring=list, bonds=list, bond=Bond)
+        rings = self.get_relevant_cycles()
+        count = 0
+        for ring in rings:
+            if len(ring) != 6:
+                # We currently only recognize 6-membered rings as being aromatic
+                continue
+
+            bonds = self.get_edges_in_cycle(ring)
+            if all([bond.is_benzene() for bond in bonds]):
+                count += 1
+
+        return count
+
     def get_aromatic_rings(self, rings=None):
         """
         Returns all aromatic rings as a list of atoms and a list of bonds.

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2650,6 +2650,13 @@ multiplicity 2
         self.assertEqual(bonds['H-O'], 2)
         self.assertEqual(bonds['H~O'], 2)
 
+    def test_count_aromatic_rings(self):
+        """Test that we can count aromatic rings correctly."""
+        mol = Molecule(smiles='c12ccccc1cccc2')
+        out = mol.generate_resonance_structures()
+        result = [m.count_aromatic_rings() for m in out]
+
+        self.assertEqual(result, [2, 1, 0])
 
 ################################################################################
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Estimating thermo for aromatic species using group additivity can sometimes give weird results because we will get an estimate for every resonance structure and then take the one with the lowest H298. In some cases, this can lead to severe underprediction of enthalpy if there is an inappropriate group which results in a lower enthalpy than a more appropriate group.

For example:

![image](https://user-images.githubusercontent.com/10817103/65707128-e3cbb480-e059-11e9-9cc7-bd5b95328d61.png)

This species has resonance structures where the radical can delocalize into the aromatic ring. One of those structures gives the estimate with the lowest H298 of 61.4 kcal/mol:
`Thermo group additivity estimation: group(Cs-(Cds-Cds)CbHH) + group(Cb-Cs) + group(Cb-(Cds-Cds)) + group(Cds-Cds(Cds-Cds)Cs) + group(Cb-H) + group(Cds-CdsCbH) + group(Cb-H) + group(Cds-Cds(Cds-Cds)H) + group(Cb-H) + group(Cb-H) + group(Cds-CdsHH) + group(Cdd-CdsCds) + polycyclic(s2_6_6_ben_ene_1) + radical(Benzyl_S_dihydronaphthalene) `

However the calculated H298 of the molecule is 101.7 kcal/mol. If we were to use GAV to estimate the thermo of resonance structure depicted above, then we would get 107.3 kcal/mol with the following groups:
`Thermo group additivity estimation: group(Cbf-CbCbCbf) + group(Cbf-CbCbCbf) + group(Cb-(Cds-Cds)) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cds-CdsCbH) + group(Cds-CdsHH) + polycyclic(s2_6_6_naphthalene) + radical(Cds_S)`

### Description of Changes
This PR adds an additional parameter, number of aromatic rings, by which to rank GAV estimates, in addition to H298.

The number of aromatic rings is determined by the actual bond orders in the resonance structure, rather than true aromaticity detection.

The result is that estimates for resonance structures with more aromatic rings is prioritized over those with fewer, even if it results in a higher H298.

### Testing
Besides testing with the species mentioned above, I ran comparisons against the SABIC_aromatics_1dHR library (not currently on master), which contains ~350 aromatic/near-aromatic species calculated using CBS-QB3 with 1D hindered rotors.

The H298 MAE on master is 5.263 kcal/mol, while the MAE on this branch is 5.228 kcal/mol. This is not a substantial difference, mainly because this change does not affect many species. However, it does suggest that this change does not have noticeable negative effects.
