### PR TITLE
Do not force change matplotlib backend in tools.plot

### DIFF
--- a/rmgpy/tools/plot.py
+++ b/rmgpy/tools/plot.py
@@ -35,7 +35,7 @@ import matplotlib as mpl
 # Force matplotlib to not use any Xwindows backend.
 # This must be called before pylab, matplotlib.pyplot, or matplotlib.backends is imported
 # Do not warn if the backend has already been set, e.g. when running from an IPython notebook
-mpl.use('Agg', warn=False)
+mpl.use('Agg', warn=False, force=False)
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
While working with an ipython notebook, I noticed that the matplotlib backend was being set to `agg` which was not happening before. Turns out that the default value for the `force` argument in `matplotlib.use` changed from False to True in matplotlib 3, which meant that it would always try to change the backend even it it was previously set.

### Description of Changes
Provide `force=False` as an argument to `mpl.use`.

### Testing
I've confirmed that this works in an ipython notebook.
