### PR TITLE
Fix WSL permisson bug for renaming directories

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -1272,7 +1272,16 @@ class RMG(util.Subject):
             if os.path.exists(seed_dir):  # This is a seed from a previous RMG run. Delete it
                 shutil.rmtree(seed_dir)
         else:  # This is a seed from the previous iteration. Move it to a temporary directory in case we run into errors
-            os.rename(seed_dir, os.path.join(temp_seed_dir))
+            try:
+                os.rename(seed_dir, os.path.join(temp_seed_dir))
+            except PermissionError:  # The Windows Subsystem for Linux (WSL) can have problems with renaming
+                # Try copying over the files instead. Unfortunately, this takes more time
+                if os.path.exists(temp_seed_dir):  # First, delete the contents of the old folder if it exists
+                    shutil.rmtree(temp_seed_dir)
+                shutil.copytree(seed_dir, temp_seed_dir)
+
+                # Now remove the contents of the seed directory
+                shutil.rmtree(seed_dir)
 
         # Now that we have either deleted or moved the seed mechanism folder, create a new one
         os.mkdir(seed_dir)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -1273,7 +1273,7 @@ class RMG(util.Subject):
                 shutil.rmtree(seed_dir)
         else:  # This is a seed from the previous iteration. Move it to a temporary directory in case we run into errors
             try:
-                os.rename(seed_dir, os.path.join(temp_seed_dir))
+                os.rename(seed_dir, temp_seed_dir)
             except PermissionError:  # The Windows Subsystem for Linux (WSL) can have problems with renaming
                 # Try copying over the files instead. Unfortunately, this takes more time
                 if os.path.exists(temp_seed_dir):  # First, delete the contents of the old folder if it exists


### PR DESCRIPTION
### Motivation or Problem
fixes #1786 

As noted in the issue this fixes, the Windows Subsystem for Linux sometimes throws a permission error 
when trying to renaming non-empty directories, even when the user has the permissions set properly on the directories and files to do so. This is problematic, because we rename the seed directory folder temporarily every time we save a new seed mechanism so that the previous seed mechanism is not lost in case we encounter an error when saving the new one. Renaming the directory does not require copying large amounts of data, so this is the preferred solution in general, but as noted can cause problems for WSL users.

There appear to be several issues opened over a few years complaining about this issue if I am not mistaken, so it appears to be a reoccurring problem. Given this, it is best to handle this case ourselves.


### Description of Changes
A try/except statement was added that avoids renaming the directory in the event of a permission error and instead copies the directory to a new location, which does not throw a permission error as far as I can tell in WSL. Note that this solution is much slower than renaming, so it should only be done as a last resort, which is exactly what we have implemented here.

### Testing
See the issue. We have tested this branch to confirm that at the very least the WSL bug goes away. It might be worth double checking that the files are copied over and then later deleted as desired.
