### PR TITLE
Fix inconsistent molecule fingerprint generation

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -988,7 +988,8 @@ class Molecule(Graph):
         if self._fingerprint is None:
             # Include these elements in this order at minimum
             element_dict = {'C': 0, 'H': 0, 'N': 0, 'O': 0, 'S': 0}
-            element_dict.update(self.get_element_count())
+            all_elements = sorted(self.get_element_count().items(), key=lambda x: x[0])  # Sort alphabetically
+            element_dict.update(all_elements)
             self._fingerprint = ''.join([f'{symbol}{num:0>2}' for symbol, num in element_dict.items()])
         return self._fingerprint
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2537,6 +2537,36 @@ multiplicity 2
         self.molecule[0].fingerprint = 'nitronate'
         self.assertEqual(self.molecule[0].fingerprint, 'nitronate')
 
+    def test_fingerprint_property_more_elements(self):
+        """Test that the Molecule.fingerprint property is consistent with many elements"""
+        mol1 = Molecule().from_adjacency_list("""
+1 Cl u0 p3 c0 {2,S}
+2 C  u0 p0 c0 {1,S} {3,S} {4,S} {6,S}
+3 F  u0 p3 c0 {2,S}
+4 O  u0 p2 c0 {2,S} {5,S}
+5 O  u0 p2 c0 {4,S} {7,S}
+6 H  u0 p0 c0 {2,S}
+7 H  u0 p0 c0 {5,S}
+""")
+        mol2 = Molecule().from_adjacency_list("""
+1 Cl u0 p3 c0 {5,S}
+2 F u0 p3 c0 {5,S}
+3 O u0 p2 c0 {4,S} {5,S}
+4 O u0 p2 c0 {3,S} {7,S}
+5 C u0 p0 c0 {1,S} {2,S} {3,S} {6,S}
+6 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {4,S}
+""")
+        # Confirm that atom orders are different
+        mol1_atoms = ''.join([atom.symbol for atom in mol1.atoms])
+        mol2_atoms = ''.join([atom.symbol for atom in mol2.atoms])
+        self.assertNotEqual(mol1_atoms, mol2_atoms)
+
+        # Test getting fingerprint
+        expected = 'C01H02N00O02S00Cl01F01'
+        self.assertEqual(mol1.fingerprint, expected)
+        self.assertEqual(mol2.fingerprint, expected)
+
     def test_saturate_unfilled_valence(self):
         """
         Test the saturateUnfilledValence for an aromatic and nonaromatic case


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The updated fingerprint approach resulted in different fingerprint depending on atom order when the molecule contained more than two elements aside from CHNOS.

This fixes #1740.

### Description of Changes
This fixes the issue by sorting the elements alphabetically.

### Testing
A unit test was written and the case outlined in the issue was also confirmed to work properly.
