### PR TITLE
Fix PES figure generation in png format

### DIFF
--- a/rmgpy/pdep/draw.py
+++ b/rmgpy/pdep/draw.py
@@ -238,7 +238,7 @@ class NetworkDrawer(object):
     def draw(self, network, file_format, path=None):
         """
         Draw the potential energy surface for the given `network` as a Cairo
-        surface of the given `format`. If `path` is given, the surface is
+        surface of the given `file_format`. If `path` is given, the surface is
         saved to that location on disk.
         """
         try:
@@ -513,7 +513,7 @@ class NetworkDrawer(object):
             self._draw_label(well, cr, x, y, file_format=file_format)
 
         # Finish Cairo drawing
-        if format == 'png':
+        if file_format == 'png':
             surface.write_to_png(path)
         else:
             surface.finish()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
One of the arguments of rmgpy.pdep.draw is renamed from `format` to `file_format` in a previous commit, but the corresponding codes are not fully refactorized, causing failures in generating PES figures in png format. This will further hinder the PES from being generated and displayed on the RMG-website.

### Description of Changes
rename `format` to `file_format` .

### Testing
By calling the draw function with `file_format="png"`, it can generate PES figure in .png format

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
