### PR TITLE
Allow generate_reactions.py script to accept number of processors 

### DIFF
--- a/rmgpy/tools/generate_reactions.py
+++ b/rmgpy/tools/generate_reactions.py
@@ -64,6 +64,7 @@ def main():
         'restart': args.restart,
         'walltime': args.walltime,
         'log': level,
+        'maxproc': args.maxproc,
         'kineticsdatastore': args.kineticsdatastore
     }
 


### PR DESCRIPTION
### Motivation or Problem
This pull request resolves #1779     

### Description of Changes
'maxproc': args.maxproc, was added as an entry to the kwargs dictionary in generate_reactions.py

### Testing
"python ~/RMG-Py/scripts/generateReactions.py -n 1 input.py" will print the expected "For reaction generation, 1 process is used" from react.py
"python ~/RMG-Py/scripts/generateReactions.py -n 2 input.py" will now print the expected "For reaction generation, 2 processes are used" from react.py
Activity monitor confirms that 2 processes are being used and indeed the run time is faster

### Reviewer Tips
All feedback and suggestions are welcome :)
