### PR TITLE
Fix two calls to Exception.message, which no longer exists

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1364,7 +1364,7 @@ def read_reactions_block(f, species_dict, read_comments=True):
             reaction = read_kinetics_entry(kinetics, species_dict, Aunits, Eunits)
             reaction = read_reaction_comments(reaction, comments, read=read_comments)
         except ChemkinError as e:
-            if e.message == "Skip reaction!":
+            if "Skip reaction!" in str(e):
                 logging.warning("Skipping the reaction {0!r}".format(kinetics))
                 continue
             else:

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -732,8 +732,8 @@ cdef class ReactionSystem(DASx):
                     if np.isnan(self.y).any():
                         raise DASxError("nans in moles")
                 except DASxError as e:
-                    logging.error("Trying to step from time {} to {} resulted in a solver (DASPK) error: "
-                                  "{}".format(prev_time, step_time, e.message))
+                    logging.error("Trying to step from time {0} to {1} resulted in a solver (DASPK) error: "
+                                  "{2!s}".format(prev_time, step_time, e))
 
                     logging.info('Resurrecting Model...')
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Exceptions no longer have a message attribute. We fixed a bunch of cases already, but missed some.

### Description of Changes
Replace calls to Exception.message with str(Exception).

### Testing
These changes fixed the issues I was having. I don't know if it's necessary to do additional testing.
