### PR TITLE
Limit aromaticity perception for strained polycyclics

### DIFF
--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2501,6 +2501,13 @@ multiplicity 2
         self.assertEqual(len(aromatic_atoms), 0)
         self.assertEqual(len(aromatic_bonds), 0)
 
+    def test_aromaticity_perception_benzonaphthalene(self):
+        """Test aromaticity perception via get_aromatic_rings for benzonaphthalene with multiple fused bonds."""
+        mol = Molecule(smiles='c1cc2ccc3ccc(c1)c2c3')
+        aromatic_atoms, aromatic_bonds = mol.get_aromatic_rings()
+        self.assertEqual(len(aromatic_atoms), 1)
+        self.assertEqual(len(aromatic_bonds), 1)
+
     def test_aromaticity_perception_save_order(self):
         """Test aromaticity perception via get_aromatic_rings for phenyl radical without changing atom order."""
         mol = Molecule().from_adjacency_list("""multiplicity 2

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -601,7 +601,9 @@ multiplicity 2
         """Test that we can handle bridged aromatics.
 
         This is affected by how we perceive rings. Using get_smallest_set_of_smallest_rings gives
-        non-deterministic output, so using get_all_cycles_of_size allows this test to pass."""
+        non-deterministic output, so using get_all_cycles_of_size allows this test to pass.
+
+        Update: Highly-strained fused rings are no longer considered aromatic."""
         mol = Molecule(smiles='c12c3cccc1c3ccc2')
         arom = Molecule().from_adjacency_list("""
 1  C u0 p0 c0 {2,B} {3,B} {8,B}
@@ -624,14 +626,16 @@ multiplicity 2
 
         out = generate_resonance_structures(mol)
 
-        self.assertEqual(len(out), 3)
-        self.assertTrue(arom.is_isomorphic(out[0]))
+        self.assertEqual(len(out), 1)
+        self.assertFalse(arom.is_isomorphic(out[0]))
 
     def test_polycyclic_aromatic_with_non_aromatic_ring(self):
         """Test that we can make aromatic resonance structures when there is a pseudo-aromatic ring.
 
         This applies in cases where RDKit misidentifies one ring as aromatic, but there are other
-        rings in the molecule that are actually aromatic."""
+        rings in the molecule that are actually aromatic.
+
+        Update: Highly-strained fused rings are no longer considered aromatic."""
         mol = Molecule(smiles='c1c2cccc1C(=C)C=[C]2')
         arom = Molecule().from_adjacency_list("""
 multiplicity 2
@@ -656,8 +660,8 @@ multiplicity 2
 
         out = generate_resonance_structures(mol)
 
-        self.assertEqual(len(out), 2)
-        self.assertTrue(arom.is_isomorphic(out[0]))
+        self.assertEqual(len(out), 5)
+        self.assertFalse(any(arom.is_isomorphic(res) for res in out))
 
     def test_polycyclic_aromatic_with_non_aromatic_ring2(self):
         """Test that we can make aromatic resonance structures when there is a pseudo-aromatic ring.
@@ -1164,9 +1168,11 @@ multiplicity 2
         self.assertEqual(len(out), 7)
         self.assertTrue(any([m.is_isomorphic(aromatic) for m in out]))
 
-    @work_in_progress
     def test_inconsistent_aromatic_structure_generation(self):
-        """Test an unusual case of inconsistent aromaticity perception."""
+        """Test an unusual case of inconsistent aromaticity perception.
+
+        Update: Highly-strained fused rings are no longer considered aromatic.
+        That prevents the inconsistent aromatic structure for this molecule."""
         mol1 = Molecule().from_adjacency_list("""
 multiplicity 2
 1  C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This implements an additional heuristic in aromaticity perception which limits the types of molecules which are considered aromatic. Generally, aromaticity requires that a molecule be planar, in order to enable the sharing of pi-electrons across the molecule. (Some amount of curvature is acceptable, such as with corannulene or bucky-balls.)

If there is substantial strain in a molecule, it can negate the potential effects of aromaticity. For example,

![image](https://user-images.githubusercontent.com/10817103/65797268-c7ed0f00-e13c-11e9-9398-1b3f91cd6c70.png)

is quite unstable despite having the correct number of pi-electrons to suggest aromaticity.

### Description of Changes
The new heuristic checks for sharing of more than 2 atoms between two rings, which will always break planarity. In such cases, RMG will no longer consider either ring to be aromatic, even if Huckel's rule is met.

The practical effect of doing so is that those rings will be represented using single/double bonds and aliphatic carbon atom types, which will affect thermo and kinetic estimation.

For the example above, the previous best resonance structure was

![image](https://user-images.githubusercontent.com/10817103/65797954-73e32a00-e13e-11e9-8560-2478e544a9fe.png)

with a GAV estimated H298 of 359.4 kJ/mol.

With these changes, the new best resonance structure is

![image](https://user-images.githubusercontent.com/10817103/65798210-0d124080-e13f-11e9-91d5-8e684d2f1b0d.png)

with a GAV estimated H298 of 397.6 kJ/mol.

Unfortunately, this is still quite far from the quantum result of 744.6 kJ/mol using M06-2X/cc-pVTZ, but is at least in the right direction.

Previously, a major concern with this change was the possibility of having duplicate species due to not having a "canonical" resonance structure. For aromatics, the fully aromatic structure is the most reliable for identifying identical species because it is always consistent., while structures with double bonds may have multiple possible double bond arrangements. However, that is no longer an issue since the implementation of the resonance-agnostic isomorphism method.

Now, I see this mainly as improving the accuracy of resonance structure representations, with a mild effect of shifting thermo and kinetics estimates for these strained species towards aliphatic behavior.

### Testing
I have been running jobs with this change for a very long time. It doesn't substantially affect models, but does seem to slightly reduce the appearance of weird aromatic species.

### Reviewing
Not sure who to assign, so if anyone would like to volunteer, that would be appreciated :)
