### PR TITLE
Include Arkane in code coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,9 +3,14 @@
 plugins = Cython.Coverage
 branch = True
 source =
+    arkane
+    Arkane.py
     rmgpy
     rmg.py
-omit = *Test.py
+omit =
+    *Test.py
+    */test_data/*
+    arkane/data/*
 
 [report]
 show_missing = False
@@ -18,7 +23,13 @@ exclude_lines =
     raise NotImplementedError
     if 0:
     if __name__ == .__main__.:
-omit = *Test.py
+include =
+    arkane/*
+    rmgpy/*
+omit =
+    *Test.py
+    */test_data/*
+    arkane/data/*
 
 [html]
 directory = testing/coverage

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,14 @@ ifneq ($(OS),Windows_NT)
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
 endif
-	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy arkane
+	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy arkane
 
 test test-unittests:
 ifneq ($(OS),Windows_NT)
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
 endif
-	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-package=rmgpy --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy arkane
+	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy arkane
 
 test-functional:
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
### Motivation or Problem
fixes #1792 

Adds the arkane folder and Arkane.py to code coverage.

### Description of Changes
Updated the sources in the .coveragerc file 

### Testing
Checking that Arkane files show up in the coverage report for this PR should suffice
