### PR TITLE
added orca parser to arkane

### DIFF
--- a/arkane/data/Orca_TS_test.log
+++ b/arkane/data/Orca_TS_test.log
@@ -1,0 +1,5229 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #  Department of molecular theory and spectroscopy    #
+                  #              Directorship: Frank Neese              #
+                  # Max Planck Institute for Chemical Energy Conversion #
+                  #                  D-45470 Muelheim/Ruhr              #
+                  #                       Germany                       #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.0.1.2 - RELEASE -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Ute Becker             : Parallelization
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Dagmar Lenk            : GEPOL surface
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Georgi Stoychev        : AutoAux
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+leaving
+Your calculation utilizes the basis: def2-SVP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+Warning: TCutStore was < 0. Adjusted to Thresh (uncritical)
+
+WARNING: Direct SCF is incompatible with Method<>HF and Method<>DFT
+  ===> : conventional SCF is chosen
+
+WARNING: The NDO methods need Guess=HUECKEL or Guess=HCORE or Guess=MOREAD
+  ===> : Guess is set to Hueckel
+
+WARNING: The NDO methods need %rel::SOCType==1
+  ===> : %rel::SOCType is set to 1
+
+WARNING: The NDO methods cannot have frozencore=1
+  ===> : %method FrozenCore=0 end
+
+WARNING: Geometry Optimization
+  ===> : Switching off AutoStart
+         For restart on a previous wavefunction, please use MOREAD
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = TS_test.inp
+|  1> ! PM3 OptTS NumFreq
+|  2> 
+|  3> *xyz -1 1
+|  4>   C   -1.99283303076949     -0.43906204115263    0.01309547131865
+|  5>   Cl  0.08654162182067     -0.43514846620583     -0.01623959206210
+|  6>   H   -2.09531444966205     -1.26265127699215    0.70686814906647
+|  7>   H   -2.12108831451492     -0.62708960496606     -1.04443065188875
+|  8>   H   -2.10329090994441      0.57197871671963    0.38153156676382
+|  9>   F   -4.09261491692978     -0.44315732740297    0.04308505680191
+| 10> *
+| 11> 
+| 12> 
+| 13>                          ****END OF INPUT****
+================================================================================
+
+                       *****************************
+                       * Geometry Optimization Run *
+                       *****************************
+
+Geometry optimization settings:
+Update method            Update   .... Bofill
+Choice of coordinates    CoordSys .... Redundant Internals
+Initial Hessian          InHess   .... Almoef's Model
+
+Convergence Tolerances:
+Energy Change            TolE     ....  5.0000e-06 Eh
+Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+
+------------------------------------------------------------------------------
+                        ORCA OPTIMIZATION COORDINATE SETUP
+------------------------------------------------------------------------------
+
+The optimization will be done in new redundant internal coordinates
+Making redundant internal coordinates   ...  (new redundants) done
+Following TS mode number                ...     0
+Evaluating the initial hessian          ...  (Almloef) done
+Evaluating the coordinates              ...  done
+Calculating the B-matrix                .... done
+Calculating the G-matrix                .... done
+Diagonalizing the G-matrix              .... done
+The first mode is                       ....    5
+The number of degrees of freedom        ....   12
+
+    -----------------------------------------------------------------
+                    Redundant Internal Coordinates
+
+
+    -----------------------------------------------------------------
+         Definition                    Initial Value    Approx d2E/dq
+    -----------------------------------------------------------------
+      1. B(Cl  1,C   0)                  2.0796         0.111313   
+      2. B(H   2,C   0)                  1.0817         0.371219   
+      3. B(H   3,C   0)                  1.0817         0.371192   
+      4. B(H   4,C   0)                  1.0817         0.371202   
+      5. B(F   5,H   2)                  2.2586         0.004094   
+      6. B(F   5,H   3)                  2.2591         0.004088   
+      7. B(F   5,C   0)                  2.1000         0.038301   
+      8. B(F   5,H   4)                  2.2589         0.004091   
+      9. A(Cl  1,C   0,H   3)           96.0323         0.279537   
+     10. A(H   2,C   0,H   3)          118.9096         0.293634   
+     11. A(Cl  1,C   0,H   4)           96.0356         0.279538   
+     12. A(H   2,C   0,H   4)          118.9137         0.293635   
+     13. A(H   3,C   0,H   4)          118.9029         0.293632   
+     14. A(H   2,C   0,F   5)           83.9513         0.228553   
+     15. A(H   3,C   0,F   5)           83.9769         0.228551   
+     16. A(H   4,C   0,F   5)           83.9646         0.228552   
+     17. A(Cl  1,C   0,H   2)           96.0392         0.279540   
+    -----------------------------------------------------------------
+
+Number of atoms                         .... 6
+Number of degrees of freedom            .... 17
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   1            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -1.992833   -0.439062    0.013095
+  Cl     0.086542   -0.435148   -0.016240
+  H     -2.095314   -1.262651    0.706868
+  H     -2.121088   -0.627090   -1.044431
+  H     -2.103291    0.571979    0.381532
+  F     -4.092615   -0.443157    0.043085
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.765909   -0.829707    0.024747
+   1 Cl    7.0000    0    35.453    0.163540   -0.822311   -0.030688
+   2 H     1.0000    0     1.008   -3.959570   -2.386065    1.335787
+   3 H     1.0000    0     1.008   -4.008276   -1.185028   -1.973688
+   4 H     1.0000    0     1.008   -3.974644    1.080883    0.720990
+   5 F     7.0000    0    18.998   -7.733921   -0.837446    0.081419
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.079585248997     0.00000000     0.00000000
+ H      1   2   0     1.081721867671    96.03923901     0.00000000
+ H      1   2   3     1.081741782418    96.03225690   239.99909738
+ H      1   2   3     1.081734493107    96.03564198   120.00574515
+ F      1   2   3     2.100000027632   179.98926119    28.59468781
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.929846592747     0.00000000     0.00000000
+ H      1   2   0     2.044158082973    96.03923901     0.00000000
+ H      1   2   3     2.044195716389    96.03225690   239.99909738
+ H      1   2   3     2.044181941588    96.03564198   120.00574515
+ F      1   2   3     3.968424933451   179.98926119    28.59468781
+
+----------------------------
+SLATER BASIS SET DIM=  15
+----------------------------
+  0 C     2 shells
+ l=0 nsto= 1
+    2       1.565085000000        1.000000000000
+ l=1 nsto= 1
+    2       1.842345000000        1.000000000000
+  1 Cl    2 shells
+ l=0 nsto= 1
+    3       2.246210000000        1.000000000000
+ l=1 nsto= 1
+    3       2.151010000000        1.000000000000
+  2 H     1 shells
+ l=0 nsto= 1
+    1       0.967807000000        1.000000000000
+  3 H     1 shells
+ l=0 nsto= 1
+    1       0.967807000000        1.000000000000
+  4 H     1 shells
+ l=0 nsto= 1
+    1       0.967807000000        1.000000000000
+  5 F     2 shells
+ l=0 nsto= 1
+    2       4.708555000000        1.000000000000
+ l=1 nsto= 1
+    2       2.491178000000        1.000000000000
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ ZDO-Hamiltonian        Method          .... NDDO
+
+
+General Settings:
+ Integral files         IntName         .... TS_test
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....   -1
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   22
+ Basis Dimension        Dim             ....   15
+ Nuclear Repulsion      ENuc            ....     32.1958375736 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Conventional
+ Integral Buffer length BufferLength    .... 1048576
+ Integral index format  IndFormat       ....     0
+ Integral value format  ValFormat       ....     0
+ Integral Storage       Thresh          ....  2.500e-11 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.028e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.006 sec
+Total time needed                          ...    0.006 sec
+
+-------------------------------
+INITIAL GUESS: EXTENDED HUECKEL
+-------------------------------
+EHT matrix was read from disk
+EHT matrix was diagonalized
+Initial density was built
+                      ------------------
+                      INITIAL GUESS DONE
+                      ------------------
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8034163655   0.000000000000 0.04678624  0.00465114  0.3469338 0.7000
+  1    -33.8184142649  -0.014997899370 0.03960933  0.00459088  0.2615279 0.7000
+                               ***Turning on DIIS***
+  2    -33.8303740683  -0.011959803437 0.03446439  0.00395026  0.1902981 0.7000
+  3    -33.8425333707  -0.012159302378 0.03416851  0.00364999  0.1376724 0.7000
+  4    -33.8527480094  -0.010214638639 0.10423088  0.01072709  0.0978136 0.0000
+  5    -33.8658449949  -0.013096985585 0.01955374  0.00200201  0.0125753 0.0000
+  6    -33.8729201712  -0.007075176227 0.01652469  0.00178225  0.0078507 0.0000
+  7    -33.8701833303   0.002736840843 0.00867338  0.00094170  0.0037713 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  8    -33.86761403   0.0025692979  0.001460  0.001460  0.003908  0.000408
+  9    -33.86552568   0.0020883535  0.000527  0.001568  0.002294  0.000234
+ 10    -33.86552843  -0.0000027462  0.000207  0.001168  0.001726  0.000192
+ 11    -33.86552919  -0.0000007666  0.000027  0.000059  0.000101  0.000019
+ 12    -33.86552921  -0.0000000196  0.000010  0.000032  0.000056  0.000010
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  13 CYCLES          *
+               *****************************************************
+
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :          -33.86552921 Eh            -921.52790 eV
+
+Components:
+Nuclear Repulsion  :           32.19583757 Eh             876.09328 eV
+Electronic Energy  :          -66.06136679 Eh           -1797.62118 eV
+One Electron Energy:         -121.92723760 Eh           -3317.80881 eV
+Two Electron Energy:           55.86587081 Eh            1520.18763 eV
+
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -3.2418e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    6.4462e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.2570e-06  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    1.6816e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    3.8050e-06  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -1.843823       -50.1730 
+   1   2.0000      -0.867997       -23.6194 
+   2   2.0000      -0.380254       -10.3472 
+   3   2.0000      -0.380240       -10.3468 
+   4   2.0000      -0.339591        -9.2407 
+   5   2.0000      -0.276646        -7.5279 
+   6   2.0000      -0.228275        -6.2117 
+   7   2.0000      -0.228274        -6.2117 
+   8   2.0000      -0.196954        -5.3594 
+   9   2.0000      -0.196952        -5.3593 
+  10   2.0000      -0.158743        -4.3196 
+  11   0.0000       0.177582         4.8322 
+  12   0.0000       0.284775         7.7491 
+  13   0.0000       0.323299         8.7974 
+  14   0.0000       0.323316         8.7979 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 C :    0.124749
+   1 Cl:   -0.653931
+   2 H :    0.117103
+   3 H :    0.117026
+   4 H :    0.117061
+   5 F :   -0.822008
+Sum of atomic charges:   -1.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 C s       :     1.559894  s :     1.559894
+      pz      :     0.906759  p :     2.315358
+      px      :     0.501741
+      py      :     0.906857
+  1 Cls       :     2.004029  s :     2.004029
+      pz      :     2.000121  p :     5.649902
+      px      :     1.649591
+      py      :     2.000190
+  2 H s       :     0.882897  s :     0.882897
+  3 H s       :     0.882974  s :     0.882974
+  4 H s       :     0.882939  s :     0.882939
+  5 F s       :     1.990048  s :     1.990048
+      pz      :     1.999345  p :     5.831959
+      px      :     1.833237
+      py      :     1.999377
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 C :    0.329639
+   1 Cl:   -0.639830
+   2 H :    0.043686
+   3 H :    0.043629
+   4 H :    0.043654
+   5 F :   -0.820777
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 C s       :     1.194666  s :     1.194666
+      pz      :     0.975528  p :     2.475695
+      px      :     0.524537
+      py      :     0.975631
+  1 Cls       :     1.993608  s :     1.993608
+      pz      :     1.999907  p :     5.646223
+      px      :     1.646340
+      py      :     1.999976
+  2 H s       :     0.956314  s :     0.956314
+  3 H s       :     0.956371  s :     0.956371
+  4 H s       :     0.956346  s :     0.956346
+  5 F s       :     1.989961  s :     1.989961
+      pz      :     1.999373  p :     5.830816
+      px      :     1.832037
+      py      :     1.999406
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 C      3.8753     4.0000     0.1247     3.4198     3.4198    -0.0000
+  1 Cl     7.6539     7.0000    -0.6539     0.5715     0.5715     0.0000
+  2 H      0.8829     1.0000     0.1171     0.9863     0.9863    -0.0000
+  3 H      0.8830     1.0000     0.1170     0.9863     0.9863     0.0000
+  4 H      0.8829     1.0000     0.1171     0.9863     0.9863    -0.0000
+  5 F      7.8220     7.0000    -0.8220     0.3253     0.3253    -0.0000
+
+  Mayer bond orders larger than 0.1
+B(  0-C ,  1-Cl) :   0.4902 B(  0-C ,  2-H ) :   0.8886 B(  0-C ,  3-H ) :   0.8887 
+B(  0-C ,  4-H ) :   0.8886 B(  0-C ,  5-F ) :   0.2636 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+Total time                  ....       0.443 sec
+Sum of individual times     ....       0.195 sec  ( 44.1%)
+
+Fock matrix formation       ....       0.091 sec  ( 20.6%)
+Diagonalization             ....       0.003 sec  (  0.7%)
+Density matrix formation    ....       0.000 sec  (  0.0%)
+Population analysis         ....       0.020 sec  (  4.4%)
+Initial guess               ....       0.003 sec  (  0.7%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.073 sec  ( 16.4%)
+SOSCF solution              ....       0.006 sec  (  1.3%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.865529214590
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.005109514    0.000009860   -0.000072593
+   2   Cl  :   -0.000001000    0.000000669   -0.000001713
+   3   H   :   -0.000004978   -0.000000063   -0.000000362
+   4   H   :    0.000005362    0.000000074   -0.000001689
+   5   H   :    0.000000186    0.000000867   -0.000000412
+   6   F   :   -0.005109084   -0.000011407    0.000076768
+
+Norm of the cartesian gradient     ...    0.007226432
+RMS gradient                       ...    0.001703286
+MAX gradient                       ...    0.005109514
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.865529215 Eh
+Current gradient norm                   ....     0.007226432 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Evaluating the initial hessian          ....  (Almloef) done
+Projecting the Hessian                  .... done
+Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+  0.013869133  0.052341127  0.052342641  0.111312836  0.178483070
+Hessian has   0 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue   0.01386913 and components:
+   1.    0.00000000
+   2.   -0.00513137
+   3.   -0.00514089
+   4.   -0.00513639
+   5.   -0.49242961
+   6.   -0.49251550
+   7.   -0.51994867
+   8.   -0.49247505
+   9.    0.01762678
+  10.   -0.00631694
+  11.    0.01762756
+  12.   -0.00631875
+  13.   -0.00631498
+  14.   -0.01760962
+  15.   -0.01764499
+  16.   -0.01762850
+  17.    0.01762877
+
+Lambda that maximizes along the TS mode:       0.01436066
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00004037   step =   0.00004037
+In cycle   2: lambdaN =  -0.00004037   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00004037
+Calculated stepsize too large (   0.6530 >    0.3000). Scaled with    0.4595.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0349499659 RMS(Int)=    0.0715479050
+ Iter   1:  RMS(Cart)=    0.0004850679 RMS(Int)=    0.0005426299
+ Iter   2:  RMS(Cart)=    0.0000095736 RMS(Int)=    0.0000127106
+ Iter   3:  RMS(Cart)=    0.0000003428 RMS(Int)=    0.0000004040
+ Iter   4:  RMS(Cart)=    0.0000000118 RMS(Int)=    0.0000000132
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          RMS gradient        0.0009180921            0.0001000000      NO
+          MAX gradient        0.0028046942            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1378356815            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0729      Max(Angles)    2.63
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.0796 -0.000001  0.0000    2.0796   
+     2. B(H   2,C   0)                1.0817 -0.000331  0.0071    1.0888   
+     3. B(H   3,C   0)                1.0817 -0.000333  0.0071    1.0888   
+     4. B(H   4,C   0)                1.0817 -0.000332  0.0071    1.0888   
+     5. B(F   5,H   2)                2.2586  0.000870  0.0729    2.3316          0.49
+     6. B(F   5,H   3)                2.2591  0.000877  0.0729    2.3320          0.49
+     7. B(F   5,C   0)                2.1000  0.002805  0.0729    2.1729          0.52
+     8. B(F   5,H   4)                2.2589  0.000874  0.0729    2.3318          0.49
+     9. A(Cl  1,C   0,H   3)           96.03  0.000772   -2.63     93.40   
+    10. A(H   2,C   0,H   3)          118.91 -0.000278    0.94    119.85   
+    11. A(Cl  1,C   0,H   4)           96.04  0.000776   -2.63     93.40   
+    12. A(H   2,C   0,H   4)          118.91 -0.000277    0.94    119.86   
+    13. A(H   3,C   0,H   4)          118.90 -0.000279    0.94    119.85   
+    14. A(H   2,C   0,F   5)           83.95 -0.000778    2.63     86.58   
+    15. A(H   3,C   0,F   5)           83.98 -0.000774    2.63     86.61   
+    16. A(H   4,C   0,F   5)           83.96 -0.000776    2.63     86.60   
+    17. A(Cl  1,C   0,H   2)           96.04  0.000779   -2.63     93.41   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   2            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.001796   -0.439076    0.013215
+  Cl     0.077581   -0.435168   -0.016107
+  H     -2.068853   -1.268155    0.711161
+  H     -2.094802   -0.628306   -1.051957
+  H     -2.076884    0.578855    0.383630
+  F     -4.153845   -0.443280    0.043968
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.782847   -0.829734    0.024973
+   1 Cl    7.0000    0    35.453    0.146606   -0.822348   -0.030437
+   2 H     1.0000    0     1.008   -3.909565   -2.396465    1.343899
+   3 H     1.0000    0     1.008   -3.958603   -1.187326   -1.987911
+   4 H     1.0000    0     1.008   -3.924742    1.093877    0.724956
+   5 F     7.0000    0    18.998   -7.849629   -0.837678    0.083087
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.079587377141     0.00000000     0.00000000
+ H      1   2   0     1.085815962446    94.14315911     0.00000000
+ H      1   2   3     1.085840787787    94.13696134   239.99910717
+ H      1   2   3     1.085831101984    94.13997400   120.00556396
+ F      1   2   3     2.152272464787   179.98839423    28.52655910
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.929850614356     0.00000000     0.00000000
+ H      1   2   0     2.051894800863    94.14315911     0.00000000
+ H      1   2   3     2.051941713958    94.13696134   239.99910717
+ H      1   2   3     2.051923410444    94.13997400   120.00556396
+ F      1   2   3     4.067205524028   179.98839423    28.52655910
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.050e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.002 sec
+Total time needed                          ...    0.002 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8639909006   0.000000000000 0.00267761  0.00039403  0.0061006 0.7000
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  1    -33.86405218  -0.0000612835  0.001690  0.001690  0.010428  0.001458
+  2    -33.86426414  -0.0002119589  0.001463  0.003827  0.005574  0.000732
+  3    -33.86429901  -0.0000348658  0.000494  0.001434  0.002131  0.000314
+  4    -33.86430277  -0.0000037618  0.000036  0.000087  0.000124  0.000020
+  5    -33.86430280  -0.0000000283  0.000019  0.000093  0.000131  0.000017
+  6    -33.86430281  -0.0000000068  0.000004  0.000007  0.000011  0.000001
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   7 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86430281 Eh            -921.49453 eV
+  Last Energy change         ...   -1.1005e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    3.8711e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.864302805737
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.002325337   -0.000004543    0.000033329
+   2   Cl  :   -0.001272040   -0.000001774    0.000016353
+   3   H   :    0.004450273   -0.002573764    0.002107960
+   4   H   :    0.004382353   -0.000581368   -0.003389258
+   5   H   :    0.004431844    0.003182265    0.001088445
+   6   F   :   -0.009667093   -0.000020816    0.000143171
+
+Norm of the cartesian gradient     ...    0.013905245
+RMS gradient                       ...    0.003277498
+MAX gradient                       ...    0.009667093
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.864302806 Eh
+Current gradient norm                   ....     0.013905245 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+  0.013628306  0.052341128  0.052342642  0.111493535  0.166318937
+Hessian has   0 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue   0.01362831 and components:
+   1.    0.04373807
+   2.    0.00429448
+   3.    0.00428656
+   4.    0.00429003
+   5.    0.51199395
+   6.    0.51184464
+   7.    0.42312345
+   8.    0.51191733
+   9.   -0.07258092
+  10.    0.01992220
+  11.   -0.07260006
+  12.    0.01993781
+  13.    0.01990403
+  14.    0.07263947
+  15.    0.07256362
+  16.    0.07260061
+  17.   -0.07262273
+
+Lambda that maximizes along the TS mode:       0.01598662
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00011622   step =   0.00011622
+In cycle   2: lambdaN =  -0.00011622   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00011622
+Calculated stepsize too large (   0.7643 >    0.3000). Scaled with    0.3925.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0351647026 RMS(Int)=    0.0692545954
+ Iter   1:  RMS(Cart)=    0.0010840087 RMS(Int)=    0.0011402029
+ Iter   2:  RMS(Cart)=    0.0000276741 RMS(Int)=    0.0000399537
+ Iter   3:  RMS(Cart)=    0.0000019938 RMS(Int)=    0.0000020933
+ Iter   4:  RMS(Cart)=    0.0000000701 RMS(Int)=    0.0000000877
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change       0.0012264089            0.0000050000      NO
+          RMS gradient        0.0018702452            0.0001000000      NO
+          MAX gradient        0.0035396405            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1177488619            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0623      Max(Angles)    4.11
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.0796 -0.001272  0.0265    2.1061   
+     2. B(H   2,C   0)                1.0858  0.001642  0.0013    1.0871   
+     3. B(H   3,C   0)                1.0858  0.001642  0.0013    1.0871   
+     4. B(H   4,C   0)                1.0858  0.001642  0.0013    1.0871   
+     5. B(F   5,H   2)                2.3394  0.003530  0.0623    2.4017          0.51
+     6. B(F   5,H   3)                2.3399  0.003540  0.0623    2.4022          0.51
+     7. B(F   5,C   0)                2.1523  0.000268  0.0623    2.2146          0.42
+     8. B(F   5,H   4)                2.3396  0.003535  0.0623    2.4019          0.51
+     9. A(Cl  1,C   0,H   3)           94.14 -0.001407   -4.11     90.03   
+    10. A(H   2,C   0,H   3)          119.48  0.000348    1.12    120.60   
+    11. A(Cl  1,C   0,H   4)           94.14 -0.001404   -4.11     90.03   
+    12. A(H   2,C   0,H   4)          119.49  0.000348    1.12    120.61   
+    13. A(H   3,C   0,H   4)          119.48  0.000349    1.12    120.59   
+    14. A(H   2,C   0,F   5)           85.85  0.001402    4.11     89.96   
+    15. A(H   3,C   0,F   5)           85.87  0.001407    4.11     89.98   
+    16. A(H   4,C   0,F   5)           85.86  0.001404    4.11     89.97   
+    17. A(Cl  1,C   0,H   2)           94.14 -0.001401   -4.11     90.03   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   3            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.029026   -0.439125    0.013593
+  Cl     0.076842   -0.435175   -0.016083
+  H     -2.040722   -1.267269    0.710056
+  H     -2.066678   -0.628056   -1.051282
+  H     -2.048762    0.577887    0.382849
+  F     -4.210253   -0.443392    0.044776
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.834304   -0.829826    0.025688
+   1 Cl    7.0000    0    35.453    0.145211   -0.822361   -0.030392
+   2 H     1.0000    0     1.008   -3.856406   -2.394791    1.341812
+   3 H     1.0000    0     1.008   -3.905456   -1.186854   -1.986636
+   4 H     1.0000    0     1.008   -3.871600    1.092047    0.723480
+   5 F     7.0000    0    18.998   -7.956226   -0.837889    0.084615
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.106081588442     0.00000000     0.00000000
+ H      1   2   0     1.082136737116    91.22111842     0.00000000
+ H      1   2   3     1.082161210671    91.21770841   239.99907223
+ H      1   2   3     1.082151445729    91.21941825   120.00603358
+ F      1   2   3     2.181453957136   179.98743030    28.39918020
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.979917417849     0.00000000     0.00000000
+ H      1   2   0     2.044942072605    91.22111842     0.00000000
+ H      1   2   3     2.044988320922    91.21770841   239.99907223
+ H      1   2   3     2.044969867854    91.21941825   120.00603358
+ F      1   2   3     4.122350552746   179.98743030    28.39918020
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.038e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.004 sec
+Total time needed                          ...    0.005 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8607509190   0.000000000000 0.00381754  0.00051922  0.0147047 0.7000
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  1    -33.86088582  -0.0001348993  0.002836  0.002836  0.013657  0.001867
+  2    -33.86137744  -0.0004916176  0.003365  0.006188  0.007881  0.001187
+  3    -33.86149854  -0.0001210995  0.001569  0.005585  0.007236  0.001156
+  4    -33.86153549  -0.0000369538  0.000182  0.000613  0.000871  0.000099
+  5    -33.86153593  -0.0000004395  0.000067  0.000302  0.000437  0.000051
+  6    -33.86153600  -0.0000000686  0.000006  0.000013  0.000015  0.000003
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   7 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86153600 Eh            -921.41924 eV
+  Last Energy change         ...   -5.6153e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.2414e-05  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.861535997822
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.006941157   -0.000012231    0.000096357
+   2   Cl  :   -0.002992275   -0.000005433    0.000041668
+   3   H   :    0.009163963   -0.000985731    0.000713107
+   4   H   :    0.009144320   -0.000211640   -0.001424142
+   5   H   :    0.009160279    0.001251397    0.000316994
+   6   F   :   -0.017535129   -0.000036362    0.000256016
+
+Norm of the cartesian gradient     ...    0.024928284
+RMS gradient                       ...    0.005875653
+MAX gradient                       ...    0.017535129
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.861535998 Eh
+Current gradient norm                   ....     0.024928284 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+  0.020044132  0.052341128  0.052342642  0.109582239  0.150915428
+Hessian has   0 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue   0.02004413 and components:
+   1.   -0.27699019
+   2.   -0.00569982
+   3.   -0.00569752
+   4.   -0.00569870
+   5.   -0.49105525
+   6.   -0.49066989
+   7.   -0.21776800
+   8.   -0.49085409
+   9.    0.15883046
+  10.   -0.02202438
+  11.    0.15888404
+  12.   -0.02207264
+  13.   -0.02196708
+  14.   -0.15898194
+  15.   -0.15879581
+  16.   -0.15888459
+  17.    0.15894784
+
+Lambda that maximizes along the TS mode:       0.02563585
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00048752   step =   0.00048752
+In cycle   2: lambdaN =  -0.00048753   step =   0.00000001
+Lambda that minimizes along all other modes:  -0.00048753
+Calculated stepsize too large (   0.9983 >    0.3000). Scaled with    0.3005.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0345286890 RMS(Int)=    0.0667274029
+ Iter   1:  RMS(Cart)=    0.0016198667 RMS(Int)=    0.0016749392
+ Iter   2:  RMS(Cart)=    0.0000479178 RMS(Int)=    0.0000703935
+ Iter   3:  RMS(Cart)=    0.0000046372 RMS(Int)=    0.0000047111
+ Iter   4:  RMS(Cart)=    0.0000001515 RMS(Int)=    0.0000002160
+ Iter   5:  RMS(Cart)=    0.0000000130 RMS(Int)=    0.0000000132
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change       0.0027668079            0.0000050000      NO
+          RMS gradient        0.0035334478            0.0001000000      NO
+          MAX gradient        0.0063375106            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.0901530148            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0477      Max(Angles)    5.17
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.1061 -0.002993  0.0477    2.1538          0.28
+     2. B(H   2,C   0)                1.0821 -0.001599  0.0026    1.0847   
+     3. B(H   3,C   0)                1.0822 -0.001600  0.0026    1.0847   
+     4. B(H   4,C   0)                1.0822 -0.001599  0.0026    1.0847   
+     5. B(F   5,H   2)                2.4142  0.006327  0.0477    2.4619          0.49
+     6. B(F   5,H   3)                2.4146  0.006338  0.0477    2.4623          0.49
+     7. B(F   5,C   0)                2.1815  0.000554  0.0477    2.2292   
+     8. B(F   5,H   4)                2.4144  0.006332  0.0477    2.4621          0.49
+     9. A(Cl  1,C   0,H   3)           91.22 -0.003532   -5.17     86.05   
+    10. A(H   2,C   0,H   3)          119.96  0.000260    0.76    120.72   
+    11. A(Cl  1,C   0,H   4)           91.22 -0.003531   -5.17     86.05   
+    12. A(H   2,C   0,H   4)          119.96  0.000260    0.76    120.72   
+    13. A(H   3,C   0,H   4)          119.95  0.000260    0.76    120.71   
+    14. A(H   2,C   0,F   5)           88.77  0.003528    5.17     93.93   
+    15. A(H   3,C   0,F   5)           88.79  0.003534    5.17     93.96   
+    16. A(H   4,C   0,F   5)           88.78  0.003531    5.17     93.95   
+    17. A(Cl  1,C   0,H   2)           91.22 -0.003531   -5.17     86.06   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   4            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.070132   -0.439203    0.014174
+  Cl     0.083439   -0.435163   -0.016175
+  H     -2.013837   -1.263447    0.706494
+  H     -2.039670   -0.627131   -1.046792
+  H     -2.021838    0.573297    0.380766
+  F     -4.256562   -0.443484    0.045442
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.911982   -0.829973    0.026784
+   1 Cl    7.0000    0    35.453    0.157677   -0.822338   -0.030566
+   2 H     1.0000    0     1.008   -3.805600   -2.387568    1.335081
+   3 H     1.0000    0     1.008   -3.854417   -1.185106   -1.978150
+   4 H     1.0000    0     1.008   -3.820721    1.083375    0.719544
+   5 F     7.0000    0    18.998   -8.043737   -0.838064    0.085874
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.153788509128     0.00000000     0.00000000
+ H      1   2   0     1.077893683009    87.60797902     0.00000000
+ H      1   2   3     1.077911137416    87.60436577   239.99896067
+ H      1   2   3     1.077904855926    87.60615547   120.00760133
+ F      1   2   3     2.186658336927   179.98713482    28.49270216
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.070070432638     0.00000000     0.00000000
+ H      1   2   0     2.036923862370    87.60797902     0.00000000
+ H      1   2   3     2.036956846420    87.60436577   239.99896067
+ H      1   2   3     2.036944976124    87.60615547   120.00760133
+ F      1   2   3     4.132185405247   179.98713482    28.49270216
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.021e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.005 sec
+Total time needed                          ...    0.005 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8556474387   0.000000000000 0.00545550  0.00077023  0.0216944 0.7000
+  1    -33.8559263238  -0.000278885149 0.00588598  0.00085441  0.0183782 0.7000
+                               ***Turning on DIIS***
+  2    -33.8561920978  -0.000265773992 0.01761760  0.00263082  0.0150826 0.0000
+  3    -33.8621321957  -0.005940097837 0.00950942  0.00152286  0.0058512 0.0000
+  4    -33.8615004563   0.000631739348 0.00585818  0.00094151  0.0028079 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.86087450   0.0006259534  0.001940  0.001940  0.003846  0.000570
+  6    -33.85737650   0.0034979993  0.000621  0.001926  0.002472  0.000301
+  7    -33.85738110  -0.0000045941  0.000271  0.001660  0.002088  0.000276
+  8    -33.85738255  -0.0000014562  0.000036  0.000080  0.000075  0.000014
+  9    -33.85738257  -0.0000000130  0.000011  0.000034  0.000047  0.000007
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.85738257 Eh            -921.30622 eV
+  Last Energy change         ...   -1.6087e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.2148e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.857382568539
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.006410116   -0.000009689    0.000084476
+   2   Cl  :   -0.004959677   -0.000009033    0.000069214
+   3   H   :    0.012917723    0.001444770   -0.001378958
+   4   H   :    0.012976186    0.000350880    0.001646757
+   5   H   :    0.012938727   -0.001720978   -0.000819866
+   6   F   :   -0.027462843   -0.000055949    0.000398378
+
+Norm of the cartesian gradient     ...    0.036512834
+RMS gradient                       ...    0.008606158
+MAX gradient                       ...    0.027462843
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.857382569 Eh
+Current gradient norm                   ....     0.036512834 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+  0.015723863  0.052341127  0.052342641  0.110689092  0.144326789
+Hessian has   0 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue   0.01572386 and components:
+   1.   -0.46201694
+   2.   -0.01158364
+   3.   -0.01160416
+   4.   -0.01159490
+   5.   -0.39686877
+   6.   -0.39676919
+   7.    0.02570723
+   8.   -0.39681528
+   9.    0.22839353
+  10.    0.00557257
+  11.    0.22839546
+  12.    0.00548563
+  13.    0.00567583
+  14.   -0.22840678
+  15.   -0.22838749
+  16.   -0.22839535
+  17.    0.22840062
+
+Lambda that maximizes along the TS mode:       0.02495233
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00196104   step =   0.00196104
+In cycle   2: lambdaN =  -0.00196156   step =   0.00000052
+In cycle   3: lambdaN =  -0.00196156   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00196156
+Calculated stepsize too large (   0.9531 >    0.3000). Scaled with    0.3148.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0384552442 RMS(Int)=    0.0723649263
+ Iter   1:  RMS(Cart)=    0.0027928640 RMS(Int)=    0.0028887283
+ Iter   2:  RMS(Cart)=    0.0001084082 RMS(Int)=    0.0001574481
+ Iter   3:  RMS(Cart)=    0.0000137766 RMS(Int)=    0.0000142073
+ Iter   4:  RMS(Cart)=    0.0000005385 RMS(Int)=    0.0000007859
+ Iter   5:  RMS(Cart)=    0.0000000683 RMS(Int)=    0.0000000703
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change       0.0041534293            0.0000050000      NO
+          RMS gradient        0.0055783231            0.0001000000      NO
+          MAX gradient        0.0090817331            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.0944284900            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0500      Max(Angles)    5.41
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.1538 -0.004960  0.0500    2.2038          0.46
+     2. B(H   2,C   0)                1.0779 -0.005595  0.0057    1.0836   
+     3. B(H   3,C   0)                1.0779 -0.005602  0.0057    1.0836   
+     4. B(H   4,C   0)                1.0779 -0.005599  0.0057    1.0836   
+     5. B(F   5,H   2)                2.4777  0.009071  0.0500    2.5277          0.40
+     6. B(F   5,H   3)                2.4782  0.009082  0.0500    2.5281          0.40
+     7. B(F   5,C   0)                2.1867  0.002942 -0.0113    2.1754   
+     8. B(F   5,H   4)                2.4780  0.009077  0.0500    2.5279          0.40
+     9. A(Cl  1,C   0,H   3)           87.60 -0.005051   -5.41     82.19   
+    10. A(H   2,C   0,H   3)          119.83 -0.000729   -0.17    119.66   
+    11. A(Cl  1,C   0,H   4)           87.61 -0.005049   -5.41     82.20   
+    12. A(H   2,C   0,H   4)          119.83 -0.000727   -0.16    119.67   
+    13. A(H   3,C   0,H   4)          119.82 -0.000731   -0.17    119.65   
+    14. A(H   2,C   0,F   5)           92.38  0.005044    5.41     97.79   
+    15. A(H   3,C   0,F   5)           92.41  0.005054    5.41     97.82   
+    16. A(H   4,C   0,F   5)           92.39  0.005049    5.41     97.80   
+    17. A(Cl  1,C   0,H   2)           87.61 -0.005048   -5.41     82.20   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   5            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.127849   -0.439314    0.014994
+  Cl     0.075686   -0.435179   -0.016061
+  H     -1.981617   -1.260004    0.703181
+  H     -2.007342   -0.626281   -1.042876
+  H     -1.989585    0.569197    0.378774
+  F     -4.287893   -0.443549    0.045898
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -4.021052   -0.830184    0.028335
+   1 Cl    7.0000    0    35.453    0.143026   -0.822369   -0.030351
+   2 H     1.0000    0     1.008   -3.744714   -2.381063    1.328820
+   3 H     1.0000    0     1.008   -3.793326   -1.183500   -1.970751
+   4 H     1.0000    0     1.008   -3.759771    1.075627    0.715779
+   5 F     7.0000    0    18.998   -8.102943   -0.838185    0.086734
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.203757913868     0.00000000     0.00000000
+ H      1   2   0     1.080979534747    82.82691111     0.00000000
+ H      1   2   3     1.081003625770    82.82319489   239.99877343
+ H      1   2   3     1.080994374463    82.82502620   120.01026333
+ F      1   2   3     2.160269136901   179.98685974    28.55895708
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.164498922672     0.00000000     0.00000000
+ H      1   2   0     2.042755277046    82.82691111     0.00000000
+ H      1   2   3     2.042800802482    82.82319489   239.99877343
+ H      1   2   3     2.042783320045    82.82502620   120.01026333
+ F      1   2   3     4.082317044306   179.98685974    28.55895708
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.034e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.004 sec
+Total time needed                          ...    0.005 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8488308275   0.000000000000 0.00689849  0.00106210  0.0289396 0.7000
+  1    -33.8493378504  -0.000507022906 0.00744139  0.00119644  0.0245277 0.7000
+                               ***Turning on DIIS***
+  2    -33.8498285600  -0.000490709656 0.02230378  0.00371282  0.0201429 0.0000
+  3    -33.8596599946  -0.009831434612 0.01255756  0.00215750  0.0078539 0.0000
+  4    -33.8578422488   0.001817745837 0.00851154  0.00130206  0.0037624 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.85649112   0.0013511329  0.002651  0.002651  0.005626  0.000759
+  6    -33.85205435   0.0044367697  0.000854  0.002644  0.003468  0.000404
+  7    -33.85206250  -0.0000081506  0.000359  0.002145  0.003030  0.000352
+  8    -33.85206493  -0.0000024318  0.000053  0.000122  0.000150  0.000023
+  9    -33.85206496  -0.0000000316  0.000016  0.000051  0.000074  0.000012
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.85206496 Eh            -921.16152 eV
+  Last Energy change         ...   -4.5457e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    6.1819e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.852064964717
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.000655917   -0.000000563    0.000006657
+   2   Cl  :   -0.012158895   -0.000022509    0.000170640
+   3   H   :    0.017470219    0.001320540   -0.001333863
+   4   H   :    0.017527153    0.000331452    0.001411852
+   5   H   :    0.017491437   -0.001548777   -0.000829029
+   6   F   :   -0.039673997   -0.000080142    0.000573743
+
+Norm of the cartesian gradient     ...    0.051475552
+RMS gradient                       ...    0.012132904
+MAX gradient                       ...    0.039673997
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.852064965 Eh
+Current gradient norm                   ....     0.051475552 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+  0.002972188  0.052341127  0.052342641  0.120316590  0.138160109
+Hessian has   0 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue   0.00297219 and components:
+   1.   -0.55105320
+   2.   -0.02464643
+   3.   -0.02467868
+   4.   -0.02466349
+   5.   -0.26020426
+   6.   -0.26006763
+   7.    0.24164696
+   8.   -0.26013291
+   9.    0.26366661
+  10.    0.07299979
+  11.    0.26366584
+  12.    0.07289168
+  13.    0.07312520
+  14.   -0.26368325
+  15.   -0.26365209
+  16.   -0.26366624
+  17.    0.26366911
+
+Lambda that maximizes along the TS mode:       0.01379159
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00625079   step =   0.00625079
+In cycle   2: lambdaN =  -0.00626594   step =   0.00001516
+In cycle   3: lambdaN =  -0.00626594   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00626594
+Calculated stepsize too large (   0.8946 >    0.3000). Scaled with    0.3353.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0391036973 RMS(Int)=    0.0738139094
+ Iter   1:  RMS(Cart)=    0.0030706616 RMS(Int)=    0.0033398672
+ Iter   2:  RMS(Cart)=    0.0001449256 RMS(Int)=    0.0001914005
+ Iter   3:  RMS(Cart)=    0.0000169157 RMS(Int)=    0.0000196649
+ Iter   4:  RMS(Cart)=    0.0000009374 RMS(Int)=    0.0000010711
+ Iter   5:  RMS(Cart)=    0.0000000894 RMS(Int)=    0.0000001122
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change       0.0053176038            0.0000050000      NO
+          RMS gradient        0.0078351821            0.0001000000      NO
+          MAX gradient        0.0126475125            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1006036986            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0532      Max(Angles)    5.32
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.2038 -0.012160  0.0532    2.2570          0.55
+     2. B(H   2,C   0)                1.0810 -0.006223  0.0078    1.0888   
+     3. B(H   3,C   0)                1.0810 -0.006230  0.0078    1.0888   
+     4. B(H   4,C   0)                1.0810 -0.006227  0.0078    1.0888   
+     5. B(F   5,H   2)                2.5333  0.012636  0.0382    2.5715          0.26
+     6. B(F   5,H   3)                2.5337  0.012648  0.0381    2.5719          0.26
+     7. B(F   5,C   0)                2.1603  0.005319 -0.0532    2.1070   
+     8. B(F   5,H   4)                2.5335  0.012642  0.0382    2.5717          0.26
+     9. A(Cl  1,C   0,H   3)           82.82 -0.006449   -5.31     77.51          0.26
+    10. A(H   2,C   0,H   3)          118.46 -0.002726   -1.43    117.04   
+    11. A(Cl  1,C   0,H   4)           82.83 -0.006448   -5.31     77.51          0.26
+    12. A(H   2,C   0,H   4)          118.47 -0.002721   -1.42    117.05   
+    13. A(H   3,C   0,H   4)          118.45 -0.002732   -1.43    117.02   
+    14. A(H   2,C   0,F   5)           97.16  0.006442    5.32    102.48          0.26
+    15. A(H   3,C   0,F   5)           97.19  0.006453    5.31    102.50          0.26
+    16. A(H   4,C   0,F   5)           97.18  0.006447    5.31    102.49          0.26
+    17. A(Cl  1,C   0,H   2)           82.83 -0.006445   -5.31     77.51          0.26
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   6            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.193377   -0.439447    0.015941
+  Cl     0.063389   -0.435198   -0.015902
+  H     -1.950982   -1.253727    0.697513
+  H     -1.976544   -0.624790   -1.035271
+  H     -1.958907    0.561599    0.375550
+  F     -4.302180   -0.443568    0.046078
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -4.144882   -0.830434    0.030125
+   1 Cl    7.0000    0    35.453    0.119789   -0.822404   -0.030050
+   2 H     1.0000    0     1.008   -3.686821   -2.369201    1.318108
+   3 H     1.0000    0     1.008   -3.735126   -1.180682   -1.956378
+   4 H     1.0000    0     1.008   -3.701797    1.061269    0.709687
+   5 F     7.0000    0    18.998   -8.129943   -0.838222    0.087075
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.256995098250     0.00000000     0.00000000
+ H      1   2   0     1.089195966613    77.74360927     0.00000000
+ H      1   2   3     1.089227028510    77.74009544   239.99858095
+ H      1   2   3     1.089214506759    77.74189115   120.01297759
+ F      1   2   3     2.109022593150   179.98886296    28.32968911
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.265102621296     0.00000000     0.00000000
+ H      1   2   0     2.058282083070    77.74360927     0.00000000
+ H      1   2   3     2.058340781549    77.74009544   239.99858095
+ H      1   2   3     2.058317118869    77.74189115   120.01297759
+ F      1   2   3     3.985475111305   179.98886296    28.32968911
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.063e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.004 sec
+Total time needed                          ...    0.004 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8432969588   0.000000000000 0.00692195  0.00122885  0.0316553 0.7000
+  1    -33.8439448409  -0.000647882111 0.00762192  0.00139319  0.0268075 0.7000
+                               ***Turning on DIIS***
+  2    -33.8445735401  -0.000628699149 0.02520316  0.00431713  0.0219852 0.0000
+  3    -33.8567040939  -0.012130553786 0.01563882  0.00238533  0.0084717 0.0000
+  4    -33.8534843115   0.003219782415 0.01051997  0.00139789  0.0042621 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.85152270   0.0019616143  0.002441  0.002441  0.006677  0.000790
+  6    -33.84736092   0.0041617775  0.000865  0.002691  0.004084  0.000420
+  7    -33.84736996  -0.0000090378  0.000355  0.002141  0.003552  0.000364
+  8    -33.84737267  -0.0000027103  0.000043  0.000103  0.000181  0.000029
+  9    -33.84737271  -0.0000000463  0.000016  0.000052  0.000085  0.000017
+ 10    -33.84737272  -0.0000000079  0.000004  0.000006  0.000013  0.000002
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  11 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.84737272 Eh            -921.03384 eV
+  Last Energy change         ...   -2.7541e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    9.7667e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.847372722294
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.006876892    0.000011058   -0.000093815
+   2   Cl  :   -0.020429937   -0.000038167    0.000287549
+   3   H   :    0.022231921   -0.000025326   -0.000264789
+   4   H   :    0.022247712    0.000034300   -0.000396967
+   5   H   :    0.022240759    0.000124312   -0.000297613
+   6   F   :   -0.053167348   -0.000106176    0.000765634
+
+Norm of the cartesian gradient     ...    0.069111036
+RMS gradient                       ...    0.016289627
+MAX gradient                       ...    0.053167348
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.847372722 Eh
+Current gradient norm                   ....     0.069111036 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.006848408  0.052341125  0.052342639  0.125544155  0.137701238
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.00684841 and components:
+   1.   -0.53887036
+   2.   -0.03781822
+   3.   -0.03784814
+   4.   -0.03783383
+   5.   -0.12991057
+   6.   -0.12953383
+   7.    0.38770543
+   8.   -0.12971529
+   9.    0.26998449
+  10.    0.14961594
+  11.    0.26998820
+  12.    0.14955367
+  13.    0.14968236
+  14.   -0.27008203
+  15.   -0.26990276
+  16.   -0.26998859
+  17.    0.27000070
+
+Lambda that maximizes along the TS mode:       0.00288568
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.01149962   step =   0.01149962
+In cycle   2: lambdaN =  -0.01158127   step =   0.00008165
+In cycle   3: lambdaN =  -0.01158127   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.01158127
+Calculated stepsize too large (   0.5032 >    0.3000). Scaled with    0.5962.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0331891856 RMS(Int)=    0.0731935878
+ Iter   1:  RMS(Cart)=    0.0014691208 RMS(Int)=    0.0016561520
+ Iter   2:  RMS(Cart)=    0.0000534753 RMS(Int)=    0.0000655990
+ Iter   3:  RMS(Cart)=    0.0000037825 RMS(Int)=    0.0000048115
+ Iter   4:  RMS(Cart)=    0.0000001809 RMS(Int)=    0.0000001849
+ Iter   5:  RMS(Cart)=    0.0000000090 RMS(Int)=    0.0000000130
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change       0.0046922424            0.0000050000      NO
+          RMS gradient        0.0101365811            0.0001000000      NO
+          MAX gradient        0.0204319957            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1788572036            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0946      Max(Angles)    3.73
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.2570 -0.020432  0.0946    2.3516          0.54
+     2. B(H   2,C   0)                1.0892 -0.004998  0.0100    1.0992   
+     3. B(H   3,C   0)                1.0892 -0.005004  0.0100    1.0992   
+     4. B(H   4,C   0)                1.0892 -0.005001  0.0100    1.0992   
+     5. B(F   5,H   2)                2.5708  0.016394 -0.0131    2.5577   
+     6. B(F   5,H   3)                2.5711  0.016406 -0.0132    2.5579   
+     7. B(F   5,C   0)                2.1090  0.008388 -0.0853    2.0237          0.39
+     8. B(F   5,H   4)                2.5710  0.016400 -0.0131    2.5578   
+     9. A(Cl  1,C   0,H   3)           77.74 -0.007126   -3.73     74.01          0.27
+    10. A(H   2,C   0,H   3)          115.62 -0.004917   -2.01    113.61   
+    11. A(Cl  1,C   0,H   4)           77.74 -0.007124   -3.73     74.01          0.27
+    12. A(H   2,C   0,H   4)          115.63 -0.004908   -2.01    113.62   
+    13. A(H   3,C   0,H   4)          115.61 -0.004928   -2.01    113.60   
+    14. A(H   2,C   0,F   5)          102.25  0.007118    3.73    105.98          0.27
+    15. A(H   3,C   0,F   5)          102.27  0.007129    3.73    106.00          0.27
+    16. A(H   4,C   0,F   5)          102.26  0.007124    3.73    105.99          0.27
+    17. A(Cl  1,C   0,H   2)           77.74 -0.007121   -3.73     74.01          0.27
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   7            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.257245   -0.439581    0.016879
+  Cl     0.094157   -0.435126   -0.016376
+  H     -1.945979   -1.248980    0.693473
+  H     -1.971464   -0.623704   -1.029207
+  H     -1.953896    0.555769    0.373384
+  F     -4.284173   -0.443509    0.045756
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -4.265576   -0.830687    0.031897
+   1 Cl    7.0000    0    35.453    0.177932   -0.822268   -0.030946
+   2 H     1.0000    0     1.008   -3.677367   -2.360230    1.310474
+   3 H     1.0000    0     1.008   -3.725528   -1.178629   -1.944919
+   4 H     1.0000    0     1.008   -3.692328    1.050251    0.705594
+   5 F     7.0000    0    18.998   -8.095913   -0.838111    0.086467
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.351642253942     0.00000000     0.00000000
+ H      1   2   0     1.099905996272    74.16474576     0.00000000
+ H      1   2   3     1.099940155642    74.16187251   239.99853399
+ H      1   2   3     1.099926164369    74.16347266   120.01358212
+ F      1   2   3     2.027136906849   179.99354948    27.24554277
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.443959824908     0.00000000     0.00000000
+ H      1   2   0     2.078521106012    74.16474576     0.00000000
+ H      1   2   3     2.078585657866    74.16187251   239.99853399
+ H      1   2   3     2.078559218191    74.16347266   120.01358212
+ F      1   2   3     3.830733589909   179.99354948    27.24554277
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.102e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.002 sec
+Total time needed                          ...    0.002 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8472376444   0.000000000000 0.00963753  0.00139293  0.0294848 0.7000
+  1    -33.8479561450  -0.000718500638 0.01186830  0.00159896  0.0248502 0.7000
+                               ***Turning on DIIS***
+  2    -33.8486540867  -0.000697941658 0.03833025  0.00493286  0.0202314 0.0000
+  3    -33.8643594728  -0.015705386159 0.02034473  0.00236037  0.0080165 0.0000
+  4    -33.8593959443   0.004963528570 0.01340419  0.00143890  0.0052395 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.85602595   0.0033699913  0.002428  0.002428  0.008087  0.000812
+  6    -33.85158892   0.0044370333  0.000934  0.002950  0.004892  0.000445
+  7    -33.85159910  -0.0000101797  0.000393  0.002416  0.004285  0.000393
+  8    -33.85160221  -0.0000031078  0.000053  0.000103  0.000197  0.000033
+  9    -33.85160226  -0.0000000563  0.000023  0.000059  0.000127  0.000020
+ 10    -33.85160227  -0.0000000111  0.000005  0.000009  0.000020  0.000003
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  11 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.85160227 Eh            -921.14893 eV
+  Last Energy change         ...   -3.9527e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.1857e-05  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.851602274926
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.018175431    0.000029959   -0.000247254
+   2   Cl  :   -0.019944374   -0.000037550    0.000281397
+   3   H   :    0.023379586   -0.003217930    0.002403680
+   4   H   :    0.023293263   -0.000690948   -0.004522112
+   5   H   :    0.023356438    0.004050465    0.001107512
+   6   F   :   -0.068260344   -0.000133995    0.000976776
+
+Norm of the cartesian gradient     ...    0.084131507
+RMS gradient                       ...    0.019829986
+MAX gradient                       ...    0.068260344
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.851602275 Eh
+Current gradient norm                   ....     0.084131507 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.026277573  0.052341118  0.052342631  0.110852280  0.132377521
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.02627757 and components:
+   1.   -0.50198368
+   2.   -0.04102693
+   3.   -0.04103206
+   4.   -0.04102931
+   5.    0.13716685
+   6.    0.13766844
+   7.    0.58430130
+   8.    0.13742696
+   9.    0.21860141
+  10.    0.13919728
+  11.    0.21861933
+  12.    0.13923101
+  13.    0.13914826
+  14.   -0.21877687
+  15.   -0.21847381
+  16.   -0.21861954
+  17.    0.21864952
+
+Lambda that maximizes along the TS mode:       0.00989135
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.01278410   step =   0.01278410
+In cycle   2: lambdaN =  -0.01293960   step =   0.00015551
+In cycle   3: lambdaN =  -0.01293962   step =   0.00000002
+In cycle   4: lambdaN =  -0.01293962   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.01293962
+Calculated stepsize too large (   0.6146 >    0.3000). Scaled with    0.4881.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0403037022 RMS(Int)=    0.0706648123
+ Iter   1:  RMS(Cart)=    0.0026305697 RMS(Int)=    0.0033391440
+ Iter   2:  RMS(Cart)=    0.0001720087 RMS(Int)=    0.0001705553
+ Iter   3:  RMS(Cart)=    0.0000109288 RMS(Int)=    0.0000163682
+ Iter   4:  RMS(Cart)=    0.0000011663 RMS(Int)=    0.0000013239
+ Iter   5:  RMS(Cart)=    0.0000000619 RMS(Int)=    0.0000000696
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0042295526            0.0000050000      NO
+          RMS gradient        0.0107743112            0.0001000000      NO
+          MAX gradient        0.0199463945            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1373000249            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0727      Max(Angles)    5.19
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.3516 -0.019946 -0.0465    2.3051          0.50
+     2. B(H   2,C   0)                1.0999 -0.002214 -0.0057    1.0942   
+     3. B(H   3,C   0)                1.0999 -0.002216 -0.0057    1.0942   
+     4. B(H   4,C   0)                1.0999 -0.002215 -0.0057    1.0942   
+     5. B(F   5,H   2)                2.5565  0.019607 -0.0178    2.5386   
+     6. B(F   5,H   3)                2.5567  0.019615 -0.0178    2.5389   
+     7. B(F   5,C   0)                2.0271  0.014711  0.0727    2.0998          0.58
+     8. B(F   5,H   4)                2.5566  0.019611 -0.0178    2.5387   
+     9. A(Cl  1,C   0,H   3)           74.16 -0.004828    5.19     79.35   
+    10. A(H   2,C   0,H   3)          112.85 -0.004123    3.38    116.23   
+    11. A(Cl  1,C   0,H   4)           74.16 -0.004826    5.19     79.35   
+    12. A(H   2,C   0,H   4)          112.86 -0.004111    3.38    116.24   
+    13. A(H   3,C   0,H   4)          112.83 -0.004138    3.38    116.21   
+    14. A(H   2,C   0,F   5)          105.83  0.004822   -5.19    100.64   
+    15. A(H   3,C   0,F   5)          105.84  0.004829   -5.19    100.65   
+    16. A(H   4,C   0,F   5)          105.84  0.004825   -5.19    100.65   
+    17. A(Cl  1,C   0,H   2)           74.16 -0.004822    5.19     79.36   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   8            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.189569   -0.439449    0.015914
+  Cl     0.115300   -0.435085   -0.016675
+  H     -1.974560   -1.261511    0.704375
+  H     -2.000430   -0.626615   -1.044864
+  H     -1.982594    0.571043    0.379366
+  F     -4.286746   -0.443514    0.045794
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -4.137686   -0.830438    0.030073
+   1 Cl    7.0000    0    35.453    0.217885   -0.822191   -0.031512
+   2 H     1.0000    0     1.008   -3.731378   -2.383910    1.331077
+   3 H     1.0000    0     1.008   -3.780265   -1.184131   -1.974507
+   4 H     1.0000    0     1.008   -3.746560    1.079115    0.716898
+   5 F     7.0000    0    18.998   -8.100776   -0.838120    0.086538
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.305103352057     0.00000000     0.00000000
+ H      1   2   0     1.093614552746    79.26537597     0.00000000
+ H      1   2   3     1.093642892834    79.26214725   239.99867781
+ H      1   2   3     1.093631743323    79.26385160   120.01176446
+ F      1   2   3     2.097393617873   179.99329909    27.56974220
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.356014045772     0.00000000     0.00000000
+ H      1   2   0     2.066632000762    79.26537597     0.00000000
+ H      1   2   3     2.066685555765    79.26214725   239.99867781
+ H      1   2   3     2.066664486243    79.26385160   120.01176446
+ F      1   2   3     3.963499532813   179.99329909    27.56974220
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.089e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.005 sec
+Total time needed                          ...    0.005 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8489279074   0.000000000000 0.00780122  0.00128418  0.0311626 0.7000
+  1    -33.8495947105  -0.000666803073 0.00909294  0.00144006  0.0263112 0.7000
+                               ***Turning on DIIS***
+  2    -33.8502311035  -0.000636393059 0.02843067  0.00439273  0.0214850 0.0000
+  3    -33.8434679289   0.006763174629 0.01592442  0.00219888  0.0079902 0.0000
+  4    -33.8474540740  -0.003986145089 0.01071142  0.00131218  0.0043226 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.84911691  -0.0016628320  0.002245  0.002245  0.006982  0.000776
+  6    -33.85290448  -0.0037875713  0.000871  0.002723  0.004353  0.000421
+  7    -33.85291368  -0.0000092020  0.000372  0.002290  0.003923  0.000382
+  8    -33.85291656  -0.0000028851  0.000039  0.000088  0.000150  0.000025
+  9    -33.85291660  -0.0000000363  0.000014  0.000048  0.000072  0.000014
+ 10    -33.85291661  -0.0000000061  0.000003  0.000005  0.000011  0.000002
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  11 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.85291661 Eh            -921.18469 eV
+  Last Energy change         ...   -2.0994e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    8.6586e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.852916607070
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.010916790    0.000017272   -0.000146998
+   2   Cl  :   -0.010204193   -0.000018994    0.000143372
+   3   H   :    0.017942478   -0.004151524    0.003258976
+   4   H   :    0.017824623   -0.000914222   -0.005634158
+   5   H   :    0.017908941    0.005174433    0.001599951
+   6   F   :   -0.054388639   -0.000106965    0.000778857
+
+Norm of the cartesian gradient     ...    0.065055644
+RMS gradient                       ...    0.015333762
+MAX gradient                       ...    0.054388639
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.852916607 Eh
+Current gradient norm                   ....     0.065055644 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.016557171  0.052341102  0.052342615  0.090407609  0.134319268
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.01655717 and components:
+   1.   -0.53030007
+   2.   -0.05006644
+   3.   -0.05007948
+   4.   -0.05007341
+   5.    0.06718512
+   6.    0.06754793
+   7.    0.51819025
+   8.    0.06737320
+   9.    0.23193146
+  10.    0.18828776
+  11.    0.23193472
+  12.    0.18830193
+  13.    0.18826021
+  14.   -0.23203547
+  15.   -0.23184303
+  16.   -0.23193529
+  17.    0.23194763
+
+Lambda that maximizes along the TS mode:       0.00391572
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00963377   step =   0.00963377
+In cycle   2: lambdaN =  -0.00973456   step =   0.00010078
+In cycle   3: lambdaN =  -0.00973457   step =   0.00000001
+Lambda that minimizes along all other modes:  -0.00973457
+Calculated stepsize too large (   0.5371 >    0.3000). Scaled with    0.5586.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0398382519 RMS(Int)=    0.0707664947
+ Iter   1:  RMS(Cart)=    0.0028737374 RMS(Int)=    0.0034116604
+ Iter   2:  RMS(Cart)=    0.0001727034 RMS(Int)=    0.0001759313
+ Iter   3:  RMS(Cart)=    0.0000122721 RMS(Int)=    0.0000171340
+ Iter   4:  RMS(Cart)=    0.0000012536 RMS(Int)=    0.0000013279
+ Iter   5:  RMS(Cart)=    0.0000000583 RMS(Int)=    0.0000000745
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0013143321            0.0000050000      NO
+          RMS gradient        0.0078977625            0.0001000000      NO
+          MAX gradient        0.0157466745            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.0951886442            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0504      Max(Angles)    4.90
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.3051 -0.010205 -0.0504    2.2547          0.53
+     2. B(H   2,C   0)                1.0936 -0.000498 -0.0075    1.0862   
+     3. B(H   3,C   0)                1.0936 -0.000501 -0.0075    1.0862   
+     4. B(H   4,C   0)                1.0936 -0.000499 -0.0075    1.0862   
+     5. B(F   5,H   2)                2.5395  0.015739 -0.0349    2.5046   
+     6. B(F   5,H   3)                2.5397  0.015747 -0.0349    2.5048   
+     7. B(F   5,C   0)                2.0974  0.011601  0.0459    2.1433          0.52
+     8. B(F   5,H   4)                2.5396  0.015743 -0.0349    2.5047   
+     9. A(Cl  1,C   0,H   3)           79.26 -0.003297    4.90     84.16   
+    10. A(H   2,C   0,H   3)          116.61 -0.002022    4.16    120.78   
+    11. A(Cl  1,C   0,H   4)           79.26 -0.003294    4.90     84.17   
+    12. A(H   2,C   0,H   4)          116.62 -0.002013    4.16    120.79   
+    13. A(H   3,C   0,H   4)          116.60 -0.002033    4.17    120.77   
+    14. A(H   2,C   0,F   5)          100.73  0.003291   -4.90     95.83   
+    15. A(H   3,C   0,F   5)          100.74  0.003297   -4.90     95.84   
+    16. A(H   4,C   0,F   5)          100.74  0.003294   -4.90     95.83   
+    17. A(Cl  1,C   0,H   2)           79.27 -0.003291    4.90     84.17   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   9            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.123093   -0.439326    0.014981
+  Cl     0.131409   -0.435047   -0.016921
+  H     -2.006457   -1.267792    0.710072
+  H     -2.032556   -0.628108   -1.052409
+  H     -2.014568    0.578617    0.382615
+  F     -4.273335   -0.443475    0.045571
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -4.012064   -0.830205    0.028310
+   1 Cl    7.0000    0    35.453    0.248328   -0.822120   -0.031975
+   2 H     1.0000    0     1.008   -3.791654   -2.395779    1.341842
+   3 H     1.0000    0     1.008   -3.840974   -1.186951   -1.988764
+   4 H     1.0000    0     1.008   -3.806982    1.093428    0.723038
+   5 F     7.0000    0    18.998   -8.075434   -0.838046    0.086116
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.254731691043     0.00000000     0.00000000
+ H      1   2   0     1.087709351131    84.44895305     0.00000000
+ H      1   2   3     1.087730216760    84.44617204   239.99877414
+ H      1   2   3     1.087722540577    84.44761037   120.01024646
+ F      1   2   3     2.150464410330   179.99529233    27.17283230
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.260825401544     0.00000000     0.00000000
+ H      1   2   0     2.055472786943    84.44895305     0.00000000
+ H      1   2   3     2.055512217268    84.44617204   239.99877414
+ H      1   2   3     2.055497711384    84.44761037   120.01024646
+ F      1   2   3     4.063788796268   179.99529233    27.17283230
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.070e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.004 sec
+Total time needed                          ...    0.004 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8518707014   0.000000000000 0.00666611  0.00122115  0.0316194 0.7000
+  1    -33.8525041221  -0.000633420669 0.00780305  0.00137715  0.0267358 0.7000
+                               ***Turning on DIIS***
+  2    -33.8531150740  -0.000610951973 0.02554570  0.00424682  0.0218834 0.0000
+  3    -33.8461520676   0.006963006474 0.01508691  0.00232578  0.0083185 0.0000
+  4    -33.8494511793  -0.003299111727 0.01026925  0.00140738  0.0043956 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.85104341  -0.0015922317  0.002762  0.002762  0.006742  0.000835
+  6    -33.85580995  -0.0047665352  0.000949  0.002945  0.004189  0.000451
+  7    -33.85582013  -0.0000101851  0.000406  0.002464  0.003734  0.000405
+  8    -33.85582328  -0.0000031455  0.000057  0.000129  0.000147  0.000023
+  9    -33.85582331  -0.0000000341  0.000017  0.000053  0.000071  0.000012
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.85582332 Eh            -921.26379 eV
+  Last Energy change         ...   -4.5328e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    5.0499e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.855823315456
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.003749149    0.000004224   -0.000046410
+   2   Cl  :   -0.000224353   -0.000000039    0.000002129
+   3   H   :    0.012440104   -0.003674493    0.002928389
+   4   H   :    0.012332145   -0.000814772   -0.004928678
+   5   H   :    0.012408387    0.004564616    0.001462993
+   6   F   :   -0.040705432   -0.000079536    0.000581578
+
+Norm of the cartesian gradient     ...    0.046927610
+RMS gradient                       ...    0.011060944
+MAX gradient                       ...    0.040705432
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.855823315 Eh
+Current gradient norm                   ....     0.046927610 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.015974001  0.052341060  0.052342575  0.074552923  0.137351897
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.01597400 and components:
+   1.   -0.60013306
+   2.   -0.04143021
+   3.   -0.04143624
+   4.   -0.04143341
+   5.   -0.02523058
+   6.   -0.02496222
+   7.    0.46459857
+   8.   -0.02509048
+   9.    0.24713089
+  10.    0.12978431
+  11.    0.24712063
+  12.    0.12977093
+  13.    0.12978877
+  14.   -0.24718578
+  15.   -0.24706296
+  16.   -0.24712110
+  17.    0.24711834
+
+Lambda that maximizes along the TS mode:       0.00001856
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00610304   step =   0.00610304
+In cycle   2: lambdaN =  -0.00614068   step =   0.00003763
+In cycle   3: lambdaN =  -0.00614068   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00614068
+The final length of the internal step   ....       0.2765
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0670634936
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0346080933 RMS(Int)=    0.0662752790
+ Iter   1:  RMS(Cart)=    0.0005790784 RMS(Int)=    0.0007088933
+ Iter   2:  RMS(Cart)=    0.0000150032 RMS(Int)=    0.0000170602
+ Iter   3:  RMS(Cart)=    0.0000005962 RMS(Int)=    0.0000007872
+ Iter   4:  RMS(Cart)=    0.0000000210 RMS(Int)=    0.0000000214
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0029067084            0.0000050000      NO
+          RMS gradient        0.0054967625            0.0001000000      NO
+          MAX gradient        0.0116310672            0.0003000000      NO
+          RMS step            0.0670634936            0.0020000000      NO
+          MAX step            0.1389244686            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0735      Max(Angles)    2.12
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.2547 -0.000224  0.0023    2.2570          0.60
+     2. B(H   2,C   0)                1.0877 -0.000017 -0.0003    1.0874   
+     3. B(H   3,C   0)                1.0877 -0.000020 -0.0003    1.0874   
+     4. B(H   4,C   0)                1.0877 -0.000018 -0.0003    1.0874   
+     5. B(F   5,H   2)                2.5020  0.011627 -0.0733    2.4287   
+     6. B(F   5,H   3)                2.5021  0.011631 -0.0735    2.4286   
+     7. B(F   5,C   0)                2.1505  0.009257 -0.0463    2.1042          0.46
+     8. B(F   5,H   4)                2.5021  0.011629 -0.0734    2.4286   
+     9. A(Cl  1,C   0,H   3)           84.45 -0.001875    2.11     86.56   
+    10. A(H   2,C   0,H   3)          119.08 -0.000619    1.78    120.86   
+    11. A(Cl  1,C   0,H   4)           84.45 -0.001873    2.11     86.56   
+    12. A(H   2,C   0,H   4)          119.09 -0.000612    1.78    120.87   
+    13. A(H   3,C   0,H   4)          119.06 -0.000627    1.78    120.85   
+    14. A(H   2,C   0,F   5)           95.55  0.001871   -2.11     93.44   
+    15. A(H   3,C   0,F   5)           95.56  0.001874   -2.12     93.44   
+    16. A(H   4,C   0,F   5)           95.55  0.001873   -2.11     93.44   
+    17. A(Cl  1,C   0,H   2)           84.45 -0.001869    2.11     86.56   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  10            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.109853   -0.439313    0.014826
+  Cl     0.146939   -0.434995   -0.017200
+  H     -2.034747   -1.270575    0.712807
+  H     -2.061045   -0.628810   -1.055478
+  H     -2.042943    0.581890    0.384290
+  F     -4.216952   -0.443326    0.044664
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.987043   -0.830181    0.028018
+   1 Cl    7.0000    0    35.453    0.277674   -0.822022   -0.032503
+   2 H     1.0000    0     1.008   -3.845114   -2.401039    1.347010
+   3 H     1.0000    0     1.008   -3.894811   -1.188280   -1.994565
+   4 H     1.0000    0     1.008   -3.860602    1.099613    0.726203
+   5 F     7.0000    0    18.998   -7.968884   -0.837765    0.084403
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.257022809505     0.00000000     0.00000000
+ H      1   2   0     1.088032951872    86.64869959     0.00000000
+ H      1   2   3     1.088045694128    86.64753363   239.99890989
+ H      1   2   3     1.088041926031    86.64821672   120.00786388
+ F      1   2   3     2.107314468048   179.99818303   214.79266830
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.265154987978     0.00000000     0.00000000
+ H      1   2   0     2.056084303719    86.64869959     0.00000000
+ H      1   2   3     2.056108383094    86.64753363   239.99890989
+ H      1   2   3     2.056101262424    86.64821672   120.00786388
+ F      1   2   3     3.982247222660   179.99818303   214.79266830
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.073e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.105 sec
+Total time needed                          ...    0.106 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8608356649   0.000000000000 0.00232459  0.00039423  0.0072905 0.7000
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  1    -33.86090342  -0.0000677562  0.002160  0.002160  0.008451  0.001438
+  2    -33.86114080  -0.0002373800  0.002254  0.004267  0.004864  0.000738
+  3    -33.86118374  -0.0000429423  0.000865  0.002605  0.003180  0.000405
+  4    -33.86119063  -0.0000068819  0.000119  0.000349  0.000435  0.000061
+  5    -33.86119080  -0.0000001775  0.000055  0.000280  0.000378  0.000044
+  6    -33.86119084  -0.0000000400  0.000007  0.000017  0.000028  0.000004
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   7 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86119084 Eh            -921.40985 eV
+  Last Energy change         ...   -5.6119e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.5774e-05  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.861190843415
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.013269538    0.000022474   -0.000181061
+   2   Cl  :    0.002997510    0.000006082   -0.000043549
+   3   H   :    0.007069317   -0.004447936    0.003647675
+   4   H   :    0.006928182   -0.001000137   -0.005831679
+   5   H   :    0.007025379    0.005490237    0.001881493
+   6   F   :   -0.037289927   -0.000070719    0.000527121
+
+Norm of the cartesian gradient     ...    0.042720423
+RMS gradient                       ...    0.010069300
+MAX gradient                       ...    0.037289927
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.861190843 Eh
+Current gradient norm                   ....     0.042720423 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.020761652  0.020426475  0.052341207  0.052342739  0.142259785
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.02076165 and components:
+   1.   -0.52597095
+   2.   -0.03442009
+   3.   -0.03438402
+   4.   -0.03440150
+   5.    0.22285383
+   6.    0.22398940
+   7.    0.60097241
+   8.    0.22343920
+   9.    0.17488531
+  10.    0.09189883
+  11.    0.17489833
+  12.    0.09194725
+  13.    0.09183368
+  14.   -0.17520154
+  15.   -0.17460740
+  16.   -0.17489495
+  17.    0.17492030
+
+Lambda that maximizes along the TS mode:       0.00662817
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00699873   step =   0.00699873
+In cycle   2: lambdaN =  -0.00769786   step =   0.00069913
+In cycle   3: lambdaN =  -0.00770168   step =   0.00000382
+In cycle   4: lambdaN =  -0.00770168   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00770168
+Calculated stepsize too large (   0.6073 >    0.3000). Scaled with    0.4940.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0357821215 RMS(Int)=    0.0713123849
+ Iter   1:  RMS(Cart)=    0.0027598218 RMS(Int)=    0.0028880609
+ Iter   2:  RMS(Cart)=    0.0001061186 RMS(Int)=    0.0001399066
+ Iter   3:  RMS(Cart)=    0.0000124916 RMS(Int)=    0.0000133511
+ Iter   4:  RMS(Cart)=    0.0000005415 RMS(Int)=    0.0000006598
+ Iter   5:  RMS(Cart)=    0.0000000548 RMS(Int)=    0.0000000603
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0053675280            0.0000050000      NO
+          RMS gradient        0.0050907187            0.0001000000      NO
+          MAX gradient        0.0123383932            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1481951697            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0784      Max(Angles)    4.71
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.2570  0.002998 -0.0784    2.1786          0.53
+     2. B(H   2,C   0)                1.0880  0.001584 -0.0088    1.0792   
+     3. B(H   3,C   0)                1.0880  0.001581 -0.0088    1.0793   
+     4. B(H   4,C   0)                1.0880  0.001583 -0.0088    1.0793   
+     5. B(F   5,H   2)                2.4275  0.009303 -0.0319    2.3956   
+     6. B(F   5,H   3)                2.4275  0.009300 -0.0318    2.3957   
+     7. B(F   5,C   0)                2.1073  0.012338  0.0514    2.1587          0.60
+     8. B(F   5,H   4)                2.4275  0.009302 -0.0318    2.3957   
+     9. A(Cl  1,C   0,H   3)           86.65  0.001413    4.71     91.36   
+    10. A(H   2,C   0,H   3)          119.66  0.000285    2.65    122.31   
+    11. A(Cl  1,C   0,H   4)           86.65  0.001416    4.71     91.36   
+    12. A(H   2,C   0,H   4)          119.67  0.000291    2.65    122.31   
+    13. A(H   3,C   0,H   4)          119.65  0.000279    2.65    122.30   
+    14. A(H   2,C   0,F   5)           93.35 -0.001415   -4.71     88.64   
+    15. A(H   3,C   0,F   5)           93.35 -0.001416   -4.71     88.64   
+    16. A(H   4,C   0,F   5)           93.35 -0.001416   -4.71     88.64   
+    17. A(Cl  1,C   0,H   2)           86.65  0.001419    4.71     91.36   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  11            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.042192   -0.439171    0.013835
+  Cl     0.136187   -0.435033   -0.017000
+  H     -2.057663   -1.265719    0.709001
+  H     -2.083762   -0.627738   -1.048914
+  H     -2.065787    0.575861    0.382423
+  F     -4.205383   -0.443329    0.044566
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.859184   -0.829914    0.026144
+   1 Cl    7.0000    0    35.453    0.257356   -0.822094   -0.032125
+   2 H     1.0000    0     1.008   -3.888420   -2.391862    1.339817
+   3 H     1.0000    0     1.008   -3.937740   -1.186253   -1.982160
+   4 H     1.0000    0     1.008   -3.903772    1.088219    0.722675
+   5 F     7.0000    0    18.998   -7.947022   -0.837770    0.084217
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.178601303322     0.00000000     0.00000000
+ H      1   2   0     1.080127512767    91.42592344     0.00000000
+ H      1   2   3     1.080148510011    91.42611483   239.99891032
+ H      1   2   3     1.080140662605    91.42606831   120.00660076
+ F      1   2   3     2.163413256914   179.99679406    26.48015410
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     4.116959818283     0.00000000     0.00000000
+ H      1   2   0     2.041145188844    91.42592344     0.00000000
+ H      1   2   3     2.041184867884    91.42611483   239.99891032
+ H      1   2   3     2.041170038436    91.42606831   120.00660076
+ F      1   2   3     4.088258570063   179.99679406    26.48015410
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.032e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.002 sec
+Total time needed                          ...    0.003 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8571466270   0.000000000000 0.00727512  0.00134107  0.0332054 0.7000
+  1    -33.8578865431  -0.000739916115 0.00899502  0.00153167  0.0280787 0.7000
+                               ***Turning on DIIS***
+  2    -33.8586091066  -0.000722563487 0.02932134  0.00477527  0.0229807 0.0000
+  3    -33.8487235042   0.009885602353 0.01680465  0.00272666  0.0087490 0.0000
+  4    -33.8521785444  -0.003455040159 0.01144359  0.00171895  0.0054601 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -33.85486173  -0.0026831847  0.003048  0.003048  0.007287  0.001008
+  6    -33.86192183  -0.0070600966  0.001089  0.003357  0.004229  0.000524
+  7    -33.86193527  -0.0000134473  0.000461  0.002767  0.003649  0.000464
+  8    -33.86193937  -0.0000040952  0.000072  0.000158  0.000154  0.000027
+  9    -33.86193942  -0.0000000517  0.000023  0.000069  0.000075  0.000013
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86193943 Eh            -921.43022 eV
+  Last Energy change         ...   -6.8380e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    5.9102e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.861939426675
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.000010349   -0.000001701    0.000004287
+   2   Cl  :    0.008763470    0.000016635   -0.000124040
+   3   H   :    0.004478721   -0.000669130    0.000504440
+   4   H   :    0.004458020   -0.000144429   -0.000936102
+   5   H   :    0.004472394    0.000841670    0.000235454
+   6   F   :   -0.022162256   -0.000043044    0.000315961
+
+Norm of the cartesian gradient     ...    0.025107366
+RMS gradient                       ...    0.005917863
+MAX gradient                       ...    0.022162256
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.861939427 Eh
+Current gradient norm                   ....     0.025107366 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.038749127  0.023033605  0.052341223  0.052342762  0.137943751
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.03874913 and components:
+   1.   -0.52981842
+   2.   -0.02099461
+   3.   -0.02097865
+   4.   -0.02098589
+   5.    0.14413986
+   6.    0.14500641
+   7.    0.61090922
+   8.    0.14458854
+   9.    0.21624578
+  10.    0.02173268
+  11.    0.21626607
+  12.    0.02176449
+  13.    0.02168714
+  14.   -0.21651414
+  15.   -0.21603112
+  16.   -0.21626396
+  17.    0.21629741
+
+Lambda that maximizes along the TS mode:       0.00023289
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00498759   step =   0.00498759
+In cycle   2: lambdaN =  -0.00517169   step =   0.00018410
+In cycle   3: lambdaN =  -0.00517186   step =   0.00000017
+In cycle   4: lambdaN =  -0.00517186   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00517186
+Calculated stepsize too large (   0.4137 >    0.3000). Scaled with    0.7251.
+The final length of the internal step   ....       0.3000
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0727606875
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0380058675 RMS(Int)=    0.0725425267
+ Iter   1:  RMS(Cart)=    0.0010886124 RMS(Int)=    0.0011535531
+ Iter   2:  RMS(Cart)=    0.0000271191 RMS(Int)=    0.0000400799
+ Iter   3:  RMS(Cart)=    0.0000021586 RMS(Int)=    0.0000022419
+ Iter   4:  RMS(Cart)=    0.0000000547 RMS(Int)=    0.0000000804
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0007485833            0.0000050000      NO
+          RMS gradient        0.0036921166            0.0001000000      NO
+          MAX gradient        0.0087643634            0.0003000000      NO
+          RMS step            0.0727606875            0.0020000000      NO
+          MAX step            0.1375590216            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0728      Max(Angles)    2.98
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.1786  0.008764 -0.0728    2.1058          0.53
+     2. B(H   2,C   0)                1.0801 -0.001549  0.0009    1.0811   
+     3. B(H   3,C   0)                1.0801 -0.001548  0.0009    1.0811   
+     4. B(H   4,C   0)                1.0801 -0.001549  0.0009    1.0811   
+     5. B(F   5,H   2)                2.3938  0.005416 -0.0702    2.3237   
+     6. B(F   5,H   3)                2.3939  0.005418 -0.0703    2.3236   
+     7. B(F   5,C   0)                2.1634  0.007661 -0.0232    2.1402          0.61
+     8. B(F   5,H   4)                2.3939  0.005417 -0.0703    2.3236   
+     9. A(Cl  1,C   0,H   3)           91.43  0.000410    2.97     94.40   
+    10. A(H   2,C   0,H   3)          119.94 -0.000035    0.33    120.27   
+    11. A(Cl  1,C   0,H   4)           91.43  0.000410    2.97     94.40   
+    12. A(H   2,C   0,H   4)          119.95 -0.000032    0.33    120.28   
+    13. A(H   3,C   0,H   4)          119.93 -0.000039    0.34    120.27   
+    14. A(H   2,C   0,F   5)           88.57 -0.000410   -2.97     85.60   
+    15. A(H   3,C   0,F   5)           88.58 -0.000410   -2.98     85.60   
+    16. A(H   4,C   0,F   5)           88.57 -0.000410   -2.97     85.60   
+    17. A(Cl  1,C   0,H   2)           91.43  0.000409    2.97     94.40   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  12            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.006306   -0.439110    0.013345
+  Cl     0.099287   -0.435086   -0.016522
+  H     -2.076936   -1.264378    0.708146
+  H     -2.103065   -0.627480   -1.046836
+  H     -2.085084    0.574111    0.382127
+  F     -4.146496   -0.443186    0.043651
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.791368   -0.829798    0.025218
+   1 Cl    7.0000    0    35.453    0.187625   -0.822194   -0.031223
+   2 H     1.0000    0     1.008   -3.924840   -2.389328    1.338201
+   3 H     1.0000    0     1.008   -3.974218   -1.185766   -1.978233
+   4 H     1.0000    0     1.008   -3.940237    1.084912    0.722115
+   5 F     7.0000    0    18.998   -7.835742   -0.837500    0.082489
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.105808204281     0.00000000     0.00000000
+ H      1   2   0     1.081112058355    94.35282532     0.00000000
+ H      1   2   3     1.081123977069    94.35376503   239.99898662
+ H      1   2   3     1.081120677401    94.35331923   120.00447238
+ F      1   2   3     2.140409081570   179.99856754   214.94895126
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.979400796655     0.00000000     0.00000000
+ H      1   2   0     2.043005710372    94.35282532     0.00000000
+ H      1   2   3     2.043028233477    94.35376503   239.99898662
+ H      1   2   3     2.043021998007    94.35331923   120.00447238
+ F      1   2   3     4.044786978726   179.99856754   214.94895126
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.030e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.002 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8630728028   0.000000000000 0.00478586  0.00073422  0.0193102 0.7000
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  1    -33.86332403  -0.0002512271  0.003208  0.003208  0.017350  0.002713
+  2    -33.86425257  -0.0009285373  0.004095  0.008770  0.014081  0.001945
+  3    -33.86451854  -0.0002659775  0.002092  0.009254  0.015346  0.002015
+  4    -33.86460877  -0.0000902233  0.000255  0.000275  0.000463  0.000068
+  5    -33.86460913  -0.0000003602  0.000065  0.000174  0.000248  0.000042
+  6    -33.86460919  -0.0000000629  0.000014  0.000033  0.000038  0.000007
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   7 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86460919 Eh            -921.50286 eV
+  Last Energy change         ...   -2.7204e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.5781e-05  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.864609193966
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :    0.000054838   -0.000000025   -0.000000863
+   2   Cl  :    0.003266586    0.000006300   -0.000046475
+   3   H   :    0.002544621   -0.000323368    0.000239261
+   4   H   :    0.002530357   -0.000068627   -0.000454318
+   5   H   :    0.002539247    0.000406250    0.000108375
+   6   F   :   -0.010935651   -0.000020530    0.000154021
+
+Norm of the cartesian gradient     ...    0.012254130
+RMS gradient                       ...    0.002888326
+MAX gradient                       ...    0.010935651
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.864609194 Eh
+Current gradient norm                   ....     0.012254130 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.037801723  0.019400551  0.052341220  0.052342757  0.137670436
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.03780172 and components:
+   1.   -0.51863080
+   2.   -0.02047542
+   3.   -0.02045163
+   4.   -0.02046275
+   5.    0.16536794
+   6.    0.16633635
+   7.    0.62037459
+   8.    0.16586890
+   9.    0.20883414
+  10.    0.01459371
+  11.    0.20885656
+  12.    0.01463079
+  13.    0.01454252
+  14.   -0.20913107
+  15.   -0.20859574
+  16.   -0.20885404
+  17.    0.20889020
+
+Lambda that maximizes along the TS mode:       0.00009843
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00158640   step =   0.00158640
+In cycle   2: lambdaN =  -0.00159581   step =   0.00000941
+In cycle   3: lambdaN =  -0.00159581   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00159581
+The final length of the internal step   ....       0.2739
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0664216586
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0338798249 RMS(Int)=    0.0664560639
+ Iter   1:  RMS(Cart)=    0.0011252568 RMS(Int)=    0.0011952153
+ Iter   2:  RMS(Cart)=    0.0000285773 RMS(Int)=    0.0000404125
+ Iter   3:  RMS(Cart)=    0.0000020974 RMS(Int)=    0.0000022773
+ Iter   4:  RMS(Cart)=    0.0000000690 RMS(Int)=    0.0000000848
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0026697673            0.0000050000      NO
+          RMS gradient        0.0016925916            0.0001000000      NO
+          MAX gradient        0.0035285680            0.0003000000      NO
+          RMS step            0.0664216586            0.0020000000      NO
+          MAX step            0.1204634120            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0637      Max(Angles)    2.99
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.1058  0.003267 -0.0637    2.0421          0.52
+     2. B(H   2,C   0)                1.0811 -0.000868  0.0009    1.0820   
+     3. B(H   3,C   0)                1.0811 -0.000870  0.0009    1.0821   
+     4. B(H   4,C   0)                1.0811 -0.000869  0.0009    1.0820   
+     5. B(F   5,H   2)                2.3236  0.002789 -0.0635    2.2601   
+     6. B(F   5,H   3)                2.3235  0.002786 -0.0635    2.2600   
+     7. B(F   5,C   0)                2.1404  0.003529 -0.0142    2.1262          0.62
+     8. B(F   5,H   4)                2.3235  0.002788 -0.0635    2.2600   
+     9. A(Cl  1,C   0,H   3)           94.35 -0.000002    2.99     97.34   
+    10. A(H   2,C   0,H   3)          119.43  0.000001   -0.51    118.93   
+    11. A(Cl  1,C   0,H   4)           94.35 -0.000003    2.99     97.34   
+    12. A(H   2,C   0,H   4)          119.43  0.000002   -0.51    118.93   
+    13. A(H   3,C   0,H   4)          119.42 -0.000001   -0.50    118.92   
+    14. A(H   2,C   0,F   5)           85.65  0.000003   -2.98     82.66   
+    15. A(H   3,C   0,F   5)           85.64  0.000002   -2.99     82.66   
+    16. A(H   4,C   0,F   5)           85.65  0.000003   -2.99     82.66   
+    17. A(Cl  1,C   0,H   2)           94.35 -0.000003    2.99     97.34   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  13            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -1.970550   -0.439042    0.012839
+  Cl     0.071303   -0.435134   -0.016141
+  H     -2.096258   -1.260810    0.705405
+  H     -2.122299   -0.626710   -1.041930
+  H     -2.104382    0.569646    0.380823
+  F     -4.096414   -0.443080    0.042914
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.723799   -0.829670    0.024263
+   1 Cl    7.0000    0    35.453    0.134742   -0.822284   -0.030502
+   2 H     1.0000    0     1.008   -3.961353   -2.382585    1.333023
+   3 H     1.0000    0     1.008   -4.010563   -1.184310   -1.968963
+   4 H     1.0000    0     1.008   -3.976705    1.076475    0.719650
+   5 F     7.0000    0    18.998   -7.741101   -0.837300    0.081096
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.042061712207     0.00000000     0.00000000
+ H      1   2   0     1.082013031115    97.27924747     0.00000000
+ H      1   2   3     1.082028632938    97.28058669   239.99905237
+ H      1   2   3     1.082023514096    97.27988453   120.00258814
+ F      1   2   3     2.126081374126   179.99724087   212.13218564
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.858937384637     0.00000000     0.00000000
+ H      1   2   0     2.044708302141    97.27924747     0.00000000
+ H      1   2   3     2.044737785313    97.28058669   239.99905237
+ H      1   2   3     2.044728112105    97.27988453   120.00258814
+ F      1   2   3     4.017711535528   179.99724087   212.13218564
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.024e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.004 sec
+Total time needed                          ...    0.005 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+  0    -33.8638541850   0.000000000000 0.00473077  0.00073440  0.0193372 0.7000
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  1    -33.86410550  -0.0002513148  0.002750  0.002750  0.017042  0.002707
+  2    -33.86503290  -0.0009274024  0.003491  0.008421  0.014286  0.001916
+  3    -33.86529430  -0.0002613937  0.001750  0.008798  0.015417  0.001975
+  4    -33.86538273  -0.0000884341  0.000256  0.000339  0.000551  0.000087
+  5    -33.86538327  -0.0000005424  0.000069  0.000276  0.000310  0.000065
+  6    -33.86538340  -0.0000001297  0.000022  0.000036  0.000057  0.000010
+  7    -33.86538341  -0.0000000051  0.000010  0.000016  0.000031  0.000006
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   8 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86538341 Eh            -921.52393 eV
+  Last Energy change         ...   -1.0160e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.8442e-06  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.865383408296
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.000103663   -0.000000070    0.000000769
+   2   Cl  :   -0.001849974   -0.000003511    0.000026275
+   3   H   :    0.000848471    0.000188221   -0.000168263
+   4   H   :    0.000849411    0.000043768    0.000227925
+   5   H   :    0.000847594   -0.000227612   -0.000094192
+   6   F   :   -0.000591840   -0.000000796    0.000007486
+
+Norm of the cartesian gradient     ...    0.002474326
+RMS gradient                       ...    0.000583204
+MAX gradient                       ...    0.001849974
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.865383408 Eh
+Current gradient norm                   ....     0.002474326 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.037434740  0.017929642  0.052341217  0.052342752  0.139641891
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.03743474 and components:
+   1.   -0.50801295
+   2.   -0.02001949
+   3.   -0.01999569
+   4.   -0.02000682
+   5.    0.17328979
+   6.    0.17430134
+   7.    0.62647884
+   8.    0.17381324
+   9.    0.20707477
+  10.    0.00954312
+  11.    0.20709990
+  12.    0.00958403
+  13.    0.00948829
+  14.   -0.20738721
+  15.   -0.20682685
+  16.   -0.20709715
+  17.    0.20713659
+
+Lambda that maximizes along the TS mode:       0.00000395
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00005302   step =   0.00005302
+In cycle   2: lambdaN =  -0.00005302   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00005302
+The final length of the internal step   ....       0.0367
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0089102629
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0057317957 RMS(Int)=    0.0089059059
+ Iter   1:  RMS(Cart)=    0.0000473038 RMS(Int)=    0.0000508781
+ Iter   2:  RMS(Cart)=    0.0000002682 RMS(Int)=    0.0000003227
+ Iter   3:  RMS(Cart)=    0.0000000030 RMS(Int)=    0.0000000036
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0007742143            0.0000050000      NO
+          RMS gradient        0.0005902621            0.0001000000      NO
+          MAX gradient        0.0018501639            0.0003000000      NO
+          RMS step            0.0089102629            0.0020000000      NO
+          MAX step            0.0139242011            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0074      Max(Angles)    0.62
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.0421 -0.001850 -0.0000    2.0420          0.51
+     2. B(H   2,C   0)                1.0820 -0.000479  0.0004    1.0825   
+     3. B(H   3,C   0)                1.0820 -0.000478  0.0004    1.0825   
+     4. B(H   4,C   0)                1.0820 -0.000479  0.0004    1.0825   
+     5. B(F   5,H   2)                2.2601  0.000362 -0.0074    2.2528   
+     6. B(F   5,H   3)                2.2600  0.000359 -0.0073    2.2527   
+     7. B(F   5,C   0)                2.1261 -0.000359  0.0036    2.1297          0.63
+     8. B(F   5,H   4)                2.2601  0.000360 -0.0073    2.2527   
+     9. A(Cl  1,C   0,H   3)           97.28 -0.000443    0.62     97.90   
+    10. A(H   2,C   0,H   3)          118.42  0.000191   -0.18    118.24   
+    11. A(Cl  1,C   0,H   4)           97.28 -0.000444    0.62     97.90   
+    12. A(H   2,C   0,H   4)          118.42  0.000190   -0.18    118.24   
+    13. A(H   3,C   0,H   4)          118.42  0.000191   -0.18    118.23   
+    14. A(H   2,C   0,F   5)           82.72  0.000445   -0.62     82.11   
+    15. A(H   3,C   0,F   5)           82.72  0.000444   -0.61     82.10   
+    16. A(H   4,C   0,F   5)           82.72  0.000445   -0.62     82.10   
+    17. A(Cl  1,C   0,H   2)           97.28 -0.000446    0.62     97.90   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  14            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -1.964312   -0.439028    0.012746
+  Cl     0.077527   -0.435125   -0.016221
+  H     -2.101332   -1.260001    0.704784
+  H     -2.127325   -0.626531   -1.040816
+  H     -2.109436    0.568637    0.380524
+  F     -4.093723   -0.443082    0.042894
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.712012   -0.829643    0.024086
+   1 Cl    7.0000    0    35.453    0.146504   -0.822267   -0.030654
+   2 H     1.0000    0     1.008   -3.970941   -2.381057    1.331849
+   3 H     1.0000    0     1.008   -4.020061   -1.183972   -1.966857
+   4 H     1.0000    0     1.008   -3.986256    1.074568    0.719086
+   5 F     7.0000    0    18.998   -7.736015   -0.837304    0.081057
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.042047746450     0.00000000     0.00000000
+ H      1   2   0     1.082445404997    97.87945908     0.00000000
+ H      1   2   3     1.082461192429    97.88027689   239.99906841
+ H      1   2   3     1.082455988116    97.87980447   120.00265878
+ F      1   2   3     2.129628185945   179.99828296   214.56427580
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.858910993181     0.00000000     0.00000000
+ H      1   2   0     2.045525370365    97.87945908     0.00000000
+ H      1   2   3     2.045555204289    97.88027689   239.99906841
+ H      1   2   3     2.045545369562    97.87980447   120.00265878
+ F      1   2   3     4.024414038516   179.99828296   214.56427580
+
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.025e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.005 sec
+Total time needed                          ...    0.005 sec
+
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0    -33.86537274 -33.8653727394  0.001362  0.001362  0.002290  0.000366
+  1    -33.86539466  -0.0000219204  0.000728  0.001279  0.001995  0.000352
+  2    -33.86540518  -0.0000105172  0.000331  0.001378  0.002328  0.000363
+  3    -33.86540866  -0.0000034790  0.000059  0.000112  0.000192  0.000027
+  4    -33.86540870  -0.0000000396  0.000019  0.000062  0.000096  0.000017
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   5 CYCLES          *
+               *****************************************************
+
+Total Energy       :          -33.86540870 Eh            -921.52462 eV
+  Last Energy change         ...   -8.3437e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.3121e-05  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.865408703905
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                          SCF GRADIENT FOR NDO METHODS
+------------------------------------------------------------------------------
+
+The cartesian gradient:
+   1   C   :   -0.000472646   -0.000000669    0.000005768
+   2   Cl  :    0.000225200    0.000000498   -0.000003258
+   3   H   :    0.000006725    0.000027574   -0.000022582
+   4   H   :    0.000003603    0.000005808    0.000035168
+   5   H   :    0.000004785   -0.000033838   -0.000011286
+   6   F   :    0.000232333    0.000000627   -0.000003810
+
+Norm of the cartesian gradient     ...    0.000576231
+RMS gradient                       ...    0.000135819
+MAX gradient                       ...    0.000472646
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   6
+Number of internal coordinates          ....  17
+Current Energy                          ....   -33.865408704 Eh
+Current gradient norm                   ....     0.000576231 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (Bofill)          .... Diagonalizing the Hessian               .... done
+Dimension of the hessian                ....  17
+Lowest eigenvalues of the Hessian:
+ -0.042028466  0.018440623  0.052341159  0.052342685  0.142589851
+Hessian has   1 negative eigenvalues
+Taking P-RFO step
+Searching for lambda that maximizes along the lowest mode
+TS mode is mode number   0 with eigenvalue  -0.04202847 and components:
+   1.   -0.52330035
+   2.   -0.01899861
+   3.   -0.01898580
+   4.   -0.01899186
+   5.    0.12308200
+   6.    0.12439529
+   7.    0.61203052
+   8.    0.12377129
+   9.    0.22501943
+  10.   -0.01383371
+  11.    0.22507758
+  12.   -0.01376925
+  13.   -0.01390361
+  14.   -0.22545393
+  15.   -0.22472535
+  16.   -0.22507180
+  17.    0.22515412
+
+Lambda that maximizes along the TS mode:       0.00000157
+Searching for lambda that minimizes along all other modes
+In cycle   1: lambdaN =  -0.00000009   step =   0.00000009
+In cycle   2: lambdaN =  -0.00000009   step =   0.00000000
+Lambda that minimizes along all other modes:  -0.00000009
+The final length of the internal step   ....       0.0062
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0014930382
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0007377702 RMS(Int)=    0.0014764489
+ Iter   1:  RMS(Cart)=    0.0000009053 RMS(Int)=    0.0000010004
+ Iter   2:  RMS(Cart)=    0.0000000008 RMS(Int)=    0.0000000008
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000252956            0.0000050000      NO
+          RMS gradient        0.0000690129            0.0001000000      YES
+          MAX gradient        0.0002252239            0.0003000000      YES
+          RMS step            0.0014930382            0.0020000000      YES
+          MAX step            0.0039677258            0.0040000000      YES
+          ........................................................
+          Max(Bonds)      0.0021      Max(Angles)    0.09
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+       Everything but the energy has converged. However, the energy
+       appears to be close enough to convergence to make sure that the
+       final evaluation at the new geometry represents the equilibrium energy.
+       Convergence will therefore be signaled now
+
+
+                    ***********************HURRAY********************
+                    ***        THE OPTIMIZATION HAS CONVERGED     ***
+                    *************************************************
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+
+                          --- Optimized Parameters ---  
+                            (Angstroem and degrees)
+
+        Definition                    OldVal   dE/dq     Step     FinalVal  comp.(TS mode)
+    ----------------------------------------------------------------------------
+     1. B(Cl  1,C   0)                2.0420  0.000225  0.0014    2.0434          0.52
+     2. B(H   2,C   0)                1.0824 -0.000022  0.0001    1.0826   
+     3. B(H   3,C   0)                1.0825 -0.000021  0.0001    1.0826   
+     4. B(H   4,C   0)                1.0825 -0.000021  0.0001    1.0826   
+     5. B(F   5,H   2)                2.2528 -0.000041 -0.0003    2.2525   
+     6. B(F   5,H   3)                2.2527 -0.000043 -0.0003    2.2524   
+     7. B(F   5,C   0)                2.1296 -0.000120 -0.0021    2.1275          0.61
+     8. B(F   5,H   4)                2.2528 -0.000043 -0.0003    2.2524   
+     9. A(Cl  1,C   0,H   3)           97.88 -0.000036   -0.09     97.79   
+    10. A(H   2,C   0,H   3)          118.15  0.000017    0.01    118.16   
+    11. A(Cl  1,C   0,H   4)           97.88 -0.000037   -0.09     97.79   
+    12. A(H   2,C   0,H   4)          118.15  0.000016    0.01    118.16   
+    13. A(H   3,C   0,H   4)          118.15  0.000018    0.01    118.16   
+    14. A(H   2,C   0,F   5)           82.12  0.000038    0.09     82.21   
+    15. A(H   3,C   0,F   5)           82.12  0.000036    0.09     82.21   
+    16. A(H   4,C   0,F   5)           82.12  0.000037    0.09     82.21   
+    17. A(Cl  1,C   0,H   2)           97.88 -0.000038   -0.09     97.79   
+    ----------------------------------------------------------------------------
+                 *******************************************************
+                 *** FINAL ENERGY EVALUATION AT THE STATIONARY POINT ***
+                 ***               (AFTER   14 CYCLES)               ***
+                 *******************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -1.965646   -0.439031    0.012764
+  Cl     0.077567   -0.435125   -0.016221
+  H     -2.101150   -1.260246    0.704986
+  H     -2.127141   -0.626585   -1.041135
+  H     -2.109251    0.568940    0.380628
+  F     -4.092979   -0.443083    0.042888
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     4.0000    0    12.011   -3.714532   -0.829647    0.024121
+   1 Cl    7.0000    0    35.453    0.146580   -0.822267   -0.030654
+   2 H     1.0000    0     1.008   -3.970597   -2.381521    1.332231
+   3 H     1.0000    0     1.008   -4.019714   -1.184074   -1.967460
+   4 H     1.0000    0     1.008   -3.985907    1.075140    0.719282
+   5 F     7.0000    0    18.998   -7.734610   -0.837305    0.081046
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     2.043421797399     0.00000000     0.00000000
+ H      1   2   0     1.082556277444    97.79779319     0.00000000
+ H      1   2   3     1.082571296976    97.79820025   239.99908041
+ H      1   2   3     1.082566456433    97.79791748   120.00289068
+ F      1   2   3     2.127550716412   179.99846352   215.81188351
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ Cl     1   0   0     3.861507573170     0.00000000     0.00000000
+ H      1   2   0     2.045734888927    97.79779319     0.00000000
+ H      1   2   3     2.045763271729    97.79820025   239.99908041
+ H      1   2   3     2.045754124428    97.79791748   120.00289068
+ F      1   2   3     4.020488190046   179.99846352   215.81188351
+
+----------------------------
+SLATER BASIS SET DIM=  15
+----------------------------
+  0 C     2 shells
+ l=0 nsto= 1
+    2       1.565085000000        1.000000000000
+ l=1 nsto= 1
+    2       1.842345000000        1.000000000000
+  1 Cl    2 shells
+ l=0 nsto= 1
+    3       2.246210000000        1.000000000000
+ l=1 nsto= 1
+    3       2.151010000000        1.000000000000
+  2 H     1 shells
+ l=0 nsto= 1
+    1       0.967807000000        1.000000000000
+  3 H     1 shells
+ l=0 nsto= 1
+    1       0.967807000000        1.000000000000
+  4 H     1 shells
+ l=0 nsto= 1
+    1       0.967807000000        1.000000000000
+  5 F     2 shells
+ l=0 nsto= 1
+    2       4.708555000000        1.000000000000
+ l=1 nsto= 1
+    2       2.491178000000        1.000000000000
+------------------------------------------------------------------------------
+                           ORCA NDO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+--------------
+NDO PARAMETERS
+--------------
+
+Gamma integral treatment              ... MOPAC
+Nuclear repulsuion treatment          ... AM1-style
+Interaction factors:
+s-s (sigma) =    1.0000
+s-p (sigma) =    1.0000
+s-d (sigma) =    1.0000
+p-p (sigma) =    1.0000  p-p(pi) =    1.0000
+p-d (sigma) =    1.0000  p-d(pi) =    1.0000
+d-d (sigma) =    1.0000  d-d(pi) =    1.0000 d-d (delta) =    1.0000
+
+--------------------------
+Parameters for Element H :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -13.073321 Beta(s) =     5.626512 Neff(s) =     1.000000
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    14.794208
+--------------------------
+Parameters for Element C :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =   -47.270320 Beta(s) =    11.910015 Neff(s) =     2.000000
+  U(p)  =   -36.266918 Beta(p) =     9.802755 Neff(p) =     2.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    11.200708
+  G(s,p)=    10.265027 G(p,p)  =     9.627141
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     7.3072 G1(s,p)=    6.8729
+--------------------------
+Parameters for Element F :
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -110.435303 Beta(s) =    48.405939 Neff(s) =     2.000000
+  U(p)  =  -105.685047 Beta(p) =    27.744660 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    10.496667
+  G(s,p)=    16.073689 G(p,p)  =    14.551347
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     1.6619 G1(s,p)=    2.1833
+--------------------------
+Parameters for Element Cl:
+--------------------------
+ One-electron parameters (in eV)
+  U(s)  =  -100.626747 Beta(s) =    27.528560 Neff(s) =     2.000000
+  U(p)  =   -53.614396 Beta(p) =    11.593922 Neff(p) =     5.000000 
+ One-center electron repulsion parameters (in eV)
+  G(s,s)=    16.013601
+  G(s,p)=     8.048115 G(p,p)  =     7.510174
+ Slater-Condon parameters (in eV)
+ F2(p,p)=     0.0753 G1(s,p)=   10.4435
+
+ Number of atoms                    ....    6
+ Number of basis functions          ....   15
+
+ Overlap integrals                  .... done
+ One electron matrix                .... done
+ Nuclear repulsion                  .... done
+ Integral list                      .... done
+ Electron-electron repulsion        .... done
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ ZDO-Hamiltonian        Method          .... NDDO
+
+
+General Settings:
+ Integral files         IntName         .... TS_test
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....   -1
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   22
+ Basis Dimension        Dim             ....   15
+ Nuclear Repulsion      ENuc            ....     32.2600317817 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Conventional
+ Integral Buffer length BufferLength    .... 1048576
+ Integral index format  IndFormat       ....     0
+ Integral value format  ValFormat       ....     0
+ Integral Storage       Thresh          ....  2.500e-11 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.026e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.005 sec
+Total time needed                          ...    0.006 sec
+
+---------------------
+INITIAL GUESS: MOREAD
+---------------------
+Guess MOs are being read from file: TS_test.gbw
+Input Geometry matches current geometry (good)
+Input basis set matches current basis set (good)
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+
+ InCore treatment chosen:
+   Memory dedicated               ...    1024 MB
+   Memory needed                  ...      0 MB
+   Number of tiny    integrals    ...       0
+   Number of small   integrals    ...      61
+   Number of regular integrals    ...     383
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0    -33.86540539 -33.8654053907  0.000339  0.000339  0.000737  0.000100
+  1    -33.86540671  -0.0000013166  0.000202  0.000611  0.000903  0.000109
+  2    -33.86540745  -0.0000007377  0.000090  0.000546  0.000833  0.000106
+  3    -33.86540769  -0.0000002469  0.000015  0.000024  0.000029  0.000006
+  4    -33.86540769  -0.0000000023  0.000004  0.000014  0.000017  0.000004
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   5 CYCLES          *
+               *****************************************************
+
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :          -33.86540769 Eh            -921.52459 eV
+
+Components:
+Nuclear Repulsion  :           32.26003178 Eh             877.84009 eV
+Electronic Energy  :          -66.12543948 Eh           -1799.36469 eV
+One Electron Energy:         -122.11675124 Eh           -3322.96574 eV
+Two Electron Energy:           55.99131176 Eh            1523.60105 eV
+
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -4.3899e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    4.3159e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    7.6911e-07  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    1.2062e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    2.5529e-06  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (TS_test.gbw) ****
+             **** DENSITY FILE WAS UPDATED (TS_test.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (TS_test.en.tmp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -1.851174       -50.3730 
+   1   2.0000      -0.865356       -23.5475 
+   2   2.0000      -0.377990       -10.2856 
+   3   2.0000      -0.377978       -10.2853 
+   4   2.0000      -0.327983        -8.9249 
+   5   2.0000      -0.279554        -7.6071 
+   6   2.0000      -0.233317        -6.3489 
+   7   2.0000      -0.233317        -6.3489 
+   8   2.0000      -0.184269        -5.0142 
+   9   2.0000      -0.184269        -5.0142 
+  10   2.0000      -0.151857        -4.1322 
+  11   0.0000       0.179844         4.8938 
+  12   0.0000       0.289364         7.8740 
+  13   0.0000       0.324226         8.8226 
+  14   0.0000       0.324232         8.8228 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 C :    0.103102
+   1 Cl:   -0.611382
+   2 H :    0.118822
+   3 H :    0.118815
+   4 H :    0.118815
+   5 F :   -0.848171
+Sum of atomic charges:   -1.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 C s       :     1.560864  s :     1.560864
+      pz      :     0.912723  p :     2.336034
+      px      :     0.510517
+      py      :     0.912795
+  1 Cls       :     2.004771  s :     2.004771
+      pz      :     2.000020  p :     5.606611
+      px      :     1.606493
+      py      :     2.000098
+  2 H s       :     0.881178  s :     0.881178
+  3 H s       :     0.881185  s :     0.881185
+  4 H s       :     0.881185  s :     0.881185
+  5 F s       :     1.991060  s :     1.991060
+      pz      :     1.999061  p :     5.857111
+      px      :     1.858961
+      py      :     1.999089
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 C :    0.308059
+   1 Cl:   -0.596225
+   2 H :    0.045079
+   3 H :    0.045076
+   4 H :    0.045075
+   5 F :   -0.847064
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 C s       :     1.194814  s :     1.194814
+      pz      :     0.980388  p :     2.497127
+      px      :     0.536269
+      py      :     0.980470
+  1 Cls       :     1.992555  s :     1.992555
+      pz      :     1.999833  p :     5.603670
+      px      :     1.603926
+      py      :     1.999911
+  2 H s       :     0.954921  s :     0.954921
+  3 H s       :     0.954924  s :     0.954924
+  4 H s       :     0.954925  s :     0.954925
+  5 F s       :     1.991042  s :     1.991042
+      pz      :     1.999116  p :     5.856022
+      px      :     1.857762
+      py      :     1.999144
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 C      3.8969     4.0000     0.1031     3.4288     3.4288    -0.0000
+  1 Cl     7.6114     7.0000    -0.6114     0.6255     0.6255    -0.0000
+  2 H      0.8812     1.0000     0.1188     0.9859     0.9859    -0.0000
+  3 H      0.8812     1.0000     0.1188     0.9859     0.9859    -0.0000
+  4 H      0.8812     1.0000     0.1188     0.9859     0.9859    -0.0000
+  5 F      7.8482     7.0000    -0.8482     0.2817     0.2817     0.0000
+
+  Mayer bond orders larger than 0.1
+B(  0-C ,  1-Cl) :   0.5408 B(  0-C ,  2-H ) :   0.8891 B(  0-C ,  3-H ) :   0.8891 
+B(  0-C ,  4-H ) :   0.8891 B(  0-C ,  5-F ) :   0.2208 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+Total time                  ....       0.218 sec
+Sum of individual times     ....       0.070 sec  ( 32.0%)
+
+Fock matrix formation       ....       0.044 sec  ( 20.4%)
+Diagonalization             ....       0.000 sec  (  0.1%)
+Density matrix formation    ....       0.000 sec  (  0.0%)
+Population analysis         ....       0.016 sec  (  7.2%)
+Initial guess               ....       0.004 sec  (  1.7%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.000 sec  (  0.0%)
+SOSCF solution              ....       0.006 sec  (  2.6%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -33.865407694733
+-------------------------   --------------------
+
+                                *** OPTIMIZATION RUN DONE ***
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... TS_test.gbw
+Electron density file                           ... TS_test.scfp.tmp
+The origin for moment calculation is the CENTER OF MASS  = (-2.855722, -0.827998  0.011907)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     25.75803       0.04913      -0.36521
+Nuclear contribution   :    -19.98040      -0.03810       0.28323
+                        -----------------------------------------
+Total Dipole Moment    :      5.77764       0.01102      -0.08198
+                        -----------------------------------------
+Magnitude (a.u.)       :      5.77823
+Magnitude (Debye)      :     14.68709
+
+
+----------------------------------------------------------------------------
+                           ORCA NUMERICAL FREQUENCIES
+----------------------------------------------------------------------------
+
+Number of atoms                ... 6
+Central differences            ... used
+Number of displacements        ... 36
+Numerical increment            ...  0.005 bohr
+IR-spectrum generation         ... on
+Raman-spectrum generation      ... off
+Surface Crossing Hessian       ... off
+
+The output will be reduced. Please look at the following files:
+SCF program output             ... >TS_test.lastscf
+Integral program output        ... >TS_test.lastint
+Gradient program output        ... >TS_test.lastgrad
+Dipole moment program output   ... >TS_test.lastmom
+
+
+         <<<Energy and Gradient at the input geometry>>>
+             <<<Displacing   1/coordinate 1 (+)>>>
+             <<<Displacing   1/coordinate 1 (-)>>>
+             <<<Displacing   1/coordinate 2 (+)>>>
+             <<<Displacing   1/coordinate 2 (-)>>>
+             <<<Displacing   1/coordinate 3 (+)>>>
+             <<<Displacing   1/coordinate 3 (-)>>>
+             <<<Displacing   2/coordinate 1 (+)>>>
+             <<<Displacing   2/coordinate 1 (-)>>>
+             <<<Displacing   2/coordinate 2 (+)>>>
+             <<<Displacing   2/coordinate 2 (-)>>>
+             <<<Displacing   2/coordinate 3 (+)>>>
+             <<<Displacing   2/coordinate 3 (-)>>>
+             <<<Displacing   3/coordinate 1 (+)>>>
+             <<<Displacing   3/coordinate 1 (-)>>>
+             <<<Displacing   3/coordinate 2 (+)>>>
+             <<<Displacing   3/coordinate 2 (-)>>>
+             <<<Displacing   3/coordinate 3 (+)>>>
+             <<<Displacing   3/coordinate 3 (-)>>>
+             <<<Displacing   4/coordinate 1 (+)>>>
+             <<<Displacing   4/coordinate 1 (-)>>>
+             <<<Displacing   4/coordinate 2 (+)>>>
+             <<<Displacing   4/coordinate 2 (-)>>>
+             <<<Displacing   4/coordinate 3 (+)>>>
+             <<<Displacing   4/coordinate 3 (-)>>>
+             <<<Displacing   5/coordinate 1 (+)>>>
+             <<<Displacing   5/coordinate 1 (-)>>>
+             <<<Displacing   5/coordinate 2 (+)>>>
+             <<<Displacing   5/coordinate 2 (-)>>>
+             <<<Displacing   5/coordinate 3 (+)>>>
+             <<<Displacing   5/coordinate 3 (-)>>>
+             <<<Displacing   6/coordinate 1 (+)>>>
+             <<<Displacing   6/coordinate 1 (-)>>>
+             <<<Displacing   6/coordinate 2 (+)>>>
+             <<<Displacing   6/coordinate 2 (-)>>>
+             <<<Displacing   6/coordinate 3 (+)>>>
+             <<<Displacing   6/coordinate 3 (-)>>>
+
+-----------------------
+VIBRATIONAL FREQUENCIES
+-----------------------
+
+   0:         0.00 cm**-1
+   1:         0.00 cm**-1
+   2:         0.00 cm**-1
+   3:         0.00 cm**-1
+   4:         0.00 cm**-1
+   5:         0.00 cm**-1
+   6:      -503.24 cm**-1 ***imaginary mode***
+   7:       173.47 cm**-1
+   8:       173.53 cm**-1
+   9:       331.23 cm**-1
+  10:       929.12 cm**-1
+  11:       929.15 cm**-1
+  12:      1074.81 cm**-1
+  13:      1269.59 cm**-1
+  14:      1269.95 cm**-1
+  15:      3107.08 cm**-1
+  16:      3186.99 cm**-1
+  17:      3187.08 cm**-1
+
+
+------------
+NORMAL MODES
+------------
+
+These modes are the cartesian displacements weighted by the diagonal matrix
+M(i,i)=1/sqrt(m[i]) where m[i] is the mass of the displaced atom
+Thus, these vectors are normalized but *not* orthogonal
+
+                  0          1          2          3          4          5    
+      0       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      1       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      2       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      3       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      4       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      5       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      6       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      7       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      8       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      9       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     10       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     11       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     12       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     13       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     14       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     15       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     16       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     17       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+                  6          7          8          9         10         11    
+      0      -0.875088   0.006553   0.000023   0.351921  -0.000385  -0.000774
+      1      -0.001834  -0.063162   0.430397   0.000468  -0.051776   0.034350
+      2       0.012973   0.430444   0.063152  -0.004377  -0.034372  -0.051725
+      3       0.087127  -0.001243  -0.000030  -0.519205   0.000102   0.000195
+      4       0.000205   0.013429  -0.091513  -0.000949   0.013775  -0.009146
+      5      -0.001364  -0.091522  -0.013428   0.007232   0.009143   0.013769
+      6       0.130605   0.163255  -0.138405  -0.090081  -0.226755   0.775848
+      7      -0.087795  -0.050282   0.478248   0.025403   0.068340  -0.027237
+      8       0.072826   0.477322   0.091964  -0.019758   0.058227   0.046274
+      9       0.126940  -0.191348  -0.066081  -0.089689  -0.556920  -0.583238
+     10      -0.020222  -0.080022   0.496331   0.005541   0.070378  -0.054269
+     11      -0.114079   0.464495   0.061810   0.035034   0.038114   0.062642
+     12       0.129297   0.049309   0.204651  -0.089996   0.785137  -0.189040
+     13       0.107855  -0.080533   0.462590  -0.032014   0.050155  -0.043635
+     14       0.038321   0.495172   0.057127  -0.009609   0.029168   0.079735
+     15       0.370135  -0.002948   0.000032   0.760732  -0.000025  -0.000064
+     16       0.000785   0.026058  -0.177584   0.001532  -0.002993   0.001989
+     17      -0.005500  -0.177588  -0.026058  -0.011029  -0.001991  -0.003002
+                 12         13         14         15         16         17    
+      0       0.004507   0.000272   0.001276   0.016143   0.000843   0.001130
+      1      -0.000012   0.088043  -0.030490   0.000082  -0.086299   0.047328
+      2      -0.000023   0.030475   0.088016  -0.000281   0.047327   0.086289
+      3       0.032077   0.000001  -0.000010   0.001387   0.000004   0.000004
+      4       0.000061  -0.000361   0.000127   0.000003  -0.000198   0.000109
+      5      -0.000457  -0.000122  -0.000359  -0.000020   0.000109   0.000199
+      6      -0.571776  -0.077996   0.115718  -0.071987   0.108339   0.021834
+      7       0.059416  -0.402652  -0.324241  -0.438422   0.600823   0.131328
+      8      -0.042788  -0.552818  -0.261743   0.369569  -0.510935  -0.088888
+      9      -0.570522  -0.064004  -0.121134  -0.085613  -0.041642  -0.123173
+     10       0.012892  -0.676157   0.395770  -0.099936  -0.060993  -0.127731
+     11       0.086043   0.167447   0.015121  -0.561694  -0.250599  -0.748959
+     12      -0.571617   0.138802  -0.008759  -0.076135  -0.076872   0.087732
+     13      -0.075435   0.084877   0.272668   0.537309   0.494623  -0.570906
+     14      -0.019053   0.041240  -0.747211   0.196078   0.194211  -0.196548
+     15       0.028228  -0.000005  -0.000036  -0.000393   0.000000   0.000001
+     16       0.000060  -0.002253   0.000777  -0.000001   0.000045  -0.000024
+     17      -0.000417  -0.000781  -0.002245   0.000006  -0.000024  -0.000042
+
+
+-----------
+IR SPECTRUM
+-----------
+
+ Mode    freq (cm**-1)   T**2         TX         TY         TZ
+-------------------------------------------------------------------
+   7:       173.47  573.889339  ( -0.347388   3.476384 -23.699861)
+   8:       173.53  573.576028  ( -0.003072 -23.695211  -3.480373)
+   9:       331.23    4.167889  (  2.041079   0.008076  -0.042648)
+  10:       929.12   12.587324  ( -0.024410  -2.953194  -1.966056)
+  11:       929.15   12.557748  ( -0.066978   1.955920  -2.954258)
+  12:      1074.81  1942.810822  ( 44.072835   0.081282  -0.624077)
+  13:      1269.59  259.183468  (  0.048361  15.215036   5.261540)
+  14:      1269.95  260.083508  (  0.219335  -5.280404  15.236559)
+  15:      3107.08  740.134705  (-27.202686  -0.053462   0.381749)
+  16:      3186.99  553.867544  ( -0.204494  20.631501 -11.321082)
+  17:      3187.08  552.452278  ( -0.259370 -11.306016 -20.604830)
+
+The first frequency considered to be a vibration is 7
+The total number of vibrations considered is 11
+
+
+--------------------------
+THERMOCHEMISTRY AT 298.15K
+--------------------------
+
+Temperature         ... 298.15 K
+Pressure            ... 1.00 atm
+Total Mass          ... 69.49 AMU
+
+Throughout the following assumptions are being made:
+  (1) The electronic state is orbitally nondegenerate
+  (2) There are no thermally accessible electronically excited states
+  (3) Hindered rotations indicated by low frequency modes are not
+      treated as such but are treated as vibrations and this may
+      cause some error
+  (4) All equations used are the standard statistical mechanics
+      equations for an ideal gas
+  (5) All vibrations are strictly harmonic
+
+freq.     173.47  E(vib)   ...       0.38 
+freq.     173.53  E(vib)   ...       0.38 
+freq.     331.23  E(vib)   ...       0.24 
+freq.     929.12  E(vib)   ...       0.03 
+freq.     929.15  E(vib)   ...       0.03 
+freq.    1074.81  E(vib)   ...       0.02 
+freq.    1269.59  E(vib)   ...       0.01 
+freq.    1269.95  E(vib)   ...       0.01 
+freq.    3107.08  E(vib)   ...       0.00 
+freq.    3186.99  E(vib)   ...       0.00 
+freq.    3187.08  E(vib)   ...       0.00 
+
+------------
+INNER ENERGY
+------------
+
+The inner energy is: U= E(el) + E(ZPE) + E(vib) + E(rot) + E(trans)
+    E(el)   - is the total energy from the electronic structure calculation
+              = E(kin-el) + E(nuc-el) + E(el-el) + E(nuc-nuc)
+    E(ZPE)  - the the zero temperature vibrational energy from the frequency calculation
+    E(vib)  - the the finite temperature correction to E(ZPE) due to population
+              of excited vibrational states
+    E(rot)  - is the rotational thermal energy
+    E(trans)- is the translational thermal energy
+
+Summary of contributions to the inner energy U:
+Electronic energy                ...    -33.86540769 Eh
+Zero point energy                ...      0.03561230 Eh      22.35 kcal/mol
+Thermal vibrational correction   ...      0.00173906 Eh       1.09 kcal/mol
+Thermal rotational correction    ...      0.00141627 Eh       0.89 kcal/mol
+Thermal translational correction ...      0.00141627 Eh       0.89 kcal/mol
+-----------------------------------------------------------------------
+Total thermal energy                    -33.82522379 Eh
+
+
+Summary of corrections to the electronic energy:
+(perhaps to be used in another calculation)
+Total thermal correction                  0.00457160 Eh       2.87 kcal/mol
+Non-thermal (ZPE) correction              0.03561230 Eh      22.35 kcal/mol
+-----------------------------------------------------------------------
+Total correction                          0.04018390 Eh      25.22 kcal/mol
+
+
+--------
+ENTHALPY
+--------
+
+The enthalpy is H = U + kB*T
+                kB is Boltzmann's constant
+Total free energy                 ...    -33.82522379 Eh 
+Thermal Enthalpy correction       ...      0.00094421 Eh       0.59 kcal/mol
+-----------------------------------------------------------------------
+Total Enthalpy                    ...    -33.82427958 Eh
+
+
+Vibrational entropy computed according to the QRRHO of S. Grimme
+Chem.Eur.J. 2012 18 9955
+
+
+-------
+ENTROPY
+-------
+
+The entropy contributions are T*S = T*(S(el)+S(vib)+S(rot)+S(trans)
+     S(el)   - electronic entropy
+     S(vib)  - vibrational entropy
+     S(rot)  - rotational entropy
+     S(trans)- translational entropy
+The entropies will be listed as mutliplied by the temperature to get
+units of energy
+
+Electronic entropy                ...      0.00000000 Eh      0.00 kcal/mol
+Vibrational entropy               ...      0.00304757 Eh      1.91 kcal/mol
+Rotational entropy                ...      0.01016026 Eh      6.38 kcal/mol
+Translational entropy             ...      0.01835566 Eh     11.52 kcal/mol
+-----------------------------------------------------------------------
+Final entropy term                ...      0.03156349 Eh     19.81 kcal/mol
+
+
+CAUTION: The rotational entropy is not quite correctly treated here
+         because it includes a symmetry number that is not yet correctly
+         implemented in ORCA!
+For a nonlinear molecule the correct rotational entropy is:
+    S(rot) = R*(ln(qrot/sn)+1.5)
+    R    = 8.31441 J/mol/K = 1.987191683e-3 kcal/mol/K
+    qrot = 31556.7272165
+    sn is the rotational symmetry number. We have assumed 3 here
+       if it is different for your molecule then you should correct
+       the printed rotational entropy by manually evaluating the equation
+       as given above
+
+For convenience we print out the resulting values for sn=1 - 12:
+ sn= 1  qrot/sn=   31556.7272 T*S(rot)=     7.03 kcal/mol T*S(tot)=    20.46 kcal/mol
+ sn= 2  qrot/sn=   15778.3636 T*S(rot)=     6.62 kcal/mol T*S(tot)=    20.05 kcal/mol
+ sn= 3  qrot/sn=   10518.9091 T*S(rot)=     6.38 kcal/mol T*S(tot)=    19.81 kcal/mol
+ sn= 4  qrot/sn=    7889.1818 T*S(rot)=     6.21 kcal/mol T*S(tot)=    19.64 kcal/mol
+ sn= 5  qrot/sn=    6311.3454 T*S(rot)=     6.07 kcal/mol T*S(tot)=    19.50 kcal/mol
+ sn= 6  qrot/sn=    5259.4545 T*S(rot)=     5.96 kcal/mol T*S(tot)=    19.40 kcal/mol
+ sn= 7  qrot/sn=    4508.1039 T*S(rot)=     5.87 kcal/mol T*S(tot)=    19.30 kcal/mol
+ sn= 8  qrot/sn=    3944.5909 T*S(rot)=     5.79 kcal/mol T*S(tot)=    19.23 kcal/mol
+ sn= 9  qrot/sn=    3506.3030 T*S(rot)=     5.72 kcal/mol T*S(tot)=    19.16 kcal/mol
+ sn=10  qrot/sn=    3155.6727 T*S(rot)=     5.66 kcal/mol T*S(tot)=    19.09 kcal/mol
+ sn=11  qrot/sn=    2868.7934 T*S(rot)=     5.61 kcal/mol T*S(tot)=    19.04 kcal/mol
+ sn=12  qrot/sn=    2629.7273 T*S(rot)=     5.55 kcal/mol T*S(tot)=    18.98 kcal/mol
+
+
+-------------------
+GIBBS FREE ENTHALPY
+-------------------
+
+The Gibbs free enthalpy is G = H - T*S
+
+Total enthalpy                    ...    -33.82427958 Eh 
+Total entropy correction          ...     -0.03156349 Eh    -19.81 kcal/mol
+-----------------------------------------------------------------------
+Final Gibbs free enthalpy         ...    -33.85584307 Eh
+
+For completeness - the Gibbs free enthalpy minus the electronic energy
+G-E(el)                           ...      0.00956462 Eh      6.00 kcal/mol
+
+
+Total Time for Numerical Frequencies  :        18.913 sec
+
+Timings for individual modules:
+
+Sum of individual times         ...        6.739 sec (=   0.112 min)
+STO integral calculation        ...        0.747 sec (=   0.012 min)  11.1 %
+SCF iterations                  ...        4.850 sec (=   0.081 min)  72.0 %
+SCF Gradient evaluation         ...        0.391 sec (=   0.007 min)   5.8 %
+Geometry relaxation             ...        0.751 sec (=   0.013 min)  11.2 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 26 seconds 770 msec

--- a/arkane/data/Orca_dlpno_test.log
+++ b/arkane/data/Orca_dlpno_test.log
@@ -1,0 +1,3206 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.2.0 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel, MM, QM/MM, CI optimization
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 4.2.3
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: cc-pVTZ 
+       H, B-Ne : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 T. H. Dunning, Jr., J. Chem. Phys. 90, 1007 (1989)
+            He : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 D. E. Woon, T. H. Dunning, Jr., J. Chem. Phys. 100, 2975 (1994)
+  Li-Be, Na-Mg : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 B. P. Prascher, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., A. K. Wilson, Theor. Chem. Acc. 128, 69 (2011)
+         Al-Ar : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 D. E. Woon, T. H. Dunning, Jr., J. Chem. Phys. 98, 1358 (1993)
+            Ca : Obtained from the Peterson Research Group Website (tyr0.chem.wsu.edu/~kipeters) Feb. 2017
+                 J. Koput, K. A. Peterson, J. Phys. Chem. 106, 9595 (2002)
+         Sc-Zn : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 N. B. Balabanov, K. A. Peterson, J. Chem. Phys. 123, 064107 (2005)
+                 N. B. Balabanov, K. A. Peterson, J. Chem. Phys. 125, 074110 (2006)
+         Ga-Kr : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 A. K. Wilson, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., J. Chem. Phys. 110, 7667 (1999)
+             Y : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+                 K. A. Peterson, D. Figgen, M. Dolg, H. Stoll, J. Chem. Phys. 126, 124101 (2007)
+        Ag, Au : Obtained from the Peterson Research Group Website (tyr0.chem.wsu.edu/~kipeters) Feb. 2017
+                 K. A. Peterson, C. Puzzarini, Theor. Chem. Acc. 114, 283 (2005)
+
+----- AuxC basis set information -----
+Your calculation utilizes the auxiliary basis: aug-cc-pVTZ/C 
+  H-He, B-F, Al-Ar, Ga-Kr : Obtained from the EMSL Basis Set Exchange (bse.pnl.gov) Feb. 2017
+                            F. Weigend, A. Kohn, C. Hattig, J. Chem. Phys. 116, 3175 (2002)
+                   Be, Mg : Obtained from the TURBOMOLE 7.0 basis set library
+                            C. Haettig, Phys. Chem. Chem. Phys. 7, 59 (2005)
+                       Ne : Obtained from the EMSL Basis Set Exchange (bse.pnl.gov) Feb. 2017
+                            C. Haettig, Phys. Chem. Chem. Phys. 7, 59 (2005)
+                            F. Weigend, A. Kohn, C. Hattig, J. Chem. Phys. 116, 3175 (2002)
+                    Sc-Zn : Obtained from the EMSL Basis Set Exchange (bse.pnl.gov) Feb. 2017
+                            J. G. Hill, J. A. Platts, J. Chem. Phys. 128, 044104 (2008)
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: MDCI localization with Augmented Hessian Foster-Boys
+  ===> : Switching off randomization!
+
+WARNING: Post HF methods need fully converged wavefunctions
+  ===> : Setting SCFConvForced true
+         You can overwrite this default with %scf ConvForced false 
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = 07_Triphenylene.inp
+|  1> !RHF DLPNO-CCSD(T) cc-pvtz aug-cc-pvtz/C TightSCF  NormalPNO 
+|  2> %maxcore 8000
+|  3> %pal
+|  4> nprocs 32
+|  5> end
+|  6> # RHF DLPNO ccsd(T)
+|  7> *xyz 0 1
+|  8> C 0.698984 3.695555 0.000000
+|  9> C 1.380511 2.495679 0.000000
+| 10> C 0.709343 1.254995 0.000000
+| 11> C -0.709343 1.254995 0.000000
+| 12> C -1.380511 2.495679 0.000000
+| 13> C -0.698984 3.695555 0.000000
+| 14> C 1.441529 -0.013189 0.000000
+| 15> C -1.441529 -0.013189 0.000000
+| 16> C -0.732186 -1.241806 0.000000
+| 17> C 0.732186 -1.241806 0.000000
+| 18> C -1.471066 -2.443397 0.000000
+| 19> H -0.953963 -3.393647 0.000000
+| 20> C -2.850953 -2.453116 0.000000
+| 21> C -3.549937 -1.242440 0.000000
+| 22> C -2.851577 -0.052282 0.000000
+| 23> H 1.248457 4.630885 0.000000
+| 24> H 2.462003 2.522980 0.000000
+| 25> H -2.462003 2.522980 0.000000
+| 26> H -1.248457 4.630885 0.000000
+| 27> H -3.386235 -3.396638 0.000000
+| 28> H -4.634692 -1.234246 0.000000
+| 29> H -3.415966 0.870667 0.000000
+| 30> C 1.471066 -2.443397 0.000000
+| 31> C 2.851577 -0.052282 0.000000
+| 32> C 2.850953 -2.453116 0.000000
+| 33> C 3.549937 -1.242440 0.000000
+| 34> H 0.953963 -3.393647 0.000000
+| 35> H 3.386235 -3.396638 0.000000
+| 36> H 4.634692 -1.234246 0.000000
+| 37> H 3.415966 0.870667 0.000000 
+| 38> *
+| 39> 
+| 40> 
+| 41>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C      0.698984    3.695555    0.000000
+  C      1.380511    2.495679    0.000000
+  C      0.709343    1.254995    0.000000
+  C     -0.709343    1.254995    0.000000
+  C     -1.380511    2.495679    0.000000
+  C     -0.698984    3.695555    0.000000
+  C      1.441529   -0.013189    0.000000
+  C     -1.441529   -0.013189    0.000000
+  C     -0.732186   -1.241806    0.000000
+  C      0.732186   -1.241806    0.000000
+  C     -1.471066   -2.443397    0.000000
+  H     -0.953963   -3.393647    0.000000
+  C     -2.850953   -2.453116    0.000000
+  C     -3.549937   -1.242440    0.000000
+  C     -2.851577   -0.052282    0.000000
+  H      1.248457    4.630885    0.000000
+  H      2.462003    2.522980    0.000000
+  H     -2.462003    2.522980    0.000000
+  H     -1.248457    4.630885    0.000000
+  H     -3.386235   -3.396638    0.000000
+  H     -4.634692   -1.234246    0.000000
+  H     -3.415966    0.870667    0.000000
+  C      1.471066   -2.443397    0.000000
+  C      2.851577   -0.052282    0.000000
+  C      2.850953   -2.453116    0.000000
+  C      3.549937   -1.242440    0.000000
+  H      0.953963   -3.393647    0.000000
+  H      3.386235   -3.396638    0.000000
+  H      4.634692   -1.234246    0.000000
+  H      3.415966    0.870667    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     6.0000    0    12.011    1.320888    6.983587    0.000000
+   1 C     6.0000    0    12.011    2.608788    4.716150    0.000000
+   2 C     6.0000    0    12.011    1.340464    2.371597    0.000000
+   3 C     6.0000    0    12.011   -1.340464    2.371597    0.000000
+   4 C     6.0000    0    12.011   -2.608788    4.716150    0.000000
+   5 C     6.0000    0    12.011   -1.320888    6.983587    0.000000
+   6 C     6.0000    0    12.011    2.724095   -0.024924    0.000000
+   7 C     6.0000    0    12.011   -2.724095   -0.024924    0.000000
+   8 C     6.0000    0    12.011   -1.383631   -2.346673    0.000000
+   9 C     6.0000    0    12.011    1.383631   -2.346673    0.000000
+  10 C     6.0000    0    12.011   -2.779912   -4.617351    0.000000
+  11 H     1.0000    0     1.008   -1.802729   -6.413063    0.000000
+  12 C     6.0000    0    12.011   -5.387520   -4.635717    0.000000
+  13 C     6.0000    0    12.011   -6.708409   -2.347871    0.000000
+  14 C     6.0000    0    12.011   -5.388700   -0.098799    0.000000
+  15 H     1.0000    0     1.008    2.359242    8.751104    0.000000
+  16 H     1.0000    0     1.008    4.652511    4.767741    0.000000
+  17 H     1.0000    0     1.008   -4.652511    4.767741    0.000000
+  18 H     1.0000    0     1.008   -2.359242    8.751104    0.000000
+  19 H     1.0000    0     1.008   -6.399057   -6.418716    0.000000
+  20 H     1.0000    0     1.008   -8.758299   -2.332387    0.000000
+  21 H     1.0000    0     1.008   -6.455240    1.645322    0.000000
+  22 C     6.0000    0    12.011    2.779912   -4.617351    0.000000
+  23 C     6.0000    0    12.011    5.388700   -0.098799    0.000000
+  24 C     6.0000    0    12.011    5.387520   -4.635717    0.000000
+  25 C     6.0000    0    12.011    6.708409   -2.347871    0.000000
+  26 H     1.0000    0     1.008    1.802729   -6.413063    0.000000
+  27 H     1.0000    0     1.008    6.399057   -6.418716    0.000000
+  28 H     1.0000    0     1.008    8.758299   -2.332387    0.000000
+  29 H     1.0000    0     1.008    6.455240    1.645322    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.379920819143     0.00000000     0.00000000
+ C      2   1   0     1.410589689485   121.99163165     0.00000000
+ C      3   2   1     1.418686000000   118.41188602     0.00000000
+ C      4   3   2     1.410589689485   118.41188602     0.00000000
+ C      5   4   3     1.379920819143   121.99163165     0.00000000
+ C      3   2   1     1.464372560673   121.58812664   180.00000000
+ C      4   3   2     1.464372560673   119.99998733   180.00000085
+ C      8   4   3     1.418685033522   119.99999013     0.00000000
+ C      7   3   2     1.418685033522   119.99999013   180.00000000
+ C      9   8   4     1.410590155106   118.41186854   180.00000000
+ H     11   9   8     1.081836667482   119.85793098   180.00000000
+ C     11   9   8     1.379921226639   121.99165536     0.00000000
+ C     13  11   9     1.397968171752   119.59644951     0.00000000
+ C     14  13  11     1.379921285641   119.59647837     0.00000000
+ H      1   2   3     1.084786977535   119.97080182   180.00000000
+ H      2   1   3     1.081836536019   118.15042453   180.00000085
+ H      5   4   3     1.081836536019   119.85794381   180.00000000
+ H      6   5   4     1.084786977535   119.97080182   180.00000000
+ H     13  11   9     1.084785962302   119.97079778   180.00000085
+ H     14  13  11     1.084785947393   120.43278738   180.00000000
+ H     15  14  13     1.081836309209   118.15043149   180.00000000
+ C     10   7   3     1.410590155106   118.41186854   180.00000000
+ C      7   3   2     1.410589814564   121.58808241     0.00000000
+ C     23  10   7     1.379921226639   121.99165536     0.00000000
+ C     24   7   3     1.379921285641   121.99162077   180.00000000
+ H     23  10   7     1.081836667482   119.85793098   180.00000000
+ H     25  23  10     1.084785962302   119.97079778   180.00000085
+ H     26  24   7     1.084785947393   119.97073424   180.00000085
+ H     24   7   3     1.081836309209   119.85794775     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.607672434677     0.00000000     0.00000000
+ C      2   1   0     2.665628200459   121.99163165     0.00000000
+ C      3   2   1     2.680928010028   118.41188602     0.00000000
+ C      4   3   2     2.665628200459   118.41188602     0.00000000
+ C      5   4   3     2.607672434677   121.99163165     0.00000000
+ C      3   2   1     2.767263097701   121.58812664   180.00000000
+ C      4   3   2     2.767263097701   119.99998733   180.00000085
+ C      8   4   3     2.680926183649   119.99999013     0.00000000
+ C      7   3   2     2.680926183649   119.99999013   180.00000000
+ C      9   8   4     2.665629080355   118.41186854   180.00000000
+ H     11   9   8     2.044375023175   119.85793098   180.00000000
+ C     11   9   8     2.607673204733   121.99165536     0.00000000
+ C     13  11   9     2.641776988550   119.59644951     0.00000000
+ C     14  13  11     2.607673316229   119.59647837     0.00000000
+ H      1   2   3     2.049950301185   119.97080182   180.00000000
+ H      2   1   3     2.044374774745   118.15042453   180.00000085
+ H      5   4   3     2.044374774745   119.85794381   180.00000000
+ H      6   5   4     2.049950301185   119.97080182   180.00000000
+ H     13  11   9     2.049948382673   119.97079778   180.00000085
+ H     14  13  11     2.049948354499   120.43278738   180.00000000
+ H     15  14  13     2.044374346136   118.15043149   180.00000000
+ C     10   7   3     2.665629080355   118.41186854   180.00000000
+ C      7   3   2     2.665628436826   121.58808241     0.00000000
+ C     23  10   7     2.607673204733   121.99165536     0.00000000
+ C     24   7   3     2.607673316229   121.99162077   180.00000000
+ H     23  10   7     2.044375023175   119.85793098   180.00000000
+ H     25  23  10     2.049948382673   119.97079778   180.00000085
+ H     26  24   7     2.049948354499   119.97073424   180.00000085
+ H     24   7   3     2.044374346136   119.85794775     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type C   : 18s5p2d1f contracted to 4s3p2d1f pattern {8811/311/11/1}
+ Group   2 Type H   : 5s2p1d contracted to 3s2p1d pattern {311/11/1}
+
+Atom   0C    basis set group =>   1
+Atom   1C    basis set group =>   1
+Atom   2C    basis set group =>   1
+Atom   3C    basis set group =>   1
+Atom   4C    basis set group =>   1
+Atom   5C    basis set group =>   1
+Atom   6C    basis set group =>   1
+Atom   7C    basis set group =>   1
+Atom   8C    basis set group =>   1
+Atom   9C    basis set group =>   1
+Atom  10C    basis set group =>   1
+Atom  11H    basis set group =>   2
+Atom  12C    basis set group =>   1
+Atom  13C    basis set group =>   1
+Atom  14C    basis set group =>   1
+Atom  15H    basis set group =>   2
+Atom  16H    basis set group =>   2
+Atom  17H    basis set group =>   2
+Atom  18H    basis set group =>   2
+Atom  19H    basis set group =>   2
+Atom  20H    basis set group =>   2
+Atom  21H    basis set group =>   2
+Atom  22C    basis set group =>   1
+Atom  23C    basis set group =>   1
+Atom  24C    basis set group =>   1
+Atom  25C    basis set group =>   1
+Atom  26H    basis set group =>   2
+Atom  27H    basis set group =>   2
+Atom  28H    basis set group =>   2
+Atom  29H    basis set group =>   2
+---------------------------------
+AUXILIARY/C BASIS SET INFORMATION
+---------------------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type C   : 9s7p6d4f2g contracted to 9s7p6d4f2g pattern {111111111/1111111/111111/1111/11}
+ Group   2 Type H   : 5s4p3d2f contracted to 5s4p3d2f pattern {11111/1111/111/11}
+
+Atom   0C    basis set group =>   1
+Atom   1C    basis set group =>   1
+Atom   2C    basis set group =>   1
+Atom   3C    basis set group =>   1
+Atom   4C    basis set group =>   1
+Atom   5C    basis set group =>   1
+Atom   6C    basis set group =>   1
+Atom   7C    basis set group =>   1
+Atom   8C    basis set group =>   1
+Atom   9C    basis set group =>   1
+Atom  10C    basis set group =>   1
+Atom  11H    basis set group =>   2
+Atom  12C    basis set group =>   1
+Atom  13C    basis set group =>   1
+Atom  14C    basis set group =>   1
+Atom  15H    basis set group =>   2
+Atom  16H    basis set group =>   2
+Atom  17H    basis set group =>   2
+Atom  18H    basis set group =>   2
+Atom  19H    basis set group =>   2
+Atom  20H    basis set group =>   2
+Atom  21H    basis set group =>   2
+Atom  22C    basis set group =>   1
+Atom  23C    basis set group =>   1
+Atom  24C    basis set group =>   1
+Atom  25C    basis set group =>   1
+Atom  26H    basis set group =>   2
+Atom  27H    basis set group =>   2
+Atom  28H    basis set group =>   2
+Atom  29H    basis set group =>   2
+
+
+           ************************************************************
+           *        Program running with 32 parallel MPI-processes    *
+           *              working on a shared directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...  564
+ # of primitive gaussian functions       ... 1092
+ # of contracted shells                  ...  252
+ # of contracted basis functions         ...  708
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  2.500e-11
+ Primitive cut-off              TCut     ...  2.500e-12
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.025 sec)
+
+
+
+           ************************************************************
+           *        Program running with 32 parallel MPI-processes    *
+           *              working on a shared directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... 07_Triphenylene
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....  120
+ Basis Dimension        Dim             ....  708
+ Nuclear Repulsion      ENuc            ....   1157.8231103215 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... LIBINT
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 1
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 5.548e-06
+Time for diagonalization                   ...    0.482 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.767 sec
+Total time needed                          ...    1.256 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...  39336 (   0.0 sec)
+# of grid points (after weights+screening)   ...  35116 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.1 sec
+Reduced shell lists constructed in    0.1 sec
+
+Total number of grid points                  ...    35116
+Total number of batches                      ...      564
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1171
+Average number of shells per batch           ...   127.84 (50.73%)
+Average number of basis functions per batch  ...   329.84 (46.59%)
+Average number of large shells per batch     ...    84.74 (66.28%)
+Average number of large basis fcns per batch ...   226.63 (68.71%)
+Maximum spatial batch extension              ...   3.17,  3.39, 19.48 au
+Average spatial batch extension              ...   0.06,  0.06,  0.12 au
+
+Time for grid setup =    0.389 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.2 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.3 sec)
+Transforming the Hamiltonian                       ... done (   0.3 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.4 sec)
+Back transforming the eigenvectors                 ... done (   0.1 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   2.2 sec)
+                      ------------------
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+  0   -688.2015609200   0.000000000000 0.03386019  0.00059283  0.1932048 0.7000
+  1   -688.4210767224  -0.219515802374 0.02580174  0.00046242  0.1296877 0.7000
+                               ***Turning on DIIS***
+  2   -688.5626632066  -0.141586484215 0.05959968  0.00107477  0.0921207 0.0000
+  3   -687.8122227914   0.750440415210 0.01226944  0.00026284  0.0268712 0.0000
+  4   -688.8512913603  -1.039068568931 0.00364650  0.00009009  0.0057487 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5   -688.84034016   0.0109511983  0.001845  0.001845  0.001675  0.000035
+               *** Restarting incremental Fock matrix formation ***
+  6   -688.86883577  -0.0284956093  0.001124  0.002496  0.001076  0.000021
+  7   -688.86886662  -0.0000308510  0.000714  0.001969  0.000686  0.000014
+  8   -688.86887773  -0.0000111098  0.000125  0.000170  0.000268  0.000005
+  9   -688.86887845  -0.0000007220  0.000026  0.000078  0.000094  0.000002
+ 10   -688.86887854  -0.0000000822  0.000014  0.000038  0.000018  0.000000
+ 11   -688.86887854  -0.0000000074  0.000007  0.000026  0.000009  0.000000
+ 12   -688.86887854   0.0000000062  0.000004  0.000025  0.000004  0.000000
+                  ***Gradient check signals convergence***
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  13 CYCLES          *
+               *****************************************************
+
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :         -688.86887852 Eh          -18745.07517 eV
+
+Components:
+Nuclear Repulsion  :         1157.82311032 Eh           31505.96856 eV
+Electronic Energy  :        -1846.69198884 Eh          -50251.04373 eV
+One Electron Energy:        -3231.21422110 Eh          -87925.80902 eV
+Two Electron Energy:         1384.52223226 Eh           37674.76529 eV
+
+Virial components:
+Potential Energy   :        -1376.73703910 Eh          -37462.91941 eV
+Kinetic Energy     :          687.86816057 Eh           18717.84425 eV
+Virial Ratio       :            2.00145481
+
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    1.4762e-08  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.8710e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    7.4419e-08  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    1.0554e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    3.6814e-06  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (07_Triphenylene.gbw) ****
+             **** DENSITY FILE WAS UPDATED (07_Triphenylene.scfp) ****
+             **** ENERGY FILE WAS UPDATED (07_Triphenylene.en.tmp) ****
+             **** THE GBW FILE WAS UPDATED (07_Triphenylene.gbw) ****
+             **** DENSITY FILE WAS UPDATED (07_Triphenylene.scfp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -11.250502      -306.1417 
+   1   2.0000     -11.250065      -306.1298 
+   2   2.0000     -11.250065      -306.1298 
+   3   2.0000     -11.249067      -306.1027 
+   4   2.0000     -11.249067      -306.1027 
+   5   2.0000     -11.248594      -306.0898 
+   6   2.0000     -11.236136      -305.7508 
+   7   2.0000     -11.236136      -305.7508 
+   8   2.0000     -11.236133      -305.7507 
+   9   2.0000     -11.235731      -305.7398 
+  10   2.0000     -11.235727      -305.7397 
+  11   2.0000     -11.235727      -305.7397 
+  12   2.0000     -11.234817      -305.7149 
+  13   2.0000     -11.234817      -305.7149 
+  14   2.0000     -11.234813      -305.7148 
+  15   2.0000     -11.234056      -305.6942 
+  16   2.0000     -11.234054      -305.6942 
+  17   2.0000     -11.234054      -305.6942 
+  18   2.0000      -1.193421       -32.4746 
+  19   2.0000      -1.146549       -31.1992 
+  20   2.0000      -1.146549       -31.1992 
+  21   2.0000      -1.070747       -29.1365 
+  22   2.0000      -1.049257       -28.5517 
+  23   2.0000      -1.049257       -28.5517 
+  24   2.0000      -0.996679       -27.1210 
+  25   2.0000      -0.982408       -26.7327 
+  26   2.0000      -0.982408       -26.7327 
+  27   2.0000      -0.871031       -23.7020 
+  28   2.0000      -0.854270       -23.2459 
+  29   2.0000      -0.854270       -23.2459 
+  30   2.0000      -0.802037       -21.8245 
+  31   2.0000      -0.802036       -21.8245 
+  32   2.0000      -0.761257       -20.7149 
+  33   2.0000      -0.733810       -19.9680 
+  34   2.0000      -0.680670       -18.5220 
+  35   2.0000      -0.680670       -18.5220 
+  36   2.0000      -0.667420       -18.1614 
+  37   2.0000      -0.646824       -17.6010 
+  38   2.0000      -0.646824       -17.6010 
+  39   2.0000      -0.600799       -16.3486 
+  40   2.0000      -0.600799       -16.3486 
+  41   2.0000      -0.590888       -16.0789 
+  42   2.0000      -0.590888       -16.0789 
+  43   2.0000      -0.583390       -15.8749 
+  44   2.0000      -0.582722       -15.8567 
+  45   2.0000      -0.555772       -15.1233 
+  46   2.0000      -0.535967       -14.5844 
+  47   2.0000      -0.514345       -13.9960 
+  48   2.0000      -0.512874       -13.9560 
+  49   2.0000      -0.512874       -13.9560 
+  50   2.0000      -0.496077       -13.4989 
+  51   2.0000      -0.496077       -13.4989 
+  52   2.0000      -0.467625       -12.7247 
+  53   2.0000      -0.467625       -12.7247 
+  54   2.0000      -0.395383       -10.7589 
+  55   2.0000      -0.376064       -10.2332 
+  56   2.0000      -0.376064       -10.2332 
+  57   2.0000      -0.318880        -8.6772 
+  58   2.0000      -0.285900        -7.7797 
+  59   2.0000      -0.285900        -7.7797 
+  60   0.0000       0.082394         2.2421 
+  61   0.0000       0.082394         2.2421 
+  62   0.0000       0.090155         2.4532 
+  63   0.0000       0.145638         3.9630 
+  64   0.0000       0.148395         4.0380 
+  65   0.0000       0.148395         4.0380 
+  66   0.0000       0.164840         4.4855 
+  67   0.0000       0.164840         4.4855 
+  68   0.0000       0.168694         4.5904 
+  69   0.0000       0.168694         4.5904 
+  70   0.0000       0.184827         5.0294 
+  71   0.0000       0.192492         5.2380 
+  72   0.0000       0.201034         5.4704 
+  73   0.0000       0.208234         5.6663 
+  74   0.0000       0.208235         5.6664 
+  75   0.0000       0.266645         7.2558 
+  76   0.0000       0.266645         7.2558 
+  77   0.0000       0.286568         7.7979 
+  78   0.0000       0.322124         8.7654 
+  79   0.0000       0.322124         8.7654 
+  80   0.0000       0.353490         9.6190 
+  81   0.0000       0.359381         9.7793 
+  82   0.0000       0.359381         9.7793 
+  83   0.0000       0.381989        10.3944 
+  84   0.0000       0.381989        10.3945 
+  85   0.0000       0.388329        10.5670 
+  86   0.0000       0.390099        10.6151 
+  87   0.0000       0.390099        10.6151 
+  88   0.0000       0.394929        10.7466 
+  89   0.0000       0.413181        11.2432 
+  90   0.0000       0.419822        11.4239 
+  91   0.0000       0.419822        11.4239 
+  92   0.0000       0.434066        11.8115 
+  93   0.0000       0.434066        11.8115 
+  94   0.0000       0.438284        11.9263 
+  95   0.0000       0.448168        12.1953 
+  96   0.0000       0.448168        12.1953 
+  97   0.0000       0.458023        12.4635 
+  98   0.0000       0.458366        12.4728 
+  99   0.0000       0.462707        12.5909 
+ 100   0.0000       0.462708        12.5909 
+ 101   0.0000       0.471948        12.8424 
+ 102   0.0000       0.472131        12.8473 
+ 103   0.0000       0.482935        13.1413 
+ 104   0.0000       0.482935        13.1413 
+ 105   0.0000       0.494523        13.4566 
+ 106   0.0000       0.516653        14.0588 
+ 107   0.0000       0.524640        14.2762 
+ 108   0.0000       0.524641        14.2762 
+ 109   0.0000       0.529190        14.4000 
+ 110   0.0000       0.531714        14.4687 
+ 111   0.0000       0.537193        14.6178 
+ 112   0.0000       0.537194        14.6178 
+ 113   0.0000       0.541853        14.7446 
+ 114   0.0000       0.541853        14.7446 
+ 115   0.0000       0.560303        15.2466 
+ 116   0.0000       0.566298        15.4097 
+ 117   0.0000       0.566298        15.4098 
+ 118   0.0000       0.584004        15.8916 
+ 119   0.0000       0.584095        15.8940 
+ 120   0.0000       0.588977        16.0269 
+ 121   0.0000       0.588977        16.0269 
+ 122   0.0000       0.592230        16.1154 
+ 123   0.0000       0.592230        16.1154 
+ 124   0.0000       0.601004        16.3541 
+ 125   0.0000       0.601004        16.3541 
+ 126   0.0000       0.614209        16.7135 
+ 127   0.0000       0.614209        16.7135 
+ 128   0.0000       0.614780        16.7290 
+ 129   0.0000       0.624950        17.0057 
+ 130   0.0000       0.633395        17.2356 
+ 131   0.0000       0.633395        17.2356 
+ 132   0.0000       0.633949        17.2506 
+ 133   0.0000       0.635493        17.2926 
+ 134   0.0000       0.635493        17.2926 
+ 135   0.0000       0.643640        17.5143 
+ 136   0.0000       0.673528        18.3276 
+ 137   0.0000       0.673528        18.3276 
+ 138   0.0000       0.674308        18.3488 
+ 139   0.0000       0.683546        18.6002 
+ 140   0.0000       0.690594        18.7920 
+ 141   0.0000       0.690594        18.7920 
+ 142   0.0000       0.698223        18.9996 
+ 143   0.0000       0.698223        18.9996 
+ 144   0.0000       0.728712        19.8293 
+ 145   0.0000       0.732147        19.9227 
+ 146   0.0000       0.732147        19.9227 
+ 147   0.0000       0.740420        20.1479 
+ 148   0.0000       0.769943        20.9512 
+ 149   0.0000       0.769943        20.9512 
+ 150   0.0000       0.783934        21.3319 
+ 151   0.0000       0.791186        21.5293 
+ 152   0.0000       0.791401        21.5351 
+ 153   0.0000       0.791401        21.5351 
+ 154   0.0000       0.809081        22.0162 
+ 155   0.0000       0.809082        22.0162 
+ 156   0.0000       0.828626        22.5481 
+ 157   0.0000       0.845556        23.0087 
+ 158   0.0000       0.845556        23.0087 
+ 159   0.0000       0.860609        23.4184 
+ 160   0.0000       0.860609        23.4184 
+ 161   0.0000       0.867512        23.6062 
+ 162   0.0000       0.879320        23.9275 
+ 163   0.0000       0.879320        23.9275 
+ 164   0.0000       0.897141        24.4125 
+ 165   0.0000       0.897736        24.4286 
+ 166   0.0000       0.909083        24.7374 
+ 167   0.0000       0.909083        24.7374 
+ 168   0.0000       0.916053        24.9271 
+ 169   0.0000       0.916054        24.9271 
+ 170   0.0000       0.920097        25.0371 
+ 171   0.0000       0.952673        25.9235 
+ 172   0.0000       0.952673        25.9235 
+ 173   0.0000       0.960275        26.1304 
+ 174   0.0000       0.968188        26.3457 
+ 175   0.0000       0.968390        26.3512 
+ 176   0.0000       0.968391        26.3513 
+ 177   0.0000       0.972706        26.4687 
+ 178   0.0000       0.979335        26.6491 
+ 179   0.0000       0.991720        26.9861 
+ 180   0.0000       0.991720        26.9861 
+ 181   0.0000       1.024079        27.8666 
+ 182   0.0000       1.026644        27.9364 
+ 183   0.0000       1.033040        28.1104 
+ 184   0.0000       1.033040        28.1105 
+ 185   0.0000       1.038242        28.2520 
+ 186   0.0000       1.038243        28.2520 
+ 187   0.0000       1.056201        28.7407 
+ 188   0.0000       1.069446        29.1011 
+ 189   0.0000       1.071530        29.1578 
+ 190   0.0000       1.072791        29.1921 
+ 191   0.0000       1.072792        29.1922 
+ 192   0.0000       1.085536        29.5389 
+ 193   0.0000       1.085537        29.5390 
+ 194   0.0000       1.102514        30.0009 
+ 195   0.0000       1.102518        30.0010 
+ 196   0.0000       1.119659        30.4675 
+ 197   0.0000       1.129540        30.7363 
+ 198   0.0000       1.129540        30.7363 
+ 199   0.0000       1.131148        30.7801 
+ 200   0.0000       1.131149        30.7801 
+ 201   0.0000       1.144749        31.1502 
+ 202   0.0000       1.162361        31.6295 
+ 203   0.0000       1.162362        31.6295 
+ 204   0.0000       1.166466        31.7412 
+ 205   0.0000       1.169421        31.8216 
+ 206   0.0000       1.169421        31.8216 
+ 207   0.0000       1.174404        31.9572 
+ 208   0.0000       1.193247        32.4699 
+ 209   0.0000       1.193249        32.4700 
+ 210   0.0000       1.215103        33.0646 
+ 211   0.0000       1.228912        33.4404 
+ 212   0.0000       1.228913        33.4404 
+ 213   0.0000       1.234340        33.5881 
+ 214   0.0000       1.235222        33.6121 
+ 215   0.0000       1.248357        33.9695 
+ 216   0.0000       1.248361        33.9696 
+ 217   0.0000       1.249299        33.9951 
+ 218   0.0000       1.249299        33.9951 
+ 219   0.0000       1.258957        34.2580 
+ 220   0.0000       1.302996        35.4563 
+ 221   0.0000       1.302996        35.4563 
+ 222   0.0000       1.309472        35.6325 
+ 223   0.0000       1.309472        35.6325 
+ 224   0.0000       1.324645        36.0454 
+ 225   0.0000       1.345381        36.6097 
+ 226   0.0000       1.345381        36.6097 
+ 227   0.0000       1.364902        37.1409 
+ 228   0.0000       1.382242        37.6127 
+ 229   0.0000       1.393324        37.9143 
+ 230   0.0000       1.401417        38.1345 
+ 231   0.0000       1.417375        38.5687 
+ 232   0.0000       1.417376        38.5687 
+ 233   0.0000       1.436780        39.0968 
+ 234   0.0000       1.451171        39.4884 
+ 235   0.0000       1.451171        39.4884 
+ 236   0.0000       1.461440        39.7678 
+ 237   0.0000       1.479717        40.2651 
+ 238   0.0000       1.479717        40.2651 
+ 239   0.0000       1.480337        40.2820 
+ 240   0.0000       1.480337        40.2820 
+ 241   0.0000       1.511399        41.1273 
+ 242   0.0000       1.511399        41.1273 
+ 243   0.0000       1.519892        41.3584 
+ 244   0.0000       1.519892        41.3584 
+ 245   0.0000       1.522632        41.4329 
+ 246   0.0000       1.528120        41.5823 
+ 247   0.0000       1.532264        41.6950 
+ 248   0.0000       1.532265        41.6950 
+ 249   0.0000       1.556984        42.3677 
+ 250   0.0000       1.568279        42.6751 
+ 251   0.0000       1.568280        42.6751 
+ 252   0.0000       1.583215        43.0815 
+ 253   0.0000       1.583215        43.0815 
+ 254   0.0000       1.587195        43.1898 
+ 255   0.0000       1.587195        43.1898 
+ 256   0.0000       1.588121        43.2150 
+ 257   0.0000       1.600981        43.5649 
+ 258   0.0000       1.629154        44.3315 
+ 259   0.0000       1.631381        44.3921 
+ 260   0.0000       1.631381        44.3921 
+ 261   0.0000       1.652039        44.9543 
+ 262   0.0000       1.662456        45.2377 
+ 263   0.0000       1.662456        45.2377 
+ 264   0.0000       1.674097        45.5545 
+ 265   0.0000       1.674097        45.5545 
+ 266   0.0000       1.678356        45.6704 
+ 267   0.0000       1.680150        45.7192 
+ 268   0.0000       1.701222        46.2926 
+ 269   0.0000       1.701222        46.2926 
+ 270   0.0000       1.726159        46.9712 
+ 271   0.0000       1.768962        48.1359 
+ 272   0.0000       1.781932        48.4888 
+ 273   0.0000       1.781933        48.4888 
+ 274   0.0000       1.796571        48.8872 
+ 275   0.0000       1.796571        48.8872 
+ 276   0.0000       1.800613        48.9972 
+ 277   0.0000       1.800613        48.9972 
+ 278   0.0000       1.833246        49.8852 
+ 279   0.0000       1.833246        49.8852 
+ 280   0.0000       1.838655        50.0324 
+ 281   0.0000       1.849361        50.3237 
+ 282   0.0000       1.849361        50.3237 
+ 283   0.0000       1.895474        51.5785 
+ 284   0.0000       1.895474        51.5785 
+ 285   0.0000       1.954937        53.1965 
+ 286   0.0000       1.954937        53.1965 
+ 287   0.0000       1.966916        53.5225 
+ 288   0.0000       2.021309        55.0026 
+ 289   0.0000       2.021312        55.0027 
+ 290   0.0000       2.040840        55.5341 
+ 291   0.0000       2.063346        56.1465 
+ 292   0.0000       2.078962        56.5714 
+ 293   0.0000       2.081896        56.6513 
+ 294   0.0000       2.118930        57.6590 
+ 295   0.0000       2.118930        57.6590 
+ 296   0.0000       2.187116        59.5144 
+ 297   0.0000       2.189386        59.5762 
+ 298   0.0000       2.195297        59.7371 
+ 299   0.0000       2.195299        59.7371 
+ 300   0.0000       2.264232        61.6129 
+ 301   0.0000       2.264233        61.6129 
+ 302   0.0000       2.282481        62.1095 
+ 303   0.0000       2.306746        62.7697 
+ 304   0.0000       2.346999        63.8651 
+ 305   0.0000       2.346999        63.8651 
+ 306   0.0000       2.357800        64.1590 
+ 307   0.0000       2.358571        64.1800 
+ 308   0.0000       2.358572        64.1800 
+ 309   0.0000       2.389155        65.0122 
+ 310   0.0000       2.389155        65.0122 
+ 311   0.0000       2.391886        65.0865 
+ 312   0.0000       2.421035        65.8797 
+ 313   0.0000       2.421035        65.8797 
+ 314   0.0000       2.421334        65.8878 
+ 315   0.0000       2.491139        67.7873 
+ 316   0.0000       2.494573        67.8808 
+ 317   0.0000       2.494573        67.8808 
+ 318   0.0000       2.496317        67.9282 
+ 319   0.0000       2.500425        68.0400 
+ 320   0.0000       2.500425        68.0400 
+ 321   0.0000       2.550542        69.4038 
+ 322   0.0000       2.550542        69.4038 
+ 323   0.0000       2.553839        69.4935 
+ 324   0.0000       2.574489        70.0554 
+ 325   0.0000       2.599559        70.7376 
+ 326   0.0000       2.599559        70.7376 
+ 327   0.0000       2.644123        71.9502 
+ 328   0.0000       2.644123        71.9503 
+ 329   0.0000       2.650572        72.1257 
+ 330   0.0000       2.656195        72.2788 
+ 331   0.0000       2.670670        72.6726 
+ 332   0.0000       2.670671        72.6726 
+ 333   0.0000       2.678968        72.8984 
+ 334   0.0000       2.700227        73.4769 
+ 335   0.0000       2.700749        73.4911 
+ 336   0.0000       2.700749        73.4911 
+ 337   0.0000       2.703894        73.5767 
+ 338   0.0000       2.740671        74.5775 
+ 339   0.0000       2.752972        74.9122 
+ 340   0.0000       2.752972        74.9122 
+ 341   0.0000       2.762447        75.1700 
+ 342   0.0000       2.762447        75.1700 
+ 343   0.0000       2.776582        75.5546 
+ 344   0.0000       2.776582        75.5546 
+ 345   0.0000       2.818297        76.6898 
+ 346   0.0000       2.818297        76.6898 
+ 347   0.0000       2.824252        76.8518 
+ 348   0.0000       2.824252        76.8518 
+ 349   0.0000       2.833029        77.0906 
+ 350   0.0000       2.853893        77.6584 
+ 351   0.0000       2.855694        77.7074 
+ 352   0.0000       2.855694        77.7074 
+ 353   0.0000       2.862819        77.9013 
+ 354   0.0000       2.864430        77.9451 
+ 355   0.0000       2.893174        78.7273 
+ 356   0.0000       2.893174        78.7273 
+ 357   0.0000       2.913424        79.2783 
+ 358   0.0000       2.924787        79.5875 
+ 359   0.0000       2.927534        79.6622 
+ 360   0.0000       2.930726        79.7491 
+ 361   0.0000       2.930726        79.7491 
+ 362   0.0000       2.940995        80.0285 
+ 363   0.0000       2.940995        80.0285 
+ 364   0.0000       2.959144        80.5224 
+ 365   0.0000       2.969385        80.8011 
+ 366   0.0000       2.969385        80.8011 
+ 367   0.0000       2.971655        80.8629 
+ 368   0.0000       2.980577        81.1056 
+ 369   0.0000       2.987926        81.3056 
+ 370   0.0000       2.987926        81.3056 
+ 371   0.0000       2.996382        81.5357 
+ 372   0.0000       3.002749        81.7090 
+ 373   0.0000       3.002750        81.7090 
+ 374   0.0000       3.007650        81.8423 
+ 375   0.0000       3.017787        82.1182 
+ 376   0.0000       3.017787        82.1182 
+ 377   0.0000       3.044976        82.8580 
+ 378   0.0000       3.044976        82.8580 
+ 379   0.0000       3.046410        82.8970 
+ 380   0.0000       3.064473        83.3886 
+ 381   0.0000       3.064473        83.3886 
+ 382   0.0000       3.070496        83.5524 
+ 383   0.0000       3.070496        83.5525 
+ 384   0.0000       3.079195        83.7892 
+ 385   0.0000       3.079984        83.8106 
+ 386   0.0000       3.108229        84.5792 
+ 387   0.0000       3.108229        84.5792 
+ 388   0.0000       3.136036        85.3359 
+ 389   0.0000       3.136037        85.3359 
+ 390   0.0000       3.156315        85.8877 
+ 391   0.0000       3.156315        85.8877 
+ 392   0.0000       3.175955        86.4221 
+ 393   0.0000       3.182812        86.6087 
+ 394   0.0000       3.182812        86.6087 
+ 395   0.0000       3.187099        86.7254 
+ 396   0.0000       3.193856        86.9092 
+ 397   0.0000       3.220228        87.6269 
+ 398   0.0000       3.220229        87.6269 
+ 399   0.0000       3.242217        88.2252 
+ 400   0.0000       3.242217        88.2252 
+ 401   0.0000       3.266524        88.8866 
+ 402   0.0000       3.272212        89.0414 
+ 403   0.0000       3.272212        89.0414 
+ 404   0.0000       3.275430        89.1290 
+ 405   0.0000       3.275430        89.1290 
+ 406   0.0000       3.284993        89.3892 
+ 407   0.0000       3.284993        89.3892 
+ 408   0.0000       3.285113        89.3925 
+ 409   0.0000       3.286968        89.4430 
+ 410   0.0000       3.290811        89.5475 
+ 411   0.0000       3.290811        89.5475 
+ 412   0.0000       3.305716        89.9531 
+ 413   0.0000       3.313807        90.1733 
+ 414   0.0000       3.324746        90.4709 
+ 415   0.0000       3.336929        90.8025 
+ 416   0.0000       3.336929        90.8025 
+ 417   0.0000       3.340232        90.8923 
+ 418   0.0000       3.359121        91.4063 
+ 419   0.0000       3.359309        91.4114 
+ 420   0.0000       3.359309        91.4115 
+ 421   0.0000       3.382448        92.0411 
+ 422   0.0000       3.386419        92.1492 
+ 423   0.0000       3.386419        92.1492 
+ 424   0.0000       3.394555        92.3705 
+ 425   0.0000       3.394555        92.3705 
+ 426   0.0000       3.396410        92.4210 
+ 427   0.0000       3.400754        92.5392 
+ 428   0.0000       3.400754        92.5392 
+ 429   0.0000       3.411366        92.8280 
+ 430   0.0000       3.411366        92.8280 
+ 431   0.0000       3.412152        92.8494 
+ 432   0.0000       3.422115        93.1205 
+ 433   0.0000       3.422115        93.1205 
+ 434   0.0000       3.429328        93.3168 
+ 435   0.0000       3.438647        93.5703 
+ 436   0.0000       3.449816        93.8743 
+ 437   0.0000       3.449816        93.8743 
+ 438   0.0000       3.452831        93.9563 
+ 439   0.0000       3.456391        94.0532 
+ 440   0.0000       3.456391        94.0532 
+ 441   0.0000       3.463591        94.2491 
+ 442   0.0000       3.492475        95.0351 
+ 443   0.0000       3.492475        95.0351 
+ 444   0.0000       3.495062        95.1055 
+ 445   0.0000       3.506944        95.4288 
+ 446   0.0000       3.506944        95.4288 
+ 447   0.0000       3.528691        96.0206 
+ 448   0.0000       3.528809        96.0238 
+ 449   0.0000       3.528809        96.0238 
+ 450   0.0000       3.533024        96.1385 
+ 451   0.0000       3.548798        96.5677 
+ 452   0.0000       3.548798        96.5677 
+ 453   0.0000       3.553480        96.6951 
+ 454   0.0000       3.561332        96.9088 
+ 455   0.0000       3.561333        96.9088 
+ 456   0.0000       3.610772        98.2541 
+ 457   0.0000       3.610772        98.2541 
+ 458   0.0000       3.626098        98.6712 
+ 459   0.0000       3.628783        98.7442 
+ 460   0.0000       3.628783        98.7442 
+ 461   0.0000       3.634511        98.9001 
+ 462   0.0000       3.640965        99.0757 
+ 463   0.0000       3.659725        99.5862 
+ 464   0.0000       3.659725        99.5862 
+ 465   0.0000       3.664753        99.7230 
+ 466   0.0000       3.677066       100.0580 
+ 467   0.0000       3.677066       100.0581 
+ 468   0.0000       3.678341       100.0927 
+ 469   0.0000       3.678341       100.0928 
+ 470   0.0000       3.699807       100.6769 
+ 471   0.0000       3.700555       100.6972 
+ 472   0.0000       3.700555       100.6972 
+ 473   0.0000       3.710267       100.9615 
+ 474   0.0000       3.722247       101.2875 
+ 475   0.0000       3.726158       101.3939 
+ 476   0.0000       3.727138       101.4206 
+ 477   0.0000       3.727139       101.4206 
+ 478   0.0000       3.740379       101.7809 
+ 479   0.0000       3.740379       101.7809 
+ 480   0.0000       3.774191       102.7010 
+ 481   0.0000       3.774191       102.7010 
+ 482   0.0000       3.801658       103.4484 
+ 483   0.0000       3.801658       103.4484 
+ 484   0.0000       3.829049       104.1937 
+ 485   0.0000       3.839222       104.4705 
+ 486   0.0000       3.839222       104.4705 
+ 487   0.0000       3.852136       104.8220 
+ 488   0.0000       3.860827       105.0584 
+ 489   0.0000       3.860827       105.0584 
+ 490   0.0000       3.878439       105.5377 
+ 491   0.0000       3.878439       105.5377 
+ 492   0.0000       3.889962       105.8513 
+ 493   0.0000       3.917730       106.6069 
+ 494   0.0000       3.917730       106.6069 
+ 495   0.0000       3.932455       107.0075 
+ 496   0.0000       3.932456       107.0076 
+ 497   0.0000       3.949560       107.4730 
+ 498   0.0000       3.951521       107.5263 
+ 499   0.0000       3.964542       107.8807 
+ 500   0.0000       3.964542       107.8807 
+ 501   0.0000       3.973542       108.1256 
+ 502   0.0000       3.984124       108.4135 
+ 503   0.0000       3.984124       108.4135 
+ 504   0.0000       4.002257       108.9069 
+ 505   0.0000       4.023055       109.4729 
+ 506   0.0000       4.029135       109.6383 
+ 507   0.0000       4.063623       110.5768 
+ 508   0.0000       4.063623       110.5768 
+ 509   0.0000       4.064643       110.6046 
+ 510   0.0000       4.064643       110.6046 
+ 511   0.0000       4.071822       110.7999 
+ 512   0.0000       4.071822       110.7999 
+ 513   0.0000       4.074136       110.8629 
+ 514   0.0000       4.091527       111.3361 
+ 515   0.0000       4.112556       111.9083 
+ 516   0.0000       4.112556       111.9083 
+ 517   0.0000       4.127321       112.3101 
+ 518   0.0000       4.128893       112.3529 
+ 519   0.0000       4.128893       112.3529 
+ 520   0.0000       4.135212       112.5248 
+ 521   0.0000       4.135296       112.5271 
+ 522   0.0000       4.137575       112.5891 
+ 523   0.0000       4.137575       112.5891 
+ 524   0.0000       4.147918       112.8706 
+ 525   0.0000       4.161430       113.2383 
+ 526   0.0000       4.170638       113.4888 
+ 527   0.0000       4.170638       113.4888 
+ 528   0.0000       4.194261       114.1316 
+ 529   0.0000       4.195178       114.1566 
+ 530   0.0000       4.195178       114.1566 
+ 531   0.0000       4.206099       114.4538 
+ 532   0.0000       4.218903       114.8022 
+ 533   0.0000       4.218903       114.8022 
+ 534   0.0000       4.255940       115.8100 
+ 535   0.0000       4.283458       116.5588 
+ 536   0.0000       4.287590       116.6713 
+ 537   0.0000       4.287590       116.6713 
+ 538   0.0000       4.295160       116.8772 
+ 539   0.0000       4.295160       116.8772 
+ 540   0.0000       4.298608       116.9711 
+ 541   0.0000       4.298608       116.9711 
+ 542   0.0000       4.310268       117.2883 
+ 543   0.0000       4.333968       117.9333 
+ 544   0.0000       4.354406       118.4894 
+ 545   0.0000       4.354406       118.4894 
+ 546   0.0000       4.356778       118.5540 
+ 547   0.0000       4.362933       118.7214 
+ 548   0.0000       4.372514       118.9822 
+ 549   0.0000       4.375101       119.0525 
+ 550   0.0000       4.375102       119.0526 
+ 551   0.0000       4.391896       119.5096 
+ 552   0.0000       4.391896       119.5096 
+ 553   0.0000       4.408327       119.9567 
+ 554   0.0000       4.417070       120.1946 
+ 555   0.0000       4.417070       120.1946 
+ 556   0.0000       4.434229       120.6615 
+ 557   0.0000       4.434229       120.6615 
+ 558   0.0000       4.454482       121.2126 
+ 559   0.0000       4.454482       121.2126 
+ 560   0.0000       4.462483       121.4303 
+ 561   0.0000       4.496637       122.3597 
+ 562   0.0000       4.496637       122.3597 
+ 563   0.0000       4.499229       122.4302 
+ 564   0.0000       4.519049       122.9696 
+ 565   0.0000       4.519049       122.9696 
+ 566   0.0000       4.521437       123.0346 
+ 567   0.0000       4.521437       123.0346 
+ 568   0.0000       4.531663       123.3128 
+ 569   0.0000       4.542693       123.6130 
+ 570   0.0000       4.542693       123.6130 
+ 571   0.0000       4.569585       124.3447 
+ 572   0.0000       4.569586       124.3448 
+ 573   0.0000       4.577411       124.5577 
+ 574   0.0000       4.592899       124.9791 
+ 575   0.0000       4.592899       124.9791 
+ 576   0.0000       4.612938       125.5244 
+ 577   0.0000       4.627392       125.9177 
+ 578   0.0000       4.627521       125.9212 
+ 579   0.0000       4.627521       125.9212 
+ 580   0.0000       4.637206       126.1848 
+ 581   0.0000       4.637206       126.1848 
+ 582   0.0000       4.643049       126.3438 
+ 583   0.0000       4.644766       126.3905 
+ 584   0.0000       4.666700       126.9874 
+ 585   0.0000       4.678292       127.3028 
+ 586   0.0000       4.678292       127.3028 
+ 587   0.0000       4.713250       128.2541 
+ 588   0.0000       4.713917       128.2722 
+ 589   0.0000       4.722010       128.4924 
+ 590   0.0000       4.722010       128.4924 
+ 591   0.0000       4.733298       128.7996 
+ 592   0.0000       4.733299       128.7996 
+ 593   0.0000       4.742895       129.0607 
+ 594   0.0000       4.751484       129.2944 
+ 595   0.0000       4.752983       129.3353 
+ 596   0.0000       4.752984       129.3353 
+ 597   0.0000       4.753458       129.3482 
+ 598   0.0000       4.753458       129.3482 
+ 599   0.0000       4.790934       130.3680 
+ 600   0.0000       4.792871       130.4206 
+ 601   0.0000       4.792871       130.4206 
+ 602   0.0000       4.863287       132.3368 
+ 603   0.0000       4.863287       132.3368 
+ 604   0.0000       4.916385       133.7816 
+ 605   0.0000       4.947363       134.6246 
+ 606   0.0000       4.993893       135.8907 
+ 607   0.0000       4.997681       135.9938 
+ 608   0.0000       4.997681       135.9938 
+ 609   0.0000       5.019511       136.5878 
+ 610   0.0000       5.019512       136.5879 
+ 611   0.0000       5.031437       136.9124 
+ 612   0.0000       5.032691       136.9465 
+ 613   0.0000       5.032693       136.9465 
+ 614   0.0000       5.054210       137.5320 
+ 615   0.0000       5.080440       138.2458 
+ 616   0.0000       5.080440       138.2458 
+ 617   0.0000       5.092838       138.5832 
+ 618   0.0000       5.092838       138.5832 
+ 619   0.0000       5.136195       139.7630 
+ 620   0.0000       5.157510       140.3430 
+ 621   0.0000       5.157510       140.3430 
+ 622   0.0000       5.187158       141.1497 
+ 623   0.0000       5.187158       141.1497 
+ 624   0.0000       5.190430       141.2388 
+ 625   0.0000       5.191351       141.2638 
+ 626   0.0000       5.212257       141.8327 
+ 627   0.0000       5.212257       141.8327 
+ 628   0.0000       5.234523       142.4386 
+ 629   0.0000       5.234524       142.4386 
+ 630   0.0000       5.248554       142.8204 
+ 631   0.0000       5.275893       143.5643 
+ 632   0.0000       5.275894       143.5644 
+ 633   0.0000       5.305554       144.3715 
+ 634   0.0000       5.333306       145.1266 
+ 635   0.0000       5.346297       145.4802 
+ 636   0.0000       5.346298       145.4802 
+ 637   0.0000       5.350792       145.6024 
+ 638   0.0000       5.383688       146.4976 
+ 639   0.0000       5.395183       146.8104 
+ 640   0.0000       5.397888       146.8840 
+ 641   0.0000       5.397888       146.8840 
+ 642   0.0000       5.428014       147.7038 
+ 643   0.0000       5.458501       148.5334 
+ 644   0.0000       5.458501       148.5334 
+ 645   0.0000       5.490809       149.4125 
+ 646   0.0000       5.490809       149.4125 
+ 647   0.0000       5.502429       149.7287 
+ 648   0.0000       5.551259       151.0574 
+ 649   0.0000       5.551259       151.0574 
+ 650   0.0000       5.569480       151.5533 
+ 651   0.0000       5.649436       153.7290 
+ 652   0.0000       5.649437       153.7290 
+ 653   0.0000       5.656759       153.9282 
+ 654   0.0000       5.656760       153.9283 
+ 655   0.0000       5.664787       154.1467 
+ 656   0.0000       5.664788       154.1467 
+ 657   0.0000       5.760383       156.7480 
+ 658   0.0000       5.772206       157.0697 
+ 659   0.0000       5.838849       158.8832 
+ 660   0.0000       5.838850       158.8832 
+ 661   0.0000       5.870271       159.7382 
+ 662   0.0000       5.921654       161.1364 
+ 663   0.0000       5.921655       161.1364 
+ 664   0.0000       5.983037       162.8067 
+ 665   0.0000       6.008057       163.4875 
+ 666   0.0000       6.008057       163.4875 
+ 667   0.0000       6.051305       164.6644 
+ 668   0.0000       6.051305       164.6644 
+ 669   0.0000       6.067348       165.1009 
+ 670   0.0000       6.067744       165.1117 
+ 671   0.0000       6.132811       166.8823 
+ 672   0.0000       6.284987       171.0232 
+ 673   0.0000       6.284987       171.0232 
+ 674   0.0000       6.348380       172.7482 
+ 675   0.0000       6.348381       172.7482 
+ 676   0.0000       6.374560       173.4606 
+ 677   0.0000       6.374561       173.4606 
+ 678   0.0000       6.381187       173.6409 
+ 679   0.0000       6.461392       175.8234 
+ 680   0.0000       6.529448       177.6753 
+ 681   0.0000       6.552526       178.3033 
+ 682   0.0000       6.552526       178.3033 
+ 683   0.0000       6.681690       181.8180 
+ 684   0.0000       6.699630       182.3062 
+ 685   0.0000       6.699630       182.3062 
+ 686   0.0000       6.913794       188.1339 
+ 687   0.0000       7.100911       193.2256 
+ 688   0.0000       7.100912       193.2256 
+ 689   0.0000       7.472595       203.3397 
+ 690   0.0000       8.453557       230.0330 
+ 691   0.0000      10.942608       297.7635 
+ 692   0.0000      10.942614       297.7637 
+ 693   0.0000      12.162220       330.9508 
+ 694   0.0000      13.144839       357.6893 
+ 695   0.0000      13.144840       357.6893 
+ 696   0.0000      13.583339       369.6214 
+ 697   0.0000      13.583342       369.6215 
+ 698   0.0000      13.619699       370.6108 
+ 699   0.0000      13.988723       380.6525 
+ 700   0.0000      13.988727       380.6526 
+ 701   0.0000      14.129408       384.4807 
+ 702   0.0000      15.195881       413.5009 
+ 703   0.0000      15.195881       413.5009 
+ 704   0.0000      16.201933       440.8770 
+ 705   0.0000      16.201933       440.8770 
+ 706   0.0000      16.386845       445.9087 
+ 707   0.0000      17.252370       469.4609 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 C :   -0.174125
+   1 C :   -0.157489
+   2 C :    0.036232
+   3 C :    0.036233
+   4 C :   -0.157489
+   5 C :   -0.174125
+   6 C :    0.036233
+   7 C :    0.036232
+   8 C :    0.036229
+   9 C :    0.036229
+  10 C :   -0.157489
+  11 H :    0.146019
+  12 C :   -0.174126
+  13 C :   -0.174125
+  14 C :   -0.157490
+  15 H :    0.149364
+  16 H :    0.146019
+  17 H :    0.146019
+  18 H :    0.149364
+  19 H :    0.149365
+  20 H :    0.149364
+  21 H :    0.146019
+  22 C :   -0.157489
+  23 C :   -0.157490
+  24 C :   -0.174126
+  25 C :   -0.174125
+  26 H :    0.146019
+  27 H :    0.149365
+  28 H :    0.149364
+  29 H :    0.146019
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 C s       :     3.271336  s :     3.271336
+      pz      :     0.953522  p :     2.800691
+      px      :     0.888791
+      py      :     0.958377
+      dz2     :     0.005857  d :     0.092223
+      dxz     :     0.020167
+      dyz     :     0.012567
+      dx2y2   :     0.023910
+      dxy     :     0.029721
+      f0      :     0.001527  f :     0.009875
+      f+1     :     0.000822
+      f-1     :     0.000819
+      f+2     :     0.000912
+      f-2     :     0.000582
+      f+3     :     0.002552
+      f-3     :     0.002663
+  1 C s       :     3.208886  s :     3.208886
+      pz      :     0.962776  p :     2.850693
+      px      :     0.999759
+      py      :     0.888158
+      dz2     :     0.006260  d :     0.087903
+      dxz     :     0.006947
+      dyz     :     0.026656
+      dx2y2   :     0.030394
+      dxy     :     0.017647
+      f0      :     0.001510  f :     0.010008
+      f+1     :     0.000842
+      f-1     :     0.000864
+      f+2     :     0.000426
+      f-2     :     0.001072
+      f+3     :     0.002505
+      f-3     :     0.002789
+  2 C s       :     3.083161  s :     3.083161
+      pz      :     0.935510  p :     2.780163
+      px      :     0.915206
+      py      :     0.929447
+      dz2     :     0.004138  d :     0.088591
+      dxz     :     0.024941
+      dyz     :     0.024237
+      dx2y2   :     0.016921
+      dxy     :     0.018354
+      f0      :     0.001845  f :     0.011852
+      f+1     :     0.000989
+      f-1     :     0.001084
+      f+2     :     0.000986
+      f-2     :     0.000786
+      f+3     :     0.002683
+      f-3     :     0.003479
+  3 C s       :     3.083161  s :     3.083161
+      pz      :     0.935510  p :     2.780163
+      px      :     0.915206
+      py      :     0.929447
+      dz2     :     0.004138  d :     0.088591
+      dxz     :     0.024941
+      dyz     :     0.024237
+      dx2y2   :     0.016921
+      dxy     :     0.018354
+      f0      :     0.001845  f :     0.011852
+      f+1     :     0.000989
+      f-1     :     0.001084
+      f+2     :     0.000986
+      f-2     :     0.000786
+      f+3     :     0.002683
+      f-3     :     0.003479
+  4 C s       :     3.208886  s :     3.208886
+      pz      :     0.962776  p :     2.850693
+      px      :     0.999759
+      py      :     0.888158
+      dz2     :     0.006260  d :     0.087903
+      dxz     :     0.006947
+      dyz     :     0.026656
+      dx2y2   :     0.030394
+      dxy     :     0.017647
+      f0      :     0.001510  f :     0.010008
+      f+1     :     0.000842
+      f-1     :     0.000864
+      f+2     :     0.000426
+      f-2     :     0.001072
+      f+3     :     0.002505
+      f-3     :     0.002789
+  5 C s       :     3.271336  s :     3.271336
+      pz      :     0.953522  p :     2.800691
+      px      :     0.888791
+      py      :     0.958377
+      dz2     :     0.005857  d :     0.092223
+      dxz     :     0.020167
+      dyz     :     0.012567
+      dx2y2   :     0.023910
+      dxy     :     0.029721
+      f0      :     0.001527  f :     0.009875
+      f+1     :     0.000822
+      f-1     :     0.000819
+      f+2     :     0.000912
+      f-2     :     0.000582
+      f+3     :     0.002552
+      f-3     :     0.002663
+  6 C s       :     3.083159  s :     3.083159
+      pz      :     0.935510  p :     2.780166
+      px      :     0.919388
+      py      :     0.925267
+      dz2     :     0.004138  d :     0.088591
+      dxz     :     0.024613
+      dyz     :     0.024565
+      dx2y2   :     0.013196
+      dxy     :     0.022079
+      f0      :     0.001845  f :     0.011852
+      f+1     :     0.001031
+      f-1     :     0.001042
+      f+2     :     0.000953
+      f-2     :     0.000819
+      f+3     :     0.002683
+      f-3     :     0.003479
+  7 C s       :     3.083159  s :     3.083159
+      pz      :     0.935510  p :     2.780166
+      px      :     0.919388
+      py      :     0.925267
+      dz2     :     0.004138  d :     0.088591
+      dxz     :     0.024613
+      dyz     :     0.024565
+      dx2y2   :     0.013196
+      dxy     :     0.022079
+      f0      :     0.001845  f :     0.011852
+      f+1     :     0.001031
+      f-1     :     0.001042
+      f+2     :     0.000953
+      f-2     :     0.000819
+      f+3     :     0.002683
+      f-3     :     0.003479
+  8 C s       :     3.083161  s :     3.083161
+      pz      :     0.935510  p :     2.780167
+      px      :     0.932387
+      py      :     0.912269
+      dz2     :     0.004138  d :     0.088591
+      dxz     :     0.024212
+      dyz     :     0.024965
+      dx2y2   :     0.022796
+      dxy     :     0.012479
+      f0      :     0.001845  f :     0.011852
+      f+1     :     0.001090
+      f-1     :     0.000983
+      f+2     :     0.000719
+      f-2     :     0.001053
+      f+3     :     0.002683
+      f-3     :     0.003479
+  9 C s       :     3.083161  s :     3.083161
+      pz      :     0.935510  p :     2.780166
+      px      :     0.932387
+      py      :     0.912269
+      dz2     :     0.004138  d :     0.088591
+      dxz     :     0.024212
+      dyz     :     0.024965
+      dx2y2   :     0.022796
+      dxy     :     0.012479
+      f0      :     0.001845  f :     0.011852
+      f+1     :     0.001090
+      f-1     :     0.000983
+      f+2     :     0.000719
+      f-2     :     0.001053
+      f+3     :     0.002683
+      f-3     :     0.003479
+ 10 C s       :     3.208886  s :     3.208886
+      pz      :     0.962775  p :     2.850693
+      px      :     0.889571
+      py      :     0.998346
+      dz2     :     0.006260  d :     0.087903
+      dxz     :     0.022142
+      dyz     :     0.011461
+      dx2y2   :     0.019452
+      dxy     :     0.028589
+      f0      :     0.001510  f :     0.010008
+      f+1     :     0.000845
+      f-1     :     0.000862
+      f+2     :     0.000914
+      f-2     :     0.000584
+      f+3     :     0.002505
+      f-3     :     0.002789
+ 11 H s       :     0.821754  s :     0.821754
+      pz      :     0.011124  p :     0.029833
+      px      :     0.008135
+      py      :     0.010575
+      dz2     :     0.000202  d :     0.002393
+      dxz     :     0.000166
+      dyz     :     0.000453
+      dx2y2   :     0.000935
+      dxy     :     0.000638
+ 12 C s       :     3.271337  s :     3.271337
+      pz      :     0.953522  p :     2.800691
+      px      :     0.901628
+      py      :     0.945540
+      dz2     :     0.005857  d :     0.092223
+      dxz     :     0.021423
+      dyz     :     0.011311
+      dx2y2   :     0.022284
+      dxy     :     0.031347
+      f0      :     0.001527  f :     0.009875
+      f+1     :     0.000791
+      f-1     :     0.000850
+      f+2     :     0.000997
+      f-2     :     0.000496
+      f+3     :     0.002552
+      f-3     :     0.002663
+ 13 C s       :     3.271337  s :     3.271337
+      pz      :     0.953522  p :     2.800690
+      px      :     0.980333
+      py      :     0.866836
+      dz2     :     0.005857  d :     0.092223
+      dxz     :     0.007511
+      dyz     :     0.025223
+      dx2y2   :     0.034253
+      dxy     :     0.019378
+      f0      :     0.001527  f :     0.009875
+      f+1     :     0.000848
+      f-1     :     0.000793
+      f+2     :     0.000331
+      f-2     :     0.001162
+      f+3     :     0.002552
+      f-3     :     0.002663
+ 14 C s       :     3.208887  s :     3.208887
+      pz      :     0.962776  p :     2.850693
+      px      :     0.942544
+      py      :     0.945372
+      dz2     :     0.006260  d :     0.087903
+      dxz     :     0.021316
+      dyz     :     0.012287
+      dx2y2   :     0.022215
+      dxy     :     0.025825
+      f0      :     0.001510  f :     0.010008
+      f+1     :     0.000872
+      f-1     :     0.000834
+      f+2     :     0.000907
+      f-2     :     0.000591
+      f+3     :     0.002505
+      f-3     :     0.002789
+ 15 H s       :     0.822006  s :     0.822006
+      pz      :     0.010712  p :     0.026400
+      px      :     0.007804
+      py      :     0.007884
+      dz2     :     0.000169  d :     0.002230
+      dxz     :     0.000141
+      dyz     :     0.000436
+      dx2y2   :     0.000862
+      dxy     :     0.000622
+ 16 H s       :     0.821755  s :     0.821755
+      pz      :     0.011124  p :     0.029833
+      px      :     0.009341
+      py      :     0.009369
+      dz2     :     0.000202  d :     0.002393
+      dxz     :     0.000605
+      dyz     :     0.000014
+      dx2y2   :     0.000501
+      dxy     :     0.001072
+ 17 H s       :     0.821755  s :     0.821755
+      pz      :     0.011124  p :     0.029833
+      px      :     0.009341
+      py      :     0.009369
+      dz2     :     0.000202  d :     0.002393
+      dxz     :     0.000605
+      dyz     :     0.000014
+      dx2y2   :     0.000501
+      dxy     :     0.001072
+ 18 H s       :     0.822006  s :     0.822006
+      pz      :     0.010712  p :     0.026400
+      px      :     0.007804
+      py      :     0.007884
+      dz2     :     0.000169  d :     0.002230
+      dxz     :     0.000141
+      dyz     :     0.000436
+      dx2y2   :     0.000862
+      dxy     :     0.000622
+ 19 H s       :     0.822006  s :     0.822006
+      pz      :     0.010712  p :     0.026400
+      px      :     0.007593
+      py      :     0.008095
+      dz2     :     0.000169  d :     0.002230
+      dxz     :     0.000162
+      dyz     :     0.000415
+      dx2y2   :     0.000869
+      dxy     :     0.000616
+ 20 H s       :     0.822006  s :     0.822006
+      pz      :     0.010712  p :     0.026400
+      px      :     0.008135
+      py      :     0.007553
+      dz2     :     0.000169  d :     0.002230
+      dxz     :     0.000563
+      dyz     :     0.000014
+      dx2y2   :     0.000496
+      dxy     :     0.000988
+ 21 H s       :     0.821754  s :     0.821754
+      pz      :     0.011124  p :     0.029833
+      px      :     0.010589
+      py      :     0.008121
+      dz2     :     0.000202  d :     0.002393
+      dxz     :     0.000157
+      dyz     :     0.000462
+      dx2y2   :     0.000923
+      dxy     :     0.000650
+ 22 C s       :     3.208886  s :     3.208886
+      pz      :     0.962775  p :     2.850693
+      px      :     0.889571
+      py      :     0.998346
+      dz2     :     0.006260  d :     0.087903
+      dxz     :     0.022142
+      dyz     :     0.011461
+      dx2y2   :     0.019452
+      dxy     :     0.028589
+      f0      :     0.001510  f :     0.010008
+      f+1     :     0.000845
+      f-1     :     0.000862
+      f+2     :     0.000914
+      f-2     :     0.000584
+      f+3     :     0.002505
+      f-3     :     0.002789
+ 23 C s       :     3.208887  s :     3.208887
+      pz      :     0.962776  p :     2.850693
+      px      :     0.942544
+      py      :     0.945372
+      dz2     :     0.006260  d :     0.087903
+      dxz     :     0.021316
+      dyz     :     0.012287
+      dx2y2   :     0.022215
+      dxy     :     0.025825
+      f0      :     0.001510  f :     0.010008
+      f+1     :     0.000872
+      f-1     :     0.000834
+      f+2     :     0.000907
+      f-2     :     0.000591
+      f+3     :     0.002505
+      f-3     :     0.002789
+ 24 C s       :     3.271337  s :     3.271337
+      pz      :     0.953522  p :     2.800691
+      px      :     0.901628
+      py      :     0.945540
+      dz2     :     0.005857  d :     0.092223
+      dxz     :     0.021423
+      dyz     :     0.011311
+      dx2y2   :     0.022284
+      dxy     :     0.031347
+      f0      :     0.001527  f :     0.009875
+      f+1     :     0.000791
+      f-1     :     0.000850
+      f+2     :     0.000997
+      f-2     :     0.000496
+      f+3     :     0.002552
+      f-3     :     0.002663
+ 25 C s       :     3.271337  s :     3.271337
+      pz      :     0.953522  p :     2.800690
+      px      :     0.980333
+      py      :     0.866836
+      dz2     :     0.005857  d :     0.092223
+      dxz     :     0.007511
+      dyz     :     0.025223
+      dx2y2   :     0.034253
+      dxy     :     0.019378
+      f0      :     0.001527  f :     0.009875
+      f+1     :     0.000848
+      f-1     :     0.000793
+      f+2     :     0.000331
+      f-2     :     0.001162
+      f+3     :     0.002552
+      f-3     :     0.002663
+ 26 H s       :     0.821755  s :     0.821755
+      pz      :     0.011124  p :     0.029833
+      px      :     0.008135
+      py      :     0.010575
+      dz2     :     0.000202  d :     0.002393
+      dxz     :     0.000166
+      dyz     :     0.000453
+      dx2y2   :     0.000935
+      dxy     :     0.000638
+ 27 H s       :     0.822006  s :     0.822006
+      pz      :     0.010712  p :     0.026400
+      px      :     0.007593
+      py      :     0.008095
+      dz2     :     0.000169  d :     0.002230
+      dxz     :     0.000162
+      dyz     :     0.000415
+      dx2y2   :     0.000869
+      dxy     :     0.000616
+ 28 H s       :     0.822006  s :     0.822006
+      pz      :     0.010712  p :     0.026400
+      px      :     0.008135
+      py      :     0.007553
+      dz2     :     0.000169  d :     0.002230
+      dxz     :     0.000563
+      dyz     :     0.000014
+      dx2y2   :     0.000496
+      dxy     :     0.000988
+ 29 H s       :     0.821754  s :     0.821754
+      pz      :     0.011124  p :     0.029833
+      px      :     0.010589
+      py      :     0.008121
+      dz2     :     0.000202  d :     0.002393
+      dxz     :     0.000157
+      dyz     :     0.000462
+      dx2y2   :     0.000923
+      dxy     :     0.000650
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 C :    0.025339
+   1 C :    0.045543
+   2 C :   -0.018990
+   3 C :   -0.018990
+   4 C :    0.045543
+   5 C :    0.025339
+   6 C :   -0.018990
+   7 C :   -0.018990
+   8 C :   -0.018990
+   9 C :   -0.018990
+  10 C :    0.045543
+  11 H :   -0.028135
+  12 C :    0.025339
+  13 C :    0.025339
+  14 C :    0.045543
+  15 H :   -0.023757
+  16 H :   -0.028135
+  17 H :   -0.028135
+  18 H :   -0.023757
+  19 H :   -0.023757
+  20 H :   -0.023757
+  21 H :   -0.028135
+  22 C :    0.045543
+  23 C :    0.045543
+  24 C :    0.025339
+  25 C :    0.025339
+  26 H :   -0.028135
+  27 H :   -0.023757
+  28 H :   -0.023757
+  29 H :   -0.028135
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 C s       :     2.696477  s :     2.696477
+      pz      :     0.837411  p :     2.815736
+      px      :     0.995736
+      py      :     0.982589
+      dz2     :     0.027496  d :     0.419553
+      dxz     :     0.067420
+      dyz     :     0.034552
+      dx2y2   :     0.132068
+      dxy     :     0.158017
+      f0      :     0.002220  f :     0.042895
+      f+1     :     0.003294
+      f-1     :     0.003087
+      f+2     :     0.006050
+      f-2     :     0.003484
+      f+3     :     0.009024
+      f-3     :     0.015736
+  1 C s       :     2.690278  s :     2.690278
+      pz      :     0.840793  p :     2.806065
+      px      :     0.966006
+      py      :     0.999266
+      dz2     :     0.028066  d :     0.415760
+      dxz     :     0.016561
+      dyz     :     0.083953
+      dx2y2   :     0.170652
+      dxy     :     0.116527
+      f0      :     0.002175  f :     0.042354
+      f+1     :     0.002853
+      f-1     :     0.003577
+      f+2     :     0.002220
+      f-2     :     0.007048
+      f+3     :     0.009144
+      f-3     :     0.015337
+  2 C s       :     2.675803  s :     2.675803
+      pz      :     0.828911  p :     2.769652
+      px      :     0.976429
+      py      :     0.964312
+      dz2     :     0.034779  d :     0.519886
+      dxz     :     0.074408
+      dyz     :     0.074934
+      dx2y2   :     0.166487
+      dxy     :     0.169277
+      f0      :     0.003514  f :     0.053649
+      f+1     :     0.003679
+      f-1     :     0.003757
+      f+2     :     0.006674
+      f-2     :     0.005681
+      f+3     :     0.009999
+      f-3     :     0.020345
+  3 C s       :     2.675803  s :     2.675803
+      pz      :     0.828911  p :     2.769652
+      px      :     0.976429
+      py      :     0.964312
+      dz2     :     0.034779  d :     0.519886
+      dxz     :     0.074408
+      dyz     :     0.074934
+      dx2y2   :     0.166487
+      dxy     :     0.169277
+      f0      :     0.003514  f :     0.053649
+      f+1     :     0.003679
+      f-1     :     0.003757
+      f+2     :     0.006674
+      f-2     :     0.005681
+      f+3     :     0.009999
+      f-3     :     0.020345
+  4 C s       :     2.690278  s :     2.690278
+      pz      :     0.840793  p :     2.806065
+      px      :     0.966006
+      py      :     0.999266
+      dz2     :     0.028066  d :     0.415760
+      dxz     :     0.016561
+      dyz     :     0.083953
+      dx2y2   :     0.170652
+      dxy     :     0.116527
+      f0      :     0.002175  f :     0.042354
+      f+1     :     0.002853
+      f-1     :     0.003577
+      f+2     :     0.002220
+      f-2     :     0.007048
+      f+3     :     0.009144
+      f-3     :     0.015337
+  5 C s       :     2.696477  s :     2.696477
+      pz      :     0.837411  p :     2.815736
+      px      :     0.995736
+      py      :     0.982589
+      dz2     :     0.027496  d :     0.419553
+      dxz     :     0.067420
+      dyz     :     0.034552
+      dx2y2   :     0.132068
+      dxy     :     0.158017
+      f0      :     0.002220  f :     0.042895
+      f+1     :     0.003294
+      f-1     :     0.003087
+      f+2     :     0.006050
+      f-2     :     0.003484
+      f+3     :     0.009024
+      f-3     :     0.015736
+  6 C s       :     2.675803  s :     2.675803
+      pz      :     0.828910  p :     2.769652
+      px      :     0.981767
+      py      :     0.958975
+      dz2     :     0.034779  d :     0.519886
+      dxz     :     0.076340
+      dyz     :     0.073002
+      dx2y2   :     0.163957
+      dxy     :     0.171807
+      f0      :     0.003514  f :     0.053649
+      f+1     :     0.003730
+      f-1     :     0.003706
+      f+2     :     0.006514
+      f-2     :     0.005842
+      f+3     :     0.009999
+      f-3     :     0.020345
+  7 C s       :     2.675803  s :     2.675803
+      pz      :     0.828910  p :     2.769652
+      px      :     0.981767
+      py      :     0.958975
+      dz2     :     0.034779  d :     0.519886
+      dxz     :     0.076340
+      dyz     :     0.073002
+      dx2y2   :     0.163957
+      dxy     :     0.171807
+      f0      :     0.003514  f :     0.053649
+      f+1     :     0.003730
+      f-1     :     0.003706
+      f+2     :     0.006514
+      f-2     :     0.005842
+      f+3     :     0.009999
+      f-3     :     0.020345
+  8 C s       :     2.675803  s :     2.675803
+      pz      :     0.828911  p :     2.769652
+      px      :     0.952916
+      py      :     0.987825
+      dz2     :     0.034779  d :     0.519886
+      dxz     :     0.073266
+      dyz     :     0.076077
+      dx2y2   :     0.173202
+      dxy     :     0.162562
+      f0      :     0.003514  f :     0.053649
+      f+1     :     0.003745
+      f-1     :     0.003691
+      f+2     :     0.005345
+      f-2     :     0.007010
+      f+3     :     0.009999
+      f-3     :     0.020345
+  9 C s       :     2.675803  s :     2.675803
+      pz      :     0.828911  p :     2.769652
+      px      :     0.952916
+      py      :     0.987825
+      dz2     :     0.034779  d :     0.519886
+      dxz     :     0.073266
+      dyz     :     0.076077
+      dx2y2   :     0.173202
+      dxy     :     0.162562
+      f0      :     0.003514  f :     0.053649
+      f+1     :     0.003745
+      f-1     :     0.003691
+      f+2     :     0.005345
+      f-2     :     0.007010
+      f+3     :     0.009999
+      f-3     :     0.020345
+ 10 C s       :     2.690278  s :     2.690278
+      pz      :     0.840792  p :     2.806064
+      px      :     0.998784
+      py      :     0.966488
+      dz2     :     0.028066  d :     0.415760
+      dxz     :     0.068076
+      dyz     :     0.032439
+      dx2y2   :     0.127282
+      dxy     :     0.159897
+      f0      :     0.002175  f :     0.042354
+      f+1     :     0.003399
+      f-1     :     0.003031
+      f+2     :     0.005833
+      f-2     :     0.003436
+      f+3     :     0.009144
+      f-3     :     0.015337
+ 11 H s       :     0.838205  s :     0.838205
+      pz      :     0.043615  p :     0.161857
+      px      :     0.050130
+      py      :     0.068112
+      dz2     :     0.002412  d :     0.028072
+      dxz     :     0.001996
+      dyz     :     0.006089
+      dx2y2   :     0.009347
+      dxy     :     0.008228
+ 12 C s       :     2.696477  s :     2.696477
+      pz      :     0.837411  p :     2.815736
+      px      :     1.002476
+      py      :     0.975849
+      dz2     :     0.027496  d :     0.419553
+      dxz     :     0.067703
+      dyz     :     0.034269
+      dx2y2   :     0.130817
+      dxy     :     0.159268
+      f0      :     0.002220  f :     0.042895
+      f+1     :     0.003338
+      f-1     :     0.003043
+      f+2     :     0.006335
+      f-2     :     0.003198
+      f+3     :     0.009024
+      f-3     :     0.015736
+ 13 C s       :     2.696477  s :     2.696477
+      pz      :     0.837410  p :     2.815736
+      px      :     0.969276
+      py      :     1.009050
+      dz2     :     0.027496  d :     0.419553
+      dxz     :     0.017835
+      dyz     :     0.084137
+      dx2y2   :     0.172243
+      dxy     :     0.117843
+      f0      :     0.002220  f :     0.042895
+      f+1     :     0.002939
+      f-1     :     0.003441
+      f+2     :     0.001915
+      f-2     :     0.007618
+      f+3     :     0.009024
+      f-3     :     0.015736
+ 14 C s       :     2.690278  s :     2.690278
+      pz      :     0.840793  p :     2.806065
+      px      :     0.983118
+      py      :     0.982154
+      dz2     :     0.028066  d :     0.415760
+      dxz     :     0.066135
+      dyz     :     0.034380
+      dx2y2   :     0.132834
+      dxy     :     0.154345
+      f0      :     0.002175  f :     0.042354
+      f+1     :     0.003393
+      f-1     :     0.003037
+      f+2     :     0.005849
+      f-2     :     0.003419
+      f+3     :     0.009144
+      f-3     :     0.015337
+ 15 H s       :     0.843734  s :     0.843734
+      pz      :     0.042522  p :     0.153033
+      px      :     0.044680
+      py      :     0.065832
+      dz2     :     0.002389  d :     0.026990
+      dxz     :     0.001939
+      dyz     :     0.005829
+      dx2y2   :     0.008673
+      dxy     :     0.008159
+ 16 H s       :     0.838205  s :     0.838205
+      pz      :     0.043615  p :     0.161857
+      px      :     0.081208
+      py      :     0.037034
+      dz2     :     0.002412  d :     0.028072
+      dxz     :     0.008037
+      dyz     :     0.000048
+      dx2y2   :     0.008146
+      dxy     :     0.009429
+ 17 H s       :     0.838205  s :     0.838205
+      pz      :     0.043615  p :     0.161857
+      px      :     0.081208
+      py      :     0.037034
+      dz2     :     0.002412  d :     0.028072
+      dxz     :     0.008037
+      dyz     :     0.000048
+      dx2y2   :     0.008146
+      dxy     :     0.009429
+ 18 H s       :     0.843734  s :     0.843734
+      pz      :     0.042522  p :     0.153033
+      px      :     0.044680
+      py      :     0.065832
+      dz2     :     0.002389  d :     0.026990
+      dxz     :     0.001939
+      dyz     :     0.005829
+      dx2y2   :     0.008673
+      dxy     :     0.008159
+ 19 H s       :     0.843734  s :     0.843734
+      pz      :     0.042522  p :     0.153034
+      px      :     0.043394
+      py      :     0.067118
+      dz2     :     0.002389  d :     0.026990
+      dxz     :     0.001992
+      dyz     :     0.005776
+      dx2y2   :     0.008679
+      dxy     :     0.008153
+ 20 H s       :     0.843734  s :     0.843734
+      pz      :     0.042522  p :     0.153034
+      px      :     0.077694
+      py      :     0.032818
+      dz2     :     0.002389  d :     0.026990
+      dxz     :     0.007722
+      dyz     :     0.000046
+      dx2y2   :     0.007896
+      dxy     :     0.008936
+ 21 H s       :     0.838205  s :     0.838205
+      pz      :     0.043615  p :     0.161857
+      px      :     0.046026
+      py      :     0.072216
+      dz2     :     0.002412  d :     0.028072
+      dxz     :     0.002094
+      dyz     :     0.005991
+      dx2y2   :     0.008870
+      dxy     :     0.008705
+ 22 C s       :     2.690278  s :     2.690278
+      pz      :     0.840792  p :     2.806064
+      px      :     0.998784
+      py      :     0.966488
+      dz2     :     0.028066  d :     0.415760
+      dxz     :     0.068076
+      dyz     :     0.032439
+      dx2y2   :     0.127282
+      dxy     :     0.159897
+      f0      :     0.002175  f :     0.042354
+      f+1     :     0.003399
+      f-1     :     0.003031
+      f+2     :     0.005833
+      f-2     :     0.003436
+      f+3     :     0.009144
+      f-3     :     0.015337
+ 23 C s       :     2.690278  s :     2.690278
+      pz      :     0.840793  p :     2.806065
+      px      :     0.983118
+      py      :     0.982154
+      dz2     :     0.028066  d :     0.415760
+      dxz     :     0.066135
+      dyz     :     0.034380
+      dx2y2   :     0.132834
+      dxy     :     0.154345
+      f0      :     0.002175  f :     0.042354
+      f+1     :     0.003393
+      f-1     :     0.003037
+      f+2     :     0.005849
+      f-2     :     0.003419
+      f+3     :     0.009144
+      f-3     :     0.015337
+ 24 C s       :     2.696477  s :     2.696477
+      pz      :     0.837411  p :     2.815736
+      px      :     1.002476
+      py      :     0.975849
+      dz2     :     0.027496  d :     0.419553
+      dxz     :     0.067703
+      dyz     :     0.034269
+      dx2y2   :     0.130817
+      dxy     :     0.159268
+      f0      :     0.002220  f :     0.042895
+      f+1     :     0.003338
+      f-1     :     0.003043
+      f+2     :     0.006335
+      f-2     :     0.003198
+      f+3     :     0.009024
+      f-3     :     0.015736
+ 25 C s       :     2.696477  s :     2.696477
+      pz      :     0.837410  p :     2.815736
+      px      :     0.969276
+      py      :     1.009050
+      dz2     :     0.027496  d :     0.419553
+      dxz     :     0.017835
+      dyz     :     0.084137
+      dx2y2   :     0.172243
+      dxy     :     0.117843
+      f0      :     0.002220  f :     0.042895
+      f+1     :     0.002939
+      f-1     :     0.003441
+      f+2     :     0.001915
+      f-2     :     0.007618
+      f+3     :     0.009024
+      f-3     :     0.015736
+ 26 H s       :     0.838205  s :     0.838205
+      pz      :     0.043615  p :     0.161857
+      px      :     0.050130
+      py      :     0.068112
+      dz2     :     0.002412  d :     0.028072
+      dxz     :     0.001996
+      dyz     :     0.006089
+      dx2y2   :     0.009347
+      dxy     :     0.008228
+ 27 H s       :     0.843734  s :     0.843734
+      pz      :     0.042522  p :     0.153034
+      px      :     0.043394
+      py      :     0.067118
+      dz2     :     0.002389  d :     0.026990
+      dxz     :     0.001992
+      dyz     :     0.005776
+      dx2y2   :     0.008679
+      dxy     :     0.008153
+ 28 H s       :     0.843734  s :     0.843734
+      pz      :     0.042522  p :     0.153034
+      px      :     0.077694
+      py      :     0.032818
+      dz2     :     0.002389  d :     0.026990
+      dxz     :     0.007722
+      dyz     :     0.000046
+      dx2y2   :     0.007896
+      dxy     :     0.008936
+ 29 H s       :     0.838205  s :     0.838205
+      pz      :     0.043615  p :     0.161857
+      px      :     0.046026
+      py      :     0.072216
+      dz2     :     0.002412  d :     0.028072
+      dxz     :     0.002094
+      dyz     :     0.005991
+      dx2y2   :     0.008870
+      dxy     :     0.008705
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 C      6.1741     6.0000    -0.1741     3.8055     3.8055    -0.0000
+  1 C      6.1575     6.0000    -0.1575     3.8275     3.8275    -0.0000
+  2 C      5.9638     6.0000     0.0362     3.9912     3.9912    -0.0000
+  3 C      5.9638     6.0000     0.0362     3.9912     3.9912    -0.0000
+  4 C      6.1575     6.0000    -0.1575     3.8275     3.8275    -0.0000
+  5 C      6.1741     6.0000    -0.1741     3.8055     3.8055    -0.0000
+  6 C      5.9638     6.0000     0.0362     3.9912     3.9912    -0.0000
+  7 C      5.9638     6.0000     0.0362     3.9913     3.9913    -0.0000
+  8 C      5.9638     6.0000     0.0362     3.9913     3.9913    -0.0000
+  9 C      5.9638     6.0000     0.0362     3.9913     3.9913    -0.0000
+ 10 C      6.1575     6.0000    -0.1575     3.8275     3.8275    -0.0000
+ 11 H      0.8540     1.0000     0.1460     0.9839     0.9839    -0.0000
+ 12 C      6.1741     6.0000    -0.1741     3.8055     3.8055    -0.0000
+ 13 C      6.1741     6.0000    -0.1741     3.8055     3.8055    -0.0000
+ 14 C      6.1575     6.0000    -0.1575     3.8275     3.8275    -0.0000
+ 15 H      0.8506     1.0000     0.1494     0.9810     0.9810    -0.0000
+ 16 H      0.8540     1.0000     0.1460     0.9839     0.9839     0.0000
+ 17 H      0.8540     1.0000     0.1460     0.9839     0.9839    -0.0000
+ 18 H      0.8506     1.0000     0.1494     0.9810     0.9810    -0.0000
+ 19 H      0.8506     1.0000     0.1494     0.9810     0.9810     0.0000
+ 20 H      0.8506     1.0000     0.1494     0.9810     0.9810    -0.0000
+ 21 H      0.8540     1.0000     0.1460     0.9839     0.9839    -0.0000
+ 22 C      6.1575     6.0000    -0.1575     3.8275     3.8275    -0.0000
+ 23 C      6.1575     6.0000    -0.1575     3.8275     3.8275     0.0000
+ 24 C      6.1741     6.0000    -0.1741     3.8055     3.8055    -0.0000
+ 25 C      6.1741     6.0000    -0.1741     3.8055     3.8055    -0.0000
+ 26 H      0.8540     1.0000     0.1460     0.9839     0.9839    -0.0000
+ 27 H      0.8506     1.0000     0.1494     0.9810     0.9810    -0.0000
+ 28 H      0.8506     1.0000     0.1494     0.9810     0.9810    -0.0000
+ 29 H      0.8540     1.0000     0.1460     0.9839     0.9839     0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-C ,  1-C ) :   1.4342 B(  0-C ,  5-C ) :   1.2928 B(  0-C , 15-H ) :   0.9825 
+B(  1-C ,  2-C ) :   1.3245 B(  1-C , 16-H ) :   0.9707 B(  2-C ,  3-C ) :   1.3686 
+B(  2-C ,  6-C ) :   1.1476 B(  3-C ,  4-C ) :   1.3245 B(  3-C ,  7-C ) :   1.1476 
+B(  4-C ,  5-C ) :   1.4342 B(  4-C , 17-H ) :   0.9707 B(  5-C , 18-H ) :   0.9825 
+B(  6-C ,  9-C ) :   1.3686 B(  6-C , 23-C ) :   1.3245 B(  7-C ,  8-C ) :   1.3686 
+B(  7-C , 14-C ) :   1.3245 B(  8-C ,  9-C ) :   1.1476 B(  8-C , 10-C ) :   1.3245 
+B(  9-C , 22-C ) :   1.3245 B( 10-C , 11-H ) :   0.9707 B( 10-C , 12-C ) :   1.4342 
+B( 12-C , 13-C ) :   1.2928 B( 12-C , 19-H ) :   0.9825 B( 13-C , 14-C ) :   1.4342 
+B( 13-C , 20-H ) :   0.9825 B( 14-C , 21-H ) :   0.9707 B( 22-C , 24-C ) :   1.4342 
+B( 22-C , 26-H ) :   0.9707 B( 23-C , 25-C ) :   1.4342 B( 23-C , 29-H ) :   0.9707 
+B( 24-C , 25-C ) :   1.2928 B( 24-C , 27-H ) :   0.9825 B( 25-C , 28-H ) :   0.9825 
+
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 7 min 55 sec 
+
+Total time                  ....     475.578 sec
+Sum of individual times     ....     470.324 sec  ( 98.9%)
+
+Fock matrix formation       ....     452.514 sec  ( 95.2%)
+Diagonalization             ....       4.840 sec  (  1.0%)
+Density matrix formation    ....       0.281 sec  (  0.1%)
+Population analysis         ....       0.851 sec  (  0.2%)
+Initial guess               ....       1.848 sec  (  0.4%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       3.463 sec  (  0.7%)
+SOSCF solution              ....       6.137 sec  (  1.3%)
+
+
+           ************************************************************
+           *        Program running with 32 parallel MPI-processes    *
+           *              working on a shared directory               *
+           ************************************************************
+
+
+------------------------------------------------------------------------------- 
+                              ORCA-MATRIX DRIVEN CI                            
+------------------------------------------------------------------------------- 
+
+
+Wavefunction type
+-----------------
+Correlation treatment                      ...      CCSD     
+Single excitations                         ... ON
+Orbital optimization                       ... OFF
+Calculation of Z vector                    ... OFF
+Calculation of Brueckner orbitals          ... OFF
+Perturbative triple excitations            ... ON
+Calculation of F12 correction              ... OFF
+Frozen core treatment                      ... chemical core (36 el)
+Reference Wavefunction                     ... RHF
+  Internal Orbitals:    18 ...   59 ( 42 MO's/ 84 electrons)
+  Virtual  Orbitals:    60 ...  707 (648 MO's              )
+Number of AO's                             ...    708
+Number of electrons                        ...    120
+Number of correlated electrons             ...     84
+
+Algorithmic settings
+--------------------
+Integral transformation                    ... All integrals via the RI transformation
+K(C) Formation                             ... RI-DLPNO
+   PNO-Integral Storage                    ... ON DISK
+   PNO occupation number cut-off           ... 3.330e-07
+   Singles PNO occupation number cut-off   ... 9.990e-09
+   PNO Mulliken prescreening cut-off       ... 1.000e-03
+   Domain cut-off (Mulliken population)    ... 1.000e-03
+   PNO Normalization                       ...    1
+Maximum number of iterations               ...        50
+Convergence tolerance (max. residuum)      ... 1.000e-05
+Level shift for amplitude update           ... 2.000e-01
+Maximum number of DIIS vectors             ...         7
+DIIS turned on at iteration                ...         0
+Damping before turning on DIIS             ...     0.500
+Damping after turning on DIIS              ...     0.000
+Pair specific amplitude update             ... OFF
+Natural orbital iterations                 ... OFF
+Perturbative natural orbital generation    ... OFF
+Printlevel                                 ... 2
+
+Singles Fock matrix elements calculated using PNOs.
+
+Memory handling:
+----------------
+Maximum memory for working arrays          ...   8000 MB
+Data storage in matrix containers          ... UNCOMPRESSED
+Data type for integral storage             ... DOUBLE
+In-Core Storage of quantities:
+   Amplitudes+Sigma Vector      ... NO
+   J+K operators                ... NO
+   DIIS vectors                 ... NO
+   3-external integrals         ... NO
+   4-external integrals         ... NO
+
+Localization treatment:
+-----------------------
+Localization option                        ...    6
+Localization threshhold                    ... -1.0e+00
+Using relative localization threshhold     ... 1.0e-08
+Neglect threshold for strong pairs         ... 1.000e-04 Eh
+Prescreening threshold for very weak pairs ... 1.000e-06 Eh
+
+Initializing the integral package          ... done
+Localizing the valence orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... 07_Triphenylene.gbw
+Output orbitals are to                   ... 07_Triphenylene.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 18 to 59
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :  1133.703101
+ITERATION   0 : L= 1325.0363155547 DL=  1.91e+02 (AVERGE_DL)=    0.4714043744 
+ITERATION   1 : L= 1390.1492626194 DL=  6.51e+01 (AVERGE_DL)=    0.2749996243 
+ITERATION   2 : L= 1394.8407366379 DL=  4.69e+00 (AVERGE_DL)=    0.0738164376 
+ITERATION   3 : L= 1395.2727280886 DL=  4.32e-01 (AVERGE_DL)=    0.0223993801 
+ITERATION   4 : L= 1395.3311758486 DL=  5.84e-02 (AVERGE_DL)=    0.0082391491 
+ITERATION   5 : L= 1395.3388144837 DL=  7.64e-03 (AVERGE_DL)=    0.0029785597 
+ITERATION   6 : L= 1395.3398268715 DL=  1.01e-03 (AVERGE_DL)=    0.0010843560 
+ITERATION   7 : L= 1395.3399624538 DL=  1.36e-04 (AVERGE_DL)=    0.0003968258 
+ITERATION   8 : L= 1395.3399807008 DL=  1.82e-05 (AVERGE_DL)=    0.0001455772 
+ITERATION   9 : L= 1395.3399831526 DL=  2.45e-06 (AVERGE_DL)=    0.0000533635 
+ITERATION  10 : L= 1395.3399834895 DL=  3.37e-07 (AVERGE_DL)=    0.0000197819 
+LOCALIZATION SUM CONVERGED
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          18 to 59
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         861
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 1395.3399834895   Grad. norm: 7.337158e-03
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  2.36e-07 -3.34e+00 -3.35e+00 -3.35e+00 ... 
+Iter:    1   L: 1395.3399836074   Grad. norm: 4.930132e-08
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -3.339e+00
+  1 -3.346e+00
+  2 -3.346e+00
+  3 -3.717e+00
+  4 -3.717e+00
+  5 -3.717e+00
+  6 -3.792e+00
+  7 -3.809e+00
+  8 -3.809e+00
+  9 -1.169e+01
+    ...
+
+
+------------------------------------------------------------------------------- 
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS                   
+------------------------------------------------------------------------------- 
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   0 strongly local MO`s
+       -  42 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Bond-like localized orbitals:
+MO  59:  29H  -   0.435799  and  23C  -   0.589657
+MO  58:  28H  -   0.434719  and  25C  -   0.599481
+MO  57:  27H  -   0.434719  and  24C  -   0.599481
+MO  56:  26H  -   0.435799  and  22C  -   0.589657
+MO  55:  25C  -   0.523648  and  24C  -   0.523648
+MO  54:  25C  -   0.476280  and  23C  -   0.469720
+MO  53:  25C  -   0.476280  and  23C  -   0.469720
+MO  52:  24C  -   0.476280  and  22C  -   0.469719
+MO  51:  24C  -   0.476280  and  22C  -   0.469719
+MO  50:  23C  -   0.536663  and   6C  -   0.491379
+MO  49:  22C  -   0.536664  and   9C  -   0.491379
+MO  48:  21H  -   0.435799  and  14C  -   0.589657
+MO  47:  20H  -   0.434719  and  13C  -   0.599481
+MO  46:  19H  -   0.434719  and  12C  -   0.599481
+MO  45:  18H  -   0.434719  and   5C  -   0.599480
+MO  44:  17H  -   0.435799  and   4C  -   0.589656
+MO  43:  16H  -   0.435799  and   1C  -   0.589656
+MO  42:  15H  -   0.434719  and   0C  -   0.599480
+MO  41:  14C  -   0.469720  and  13C  -   0.476280
+MO  40:  14C  -   0.469720  and  13C  -   0.476280
+MO  39:  14C  -   0.536663  and   7C  -   0.491379
+MO  38:  13C  -   0.523648  and  12C  -   0.523648
+MO  37:  12C  -   0.476280  and  10C  -   0.469719
+MO  36:  12C  -   0.476280  and  10C  -   0.469719
+MO  35:  11H  -   0.435799  and  10C  -   0.589657
+MO  34:  10C  -   0.536664  and   8C  -   0.491379
+MO  33:   9C  -   0.521361  and   8C  -   0.521361
+MO  32:   9C  -   0.455190  and   6C  -   0.455190
+MO  31:   9C  -   0.455190  and   6C  -   0.455190
+MO  30:   8C  -   0.455190  and   7C  -   0.455190
+MO  29:   8C  -   0.455190  and   7C  -   0.455190
+MO  28:   7C  -   0.521361  and   3C  -   0.521361
+MO  27:   6C  -   0.521361  and   2C  -   0.521361
+MO  26:   5C  -   0.476280  and   4C  -   0.469720
+MO  25:   5C  -   0.476280  and   4C  -   0.469720
+MO  24:   5C  -   0.523648  and   0C  -   0.523648
+MO  23:   4C  -   0.536663  and   3C  -   0.491379
+MO  22:   3C  -   0.455190  and   2C  -   0.455190
+MO  21:   3C  -   0.455190  and   2C  -   0.455190
+MO  20:   2C  -   0.491379  and   1C  -   0.536663
+MO  19:   1C  -   0.469720  and   0C  -   0.476280
+MO  18:   1C  -   0.469720  and   0C  -   0.476280
+Localized MO's were stored in: 07_Triphenylene.loc
+
+Localizing the core orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... 07_Triphenylene.loc
+Output orbitals are to                   ... 07_Triphenylene.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 0 to 17
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :   521.906465
+ITERATION   0 : L=  521.9065296437 DL=  6.46e-05 (AVERGE_DL)=    0.0006500319 
+ITERATION   1 : L=  521.9065296437 DL=  0.00e+00 (AVERGE_DL)=    0.0000000000 
+LOCALIZATION SUM CONVERGED
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          0 to 17
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         153
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 521.9065296437   Grad. norm: 1.687084e-03
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  4.70e-09 -2.72e+01 -2.72e+01 -2.72e+01 ... 
+Iter:    1   L: 521.9065296461   Grad. norm: 3.617145e-15
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -2.720e+01
+  1 -2.720e+01
+  2 -2.720e+01
+  3 -2.720e+01
+  4 -2.720e+01
+  5 -2.720e+01
+  6 -2.792e+01
+  7 -2.792e+01
+  8 -2.792e+01
+  9 -2.842e+01
+    ...
+
+
+------------------------------------------------------------------------------- 
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS                   
+------------------------------------------------------------------------------- 
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -  18 strongly local MO`s
+       -   0 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO  17:  25C  -   1.001811
+MO  16:  24C  -   1.001811
+MO  15:  23C  -   1.002720
+MO  14:  22C  -   1.002720
+MO  13:  14C  -   1.002720
+MO  12:  13C  -   1.001811
+MO  11:  12C  -   1.001811
+MO  10:  10C  -   1.002720
+MO   9:   9C  -   1.003773
+MO   8:   8C  -   1.003773
+MO   7:   7C  -   1.003773
+MO   6:   6C  -   1.003773
+MO   5:   5C  -   1.001811
+MO   4:   4C  -   1.002720
+MO   3:   3C  -   1.003773
+MO   2:   2C  -   1.003773
+MO   1:   1C  -   1.002720
+MO   0:   0C  -   1.001811
+Localized MO's were stored in: 07_Triphenylene.loc
+
+Warning: reference  - re-canonicalizations have been set to INT 1 VIRT 1
+Warning: internal orbitals are localized - no re-canonicalization of internal orbitals
+Warning: UsePNO is turned on - no re-canonicalization of internal and virtual orbitals
+
+--------------------------
+CLOSED-SHELL FOCK OPERATOR
+--------------------------
+
+<ss|ss>:     11608971 b      5045313 skpd ( 43.5%)    0.638 s ( 0.000 ms/b)
+<ss|sp>:     32405868 b     12983593 skpd ( 40.1%)    2.518 s ( 0.000 ms/b)
+<ss|sd>:     19031100 b      8323950 skpd ( 43.7%)    2.161 s ( 0.000 ms/b)
+<ss|sf>:      7516080 b      3400132 skpd ( 45.2%)    1.078 s ( 0.000 ms/b)
+<ss|pp>:     11621016 b      4146010 skpd ( 35.7%)    1.211 s ( 0.000 ms/b)
+<ss|pd>:     13297680 b      5232913 skpd ( 39.4%)    1.415 s ( 0.000 ms/b)
+<ss|pf>:      5116716 b      2033240 skpd ( 39.7%)    0.563 s ( 0.000 ms/b)
+<ss|dd>:      3945942 b      1671038 skpd ( 42.3%)    0.363 s ( 0.000 ms/b)
+<ss|df>:      2948616 b      1268600 skpd ( 43.0%)    0.398 s ( 0.000 ms/b)
+<ss|ff>:       635976 b       272379 skpd ( 42.8%)    0.148 s ( 0.000 ms/b)
+<sp|sp>:     22622901 b      8187599 skpd ( 36.2%)    1.574 s ( 0.000 ms/b)
+<sp|sd>:     26567700 b     10625284 skpd ( 40.0%)    3.381 s ( 0.000 ms/b)
+<sp|sf>:     10492560 b      4357602 skpd ( 41.5%)    1.930 s ( 0.000 ms/b)
+<sp|pp>:     16223112 b      5153372 skpd ( 31.8%)    2.345 s ( 0.000 ms/b)
+<sp|pd>:     18563760 b      6551018 skpd ( 35.3%)    2.505 s ( 0.000 ms/b)
+<sp|pf>:      7143012 b      2535178 skpd ( 35.5%)    1.406 s ( 0.000 ms/b)
+<sp|dd>:      5508594 b      2106322 skpd ( 38.2%)    1.027 s ( 0.000 ms/b)
+<sp|df>:      4116312 b      1610692 skpd ( 39.1%)    1.126 s ( 0.000 ms/b)
+<sp|ff>:       887832 b       346900 skpd ( 39.1%)    0.413 s ( 0.001 ms/b)
+<sd|sd>:      7803225 b      3453100 skpd ( 44.3%)    0.935 s ( 0.000 ms/b)
+<sd|sf>:      6162000 b      2845052 skpd ( 46.2%)    1.059 s ( 0.000 ms/b)
+<sd|pp>:      9527400 b      3350404 skpd ( 35.2%)    1.526 s ( 0.000 ms/b)
+<sd|pd>:     10902000 b      4314200 skpd ( 39.6%)    2.356 s ( 0.000 ms/b)
+<sd|pf>:      4194900 b      1688704 skpd ( 40.3%)    1.327 s ( 0.001 ms/b)
+<sd|dd>:      3235050 b      1401108 skpd ( 43.3%)    0.994 s ( 0.001 ms/b)
+<sd|df>:      2417400 b      1068558 skpd ( 44.2%)    1.221 s ( 0.001 ms/b)
+<sd|ff>:       521400 b       229168 skpd ( 44.0%)    0.506 s ( 0.002 ms/b)
+<sf|sf>:      1217580 b       589811 skpd ( 48.4%)    0.406 s ( 0.001 ms/b)
+<sf|pp>:      3762720 b      1375792 skpd ( 36.6%)    1.012 s ( 0.000 ms/b)
+<sf|pd>:      4305600 b      1775868 skpd ( 41.2%)    1.739 s ( 0.001 ms/b)
+<sf|pf>:      1656720 b       705094 skpd ( 42.6%)    0.999 s ( 0.001 ms/b)
+<sf|dd>:      1277640 b       581706 skpd ( 45.5%)    0.738 s ( 0.001 ms/b)
+<sf|df>:       954720 b       446744 skpd ( 46.8%)    0.925 s ( 0.002 ms/b)
+<sf|ff>:       205920 b        97726 skpd ( 47.5%)    0.413 s ( 0.004 ms/b)
+<pp|pp>:      2910078 b       809437 skpd ( 27.8%)    0.590 s ( 0.000 ms/b)
+<pp|pd>:      6657120 b      2041314 skpd ( 30.7%)    2.029 s ( 0.000 ms/b)
+<pp|pf>:      2561544 b       786648 skpd ( 30.7%)    1.143 s ( 0.001 ms/b)
+<pp|dd>:      1975428 b       660659 skpd ( 33.4%)    0.918 s ( 0.001 ms/b)
+<pp|df>:      1476144 b       502140 skpd ( 34.0%)    1.090 s ( 0.001 ms/b)
+<pp|ff>:       318384 b       109100 skpd ( 34.3%)    0.415 s ( 0.002 ms/b)
+<pd|pd>:      3810180 b      1325525 skpd ( 34.8%)    1.992 s ( 0.001 ms/b)
+<pd|pf>:      2931120 b      1029026 skpd ( 35.1%)    2.191 s ( 0.001 ms/b)
+<pd|dd>:      2260440 b       868404 skpd ( 38.4%)    1.763 s ( 0.001 ms/b)
+<pd|df>:      1689120 b       662484 skpd ( 39.2%)    2.132 s ( 0.002 ms/b)
+<pd|ff>:       364320 b       143392 skpd ( 39.4%)    0.870 s ( 0.004 ms/b)
+<pf|pf>:       564453 b       203787 skpd ( 36.1%)    0.777 s ( 0.002 ms/b)
+<pf|dd>:       869778 b       343466 skpd ( 39.5%)    1.153 s ( 0.002 ms/b)
+<pf|df>:       649944 b       265820 skpd ( 40.9%)    1.406 s ( 0.004 ms/b)
+<pf|ff>:       140184 b        58392 skpd ( 41.7%)    0.563 s ( 0.007 ms/b)
+<dd|dd>:       335790 b       147121 skpd ( 43.8%)    0.481 s ( 0.003 ms/b)
+<dd|df>:       501228 b       224414 skpd ( 44.8%)    1.088 s ( 0.004 ms/b)
+<dd|ff>:       108108 b        48276 skpd ( 44.7%)    0.445 s ( 0.007 ms/b)
+<df|df>:       187578 b        88322 skpd ( 47.1%)    0.699 s ( 0.007 ms/b)
+<df|ff>:        80784 b        38370 skpd ( 47.5%)    0.552 s ( 0.013 ms/b)
+<ff|ff>:         8778 b         4368 skpd ( 49.8%)    0.131 s ( 0.030 ms/b)
+Time needed for Fock operator              ...           65.353 sec
+Reference energy                           ...   -688.868878529
+
+--------------
+DLPNO SETTINGS (2015 fully linear scaling implementation)
+--------------
+
+TCutMKN:           1.000e-03
+TCutPAO:           1.000e-03
+TCutPNO:           3.330e-07
+TCutPNOSingles:    9.990e-09
+TCutEN:            9.700e-01
+TCutPAOExt:        1.000e-01
+TCutPairs:         1.000e-04
+TCutPre:           1.000e-06
+TCutOSV:           1.000e-06
+TCutDOij:          1.000e-05
+TCutDO:            1.000e-02
+TCutC:             1.000e-04
+TCutCPAO:          1.000e-03
+TCutCMO:           1.000e-03
+TScaleDOMP2PreScr: 2.000e+00
+TScaleMKNMP2PreScr:1.000e+01
+TScalePNOMP2PreScr:1.000e+00
+PAO overlap thresh 1.000e-08
+Using PNOs for Singles Fock computation
+Use new domains
+Use fully linear algorithm
+TCutTNO:           1.000e-09
+TCutMP2Pairs:      1.000e-05
+TCutDOStrong:      2.000e-03
+TCutMKNStrong:     1.000e-02
+TCutMKNWeak:       1.000e-01
+TCutDOWeak:        4.000e-03
+NTCutTNO:          1
+
+--------------------------
+Calculating differential overlap integrals ... ok
+--------------------------
+ELECTRON PAIR PRESCREENING
+--------------------------
+
+Dipole-based pair screening          .... used
+
+   TCutDOij = 1.000000e-05
+   TCutPre  = 1.000000e-06
+   .... Finished loop over pairs
+Total time spent in the prescreening                  ...     0.111 sec
+sum of pair energies estimated for screened out pairs ...       0.000000000000 Eh
+Thresholds for map construction and integral transformation for crude MP2:
+   TCutMKN                    ...     1.0e-02
+   TCutDO                     ...     2.0e-02
+   TCutPairs                  ...     1.0e-04
+   TCutPNO_CrudeMP2           ...     3.3e-07
+   TCutPNOSingles_CrudeMP2    ...     1.0e-08
+--------------------------------
+LOCAL RI TRANSFORMATION (IAVPAO)
+--------------------------------
+
+Orbital window:      18 to 59
+Number of PAOs:     708
+Basis functions:    708 (252 shells)
+Aux. functions:    2460 (672 shells)
+
+Processing maps (0.1 sec)
+Average map sizes:
+   Aux shells -> MOs              42.0
+   Aux shells -> PAOs            708.0
+   MOs        -> AO shells       233.9
+   PAOs       -> AO shells       252.0
+
+Calculating integrals (5.6 sec, 558.123 MB)
+Sorting integrals (5.3 sec, 558.095 MB)
+Total time for the integral transformation: 11.5 sec
+--------------------------------
+INITIAL GUESS AND PNO GENERATION
+--------------------------------
+
+PNO truncation parameters                   .... 
+    PAOOverlapThresh   =        1.000e-08
+
+    TCutPairs          =        1.000e-04
+    TCutPNO            =        3.330e-07
+    TCutPNOSingles     =        9.990e-09
+    TCutMP2Pairs       =        1.000e-05
+    TCutMKN            =        1.000e-02
+    TCutDO             =        2.000e-02
+
+Pair selection                          .... not used
+Type of local MP2 treatment                 .... semi-local MP2
+Strategy for PNO selection                  .... occupation number selection
+Pair density normalization                  .... MP2 norm
+Spin component scaling                      .... not used
+
+   .... Finished loop over pairs
+Making pair pair interaction lists          ... done
+
+                       ===========================
+                        510 OF  903 PAIRS ARE KEPT CCSD PAIRS
+                        270 OF  903 PAIRS ARE KEPT MP2 PAIRS FOR (T)
+                        123 OF  903 PAIRS ARE SKIPPED
+                       ===========================
+
+Total time spent in the initial guess                 ...    35.858 sec
+SL-MP2 correlation energy (all non-screened pairs)    ...      -2.677734999197 Eh
+
+Initial PNO correlation energy                        ...      -2.655720522200 Eh
+sum of pair energies prescreened and skipped MP2 pairs...      -0.000602456976 Eh
+sum of pair energies of crude MP2 skipped pairs only  ...      -0.000602456976 Eh
+sum of MP2 pair energies for pairs that were not kept ...      -0.011681427884 Eh
+sum of PNO error estimates for the kept pairs         ...      -0.010333049114 Eh
+                                                          --------------------
+sum of all corrections                                         -0.022014476998
+Initial total correlation energy                               -2.677734999197
+Thresholds for map construction and integral transformation for fine MP2 and CCSD(T) calculation:
+   TCutMKN   ...     1.0e-03
+   TCutDO    ...     1.0e-02
+   TCutPairs ...     1.0e-04
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+Thresholds for map construction and integral transformation for strong Triples:
+   TCutMKN   ...     1.0e-02
+   TCutDO    ...     2.0e-02
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+Thresholds for map construction and integral transformation for weak Triples:
+   TCutMKN   ...     1.0e-01
+   TCutDO    ...     4.0e-02
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+--------------------------------
+LOCAL RI TRANSFORMATION (IAVPAO)
+--------------------------------
+
+Orbital window:      18 to 59
+Number of PAOs:     708
+Basis functions:    708 (252 shells)
+Aux. functions:    2460 (672 shells)
+
+Processing maps (0.1 sec)
+Average map sizes:
+   Aux shells -> MOs              41.6
+   Aux shells -> PAOs            708.0
+   MOs        -> AO shells       233.9
+   PAOs       -> AO shells       252.0
+
+Calculating integrals (5.1 sec, 553.650 MB)
+Sorting integrals (6.2 sec, 553.622 MB)
+Total time for the integral transformation: 12.3 sec
+--------------------------------
+INITIAL GUESS AND PNO GENERATION
+--------------------------------
+
+PNO truncation parameters                   .... 
+    PAOOverlapThresh   =        1.000e-08
+
+    TCutPairs          =        1.000e-04
+    TCutPNO            =        3.330e-07
+    TCutPNOSingles     =        9.990e-09
+    TCutMP2Pairs       =        1.000e-05
+    TCutMKN            =        1.000e-03
+    TCutDO             =        1.000e-02
+
+Pair selection                          .... not used
+Type of local MP2 treatment                 .... semi-local MP2
+Strategy for PNO selection                  .... occupation number selection
+Pair density normalization                  .... MP2 norm
+Spin component scaling                      .... not used
+
+   .... Finished loop over pairs
+
+ PNO Occupation Number Statistics: 
+  | Av. % of trace(Dij) retained        ...  96.722039947008
+  | sigma^2 in % of trace(Dij) retained ...   1.22e+01
+  | Av. % of trace(Di) retained         ...  99.998683356292
+  | sigma^2 in % of trace(Di) retained  ...   2.23e-07
+ Distributions of % trace(Dij) recovered:
+  |       >= 99.9  ...   141 ( 18.1 % of all pairs)
+  |   [80.0, 90.0) ...    36 (  4.6 % of all pairs)
+  |   [90.0, 99.0) ...   408 ( 52.3 % of all pairs)
+  |   [99.0, 99.9) ...   195 ( 25.0 % of all pairs)
+ Distributions of % trace(Di) recovered :
+  |       >= 99.9  ...    42 (100.0 % of all I-pairs )
+
+Making pair pair interaction lists          ... done
+
+                       ===========================
+                        510 OF  780 PAIRS ARE KEPT
+                       ===========================
+
+Total time spent in the initial guess                 ...   123.103 sec
+SL-MP2 correlation energy (all non-screened pairs)    ...      -2.678939584799 Eh
+
+Initial PNO correlation energy                        ...      -2.657403506812 Eh
+sum of pair energies estimated for screened out pairs ...      -0.000602456976 Eh
+sum of MP2 pair energies for pairs that were not kept ...      -0.011073207869 Eh
+sum of PNO error estimates for the kept pairs         ...      -0.010462870117 Eh
+                                                          --------------------
+sum of all corrections                                         -0.022138534962
+Initial total correlation energy                               -2.679542041775
+Thresholds for map construction and integral transformation for fine MP2 and CCSD(T) calculation:
+   TCutMKN   ...     1.0e-03
+   TCutDO    ...     1.0e-02
+   TCutPairs ...     1.0e-04
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+Time for aux screen maps:            0.027
+Time for maps after fine MP2:            0.126
+-----------------------------
+LOCAL RI TRANSFORMATION (IJV)
+-----------------------------
+
+Orbital window:      18 to 59
+Basis functions:    708 (252 shells)
+Aux. functions:    2460 (672 shells)
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs(i)           39.0
+   Aux shells -> MOs(j)           42.0
+   MOs        -> AO shells       233.9
+
+Calculating integrals (4.1 sec, 30.959 MB)
+Sorting integrals (1.3 sec, 30.931 MB)
+Total time for the integral transformation: 5.5 sec
+--------------------------------
+LOCAL RI TRANSFORMATION (VABPAO)
+--------------------------------
+
+Number of PAOs:     708
+Basis functions:    708 (252 shells)
+Aux. functions:    2460 (672 shells)
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> PAOs            708.0
+   PAOs       -> AO shells       252.0
+
+Calculating integrals (73.7 sec, 18590.176 MB)
+Finished
+
+
+-------------------------------------
+Pair Pair Term precalculation with     
+RI-(ij|mn) and (im|jn) transformation  
+ON THE FLY                             
+-------------------------------------
+
+   IBatch   1 (of   2)              ... done (  390.014 sec)
+   IBatch   2 (of   2)              ... done (  193.809 sec)
+Total EXT                           ...         583.824 sec
+
+---------------------
+RI-PNO TRANSFORMATION
+---------------------
+
+Total Number of PNOs                   ... 19794
+Average number of PNOs per pair        ...    38
+Maximal number of PNOs per pair        ...    82
+   #pairs with  1 -  5 PNOs   :    0
+   #pairs with  6 - 10 PNOs   :    0
+   #pairs with 11 - 15 PNOs   :   36
+   #pairs with 16 - 20 PNOs   :   66
+   #pairs with 21 - 25 PNOs   :   18
+   #pairs with 26 - 30 PNOs   :   51
+   #pairs with 31 - 35 PNOs   :   96
+   #pairs with 36 - 40 PNOs   :   48
+   #pairs with 41 - 45 PNOs   :   21
+   #pairs with 46 - 50 PNOs   :   27
+   #pairs with 51 - 55 PNOs   :   30
+   #pairs with 56 - 60 PNOs   :   54
+   #pairs with 61 - 65 PNOs   :   12
+   #pairs with 66 - 70 PNOs   :    6
+   #pairs with 71 - 75 PNOs   :   36
+   #pairs with 76 - 80 PNOs   :    6
+   #pairs with 81 - 85 PNOs   :    3
+
+Generation of (ij|ab)[P] integrals            ... on
+Generation of (ia|bc)[P],(ja|bc)[P] integrals ... on
+Storage of 3 and 4 external integrals         ... on
+Generation of ALL (ka|bc)[P] integrals        ... on
+Keep RI integrals in memory                   ... off
+
+Ibatch:  1 (of  1)
+Starting 2-4 index PNO integral generation ... done
+
+Timings:
+Total PNO integral transformation time     ...        390.936 sec
+Size of the 3-external file                ...       384 MB
+Size of the 4-external file                ...      2855 MB
+Size of the IKJL file                      ...         0 MB
+Size of the all 3-external file            ...      8036 MB
+Size of the 1-external file                ...        18 MB
+
+Making pair/pair overlap matrices          ... done (  120.580 sec)
+Size of the pair overlap file              ... 2193 MB
+Redoing the guess amplitudes               ... done (    0.077 sec)
+
+-------------------------
+FINAL STARTUP INFORMATION
+-------------------------
+
+E(0)                                       ...   -688.868878529
+E(SL-MP2)                                  ...     -2.678939585
+E(SL-MP2) including corrections            ...     -2.679542042
+Initial E(tot)                             ...   -691.548420571
+<T|T>                                      ...      0.831820777
+Number of pairs included                   ... 510
+Total number of pairs                      ... 903
+
+------------------------------------------------
+                  RHF COUPLED CLUSTER ITERATIONS
+------------------------------------------------
+
+Number of PNO amplitudes to be optimized   ...       926796
+Number of non-PNO amplitudes               ...    214151040
+Untruncated number of regular amplitudes   ...    379173312
+
+Iter       E(tot)           E(Corr)          Delta-E          Residual     Time
+  0   -691.548587717     -2.657570653      0.021368932      0.015715930  367.21
+                           *** Turning on DIIS ***
+  1   -691.622869272     -2.731852208     -0.074281555      0.007012796  328.37
+  2   -691.687036721     -2.796019658     -0.064167450      0.003326147  334.31
+  3   -691.700166836     -2.809149772     -0.013130115      0.001935019  326.40
+  4   -691.704147871     -2.813130808     -0.003981035      0.000951869  330.28
+  5   -691.705466575     -2.814449511     -0.001318703      0.000341439  328.97
+  6   -691.705808027     -2.814790963     -0.000341452      0.000088066  331.16
+  7   -691.705829590     -2.814812526     -0.000021563      0.000028151  332.77
+  8   -691.705839367     -2.814822303     -0.000009777      0.000015230  330.05
+  9   -691.705830881     -2.814813817      0.000008486      0.000008300  335.75
+               --- The Coupled-Cluster iterations have converged ---
+
+----------------------
+COUPLED CLUSTER ENERGY
+----------------------
+
+E(0)                                       ...   -688.868878529
+E(CORR)(strong-pairs)                      ...     -2.814813817
+E(CORR)(weak-pairs)                        ...     -0.022138535
+E(CORR)(corrected)                         ...     -2.836952352
+E(TOT)                                     ...   -691.705830881
+Singles Norm <S|S>**1/2                    ...      0.090480555  
+T1 diagnostic                              ...      0.009872238  
+
+------------------
+LARGEST AMPLITUDES
+------------------
+  28-> 63  28-> 63       0.044229
+  27-> 63  27-> 63       0.044229
+  33-> 63  33-> 63       0.044229
+  45-> 64  45-> 64       0.043432
+  42-> 64  42-> 64       0.043432
+  46-> 64  46-> 64       0.043432
+  57-> 64  57-> 64       0.043432
+  47-> 64  47-> 64       0.043401
+  58-> 64  58-> 64       0.043401
+  44-> 64  44-> 64       0.040453
+  43-> 64  43-> 64       0.040453
+  56-> 64  56-> 64       0.040453
+  35-> 64  35-> 64       0.040453
+  48-> 64  48-> 64       0.040452
+  59-> 64  59-> 64       0.040452
+  37-> 60  37-> 60       0.038635
+
+
+-------------------------------------------
+DLPNO BASED TRIPLES CORRECTION
+-------------------------------------------
+
+Singles multiplier          ...  1.000000
+TCutTNO                     ... 1.000e-09
+TCutMP2Pairs                ... 1.000e-05
+TCutDOStrong                ... 2.000e-02
+TCutMKNStrong               ... 1.000e-02
+TCutDOWeak                  ... 4.000e-02
+TCutMKNWeak                 ... 1.000e-01
+
+Fragment selection                          .... not used
+Fock matrix occ-virt block is zero --> Setting DT_in_Triples to false.
+Number of Triples that are to be computed   ...      6083
+
+ . . . . . . . . .
+10% done  
+20% done  
+30% done  
+40% done  
+50% done  
+60% done  
+70% done  
+80% done  
+90% done               (   1912.441 sec)
+Triples timings:
+Total time for T0               ...  2008.048 sec
+Total time for Iterative (T)    ...     0.000 sec
+Total time of overall (T)       ...  2202.127 sec
+
+Triples List generation         ...     0.000 sec
+TNO generation                  ...    95.251 sec
+Pair density generation         ...     0.041 sec
+Look up tables                  ...     0.000 sec
+Generating 3-index integrals    ...  1498.791 sec
+  Make 4-ind.int. from 3-ind.int...   119.712 sec
+  Projecting amplitudes (D + S) ...   199.705 sec
+  Downprojecting integrals      ...     0.005 sec
+  Energy contr. (sum over a,b,c)...    17.158 sec
+Fitting ET(->0)                 ...     0.000 sec
+
+Everything after 3-index        ...   413.650 sec
+
+Timing details:
+ TNO integrals                  ...  1594.162 sec
+   Reading 3-index integrals    ...    18.527 sec
+   Sorting integrals            ...    95.797 sec
+       Sorting integrals 1      ...     0.003 sec
+       Sorting integrals 2      ...    84.856 sec
+       Sorting integrals 3      ...     2.242 sec
+       Sorting integrals 4      ...     0.168 sec
+       Sorting integrals 5      ...     1.261 sec
+       Sorting integrals 6      ...     7.267 sec
+   Calculating local VM**-1/2   ...     6.957 sec
+   Orthogonal. integrals        ...    11.451 sec
+   Multipl. 3-index integrals   ...  1461.431 sec
+   All concerning IRIab (w/TNO) ...    90.703 sec
+
+ Calculate W0/W1                ...    77.059 sec
+ W 3-ext contribution           ...    48.880 sec
+ W 3-int contribution           ...    18.619 sec
+ Sorting W                      ...     8.975 sec
+
+ V exchange contribution        ...     7.273 sec
+
+ Timings for Triples without generation
+     of 3-index integrals       ...   413.648 sec
+       0 weak pairs             ...   306.132 sec
+       1 weak pair              ...   107.516 sec
+       2 weak pairs             ...     0.000 sec
+       3 weak pairs             ...     0.000 sec
+  Extra time for extrapolation  ...     0.000 sec
+
+Number of Triples   (0, 1, 2, 3 weak pairs; overall):   3551    2532       0       0  (  6083)
+Number of Atoms     (0, 1, 2, 3 weak pairs; overall):   17.5    14.2     0.0     0.0  (    30)
+Number of PAOs      (0, 1, 2, 3 weak pairs; overall):  453.1   373.4     0.0     0.0  (   708)
+Number of AuxFcns   (0, 1, 2, 3 weak pairs; overall):  790.4   576.6     0.0     0.0  (  2460)
+Number of TNOs      (0, 1, 2, 3 weak pairs         ):  105.8    76.4     0.0     0.0
+Aver. Number of NTNO, Atoms, PAOs, AuxFcns / Triples:   6083    93.6    16.1   419.9   701.4
+
+Triples Correction (T)                     ...     -0.151341889
+Final correlation energy                   ...     -2.988294241
+E(CCSD)                                    ...   -691.705830881
+E(CCSD(T))                                 ...   -691.857172770
+
+
+Maximum memory used throughout the entire calculation: 7719.0 MB
+
+
+------------------------------------------------------------------------------- 
+                                     TIMINGS                                   
+------------------------------------------------------------------------------- 
+
+
+Total execution time                   ...     7125.272 sec
+
+Localization of occupied MO's          ...        7.653 sec (  0.1%)
+Fock Matrix Formation                  ...       65.353 sec (  0.9%)
+Global overlap, Fock, MKN matrices     ...        1.540 sec (  0.0%)
+Differential overlap integrals         ...        1.471 sec (  0.0%)
+Organizing maps                        ...        0.321 sec (  0.0%)
+RI 3-index integral generations        ...      103.018 sec (  1.4%)
+RI-PNO integral transformation         ...     1236.763 sec ( 17.4%)
+Initial Guess                          ...      159.498 sec (  2.2%)
+DIIS Solver                            ...        9.561 sec (  0.1%)
+State Vector Update                    ...        0.152 sec (  0.0%)
+Sigma-vector construction              ...     3335.532 sec ( 46.8%)
+  <0|H|D>                              ...        0.002 sec (  0.0% of sigma)
+  <D|H|D>(0-ext)                       ...      439.580 sec ( 13.2% of sigma)
+  <D|H|D>(2-ext Fock)                  ...        0.034 sec (  0.0% of sigma)
+  <D|H|D>(2-ext)                       ...      182.748 sec (  5.5% of sigma)
+  <D|H|D>(4-ext)                       ...       28.264 sec (  0.8% of sigma)
+  <D|H|D>(4-ext-corr)                  ...      164.536 sec (  4.9% of sigma)
+  CCSD doubles correction              ...       52.017 sec (  1.6% of sigma)
+  <S|H|S>                              ...      298.838 sec (  9.0% of sigma)
+  <S|H|D>(1-ext)                       ...        9.579 sec (  0.3% of sigma)
+  <D|H|S>(1-ext)                       ...        0.217 sec (  0.0% of sigma)
+  <S|H|D>(3-ext)                       ...        3.363 sec (  0.1% of sigma)
+  Fock-dressing                        ...      710.030 sec ( 21.3% of sigma)
+  Singles amplitudes                   ...      297.456 sec (  8.9% of sigma)
+  (ik|jl)-dressing                     ...      374.148 sec ( 11.2% of sigma)
+  (ij|ab),(ia|jb)-dressing             ...      281.501 sec (  8.4% of sigma)
+  Pair energies                        ...        0.030 sec (  0.0% of sigma)
+Total Time for computing (T)           ...     2202.326 sec ( 30.9% of ALL)
+
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -691.857172770092
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... 07_Triphenylene.gbw
+Electron density file                           ... 07_Triphenylene.scfp
+The origin for moment calculation is the CENTER OF MASS  = (-0.000000, -0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000      -0.00000       0.00000
+Nuclear contribution   :     -0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000      -0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.017117     0.017117     0.008559 
+Rotational constants in MHz :   513.159999   513.159948   256.579987 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.000000    -0.000001     0.000000 
+x,y,z [Debye]:    -0.000000    -0.000003     0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...     7631.404 sec (= 127.190 min)
+GTO integral calculation        ...        8.225 sec (=   0.137 min)   0.1 %
+SCF iterations                  ...      481.432 sec (=   8.024 min)   6.3 %
+MDCI module                     ...     7141.747 sec (= 119.029 min)  93.6 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 2 hours 7 minutes 18 seconds 496 msec

--- a/arkane/data/Orca_opt_freq_test.log
+++ b/arkane/data/Orca_opt_freq_test.log
@@ -1,0 +1,2128 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.2.0 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel, MM, QM/MM, CI optimization
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 4.2.3
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-TZVP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: The environment variable RSH_COMMAND is not set!
+  ===> : All Displacements for the Numerical Hessian calculation
+         will be started on localhost
+
+WARNING: Geometry Optimization
+  ===> : Switching off AutoStart
+         For restart on a previous wavefunction, please use MOREAD
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = h2o_01_opt_freq.inp
+|  1> ! Opt NumFreq  B3LYP def2-TZVP   PAL16
+|  2> %maxcore 3000
+|  3> 
+|  4> # opt freq
+|  5> *xyz 0 1
+|  6> O        0.000000000      0.000000000      0.000000000
+|  7> H        0.000000000      0.759337000      0.596043000
+|  8> H        0.000000000     -0.759337000      0.596043000
+|  9> *
+| 10> 
+| 11> 
+| 12> 
+| 13>                          ****END OF INPUT****
+================================================================================
+
+                       *****************************
+                       * Geometry Optimization Run *
+                       *****************************
+
+Geometry optimization settings:
+Update method            Update   .... BFGS
+Choice of coordinates    CoordSys .... Z-matrix Internals
+Initial Hessian          InHess   .... Almoef's Model
+
+Convergence Tolerances:
+Energy Change            TolE     ....  5.0000e-06 Eh
+Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+Strict Convergence                ....  False
+------------------------------------------------------------------------------
+                        ORCA OPTIMIZATION COORDINATE SETUP
+------------------------------------------------------------------------------
+
+The optimization will be done in new redundant internal coordinates
+Making redundant internal coordinates   ...  (new redundants) done
+Evaluating the initial hessian          ...  (Almloef) done
+Evaluating the coordinates              ...  done
+Calculating the B-matrix                .... done
+Calculating the G-matrix                .... done
+Diagonalizing the G-matrix              .... done
+The first mode is                       ....    0
+The number of degrees of freedom        ....    3
+
+    -----------------------------------------------------------------
+                    Redundant Internal Coordinates
+
+
+    -----------------------------------------------------------------
+         Definition                    Initial Value    Approx d2E/dq
+    -----------------------------------------------------------------
+      1. B(H   1,O   0)                  0.9653         0.509876   
+      2. B(H   2,O   0)                  0.9653         0.509876   
+      3. A(H   1,O   0,H   2)          103.7396         0.319780   
+    -----------------------------------------------------------------
+
+Number of atoms                         .... 3
+Number of degrees of freedom            .... 3
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   1            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O      0.000000    0.000000    0.000000
+  H      0.000000    0.759337    0.596043
+  H      0.000000   -0.759337    0.596043
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999    0.000000    0.000000    0.000000
+   1 H     1.0000    0     1.008    0.000000    1.434939    1.126358
+   2 H     1.0000    0     1.008    0.000000   -1.434939    1.126358
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     0.965328927060     0.00000000     0.00000000
+ H      1   2   0     0.965328927060   103.73958501     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.824207301295     0.00000000     0.00000000
+ H      1   2   0     1.824207301295   103.73958501     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   2 Type H   : 5s1p contracted to 3s1p pattern {311/1}
+
+Atom   0O    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   32
+ # of primitive gaussian functions       ...   62
+ # of contracted shells                  ...   19
+ # of contracted basis functions         ...   43
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    6
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  2.500e-11
+ Primitive cut-off              TCut     ...  2.500e-12
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+ Exchange Functional    Exchange        .... B88
+   X-Alpha parameter    XAlpha          ....  0.666667
+   Becke's b parameter  XBeta           ....  0.004200
+ Correlation Functional Correlation     .... LYP
+ LDA part of GGA corr.  LDAOpt          .... VWN-5
+ Gradients option       PostSCFGGA      .... off
+ Hybrid DFT is turned on
+   Fraction HF Exchange ScalHFX         ....  0.200000
+   Scaling of DF-GGA-X  ScalDFX         ....  0.720000
+   Scaling of DF-GGA-C  ScalDFC         ....  0.810000
+   Scaling of DF-LDA-C  ScalLDAC        ....  1.000000
+   Perturbative correction              ....  0.000000
+   Density functional embedding theory  .... OFF
+   NL short-range parameter             ....  4.800000
+
+
+General Settings:
+ Integral files         IntName         .... h2o_01_opt_freq
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   10
+ Basis Dimension        Dim             ....   43
+ Nuclear Repulsion      ENuc            ....      9.1193798645 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... LIBINT
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 8.586e-03
+Time for diagonalization                   ...    0.001 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.010 sec
+Total time needed                          ...    0.012 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   3304 (   0.0 sec)
+# of grid points (after weights+screening)   ...   3254 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     3254
+Total number of batches                      ...       52
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1085
+Average number of shells per batch           ...    13.20 (69.47%)
+Average number of basis functions per batch  ...    31.60 (73.49%)
+Average number of large shells per batch     ...    11.20 (84.85%)
+Average number of large basis fcns per batch ...    26.80 (84.81%)
+Maximum spatial batch extension              ...  15.11, 10.94, 14.83 au
+Average spatial batch extension              ...   0.88,  0.71,  0.85 au
+
+Time for grid setup =    0.058 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+  promolecular density results
+     # of electrons  =      9.996459369
+     EX              =     -8.780328300
+     EC              =     -0.334510690
+     EX+EC           =     -9.114838990
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.3 sec)
+                      ------------------
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+  0    -76.3214696567   0.000000000000 0.06330727  0.00407947  0.3466369 0.7000
+  1    -76.3741049641  -0.052635307329 0.03603737  0.00237498  0.1350160 0.7000
+                               ***Turning on DIIS***
+  2    -76.3901084480  -0.016003483959 0.02801090  0.00252541  0.0249969 0.0000
+  3    -76.4203452054  -0.030236757414 0.02490055  0.00145188  0.0815432 0.0000
+  4    -76.4255599613  -0.005214755905 0.00508029  0.00034001  0.0117544 0.0000
+                      *** Initiating the SOSCF procedure ***
+                           *** Shutting down DIIS ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  5    -76.42570225  -0.0001422888  0.000591  0.000591  0.001013  0.000079
+               *** Restarting incremental Fock matrix formation ***
+  6    -76.42570584  -0.0000035901  0.000243  0.000599  0.000650  0.000043
+  7    -76.42570615  -0.0000003146  0.000114  0.000126  0.000133  0.000013
+  8    -76.42570617  -0.0000000171  0.000099  0.000104  0.000112  0.000009
+  9    -76.42570622  -0.0000000504  0.000003  0.000003  0.000004  0.000000
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+Setting up the final grid:
+
+General Integration Accuracy     IntAcc      ...  4.670
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-302
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...  13000 (   0.0 sec)
+# of grid points (after weights+screening)   ...  12898 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.1 sec
+Reduced shell lists constructed in    0.1 sec
+
+Total number of grid points                  ...    12898
+Total number of batches                      ...      204
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4299
+Average number of shells per batch           ...     8.14 (42.86%)
+Average number of basis functions per batch  ...    17.43 (40.53%)
+Average number of large shells per batch     ...     5.79 (71.05%)
+Average number of large basis fcns per batch ...    10.93 (62.70%)
+Maximum spatial batch extension              ...  13.13, 16.88, 11.55 au
+Average spatial batch extension              ...   0.53,  0.58,  0.53 au
+
+Final grid set up in    0.1 sec
+Final integration                            ... done (   0.1 sec)
+Change in XC energy                          ...    -0.000148796
+Integrated number of electrons               ...     9.999993332
+Previous integrated no of electrons          ...     9.997409252
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :          -76.42585502 Eh           -2079.65324 eV
+
+Components:
+Nuclear Repulsion  :            9.11937986 Eh             248.15094 eV
+Electronic Energy  :          -85.54523488 Eh           -2327.80418 eV
+One Electron Energy:         -122.97226007 Eh           -3346.24532 eV
+Two Electron Energy:           37.42702519 Eh            1018.44113 eV
+
+Virial components:
+Potential Energy   :         -152.58484748 Eh           -4152.04479 eV
+Kinetic Energy     :           76.15899246 Eh            2072.39154 eV
+Virial Ratio       :            2.00350402
+
+
+DFT components:
+N(Alpha)           :        4.999996665770 electrons
+N(Beta)            :        4.999996665770 electrons
+N(Total)           :        9.999993331541 electrons
+E(X)               :       -7.114261317118 Eh       
+E(C)               :       -0.401692193979 Eh       
+E(XC)              :       -7.515953511097 Eh       
+DFET-embed. en.    :        0.000000000000 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -5.0065e-11  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    4.2898e-07  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    4.1000e-08  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    1.2264e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    6.4202e-07  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+             **** ENERGY FILE WAS UPDATED (h2o_01_opt_freq.en.tmp) ****
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -19.124466      -520.4032 
+   1   2.0000      -1.010434       -27.4953 
+   2   2.0000      -0.528108       -14.3706 
+   3   2.0000      -0.389634       -10.6025 
+   4   2.0000      -0.312672        -8.5082 
+   5   0.0000       0.016378         0.4457 
+   6   0.0000       0.090849         2.4721 
+   7   0.0000       0.357919         9.7395 
+   8   0.0000       0.412827        11.2336 
+   9   0.0000       0.428331        11.6555 
+  10   0.0000       0.438021        11.9192 
+  11   0.0000       0.572483        15.5781 
+  12   0.0000       0.600712        16.3462 
+  13   0.0000       1.157883        31.5076 
+  14   0.0000       1.190845        32.4045 
+  15   0.0000       1.292369        35.1672 
+  16   0.0000       1.524925        41.4953 
+  17   0.0000       1.638035        44.5732 
+  18   0.0000       1.753318        47.7102 
+  19   0.0000       1.980036        53.8795 
+  20   0.0000       2.058684        56.0196 
+  21   0.0000       2.094197        56.9860 
+  22   0.0000       2.283474        62.1365 
+  23   0.0000       2.364599        64.3440 
+  24   0.0000       2.570162        69.9377 
+  25   0.0000       2.593369        70.5691 
+  26   0.0000       2.606148        70.9169 
+  27   0.0000       2.770860        75.3989 
+  28   0.0000       3.637951        98.9937 
+  29   0.0000       3.910429       106.4082 
+  30   0.0000       5.101004       138.8054 
+  31   0.0000       5.203781       141.6021 
+  32   0.0000       5.370668       146.1433 
+  33   0.0000       5.398776       146.9082 
+  34   0.0000       5.445991       148.1930 
+  35   0.0000       6.017793       163.7525 
+  36   0.0000       6.197495       168.6424 
+  37   0.0000       6.298119       171.3805 
+  38   0.0000       6.358546       173.0248 
+  39   0.0000       6.421225       174.7304 
+  40   0.0000       6.875268       187.0856 
+  41   0.0000       6.994321       190.3252 
+  42   0.0000      43.223481      1176.1707 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.622440
+   1 H :    0.311220
+   2 H :    0.311220
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.811714  s :     3.811714
+      pz      :     1.568675  p :     4.788732
+      px      :     1.963588
+      py      :     1.256470
+      dz2     :     0.003188  d :     0.020691
+      dxz     :     0.002524
+      dyz     :     0.013248
+      dx2y2   :     0.001730
+      dxy     :     0.000000
+      f0      :     0.000027  f :     0.001302
+      f+1     :     0.000022
+      f-1     :     0.000091
+      f+2     :     0.000663
+      f-2     :     0.000000
+      f+3     :     0.000121
+      f-3     :     0.000378
+  1 H s       :     0.640655  s :     0.640655
+      pz      :     0.014918  p :     0.048125
+      px      :     0.016872
+      py      :     0.016334
+  2 H s       :     0.640655  s :     0.640655
+      pz      :     0.014918  p :     0.048125
+      px      :     0.016872
+      py      :     0.016334
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.312505
+   1 H :    0.156252
+   2 H :    0.156252
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.468904  s :     3.468904
+      pz      :     1.608852  p :     4.808460
+      px      :     1.905562
+      py      :     1.294046
+      dz2     :     0.001587  d :     0.032619
+      dxz     :     0.000893
+      dyz     :     0.024964
+      dx2y2   :     0.005175
+      dxy     :     0.000000
+      f0      :     0.000211  f :     0.002521
+      f+1     :     0.000000
+      f-1     :     0.000576
+      f+2     :     0.001224
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000509
+  1 H s       :     0.685249  s :     0.685249
+      pz      :     0.056124  p :     0.158498
+      px      :     0.046772
+      py      :     0.055603
+  2 H s       :     0.685249  s :     0.685249
+      pz      :     0.056124  p :     0.158498
+      px      :     0.046772
+      py      :     0.055603
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.6224     8.0000    -0.6224     1.8278     1.8278     0.0000
+  1 H      0.6888     1.0000     0.3112     0.9185     0.9185     0.0000
+  2 H      0.6888     1.0000     0.3112     0.9185     0.9185     0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-H ) :   0.9139 B(  0-O ,  2-H ) :   0.9139 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 6 sec 
+
+Total time                  ....       6.037 sec
+Sum of individual times     ....       5.316 sec  ( 88.1%)
+
+Fock matrix formation       ....       4.474 sec  ( 74.1%)
+  XC integration            ....       1.195 sec  ( 26.7% of F)
+    Basis function eval.    ....       0.011 sec  (  0.9% of XC)
+    Density eval.           ....       0.017 sec  (  1.4% of XC)
+    XC-Functional eval.     ....       0.032 sec  (  2.7% of XC)
+    XC-Potential eval.      ....       0.007 sec  (  0.6% of XC)
+Diagonalization             ....       0.085 sec  (  1.4%)
+Density matrix formation    ....       0.093 sec  (  1.5%)
+Population analysis         ....       0.065 sec  (  1.1%)
+Initial guess               ....       0.265 sec  (  4.4%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.053 sec  (  0.9%)
+SOSCF solution              ....       0.081 sec  (  1.3%)
+Grid generation             ....       0.201 sec  (  3.3%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -76.425855018771
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Gradient of the Kohn-Sham DFT energy:
+Kohn-Sham wavefunction type      ... RKS
+Hartree-Fock exchange scaling    ...    0.200
+Number of operators              ...    1
+Number of atoms                  ...    3
+Basis set dimensions             ...   43
+Integral neglect threshold       ... 2.5e-11
+Integral primitive cutoff        ... 2.5e-12
+
+Nuclear repulsion gradient       ... done
+One Electron Gradient            ... done
+Pre-screening matrix             ... done
+Starting the two electron gradient:
+Two electron gradient done
+Exchange-correlation gradient    ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000000000   -0.000000000   -0.005158619
+   2   H   :    0.000000000   -0.000071366    0.002579309
+   3   H   :   -0.000000000    0.000071366    0.002579309
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the cartesian gradient     ...    0.0063187977
+RMS gradient                       ...    0.0021062659
+MAX gradient                       ...    0.0051586186
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time            ...        0.541 sec
+
+One electron gradient       ....       0.002 sec  (  0.3%)
+Prescreening matrices       ....       0.018 sec  (  3.4%)
+Two electron gradient       ....       0.062 sec  ( 11.5%)
+XC gradient                 ....       0.156 sec  ( 28.8%)
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   3
+Number of internal coordinates          ....   3
+Current Energy                          ....   -76.425855019 Eh
+Current gradient norm                   ....     0.006318798 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Evaluating the initial hessian          ....  (Almloef) done
+Projecting the Hessian                  .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999921034
+Lowest eigenvalues of augmented Hessian:
+ -0.000053970  0.319824315  0.509876244
+Length of the computed step             ....  0.012567862
+The final length of the internal step   ....  0.012567862
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0072560586
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0034658333 RMS(Int)=    0.0072578244
+ Iter   1:  RMS(Cart)=    0.0000170688 RMS(Int)=    0.0000284178
+ Iter   2:  RMS(Cart)=    0.0000000525 RMS(Int)=    0.0000001324
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          RMS gradient        0.0025180297            0.0001000000      NO
+          MAX gradient        0.0037815352            0.0003000000      NO
+          RMS step            0.0072560586            0.0020000000      NO
+          MAX step            0.0118234467            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0016      Max(Angles)    0.68
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(H   1,O   0)                0.9653  0.001536 -0.0016    0.9637   
+     2. B(H   2,O   0)                0.9653  0.001536 -0.0016    0.9637   
+     3. A(H   1,O   0,H   2)          103.74 -0.003782    0.68    104.42   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   2            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O      0.000000    0.000000    0.003651
+  H      0.000000    0.761587    0.594218
+  H      0.000000   -0.761587    0.594218
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999    0.000000    0.000000    0.006899
+   1 H     1.0000    0     1.008    0.000000    1.439192    1.122908
+   2 H     1.0000    0     1.008    0.000000   -1.439192    1.122908
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     0.963734474860     0.00000000     0.00000000
+ H      1   2   0     0.963734474952   104.41701855     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.821194223304     0.00000000     0.00000000
+ H      1   2   0     1.821194223478   104.41701855     0.00000000
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 8.533e-03
+Time for diagonalization                   ...    0.001 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.011 sec
+Total time needed                          ...    0.012 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   3304 (   0.0 sec)
+# of grid points (after weights+screening)   ...   3258 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     3258
+Total number of batches                      ...       52
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1086
+Average number of shells per batch           ...    13.20 (69.47%)
+Average number of basis functions per batch  ...    31.60 (73.49%)
+Average number of large shells per batch     ...    11.60 (87.88%)
+Average number of large basis fcns per batch ...    27.20 (86.08%)
+Maximum spatial batch extension              ...  15.11, 10.94, 14.48 au
+Average spatial batch extension              ...   0.88,  0.69,  0.87 au
+
+Time for grid setup =    0.299 sec
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0    -76.42574438 -76.4257443784  0.001054  0.001054  0.001225  0.000093
+               *** Restarting incremental Fock matrix formation ***
+  1    -76.42575118  -0.0000068022  0.000346  0.000432  0.000630  0.000043
+  2    -76.42575129  -0.0000001071  0.000359  0.000214  0.000329  0.000022
+  3    -76.42575191  -0.0000006188  0.000030  0.000055  0.000082  0.000006
+  4    -76.42575192  -0.0000000091  0.000005  0.000007  0.000009  0.000001
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   5 CYCLES          *
+               *****************************************************
+
+Setting up the final grid:
+
+General Integration Accuracy     IntAcc      ...  4.670
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-302
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...  13000 (   0.0 sec)
+# of grid points (after weights+screening)   ...  12902 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.1 sec
+Reduced shell lists constructed in    0.1 sec
+
+Total number of grid points                  ...    12902
+Total number of batches                      ...      204
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4301
+Average number of shells per batch           ...     8.50 (44.74%)
+Average number of basis functions per batch  ...    17.79 (41.36%)
+Average number of large shells per batch     ...     5.86 (68.91%)
+Average number of large basis fcns per batch ...    11.14 (62.65%)
+Maximum spatial batch extension              ...  13.13, 16.88, 11.55 au
+Average spatial batch extension              ...   0.53,  0.58,  0.53 au
+
+Final grid set up in    0.1 sec
+Final integration                            ... done (   0.1 sec)
+Change in XC energy                          ...    -0.000144441
+Integrated number of electrons               ...     9.999994479
+Previous integrated no of electrons          ...     9.997467731
+Total Energy       :          -76.42589636 Eh           -2079.65437 eV
+  Last Energy change         ...   -1.7310e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.0412e-07  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+             **** ENERGY FILE WAS UPDATED (h2o_01_opt_freq.en.tmp) ****
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+Total SCF time: 0 days 0 hours 0 min 4 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -76.425896356629
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Gradient of the Kohn-Sham DFT energy:
+Kohn-Sham wavefunction type      ... RKS
+Hartree-Fock exchange scaling    ...    0.200
+Number of operators              ...    1
+Number of atoms                  ...    3
+Basis set dimensions             ...   43
+Integral neglect threshold       ... 2.5e-11
+Integral primitive cutoff        ... 2.5e-12
+
+Nuclear repulsion gradient       ... done
+One Electron Gradient            ... done
+Pre-screening matrix             ... done
+Starting the two electron gradient:
+Two electron gradient done
+Exchange-correlation gradient    ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000000000   -0.000000000   -0.002239451
+   2   H   :    0.000000000   -0.000430720    0.001119726
+   3   H   :   -0.000000000    0.000430721    0.001119725
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the cartesian gradient     ...    0.0028095820
+RMS gradient                       ...    0.0009365273
+MAX gradient                       ...    0.0022394509
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time            ...        0.421 sec
+
+One electron gradient       ....       0.002 sec  (  0.6%)
+Prescreening matrices       ....       0.018 sec  (  4.4%)
+Two electron gradient       ....       0.062 sec  ( 14.7%)
+XC gradient                 ....       0.046 sec  ( 11.0%)
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   3
+Number of internal coordinates          ....   3
+Current Energy                          ....   -76.425896357 Eh
+Current gradient norm                   ....     0.002809582 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999903599
+Lowest eigenvalues of augmented Hessian:
+ -0.000029756  0.153974030  0.509876244
+Length of the computed step             ....  0.013886324
+The final length of the internal step   ....  0.013886324
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0080172729
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0042288979 RMS(Int)=    0.0080183524
+ Iter   1:  RMS(Cart)=    0.0000195777 RMS(Int)=    0.0000356289
+ Iter   2:  RMS(Cart)=    0.0000000925 RMS(Int)=    0.0000001901
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000413379            0.0000050000      NO
+          RMS gradient        0.0012404806            0.0001000000      NO
+          MAX gradient        0.0020921873            0.0003000000      NO
+          RMS step            0.0080172729            0.0020000000      NO
+          MAX step            0.0137167434            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0008      Max(Angles)    0.79
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(H   1,O   0)                0.9637  0.000346 -0.0008    0.9629   
+     2. B(H   2,O   0)                0.9637  0.000346 -0.0008    0.9629   
+     3. A(H   1,O   0,H   2)          104.42 -0.002092    0.79    105.20   
+    ----------------------------------------------------------------------------
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   3            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O      0.000000    0.000000    0.007470
+  H      0.000000    0.764977    0.592308
+  H      0.000000   -0.764977    0.592308
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999    0.000000    0.000000    0.014117
+   1 H     1.0000    0     1.008    0.000000    1.445596    1.119300
+   2 H     1.0000    0     1.008    0.000000   -1.445596    1.119300
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     0.962924906286     0.00000000     0.00000000
+ H      1   2   0     0.962924907477   105.20293001     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.819664360412     0.00000000     0.00000000
+ H      1   2   0     1.819664362663   105.20293001     0.00000000
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 8.511e-03
+Time for diagonalization                   ...    0.001 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.010 sec
+Total time needed                          ...    0.012 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   3304 (   0.0 sec)
+# of grid points (after weights+screening)   ...   3262 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     3262
+Total number of batches                      ...       53
+Average number of points per batch           ...       61
+Average number of grid points per atom       ...     1087
+Average number of shells per batch           ...    13.20 (69.47%)
+Average number of basis functions per batch  ...    31.60 (73.49%)
+Average number of large shells per batch     ...    11.60 (87.88%)
+Average number of large basis fcns per batch ...    27.20 (86.08%)
+Maximum spatial batch extension              ...  15.11, 10.94, 14.48 au
+Average spatial batch extension              ...   0.86,  0.67,  0.85 au
+
+Time for grid setup =    1.163 sec
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0    -76.42576942 -76.4257694216  0.000905  0.000905  0.001272  0.000098
+               *** Restarting incremental Fock matrix formation ***
+  1    -76.42577677  -0.0000073507  0.000332  0.000417  0.000600  0.000041
+  2    -76.42577715  -0.0000003772  0.000185  0.000192  0.000331  0.000021
+  3    -76.42577727  -0.0000001245  0.000077  0.000097  0.000174  0.000012
+  4    -76.42577732  -0.0000000509  0.000006  0.000007  0.000010  0.000001
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   5 CYCLES          *
+               *****************************************************
+
+Setting up the final grid:
+
+General Integration Accuracy     IntAcc      ...  4.670
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-302
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...  13000 (   0.0 sec)
+# of grid points (after weights+screening)   ...  12910 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.1 sec
+Reduced shell lists constructed in    0.1 sec
+
+Total number of grid points                  ...    12910
+Total number of batches                      ...      203
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4303
+Average number of shells per batch           ...     8.50 (44.74%)
+Average number of basis functions per batch  ...    17.79 (41.36%)
+Average number of large shells per batch     ...     5.93 (69.75%)
+Average number of large basis fcns per batch ...    11.36 (63.86%)
+Maximum spatial batch extension              ...  13.13, 16.88, 11.55 au
+Average spatial batch extension              ...   0.55,  0.56,  0.53 au
+
+Final grid set up in    0.1 sec
+Final integration                            ... done (   0.1 sec)
+Change in XC energy                          ...    -0.000135196
+Integrated number of electrons               ...     9.999995823
+Previous integrated no of electrons          ...     9.997552806
+Total Energy       :          -76.42591252 Eh           -2079.65481 eV
+  Last Energy change         ...   -2.3147e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    7.1638e-07  Tolerance :   1.0000e-07
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+             **** ENERGY FILE WAS UPDATED (h2o_01_opt_freq.en.tmp) ****
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+Total SCF time: 0 days 0 hours 0 min 4 sec 
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -76.425912520919
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Gradient of the Kohn-Sham DFT energy:
+Kohn-Sham wavefunction type      ... RKS
+Hartree-Fock exchange scaling    ...    0.200
+Number of operators              ...    1
+Number of atoms                  ...    3
+Basis set dimensions             ...   43
+Integral neglect threshold       ... 2.5e-11
+Integral primitive cutoff        ... 2.5e-12
+
+Nuclear repulsion gradient       ... done
+One Electron Gradient            ... done
+Pre-screening matrix             ... done
+Starting the two electron gradient:
+Two electron gradient done
+Exchange-correlation gradient    ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000000000    0.000000001    0.000002417
+   2   H   :   -0.000000000   -0.000032336   -0.000001209
+   3   H   :   -0.000000000    0.000032335   -0.000001208
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Norm of the cartesian gradient     ...    0.0000458251
+RMS gradient                       ...    0.0000152750
+MAX gradient                       ...    0.0000323361
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time            ...        0.424 sec
+
+One electron gradient       ....       0.004 sec  (  0.9%)
+Prescreening matrices       ....       0.018 sec  (  4.3%)
+Two electron gradient       ....       0.063 sec  ( 14.8%)
+XC gradient                 ....       0.040 sec  (  9.5%)
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (new redundants).... done
+Validating the new internal coordinates .... (new redundants).... done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....   3
+Number of internal coordinates          ....   3
+Current Energy                          ....   -76.425912521 Eh
+Current gradient norm                   ....     0.000045825 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999999978
+Lowest eigenvalues of augmented Hessian:
+ -0.000000009  0.151773432  0.509876244
+Length of the computed step             ....  0.000207995
+The final length of the internal step   ....  0.000207995
+Converting the step to cartesian space:
+ Initial RMS(Int)=    0.0001200858
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0000744027 RMS(Int)=    0.0001200853
+ Iter   1:  RMS(Cart)=    0.0000000033 RMS(Int)=    0.0000000079
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000161643            0.0000050000      NO
+          RMS gradient        0.0000291637            0.0001000000      YES
+          MAX gradient        0.0000339893            0.0003000000      YES
+          RMS step            0.0001200858            0.0020000000      YES
+          MAX step            0.0002009587            0.0040000000      YES
+          ........................................................
+          Max(Bonds)      0.0000      Max(Angles)    0.01
+          Max(Dihed)        0.00      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+       Everything but the energy has converged. However, the energy
+       appears to be close enough to convergence to make sure that the
+       final evaluation at the new geometry represents the equilibrium energy.
+       Convergence will therefore be signaled now
+
+
+                    ***********************HURRAY********************
+                    ***        THE OPTIMIZATION HAS CONVERGED     ***
+                    *************************************************
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+
+                          --- Optimized Parameters ---  
+                            (Angstroem and degrees)
+
+        Definition                    OldVal   dE/dq     Step     FinalVal
+    ----------------------------------------------------------------------------
+     1. B(H   1,O   0)                0.9629 -0.000026  0.0000    0.9629   
+     2. B(H   2,O   0)                0.9629 -0.000026  0.0000    0.9629   
+     3. A(H   1,O   0,H   2)          105.20 -0.000034    0.01    105.21   
+    ----------------------------------------------------------------------------
+                 *******************************************************
+                 *** FINAL ENERGY EVALUATION AT THE STATIONARY POINT ***
+                 ***               (AFTER    3 CYCLES)               ***
+                 *******************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O      0.000000   -0.000000    0.007513
+  H      0.000000    0.765051    0.592286
+  H      0.000000   -0.765051    0.592286
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999    0.000000   -0.000000    0.014198
+   1 H     1.0000    0     1.008    0.000000    1.445737    1.119259
+   2 H     1.0000    0     1.008    0.000000   -1.445737    1.119259
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     0.962944978685     0.00000000     0.00000000
+ H      1   2   0     0.962944978404   105.21444409     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.819702291750     0.00000000     0.00000000
+ H      1   2   0     1.819702291218   105.21444409     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   2 Type H   : 5s1p contracted to 3s1p pattern {311/1}
+
+Atom   0O    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   32
+ # of primitive gaussian functions       ...   62
+ # of contracted shells                  ...   19
+ # of contracted basis functions         ...   43
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    6
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  2.500e-11
+ Primitive cut-off              TCut     ...  2.500e-12
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+ Exchange Functional    Exchange        .... B88
+   X-Alpha parameter    XAlpha          ....  0.666667
+   Becke's b parameter  XBeta           ....  0.004200
+ Correlation Functional Correlation     .... LYP
+ LDA part of GGA corr.  LDAOpt          .... VWN-5
+ Gradients option       PostSCFGGA      .... off
+ Hybrid DFT is turned on
+   Fraction HF Exchange ScalHFX         ....  0.200000
+   Scaling of DF-GGA-X  ScalDFX         ....  0.720000
+   Scaling of DF-GGA-C  ScalDFC         ....  0.810000
+   Scaling of DF-LDA-C  ScalLDAC        ....  1.000000
+   Perturbative correction              ....  0.000000
+   Density functional embedding theory  .... OFF
+   NL short-range parameter             ....  4.800000
+
+
+General Settings:
+ Integral files         IntName         .... h2o_01_opt_freq
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   10
+ Basis Dimension        Dim             ....   43
+ Nuclear Repulsion      ENuc            ....      9.1384913292 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... LIBINT
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 8.512e-03
+Time for diagonalization                   ...    0.001 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.011 sec
+Total time needed                          ...    0.012 sec
+
+---------------------
+INITIAL GUESS: MOREAD
+---------------------
+Guess MOs are being read from file: h2o_01_opt_freq.gbw
+Input Geometry matches current geometry (good)
+Input basis set matches current basis set (good)
+MOs were renormalized
+MOs were reorthogonalized (Cholesky)
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   3304 (   0.0 sec)
+# of grid points (after weights+screening)   ...   3262 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     3262
+Total number of batches                      ...       53
+Average number of points per batch           ...       61
+Average number of grid points per atom       ...     1087
+Average number of shells per batch           ...    13.20 (69.47%)
+Average number of basis functions per batch  ...    31.60 (73.49%)
+Average number of large shells per batch     ...    11.60 (87.88%)
+Average number of large basis fcns per batch ...    27.20 (86.08%)
+Maximum spatial batch extension              ...  15.11, 10.94, 14.48 au
+Average spatial batch extension              ...   0.86,  0.67,  0.85 au
+
+Time for grid setup =    0.052 sec
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0    -76.42577760 -76.4257776022  0.000013  0.000013  0.000017  0.000001
+               *** Restarting incremental Fock matrix formation ***
+  1    -76.42577760  -0.0000000015  0.000003  0.000004  0.000009  0.000001
+  2    -76.42577760  -0.0000000000  0.000003  0.000002  0.000003  0.000000
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   3 CYCLES          *
+               *****************************************************
+
+Setting up the final grid:
+
+General Integration Accuracy     IntAcc      ...  4.670
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-302
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...  13000 (   0.0 sec)
+# of grid points (after weights+screening)   ...  12910 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.1 sec
+Reduced shell lists constructed in    0.1 sec
+
+Total number of grid points                  ...    12910
+Total number of batches                      ...      203
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4303
+Average number of shells per batch           ...     8.50 (44.74%)
+Average number of basis functions per batch  ...    17.79 (41.36%)
+Average number of large shells per batch     ...     5.93 (69.75%)
+Average number of large basis fcns per batch ...    11.36 (63.86%)
+Maximum spatial batch extension              ...  13.13, 16.88, 11.55 au
+Average spatial batch extension              ...   0.55,  0.56,  0.53 au
+
+Final grid set up in    0.1 sec
+Final integration                            ... done (   0.1 sec)
+Change in XC energy                          ...    -0.000134942
+Integrated number of electrons               ...     9.999995843
+Previous integrated no of electrons          ...     9.997554463
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :          -76.42591255 Eh           -2079.65481 eV
+
+Components:
+Nuclear Repulsion  :            9.13849133 Eh             248.67099 eV
+Electronic Energy  :          -85.56440387 Eh           -2328.32580 eV
+One Electron Energy:         -123.00979351 Eh           -3347.26665 eV
+Two Electron Energy:           37.44538963 Eh            1018.94085 eV
+
+Virial components:
+Potential Energy   :         -152.59049687 Eh           -4152.19851 eV
+Kinetic Energy     :           76.16458432 Eh            2072.54371 eV
+Virial Ratio       :            2.00343110
+
+
+DFT components:
+N(Alpha)           :        4.999997921368 electrons
+N(Beta)            :        4.999997921368 electrons
+N(Total)           :        9.999995842736 electrons
+E(X)               :       -7.115828540369 Eh       
+E(C)               :       -0.401780436163 Eh       
+E(XC)              :       -7.517608976532 Eh       
+DFET-embed. en.    :        0.000000000000 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -3.6422e-11  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.4648e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    9.4976e-08  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    8.2091e-07  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.0765e-06  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+             **** ENERGY FILE WAS UPDATED (h2o_01_opt_freq.en.tmp) ****
+             **** THE GBW FILE WAS UPDATED (h2o_01_opt_freq.gbw) ****
+             **** DENSITY FILE WAS UPDATED (h2o_01_opt_freq.scfp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -19.123488      -520.3766 
+   1   2.0000      -1.010392       -27.4942 
+   2   2.0000      -0.531648       -14.4669 
+   3   2.0000      -0.387084       -10.5331 
+   4   2.0000      -0.312544        -8.5048 
+   5   0.0000       0.017070         0.4645 
+   6   0.0000       0.091246         2.4829 
+   7   0.0000       0.361107         9.8262 
+   8   0.0000       0.410563        11.1720 
+   9   0.0000       0.428301        11.6547 
+  10   0.0000       0.437632        11.9086 
+  11   0.0000       0.573212        15.5979 
+  12   0.0000       0.599780        16.3208 
+  13   0.0000       1.169546        31.8250 
+  14   0.0000       1.188367        32.3371 
+  15   0.0000       1.297505        35.3069 
+  16   0.0000       1.523602        41.4593 
+  17   0.0000       1.632615        44.4257 
+  18   0.0000       1.747454        47.5507 
+  19   0.0000       1.977031        53.7977 
+  20   0.0000       2.052600        55.8541 
+  21   0.0000       2.103163        57.2300 
+  22   0.0000       2.279251        62.0216 
+  23   0.0000       2.382282        64.8252 
+  24   0.0000       2.572452        70.0000 
+  25   0.0000       2.600253        70.7565 
+  26   0.0000       2.605921        70.9107 
+  27   0.0000       2.774192        75.4896 
+  28   0.0000       3.625695        98.6602 
+  29   0.0000       3.924052       106.7789 
+  30   0.0000       5.102050       138.8338 
+  31   0.0000       5.198054       141.4462 
+  32   0.0000       5.375589       146.2772 
+  33   0.0000       5.397731       146.8797 
+  34   0.0000       5.466480       148.7505 
+  35   0.0000       6.016457       163.7161 
+  36   0.0000       6.207159       168.9054 
+  37   0.0000       6.295527       171.3100 
+  38   0.0000       6.362772       173.1398 
+  39   0.0000       6.410453       174.4373 
+  40   0.0000       6.900831       187.7812 
+  41   0.0000       6.980084       189.9377 
+  42   0.0000      43.224550      1176.1998 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.625822
+   1 H :    0.312911
+   2 H :    0.312911
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.807674  s :     3.807674
+      pz      :     1.580599  p :     4.796565
+      px      :     1.963466
+      py      :     1.252500
+      dz2     :     0.002979  d :     0.020254
+      dxz     :     0.002480
+      dyz     :     0.012965
+      dx2y2   :     0.001830
+      dxy     :     0.000000
+      f0      :     0.000036  f :     0.001329
+      f+1     :     0.000020
+      f-1     :     0.000073
+      f+2     :     0.000678
+      f-2     :     0.000000
+      f+3     :     0.000126
+      f-3     :     0.000397
+  1 H s       :     0.638800  s :     0.638800
+      pz      :     0.014914  p :     0.048289
+      px      :     0.016954
+      py      :     0.016421
+  2 H s       :     0.638800  s :     0.638800
+      pz      :     0.014914  p :     0.048289
+      px      :     0.016954
+      py      :     0.016421
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.310238
+   1 H :    0.155119
+   2 H :    0.155119
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.463143  s :     3.463143
+      pz      :     1.616905  p :     4.812328
+      px      :     1.904862
+      py      :     1.290560
+      dz2     :     0.001377  d :     0.032251
+      dxz     :     0.000877
+      dyz     :     0.024684
+      dx2y2   :     0.005313
+      dxy     :    -0.000000
+      f0      :     0.000231  f :     0.002516
+      f+1     :     0.000000
+      f-1     :     0.000516
+      f+2     :     0.001223
+      f-2     :    -0.000000
+      f+3     :     0.000000
+      f-3     :     0.000546
+  1 H s       :     0.685286  s :     0.685286
+      pz      :     0.055871  p :     0.159595
+      px      :     0.047130
+      py      :     0.056594
+  2 H s       :     0.685286  s :     0.685286
+      pz      :     0.055871  p :     0.159595
+      px      :     0.047130
+      py      :     0.056594
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.6258     8.0000    -0.6258     1.8252     1.8252    -0.0000
+  1 H      0.6871     1.0000     0.3129     0.9178     0.9178    -0.0000
+  2 H      0.6871     1.0000     0.3129     0.9178     0.9178    -0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-H ) :   0.9126 B(  0-O ,  2-H ) :   0.9126 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 3 sec 
+
+Total time                  ....       3.197 sec
+Sum of individual times     ....       2.398 sec  ( 75.0%)
+
+Fock matrix formation       ....       1.938 sec  ( 60.6%)
+  XC integration            ....       0.580 sec  ( 29.9% of F)
+    Basis function eval.    ....       0.005 sec  (  0.9% of XC)
+    Density eval.           ....       0.006 sec  (  1.1% of XC)
+    XC-Functional eval.     ....       0.010 sec  (  1.7% of XC)
+    XC-Potential eval.      ....       0.003 sec  (  0.6% of XC)
+Diagonalization             ....       0.015 sec  (  0.5%)
+Density matrix formation    ....       0.133 sec  (  4.1%)
+Population analysis         ....       0.052 sec  (  1.6%)
+Initial guess               ....       0.011 sec  (  0.4%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.001 sec  (  0.0%)
+DIIS solution               ....       0.000 sec  (  0.0%)
+SOSCF solution              ....       0.067 sec  (  2.1%)
+Grid generation             ....       0.182 sec  (  5.7%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -76.425912545290
+-------------------------   --------------------
+
+                                *** OPTIMIZATION RUN DONE ***
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... h2o_01_opt_freq.gbw
+Electron density file                           ... h2o_01_opt_freq.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000, -0.000000  0.137862)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000       0.00000      -0.16277
+Nuclear contribution   :      0.00000       0.00000       0.97348
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000       0.00000       0.81071
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.81071
+Magnitude (Debye)      :      2.06067
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:    27.534237    14.286481     9.406040 
+Rotational constants in MHz : 825455.664078 428297.932197 281985.993975 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.000000     0.810712     0.000000 
+x,y,z [Debye]:    -0.000000     2.060667     0.000000 
+
+ 
+
+----------------------------------------------------------------------------
+                           ORCA NUMERICAL FREQUENCIES
+                              (16-process run)
+----------------------------------------------------------------------------
+
+Number of atoms                ... 3
+Central differences            ... used
+Number of displacements        ... 18
+Numerical increment            ... 5.000e-03 bohr
+IR-spectrum generation         ... on
+Raman-spectrum generation      ... off
+Surface Crossing Hessian       ... off
+
+ WARNING: There are more processes than displacements to do
+  ====> : Reducing number of processes to   9
+
+The output will be reduced. Please look at the following files:
+SCF program output             ... >h2o_01_opt_freq.lastscf
+Integral program output        ... >h2o_01_opt_freq.lastint
+Gradient program output        ... >h2o_01_opt_freq.lastgrad
+Dipole moment program output   ... >h2o_01_opt_freq.lastmom
+AutoCI program output          ... >h2o_01_opt_freq.lastautoci
+
+
+         <<< Energy and Gradient at the input geometry >>>
+
+        <<< Energy and Gradient at displaced geometries >>>
+             <<<Displacing   1/coordinate 3 (+)>>>
+             <<<Displacing   1/coordinate 1 (+)>>>
+             <<<Displacing   2/coordinate 1 (+)>>>
+             <<<Displacing   3/coordinate 2 (+)>>>
+             <<<Displacing   3/coordinate 1 (+)>>>
+             <<<Displacing   2/coordinate 2 (+)>>>
+             <<<Displacing   1/coordinate 2 (+)>>>
+             <<<Displacing   2/coordinate 3 (+)>>>
+             <<<Displacing   3/coordinate 3 (+)>>>
+             <<<Displacing   1/coordinate 3 (-)>>>
+             <<<Displacing   3/coordinate 2 (-)>>>
+             <<<Displacing   1/coordinate 1 (-)>>>
+             <<<Displacing   3/coordinate 1 (-)>>>
+             <<<Displacing   3/coordinate 3 (-)>>>
+             <<<Displacing   1/coordinate 2 (-)>>>
+             <<<Displacing   2/coordinate 1 (-)>>>
+             <<<Displacing   2/coordinate 2 (-)>>>
+             <<<Displacing   2/coordinate 3 (-)>>>
+
+-----------------------
+VIBRATIONAL FREQUENCIES
+-----------------------
+
+Scaling factor for frequencies =  1.000000000 (already applied!)
+
+   0:         0.00 cm**-1
+   1:         0.00 cm**-1
+   2:         0.00 cm**-1
+   3:         0.00 cm**-1
+   4:         0.00 cm**-1
+   5:         0.00 cm**-1
+   6:      1613.10 cm**-1
+   7:      3780.96 cm**-1
+   8:      3885.26 cm**-1
+
+
+------------
+NORMAL MODES
+------------
+
+These modes are the cartesian displacements weighted by the diagonal matrix
+M(i,i)=1/sqrt(m[i]) where m[i] is the mass of the displaced atom
+Thus, these vectors are normalized but *not* orthogonal
+
+                  0          1          2          3          4          5    
+      0       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      1       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      2       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      3       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      4       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      5       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      6       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      7       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+      8       0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+                   6          7          8    
+      0       0.000000   0.000000   0.000000
+      1      -0.000000  -0.000000  -0.070613
+      2       0.071165  -0.049248   0.000000
+      3       0.000000   0.000000   0.000000
+      4       0.422505   0.588252   0.560388
+      5      -0.564763   0.390829   0.428337
+      6       0.000000   0.000000   0.000000
+      7      -0.422505  -0.588251   0.560388
+      8      -0.564763   0.390829  -0.428337
+
+
+-----------
+IR SPECTRUM  
+-----------
+
+ Mode    freq (cm**-1)   T**2         TX         TY         TZ
+-------------------------------------------------------------------
+   6:      1613.10   77.068803  (  0.000000   0.000000  -8.778884)
+   7:      3780.96    5.261237  ( -0.000000   0.000002   2.293739)
+   8:      3885.26   48.270273  (  0.000000   6.947681  -0.000001)
+
+The first frequency considered to be a vibration is 6
+The total number of vibrations considered is 3
+
+
+--------------------------
+THERMOCHEMISTRY AT 298.15K
+--------------------------
+
+Temperature         ... 298.15 K
+Pressure            ... 1.00 atm
+Total Mass          ... 18.02 AMU
+
+Throughout the following assumptions are being made:
+  (1) The electronic state is orbitally nondegenerate
+  (2) There are no thermally accessible electronically excited states
+  (3) Hindered rotations indicated by low frequency modes are not
+      treated as such but are treated as vibrations and this may
+      cause some error
+  (4) All equations used are the standard statistical mechanics
+      equations for an ideal gas
+  (5) All vibrations are strictly harmonic
+
+freq.    1613.10  E(vib)   ...       0.00 
+freq.    3780.96  E(vib)   ...       0.00 
+freq.    3885.26  E(vib)   ...       0.00 
+
+------------
+INNER ENERGY
+------------
+
+The inner energy is: U= E(el) + E(ZPE) + E(vib) + E(rot) + E(trans)
+    E(el)   - is the total energy from the electronic structure calculation
+              = E(kin-el) + E(nuc-el) + E(el-el) + E(nuc-nuc)
+    E(ZPE)  - the the zero temperature vibrational energy from the frequency calculation
+    E(vib)  - the the finite temperature correction to E(ZPE) due to population
+              of excited vibrational states
+    E(rot)  - is the rotational thermal energy
+    E(trans)- is the translational thermal energy
+
+Summary of contributions to the inner energy U:
+Electronic energy                ...    -76.42591254 Eh
+Zero point energy                ...      0.02113985 Eh      13.27 kcal/mol
+Thermal vibrational correction   ...      0.00000306 Eh       0.00 kcal/mol
+Thermal rotational correction    ...      0.00141627 Eh       0.89 kcal/mol
+Thermal translational correction ...      0.00141627 Eh       0.89 kcal/mol
+-----------------------------------------------------------------------
+Total thermal energy                    -76.40193709 Eh
+
+
+Summary of corrections to the electronic energy:
+(perhaps to be used in another calculation)
+Total thermal correction                  0.00283560 Eh       1.78 kcal/mol
+Non-thermal (ZPE) correction              0.02113985 Eh      13.27 kcal/mol
+-----------------------------------------------------------------------
+Total correction                          0.02397545 Eh      15.04 kcal/mol
+
+
+--------
+ENTHALPY
+--------
+
+The enthalpy is H = U + kB*T
+                kB is Boltzmann's constant
+Total free energy                 ...    -76.40193709 Eh 
+Thermal Enthalpy correction       ...      0.00094421 Eh       0.59 kcal/mol
+-----------------------------------------------------------------------
+Total Enthalpy                    ...    -76.40099288 Eh
+
+
+Note: Rotational entropy computed according to Herzberg 
+Infrared and Raman Spectra, Chapter V,1, Van Nostrand Reinhold, 1945 
+Point Group:  C2v, Symmetry Number:   2  
+Rotational constants in cm-1:    27.534237    14.286481     9.406040 
+
+Vibrational entropy computed according to the QRRHO of S. Grimme
+Chem.Eur.J. 2012 18 9955
+
+
+-------
+ENTROPY
+-------
+
+The entropy contributions are T*S = T*(S(el)+S(vib)+S(rot)+S(trans))
+     S(el)   - electronic entropy
+     S(vib)  - vibrational entropy
+     S(rot)  - rotational entropy
+     S(trans)- translational entropy
+The entropies will be listed as mutliplied by the temperature to get
+units of energy
+
+Electronic entropy                ...      0.00000000 Eh      0.00 kcal/mol
+Vibrational entropy               ...      0.00000345 Eh      0.00 kcal/mol
+Rotational entropy                ...      0.00497761 Eh      3.12 kcal/mol
+Translational entropy             ...      0.01644380 Eh     10.32 kcal/mol
+-----------------------------------------------------------------------
+Final entropy term                ...      0.02142487 Eh     13.44 kcal/mol
+
+In case the symmetry of your molecule has not been determined correctly
+or in case you have a reason to use a different symmetry number we print 
+out the resulting rotational entropy values for sn=1,12 :
+ --------------------------------------------------------
+|  sn= 1 | S(rot)=       0.00563207 Eh      3.53 kcal/mol|
+|  sn= 2 | S(rot)=       0.00497761 Eh      3.12 kcal/mol|
+|  sn= 3 | S(rot)=       0.00459478 Eh      2.88 kcal/mol|
+|  sn= 4 | S(rot)=       0.00432316 Eh      2.71 kcal/mol|
+|  sn= 5 | S(rot)=       0.00411247 Eh      2.58 kcal/mol|
+|  sn= 6 | S(rot)=       0.00394032 Eh      2.47 kcal/mol|
+|  sn= 7 | S(rot)=       0.00379478 Eh      2.38 kcal/mol|
+|  sn= 8 | S(rot)=       0.00366870 Eh      2.30 kcal/mol|
+|  sn= 9 | S(rot)=       0.00355749 Eh      2.23 kcal/mol|
+|  sn=10 | S(rot)=       0.00345801 Eh      2.17 kcal/mol|
+|  sn=11 | S(rot)=       0.00336802 Eh      2.11 kcal/mol|
+|  sn=12 | S(rot)=       0.00328587 Eh      2.06 kcal/mol|
+ --------------------------------------------------------
+
+
+-------------------
+GIBBS FREE ENERGY
+-------------------
+
+The Gibbs free energy is G = H - T*S
+
+Total enthalpy                    ...    -76.40099288 Eh 
+Total entropy correction          ...     -0.02142487 Eh    -13.44 kcal/mol
+-----------------------------------------------------------------------
+Final Gibbs free energy         ...    -76.42241775 Eh
+
+For completeness - the Gibbs free energy minus the electronic energy
+G-E(el)                           ...      0.00349479 Eh      2.19 kcal/mol
+
+
+Total Time for Numerical Frequencies  :        59.033 sec
+
+Timings for individual modules:
+
+Sum of individual times         ...       54.976 sec (=   0.916 min)
+GTO integral calculation        ...        6.495 sec (=   0.108 min)  11.8 %
+SCF iterations                  ...       27.189 sec (=   0.453 min)  49.5 %
+SCF Gradient evaluation         ...       13.402 sec (=   0.223 min)  24.4 %
+Geometry relaxation             ...        7.890 sec (=   0.132 min)  14.4 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 1 minutes 48 seconds 606 msec

--- a/arkane/orca.py
+++ b/arkane/orca.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+Arkane Orca module
+Used to parse Orca output files
+"""
+
+import logging
+import numpy
+import rmgpy.constants as constants
+
+from arkane.common import get_element_mass
+from arkane.log import Log
+from arkane.exceptions import LogError
+
+
+################################################################################
+
+
+class OrcaLog(Log):
+    """
+    Represent an output file from Orca. The attribute `path` refers to the
+    location on disk of the Orca output file of interest. Methods are provided
+    to extract a variety of information into Arkane classes and/or NumPy
+    arrays.
+    """
+
+    def __init__(self, path):
+        super(OrcaLog, self).__init__(path)
+
+    def get_number_of_atoms(self):
+        """
+        Return the number of atoms in the molecular configuration used in
+        the Orca output file.
+        """
+        natoms = 0
+
+        with open(self.path, 'r') as f:
+            line = f.readline()
+            while line != '' and natoms == 0:
+                # Automatically determine the number of atoms
+                if 'CARTESIAN COORDINATES (ANGSTROEM)' in line and natoms == 0:
+                    for i in range(2):
+                        line = f.readline()
+
+                    while '---------------------------------' not in line:
+                        natoms += 1
+                        line = f.readline()
+                        if not line.strip():
+                            f.close()
+                            return natoms
+                line = f.readline()
+
+    def load_force_constant_matrix(self):
+        """not implemented in orca"""
+        # Orca print the hessian to .hess file.  you need to provide .hess instead of .log
+
+        raise LogError('The load_force_constant_matrix method is not implemented for Orca Logs')
+
+    def load_geometry(self):
+        """
+        Return the optimum geometry of the molecular configuration from the
+        Orca log file. If multiple such geometries are identified, only the
+        last is returned.
+        """
+        atoms, coords, numbers, mass = [], [], [], []
+
+        with open(self.path) as f:
+            log = f.readlines()
+
+        # First check that the Orca job file (not necessarily a geometry optimization)
+        # has successfully completed, if not an error is thrown
+        completed_job = False
+        for line in reversed(log):
+            if 'ORCA TERMINATED NORMALLY' in line:
+                logging.debug('Found a successfully completed Orca Job')
+                completed_job = True
+                break
+
+        if not completed_job:
+            raise LogError(
+                'Could not find a successfully completed Orca job in Orca output file {0}'.format(self.path))
+
+        # Now look for the geometry.
+        # Will return the final geometry in the file under Standard Nuclear Orientation.
+        geometry_flag = False
+        for i in reversed(range(len(log))):
+            line = log[i]
+            if 'CARTESIAN COORDINATES (ANGSTROEM)' in line:
+                for line in log[(i + 2):]:
+                    if not line.strip():
+                        break
+                    if '---------------------------------' not in line:
+                        data = line.split()
+                        atoms.append(data[0])
+                        coords.append([float(c) for c in data[1:]])
+                        geometry_flag = True
+
+                if geometry_flag:
+                    break
+
+        # Assign appropriate mass to each atom in the molecule
+        for atom1 in atoms:
+            mass1, num1 = get_element_mass(atom1)
+            mass.append(mass1)
+            numbers.append(num1)
+        coord = numpy.array(coords, numpy.float64)
+        number = numpy.array(numbers, numpy.int)
+        mass = numpy.array(mass, numpy.float64)
+        if len(number) == 0 or len(coord) == 0 or len(mass) == 0:
+            raise LogError('Unable to read atoms from Orca geometry output file {0}'.format(self.path))
+
+        return coords, numbers, mass
+
+    def load_conformer(self, symmetry=None, spin_multiplicity=0, optical_isomers=None, label=''):
+        """
+        Load the molecular degree of freedom data from a log file created as
+        the result of a Orca "Freq" quantum chemistry calculation. As
+        CAUTION: The rotational entropy is not quite correctly treated here
+         because it includes a symmetry number that is not yet correctly
+         implemented in ORCA. Orca does not provide Rotational temperatures. Only E(rot) and E(trans) energies
+         Consider using another supported software (such as Gaussian or QChem) to calculate the frequencies and derive E0
+        """
+
+        raise NotImplementedError('Could not find a successfully load Orca scan:Parser is not inpemented')
+
+    def load_energy(self, zpe_scale_factor=1.):
+        """
+        Load the energy in J/ml from an Orca log file. Only the last energy
+        in the file is returned. The zero-point energy is *not* included in
+        the returned value.
+        """
+        e_elect = None
+        with open(self.path, 'r') as f:
+            for line in f:
+                if 'FINAL SINGLE POINT ENERGY' in line:  # for all methods in Orca
+                    e_elect = float(line.split()[-1])
+        if e_elect is None:
+            raise LogError('Unable to find energy in Orca output file.')
+        return e_elect * constants.E_h * constants.Na
+
+    def load_zero_point_energy(self):
+        """
+        Load the unscaled zero-point energy in J/mol from a Orca output file.
+        """
+        zpe = None
+        with open(self.path, 'r') as f:
+            for line in f:
+                if 'Zero point energy' in line:
+                    zpe = float(line.split()[-4]) * constants.E_h * constants.Na
+        if zpe is None:
+            raise LogError('Unable to find zero-point energy in Orca output file.')
+        return zpe
+
+    def load_scan_energies(self):
+        """not implemented in Orca"""
+
+        raise NotImplementedError('Could not find a successfully load Orca scan:Parser is not implemented')
+
+    def load_negative_frequency(self):
+        """
+        Return the imaginary frequency from a transition state frequency
+        calculation in cm^-1.
+        """
+        frequency = 0
+        with open(self.path, 'r') as f:
+            for line in f:
+                # Read imaginary frequency
+                if '***imaginary mode***' in line:
+                    frequency = float((line.split()[1]))
+                    break
+        # Make sure the frequency is imaginary:
+        if frequency < 0:
+            return frequency
+        else:
+            raise LogError('Unable to find imaginary frequency in Orca output file {0}'.format(self.path))
+
+    def load_scan_pivot_atoms(self):
+        """Not implemented for Orca"""
+        raise NotImplementedError('The load_scan_pivot_atoms method is not implemented for Orca Logs')
+
+    def load_scan_frozen_atoms(self):
+        """Not implemented for Orca"""
+        raise NotImplementedError('The load_scan_frozen_atoms method is not implemented for Orca Logs')
+
+    def get_D1_diagnostic(self):
+        """Not implemented for Orca"""
+        raise NotImplementedError('The get_D1_diagnostic method is not implemented for Orca Logs')
+
+    def get_T1_diagnostic(self):
+        """
+        Returns the T1 diagnostic from output log.
+        If multiple occurrences exist, returns the last occurrence
+        """
+        with open(self.path) as f:
+            log = f.readlines()
+
+        for line in reversed(log):
+            if 'T1 diagnostic ' in line:
+                items = line.split()
+                return float(items[-1])
+        raise LogError('Unable to find T1 diagnostic in energy file: {}'.format(self.path))

--- a/arkane/orcaTest.py
+++ b/arkane/orcaTest.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This module contains unit tests of the :mod:`arkane.orca` module.
+"""
+
+import os
+import unittest
+from arkane.orca import OrcaLog
+
+
+################################################################################
+
+
+class OrcaTest(unittest.TestCase):
+    """
+    Contains unit tests for the chempy.io.orca module, used for reading
+    and writing Orca files.
+    """
+
+    def test_number_of_atoms_from_orca_log(self):
+        """
+        Uses a Orca log files to test that
+        number of atoms can be properly read.
+        """
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_opt_freq_test.log'))
+        self.assertEqual(log.get_number_of_atoms(), 3)
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_dlpno_test.log'))
+        self.assertEqual(log.get_number_of_atoms(), 30)
+
+    def test_read_coordinates_from_orca_log(self):
+        """
+        Uses a Orca log files to test that
+        coordinate can be properly read.
+        """
+        log1 = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_opt_freq_test.log'))
+        coord, number, mass = log1.load_geometry()
+        self.assertEqual(len(coord), 3)
+        log2 = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_dlpno_test.log'))
+        coord, number, mass = log2.load_geometry()
+        self.assertEqual(len(coord), 30)
+
+    def test_energy_from_orca_log(self):
+        """
+        Uses a Orca log files to test that
+        molecular energies can be properly read.
+        """
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_opt_freq_test.log'))
+        self.assertAlmostEqual(log.load_energy(), -200656222.56292167, delta=1e-3)
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_TS_test.log'))
+        self.assertAlmostEqual(log.load_energy(), -88913623.10592663, delta=1e-3)
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_dlpno_test.log'))
+        self.assertAlmostEqual(log.load_energy(), -1816470909.1153, delta=1e-3)
+
+    def test_load_zero_point_energy_from_orca_log(self):
+        """
+        Uses a Orca log files to test that
+        molecular zero point_energy can be properly read.
+        """
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_opt_freq_test.log'))
+        self.assertAlmostEqual(log.load_zero_point_energy(), 55502.673180815, delta=1e-3)
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_TS_test.log'))
+        self.assertAlmostEqual(log.load_zero_point_energy(), 93500.08860598055, delta=1e-3)
+
+    def test_load_negative_frequency_from_orca_log(self):
+        """
+        Uses a orca log file for npropyl to test that its
+        negative frequency can be properly read.
+        """
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_TS_test.log'))
+        self.assertAlmostEqual(log.load_negative_frequency(), -503.24, delta=1e-1)
+
+    def test_T1_diagnostic_from_orca_log(self):
+        """
+        Uses a Orca log file for npropyl to test that its
+        T1_diagnostic of freedom can be properly read.
+        """
+        log = OrcaLog(os.path.join(os.path.dirname(__file__), 'data', 'Orca_dlpno_test.log'))
+        self.assertAlmostEqual(log.get_T1_diagnostic(), 0.009872238, delta=1e-3)
+
+
+################################################################################
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -58,6 +58,7 @@ from arkane.gaussian import GaussianLog
 from arkane.log import Log
 from arkane.molpro import MolproLog
 from arkane.output import prettify
+from arkane.orca import OrcaLog
 from arkane.qchem import QChemLog
 from arkane.util import determine_qm_software
 
@@ -264,6 +265,7 @@ class StatMechJob(object):
             # File formats
             'GaussianLog': GaussianLog,
             'QChemLog': QChemLog,
+            'OrcaLog': OrcaLog,
             'MolproLog': MolproLog,
             'ScanLog': ScanLog,
             'Log': Log

--- a/arkane/util.py
+++ b/arkane/util.py
@@ -35,6 +35,7 @@ from rmgpy.exceptions import InputError
 
 from arkane.gaussian import GaussianLog
 from arkane.molpro import MolproLog
+from arkane.orca import OrcaLog
 from arkane.qchem import QChemLog
 
 ################################################################################
@@ -59,6 +60,10 @@ def determine_qm_software(fullpath):
             elif 'molpro' in line.lower():
                 f.close()
                 software_log = MolproLog(fullpath)
+                break
+            elif 'orca' in line.lower():
+                f.close()
+                software_log = OrcaLog(fullpath)
                 break
             line = f.readline()
         else:


### PR DESCRIPTION
add OrcaLog and orca test to Arkane. currently limited to parsing energy, geometry, number of atoms, t1 diagnostic.  Freq, spin multiplicity, scan, conformers are not implemented   