### PR TITLE
Title underline too short.

### DIFF
--- a/documentation/source/users/rmg/running.rst
+++ b/documentation/source/users/rmg/running.rst
@@ -28,7 +28,7 @@ We recommend you make a job-specific directory for each RMG simulation. Some job
 
 
 Details on the multiprocessing implementation
---------------------------------
+----------------------------------------------
 
 Currently, multiprocessing is implemented for reaction generation and the generation of QMfiles when using the QMTP option to compute thermodynamic properties of species. The processes are spawned and closed within each function. The number of processes is determined based on the ratio of currently available RAM and currently used RAM. The user can input the maximum number of allowed processes from the command line. For each reaction generation or QMTP call the number of processes will be the minimum value of either the number of allowed processes due to user input or the value obtained by the RAM ratio. The RAM limitation is employed, because multiprocessing is forking the base process and the memory limit (SWAP + RAM) might be exceeded when using too many processors for a base process large in memory.
 


### PR DESCRIPTION
Currently renders a warning message:
System Message: WARNING/2 (/home/travis/build/ReactionMechanismGenerator/RMG-Py/documentation/source/users/rmg/running.rst, line 31)

Title underline too short.


Tiny tweak, barely worth a PR