### PR TITLE
Output RMG libraries in Arkane

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -645,7 +645,7 @@ def load_input_file(path):
             if atom_energies is not None:
                 job.arkane_species.atom_energies = atom_energies
 
-    return job_list, reaction_dict, species_dict, transition_state_dict, network_dict
+    return job_list, reaction_dict, species_dict, transition_state_dict, network_dict, model_chemistry
 
 
 def process_model_chemistry(model_chemistry):

--- a/arkane/inputTest.py
+++ b/arkane/inputTest.py
@@ -211,7 +211,8 @@ class InputTest(unittest.TestCase):
         """Test loading an Arkane input file"""
         path = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)), 'examples', 'arkane', 'networks',
                             'acetyl+O2', 'input.py')
-        job_list, reaction_dict, species_dict, transition_state_dict, network_dict = load_input_file(path)
+        job_list, reaction_dict, species_dict, transition_state_dict, network_dict, model_chemistry \
+            = load_input_file(path)
 
         self.assertEqual(len(job_list), 1)
 
@@ -229,6 +230,8 @@ class InputTest(unittest.TestCase):
 
         self.assertEqual(len(network_dict), 1)
         self.assertTrue('acetyl + O2' in network_dict)
+
+        self.assertEqual(model_chemistry, '')
 
     def test_process_model_chemistry(self):
         """

--- a/arkane/main.py
+++ b/arkane/main.py
@@ -153,8 +153,8 @@ class Arkane(object):
         loaded set of jobs as a list.
         """
         self.input_file = input_file
-        self.job_list, self.reaction_dict, self.species_dict, self.transition_state_dict, self.network_dict = \
-            load_input_file(self.input_file)
+        self.job_list, self.reaction_dict, self.species_dict, self.transition_state_dict, self.network_dict, \
+            self.model_chemistry = load_input_file(self.input_file)
         logging.info('')
         return self.job_list
 

--- a/arkane/outputTest.py
+++ b/arkane/outputTest.py
@@ -39,8 +39,11 @@ import unittest
 from nose.plugins.attrib import attr
 
 import rmgpy
+
+from arkane.gaussian import GaussianLog
 from arkane.main import Arkane
-from arkane.output import prettify
+from arkane.output import prettify, get_str_xyz
+from rmgpy.species import Species
 
 
 @attr('functional')
@@ -128,6 +131,23 @@ class OutputUnitTest(unittest.TestCase):
     optical_isomers = 1,
 )"""
         self.assertEqual(prettify(input_str), expected_output)
+
+    def test_get_str_xyz(self):
+        """Test generating an xyz string from the species.conformer object"""
+        log = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'ethylene_G3.log'))
+        conformer = log.load_conformer()[0]
+        coords, number, mass = log.load_geometry()
+        conformer.coordinates, conformer.number, conformer.mass = (coords, "angstroms"), number, (mass, "amu")
+        spc1 = Species(smiles='C=C')
+        spc1.conformer = conformer
+        xyz_str = get_str_xyz(spc1)
+        expected_xyz_str = """C       0.00545100    0.00000000    0.00339700
+H       0.00118700    0.00000000    1.08823200
+H       0.97742900    0.00000000   -0.47841600
+C      -1.12745800    0.00000000   -0.70256500
+H      -1.12319800    0.00000000   -1.78740100
+H      -2.09943900    0.00000000   -0.22075700"""
+        self.assertEqual(xyz_str, expected_xyz_str)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation or Problem
The current Arkane output is not in a format that can be directly pasted into RMG libraries. See #1768 

### Description of Changes
Now Arkane will output thermo and kinetic libraries into an RMG_libraries folder. Note that only species with structure will be considered for the thermo library, and only reactions with structures for all their reactants and products will be considered for the kinetics libarry.

### Testing
Added a unit test for an intermediate newly added function, could add functional tests as well.

### Reviewer Tips
Run a thermo job, specifying structure for a species, and see the resulting thermo library.
Run kinetics and pdep jobs, specifying structures for all species, and see the resulting kinetics library.