### PR TITLE
Fix conda build issues

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -12,7 +12,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }} # [unix]
-    - mingwpy # [win]
   host:
     - boost ==1.56.0
     - cython >=0.25.2

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -13,26 +13,23 @@ requirements:
   build:
     - {{ compiler('c') }} # [unix]
   host:
-    - boost ==1.56.0
     - cython >=0.25.2
-    - jinja2
     - lpsolve55
     - numpy
-    - openbabel >=2.4.1
+    - openbabel
     - pydas >=1.0.2
     - pydqed >=1.0.1
     - pyrdl
-    - python
-    - pyzmq
+    - python >=3.7
     - quantities
     - rdkit >=2018
     - scipy
     - setuptools
   run:
-    - argparse # [py26]
     - cairo
     - cairocffi
     - cantera >=2.3.0
+    - cclib
     - chemprop
     - coolprop
     - coverage
@@ -40,25 +37,29 @@ requirements:
     - ffmpeg
     - gprof2dot
     - graphviz
-    - guppy
+    - h5py
     - jinja2
+    - jupyter
     - lpsolve55
     - markupsafe
     - matplotlib >=1.5
     - mock
     - mopac
     - mpmath
+    - networkx
     - nose
+    - numdifftools
     - {{ pin_compatible('numpy') }}
-    - openbabel >=2.4.1
+    - openbabel
     - psutil
     - pydas >=1.0.2
-    - pydot ==1.2.2
+    - pydot
     - pydqed >=1.0.1
     - pymongo
     - pyparsing
     - pyrdl
-    - python
+    - python >=3.7
+    - pyyaml
     - pyzmq
     - quantities
     - rdkit >=2018
@@ -66,7 +67,6 @@ requirements:
     - scikit-learn
     - scipy
     - symmetry
-    - textgenrnn
     - xlwt
 test:
   source_files:

--- a/Makefile
+++ b/Makefile
@@ -38,18 +38,7 @@ clean-solver:
 	@ python utilities.py clean-solver
 
 install:
-	@ echo "Checking you have PyDQED..."
-	@ python -c 'import pydqed; print(pydqed.__file__)'
-ifneq ($(DASPK),)
-	@ echo "DASPK solver found. Compiling with DASPK and sensitivity analysis capability..."
-	@ (echo DEF DASPK = 1) > rmgpy/solver/settings.pxi
-else ifneq ($(DASSL),)
-	@ echo "DASSL solver found. Compiling with DASSL.  Sensitivity analysis capabilities are off..."
-	@ (echo DEF DASPK = 0) > rmgpy/solver/settings.pxi
-else
-	@ echo 'No PyDAS solvers found.  Please check if you have the latest version of PyDAS.'
-	@ python -c 'import pydas.dassl'
-endif
+	@ python utilities.py check-pydas
 	python setup.py install
 
 q2dtor:

--- a/rmg.py
+++ b/rmg.py
@@ -35,8 +35,14 @@ import os.path
 import logging
 
 # Before importing any RMG modules, check Python version
-import utilities
-utilities.check_python()
+try:
+    import utilities
+except ImportError:  # This is likely the binary install version, which does not include utilities
+    # If this is in fact the binary version, conda has ensured that the python version is correct.
+    # It is okay to skip this test here
+    utilities = None
+else:
+    utilities.check_python()
 
 import rmgpy
 from rmgpy.rmg.main import RMG, initialize_log, process_profile_stats, make_profile_graph


### PR DESCRIPTION
### Motivation or Problem
In order to build the conda package for RMG-Py 3.0, there are a couple of dependencies that needed to be updated in the conda recipe, as well as a bug or two that needed fixing. While this PR does not update the version numbers, it is possible to build a binary from this branch with these changes **so long as a python 3 version of the database exists as well**.

### Description of Changes

- Update dependencies in the conda recipe
- Fix a bug in setup.py that prevented `python setup.py install` from working (by calling the solver check that has now been moved to utilities.py)
- Prevent throwing an error if utilities.py is not available, which is the case for the binary builds.

### Testing
I built the RMG 3.0.0b successfully from this branch, so everything should be in order.