### PR TITLE
Removing RMG job scheduler instructions and updating RMG-parallel run…

### DIFF
--- a/documentation/source/users/rmg/running.rst
+++ b/documentation/source/users/rmg/running.rst
@@ -20,83 +20,17 @@ Run with CPU profiling::
 
     python rmg.py input.py -p
 
-We recommend you make a job-specific directory for each RMG simulation. Some jobs can take quite a while to complete, so we also recommend using a job scheduler if working in an linux environment. 
+Run with multiprocessing for reaction generation and QMTP::
 
-The instructions below describe special cases for running an RMG job.
+    python rmg.py -n <Max number of processes allowed> input.py 
 
-Running RMG in parallel with SLURM
-----------------------------------
-
-RMG has the option to use multiple processes on one node for reaction generation and on-the-fly Quantum Mechanics Thermodynamic Property (QMTP) calculation. Here is an example submission script for an RMG-Py job with a SLURM scheduler.
-
-The job reserves 24 tasks on a single node, but uses only 12 processes in parallel during
-the RMG-Py simulation.
-
-Make sure that: 
-
-- the queue named ``debug`` exists on your SLURM scheduler. 
-- you modify the path to the parent folder of the RMG-Py installation folder.
-- you have an anaconda environment named ``rmg_env`` that contains RMG-Py's dependencies.
-- the working directory from which you launched the job contains the RMG-Py input file ``input.py``
-
-.. code:: bash
-
-    #!/bin/bash
-
-    #SBATCH -p debug
-    #SBATCH -J jobname
-    #SBATCH -n 24
-
-    Processes=12
-    RMG_WS=/path/to/RMG/parent/folder
-    export PYTHONPATH=$PYTHONPATH:$RMG_WS/RMG-Py/
-
-    source activate rmg_env
-
-    python $RMG_WS/RMG-Py/rmg.py -n $Processes input.py
-
-    source deactivate
-
-Running RMG in parallel with SGE
---------------------------------
-
-RMG has the option to use multiple processes on one node for reaction generation and on-the-fly Quantum Mechanics Thermodynamic Property (QMTP) calculation. Here is an example submission script for an RMG-Py job with a SGE scheduler.
-
-The job reserves 24 tasks on a single node, but uses only 12 processes in parallel during
-the RMG-Py simulation.
-
-Make sure that:
-
--  the queue named ``debug`` exists on your SGE scheduler.
--  you modify the path to the parent folder of the RMG-Py installation
-   folder.
--  you have an anaconda environment named ``rmg_env`` that contains
-   RMG-Py's dependencies.
--  the working directory from which you launched the job
-   contains the RMG-Py input file ``input.py``.
-
-.. code:: bash
-
-    #! /bin/bash
-
-    #$ -l debug
-    #$ -N jobname
-    #$ -pe singlenode 24
-
-    Processes=12
-    RMG_WS=/path/to/RMG/parent/folder
-    export PYTHONPATH=$PYTHONPATH:$RMG_WS/RMG-Py/
-
-    source activate rmg_env
-
-    python $RMG_WS/RMG-Py/rmg.py -n $Processes input.py
-
-    source deactivate
+We recommend you make a job-specific directory for each RMG simulation. Some jobs can take quite a while to complete, so we also recommend using a job scheduler if working in a linux environment. 
 
 
-Details on the implementation
+Details on the multiprocessing implementation
 --------------------------------
 
 Currently, multiprocessing is implemented for reaction generation and the generation of QMfiles when using the QMTP option to compute thermodynamic properties of species. The processes are spawned and closed within each function. The number of processes is determined based on the ratio of currently available RAM and currently used RAM. The user can input the maximum number of allowed processes from the command line. For each reaction generation or QMTP call the number of processes will be the minimum value of either the number of allowed processes due to user input or the value obtained by the RAM ratio. The RAM limitation is employed, because multiprocessing is forking the base process and the memory limit (SWAP + RAM) might be exceeded when using too many processors for a base process large in memory.
 
 In python 3.4 new forking contexts 'spawn' and 'forkserver' are available. These methods will create new processes which share nothing or limited state with the parent and all memory passing is explicit. Once RMG is transferred to python 3 it is recommended to use the spawn or forkserver forking context to potentially allow for an increased number of processes.
+


### PR DESCRIPTION
… instructions.

### Motivation and Changes
This pull request is in response to #1762. Keeping in mind that people outside of the group will not benefit from group specific job scheduler instructions they were removed completely as suggested by @cgrambow. Instructions on how to run an RMG job in parallel have been added to '6. Running a Job' instead.  


### Testing
I tested the updated instructions for an RMG parallel run with the RMG minimal example and 3 processes.

### Reviewer Tips
Confirm that everything that was deleted should be deleted. In addition, you could also run a parallel run with the updated instructions.
