### PR TITLE
Fix: numeric energy input for ARKANE

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -316,7 +316,9 @@ class StatMechJob(object):
             except KeyError:
                 raise InputError('Model chemistry {0!r} not found in from dictionary of energy values in species file '
                                  '{1!r}.'.format(self.modelChemistry, path))
-        if not os.path.isfile(energy.path):
+        if not hasattr(energy, 'path'):
+            pass	
+        elif not os.path.isfile(energy.path):
             modified_energy_path = os.path.join(directory, energy.path)
             if not os.path.isfile(modified_energy_path):
                 raise InputError('Could not find single point energy file for species {0} '


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
I wanted to manually put energy in Arkane input file since Arkane doesn't contain model chemistry that I used. However, Arkane assumed float type as 'path' and giving out the error.

### Description of Changes
added lines that can recognize the float type before it assumes as the path

### Testing
it worked in my laptop..?

### Reviewer Tips
Actually, Jerry did this fix...

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
