### PR TITLE
Add thermo library list to rmgpy/data/thermoTest.py

### DIFF
--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -54,7 +54,10 @@ def setUpModule():
     """A function that is run ONCE before all unit tests in this module."""
     global database
     database = RMGDatabase()
-    database.load_thermo(os.path.join(settings['database.directory'], 'thermo'))
+    database.load_thermo(
+        os.path.join(settings['database.directory'], 'thermo'),
+        thermo_libraries=['DFT_QCI_thermo', 'SABIC_aromatics', 'primaryThermoLibrary']
+    )
 
 
 def tearDownModule():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
By default, RMG loads all thermo libraries by searching the libraries directory using os.walk, which uses os.scandir to get files. The resulting file (and library) order is arbitrary.

Additionally, changes the the database (such as adding new libraries) could potentially affect these tests.

This fixes #1733.

### Description of Changes
This PR adds a thermo library list when loading the thermo database in thermoTest, which ensures more deterministic behavior. The chosen libraries were the minimum necessary for all existing tests to pass.

### Testing
Confirm that unit tests pass.
