### PR TITLE
Fix solvaion radical bug

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -798,8 +798,8 @@ class SolvationDatabase(object):
         for atom in saturated_struct.atoms:
             # Iterate over heavy (non-hydrogen) atoms
             if atom.is_non_hydrogen() and atom.radical_electrons > 0:
-                for electron in range(1, atom.radical_electrons):
-                    # Get solute data for radical group    
+                for electron in range(atom.radical_electrons):
+                    # Get solute data for radical group
                     try:
                         self._add_group_solute_data(solute_data, self.groups['radical'], saturated_struct, {'*': atom})
                     except KeyError:

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -193,6 +193,12 @@ class TestSoluteDatabase(TestCase):
         solute_data = self.database.get_solute_data_from_groups(species)
         self.assertIsNotNone(solute_data)
 
+    def test_radical_solute_group(self):
+        """Test that the existing radical group is found for the radical species when using group additivity"""
+        species = Species(molecule=[Molecule(smiles='[OH]')])
+        solute_data = self.database.get_solute_data_from_groups(species)
+        self.assertTrue('radical' in solute_data.comment)
+
     def test_correction_generation(self):
         """Test we can estimate solvation thermochemistry."""
         self.testCases = [

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -195,9 +195,19 @@ class TestSoluteDatabase(TestCase):
 
     def test_radical_solute_group(self):
         """Test that the existing radical group is found for the radical species when using group additivity"""
-        species = Species(molecule=[Molecule(smiles='[OH]')])
-        solute_data = self.database.get_solute_data_from_groups(species)
-        self.assertTrue('radical' in solute_data.comment)
+        # First check whether the radical group is found for the radical species
+        rad_species = Species(smiles='[OH]')
+        rad_solute_data = self.database.get_solute_data_from_groups(rad_species)
+        self.assertTrue('radical' in rad_solute_data.comment)
+        # Then check that the radical and its saturated species give different solvation free energies
+        saturated_struct = rad_species.molecule[0].copy(deep=True)
+        saturated_struct.saturate_radicals()
+        sat_species = Species(molecule=[saturated_struct])
+        sat_solute_data = self.database.get_solute_data_from_groups(sat_species)
+        solvent_data = self.database.get_solvent_data('water')
+        rad_solvation_correction = self.database.get_solvation_correction(rad_solute_data, solvent_data)
+        sat_solvation_correction = self.database.get_solvation_correction(sat_solute_data, solvent_data)
+        self.assertNotAlmostEqual(rad_solvation_correction.gibbs / 1000, sat_solvation_correction.gibbs / 1000)
 
     def test_correction_generation(self):
         """Test we can estimate solvation thermochemistry."""


### PR DESCRIPTION
### Motivation or Problem
Solvation correction for radical groups were not applied for radical species even if their radical groups were found in the solvation radical database.

### Description of Changes
Before, when the radical solvation correction would apply, it applied the correction for each individual radical electron found by using such for loop:
`for electron in range(1, atom.radical_electrons):`
But this was wrong, because the range should start from 0, not 1. If the number of radical electron is 1, then the range is from (1,1), which doesn't really start the for loop at all.
I changed this for loop to:
`for electron in range(atom.radical_electrons):`
such that if the number of electron is 1, the range will be from [0, 1], making the correction to be applied once. Since the number of radical electrons are always 0 or positive integer, this change should be appropriate.

### Testing
I also added a unit test in solvationTest.py, which checks whether the solvation radical group is found for the radical speices '[OH]' when calculating its solute data from group additivity method.

### Reviewer Tips
fixes #1743 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
