### PR TITLE
Revert 'spin_multiplicity' to 'spinMultiplicity' in Arkane pdep

### DIFF
--- a/arkane/pdep.py
+++ b/arkane/pdep.py
@@ -699,7 +699,7 @@ class PressureDependenceJob(object):
                         for mode in ts.conformer.modes:
                             f.write('        {0!r},\n'.format(mode))
                         f.write('    ],\n')
-                    f.write('    spin_multiplicity = {0:d},\n'.format(ts.conformer.spin_multiplicity))
+                    f.write('    spinMultiplicity = {0:d},\n'.format(ts.conformer.spin_multiplicity))
                     f.write('    opticalIsomers = {0:d},\n'.format(ts.conformer.optical_isomers))
                 if ts.frequency is not None:
                     f.write('    frequency = {0!r},\n'.format(ts.frequency))


### PR DESCRIPTION
### Motivation or Problem
Running an RMG-generated network file results in:`TypeError: transition_state() got an unexpected keyword argument 'spin_multiplicity'.`

### Description of Changes
Reverted `spin_multiplicity` to `spinMultiplicity` in Arkane pdep.py where these networks are being generated. The bug only relates to sting representations of TSs, Species were unaffected.

### Testing
Run a RMG with PDep on on master and on this branch, try to execute a sample network file via Arkane.