### PR TITLE
Allow mole fractions to be normalized if they do not sum to one

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -226,6 +226,23 @@ def simple_reactor(temperature,
             [not isinstance(x, list) for x in initialMoleFractions.values()]):
         nSims = 1
 
+    # normalize mole fractions if not using a mole fraction range
+    if all([not isinstance(x, list) for x in initialMoleFractions.values()]):
+        total_initial_moles = sum(initialMoleFractions.values())
+        if total_initial_moles != 1:
+            logging.warning('Initial mole fractions do not sum to one; normalizing.')
+            logging.info('')
+            logging.info('Original composition:')
+            for spec, molfrac in initialMoleFractions.items():
+                logging.info('{0} = {1}'.format(spec, molfrac))
+            for spec in initialMoleFractions:
+                initialMoleFractions[spec] /= total_initial_moles
+            logging.info('')
+            logging.info('Normalized mole fractions:')
+            for spec, molfrac in initialMoleFractions.items():
+                logging.info('{0} = {1}'.format(spec, molfrac))
+            logging.info('')
+
     termination = []
     if terminationConversion is not None:
         for spec, conv in terminationConversion.items():


### PR DESCRIPTION
Added some code in rmgpy/rmg/input.py that normalizes the mole fractions if necessary. This resolves issue #1750 


### Motivation or Problem
RMG previously would normalize initial mole fractions specified in input files. This functionality was removed in #1331.

### Description of Changes
Added some code in rmgpy/rmg/input.py that normalizes the mole fractions if necessary

### Testing
I tested this on the superminimal example with two conditions:
```
initialMoleFractions={
        'H2': 0.67, 'O2': 0.33,
    },
```
and 
```
initialMoleFractions={
        'H2': 67, 'O2': 33,
    },
```
The feature seems to work as expected

### Reviewer Tips
Minor question: I used `for spec, molfrac in initialMoleFractions.items():` to be explicit about what we were looping over. The code immediately above this addition in line 195 uses a more general `for key, value in initialMoleFractions.item():`. I assume these should be consistent. What do you recommend? Thanks!

