### PR TITLE
Gaussian energies

### DIFF
--- a/arkane/data/B2PLYP.LOG
+++ b/arkane/data/B2PLYP.LOG
@@ -1,0 +1,453 @@
+ Entering Link 1 = C:\G09W\l1.exe PID=     20588.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  IA32W-G09RevD.01 24-Apr-2013
+                07-Nov-2019 
+ ******************************************
+ %chk=C:\Users\drana\Desktop\work\Scratch\G09\MarkG\Energy\G09\b3plyp.chk
+ ---------------------------------
+ #p b2plyp/3-21g geom=connectivity
+ ---------------------------------
+ 1/38=1,57=2/1;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=5,11=9,16=1,25=1,30=1,74=-47/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 8/10=1/1;
+ 9/16=-3/6;
+ 6/7=2,8=2,9=2,10=2/1;
+ 99/5=1,9=1/99;
+ Leave Link    1 at Thu Nov 07 11:12:24 2019, MaxMem=           0 cpu:         0.0
+ (Enter C:\G09W\l101.exe)
+ -------------------
+ Title Card Required
+ -------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ C                     1.29707   0.70607   0. 
+ H                     1.65373  -0.30274   0. 
+ H                     1.65374   1.21047   0.87365 
+ H                     1.65374   1.21047  -0.87365 
+ H                     0.22707   0.70608   0. 
+ 
+ NAtoms=      5 NQM=        5 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5
+ IAtWgt=          12           1           1           1           1
+ AtmWgt=  12.0000000   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           0           1           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   6.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+ Leave Link  101 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        1.297071    0.706067    0.000000
+      2          1           0        1.653726   -0.302743    0.000000
+      3          1           0        1.653744    1.210465    0.873652
+      4          1           0        1.653744    1.210465   -0.873652
+      5          1           0        0.227071    0.706080    0.000000
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  H    1.070000   0.000000
+     3  H    1.070000   1.747302   0.000000
+     4  H    1.070000   1.747302   1.747303   0.000000
+     5  H    1.070000   1.747303   1.747303   1.747303   0.000000
+ Stoichiometry    CH4
+ Framework group  T[O(C),4C3(H)]
+ Deg. of freedom     1
+ Full point group                 T       NOp  12
+ Largest Abelian subgroup         D2      NOp   4
+ Largest concise Abelian subgroup D2      NOp   4
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        0.000000    0.000000    0.000000
+      2          1           0        0.617765    0.617765    0.617765
+      3          1           0       -0.617765   -0.617765    0.617765
+      4          1           0       -0.617765    0.617765   -0.617765
+      5          1           0        0.617765   -0.617765   -0.617765
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    164.2463759    164.2463759    164.2463759
+ Leave Link  202 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l301.exe)
+ Standard basis: 3-21G (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are     5 symmetry adapted cartesian basis functions of A   symmetry.
+ There are     4 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     4 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are     4 symmetry adapted cartesian basis functions of B3  symmetry.
+ There are     5 symmetry adapted basis functions of A   symmetry.
+ There are     4 symmetry adapted basis functions of B1  symmetry.
+ There are     4 symmetry adapted basis functions of B2  symmetry.
+ There are     4 symmetry adapted basis functions of B3  symmetry.
+    17 basis functions,    27 primitive gaussians,    17 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy        13.6865184431 Hartrees.
+ IExCor=  419 DFT=T Ex+Corr=B2PLYP ExCW=0 ScaHFX=  0.530000
+ ScaDFX=  0.470000  0.470000  0.730000  0.730000 ScalE2=  0.270000  0.270000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    5 NActive=    5 NUniq=    2 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    262144 words long.
+ Regular integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=    17 RedAO= T EigKep=  4.03D-02  NBF=     5     4     4     4
+ NBsUse=    17 1.00D-06 EigRej= -1.00D+00 NBFU=     5     4     4     4
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          16
+ NSgBfM=    17    17    17    17    17 MxSgAt=     5 MxSgA2=     5.
+ Leave Link  302 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l401.exe)
+ ExpMin= 1.83D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  419 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  419 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -40.3389689758633    
+ JPrj=0 DoOrth=F DoCkMO=F.
+ Initial guess orbital symmetries:
+       Occupied  (A) (A) (T) (T) (T)
+       Virtual   (A) (T) (T) (T) (T) (T) (T) (A) (T) (T) (T) (A)
+ The electronic state of the initial guess is 1-A.
+ Leave Link  401 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=887875.
+ IVT=       20113 IEndB=       20113 NGot=    33554432 MDV=    33530844
+ LenX=    33530844 LenY=    33529962
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    153 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -40.0981649461019    
+ DIIS: error= 7.33D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -40.0981649461019     IErMin= 1 ErrMin= 7.33D-02
+ ErrMax= 7.33D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.51D-02 BMatP= 8.51D-02
+ IDIUse=3 WtCom= 2.67D-01 WtEn= 7.33D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.604 Goal=   None    Shift=    0.000
+ GapD=    0.604 DampG=2.000 DampE=0.500 DampFc=1.0000 IDamp=-1.
+ RMSDP=2.40D-02 MaxDP=1.34D-01              OVMax= 1.46D-01
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -40.1434815728746     Delta-E=       -0.045316626773 Rises=F Damp=F
+ DIIS: error= 4.84D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -40.1434815728746     IErMin= 2 ErrMin= 4.84D-02
+ ErrMax= 4.84D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.17D-02 BMatP= 8.51D-02
+ IDIUse=3 WtCom= 5.16D-01 WtEn= 4.84D-01
+ Coeff-Com:  0.410D+00 0.590D+00
+ Coeff-En:   0.278D+00 0.722D+00
+ Coeff:      0.346D+00 0.654D+00
+ Gap=     0.673 Goal=   None    Shift=    0.000
+ RMSDP=1.04D-02 MaxDP=5.76D-02 DE=-4.53D-02 OVMax= 5.96D-02
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -40.1850864359784     Delta-E=       -0.041604863104 Rises=F Damp=F
+ DIIS: error= 5.97D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -40.1850864359784     IErMin= 3 ErrMin= 5.97D-03
+ ErrMax= 5.97D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.70D-04 BMatP= 4.17D-02
+ IDIUse=3 WtCom= 9.40D-01 WtEn= 5.97D-02
+ Coeff-Com: -0.217D-01 0.800D-01 0.942D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.204D-01 0.752D-01 0.945D+00
+ Gap=     0.670 Goal=   None    Shift=    0.000
+ RMSDP=1.05D-03 MaxDP=5.14D-03 DE=-4.16D-02 OVMax= 6.79D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -40.1856477513352     Delta-E=       -0.000561315357 Rises=F Damp=F
+ DIIS: error= 2.25D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -40.1856477513352     IErMin= 4 ErrMin= 2.25D-04
+ ErrMax= 2.25D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.36D-07 BMatP= 5.70D-04
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 2.25D-03
+ Coeff-Com:  0.110D-02-0.122D-01-0.794D-01 0.109D+01
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.110D-02-0.122D-01-0.792D-01 0.109D+01
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=5.28D-05 MaxDP=4.28D-04 DE=-5.61D-04 OVMax= 2.69D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -40.1856485017618     Delta-E=       -0.000000750427 Rises=F Damp=F
+ DIIS: error= 7.43D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -40.1856485017618     IErMin= 5 ErrMin= 7.43D-06
+ ErrMax= 7.43D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.93D-10 BMatP= 7.36D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.651D-04-0.118D-04-0.184D-02-0.487D-01 0.105D+01
+ Coeff:      0.651D-04-0.118D-04-0.184D-02-0.487D-01 0.105D+01
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=2.38D-06 MaxDP=2.80D-05 DE=-7.50D-07 OVMax= 1.27D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -40.1856263419652     Delta-E=        0.000022159797 Rises=F Damp=F
+ DIIS: error= 5.73D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -40.1856263419652     IErMin= 1 ErrMin= 5.73D-06
+ ErrMax= 5.73D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.33D-10 BMatP= 7.33D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=2.38D-06 MaxDP=2.80D-05 DE= 2.22D-05 OVMax= 1.43D-05
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -40.1856263434286     Delta-E=       -0.000000001463 Rises=F Damp=F
+ DIIS: error= 8.41D-07 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -40.1856263434286     IErMin= 2 ErrMin= 8.41D-07
+ ErrMax= 8.41D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.32D-11 BMatP= 7.33D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.166D+00 0.117D+01
+ Coeff:     -0.166D+00 0.117D+01
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=7.30D-07 MaxDP=3.31D-06 DE=-1.46D-09 OVMax= 2.51D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -40.1856263434675     Delta-E=       -0.000000000039 Rises=F Damp=F
+ DIIS: error= 3.89D-07 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -40.1856263434675     IErMin= 3 ErrMin= 3.89D-07
+ ErrMax= 3.89D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.47D-12 BMatP= 2.32D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.527D-01 0.385D+00 0.667D+00
+ Coeff:     -0.527D-01 0.385D+00 0.667D+00
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=8.27D-08 MaxDP=3.67D-07 DE=-3.89D-11 OVMax= 5.24D-07
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -40.1856263434697     Delta-E=       -0.000000000002 Rises=F Damp=F
+ DIIS: error= 7.84D-08 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -40.1856263434697     IErMin= 4 ErrMin= 7.84D-08
+ ErrMax= 7.84D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.09D-14 BMatP= 2.47D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.630D-02-0.570D-01 0.860D-01 0.965D+00
+ Coeff:      0.630D-02-0.570D-01 0.860D-01 0.965D+00
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=1.79D-08 MaxDP=1.53D-07 DE=-2.22D-12 OVMax= 9.13D-08
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -40.1856263434700     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 2.74D-09 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -40.1856263434700     IErMin= 5 ErrMin= 2.74D-09
+ ErrMax= 2.74D-09  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.76D-17 BMatP= 8.09D-14
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.864D-03 0.808D-02-0.149D-01-0.160D+00 0.117D+01
+ Coeff:     -0.864D-03 0.808D-02-0.149D-01-0.160D+00 0.117D+01
+ Gap=     0.671 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-09 MaxDP=1.34D-08 DE=-2.70D-13 OVMax= 6.04D-09
+
+ SCF Done:  E(RB2PLYP) =  -40.1856263435     A.U. after   10 cycles
+            NFock= 10  Conv=0.11D-08     -V/T= 2.0048
+ KE= 3.999316782235D+01 PE=-1.199505132181D+02 EE= 2.608520060914D+01
+ Leave Link  502 at Thu Nov 07 11:12:24 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l801.exe)
+ DoSCS=T DFT=T ScalE2(SS,OS)=  0.270000  0.270000
+ ExpMin= 1.83D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV=-2 UseB2=F ITyADJ=14
+ ICtDFT= 12500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ Largest valence mixing into a core orbital is  2.13D-04
+ Largest core mixing into a valence orbital is  1.70D-05
+ Range of M.O.s used for correlation:     2    17
+ NBasis=    17 NAE=     5 NBE=     5 NFC=     1 NFV=     0
+ NROrb=     16 NOA=     4 NOB=     4 NVA=    12 NVB=    12
+ Leave Link  801 at Thu Nov 07 11:12:25 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l906.exe)
+ DoSCS=T DFT=T ScalE2(SS,OS)=  0.270000  0.270000
+ FulOut=F Deriv=F AODrv=F NAtomX=     5
+   MMem=       13705  MDisk=           4 MDiskD=           4
+  W3Min=         816 MinDsk=       53041 NBas6D=          17
+ NBas2D=         165    NTT=         153    LW2=     2000000
+    MDV=    33549921 MDiskM=       19332 NBas2p=          87
+ Fully in-core method, ICMem=     6034076.
+ IMap=   1   2   3   4
+ JobTyp=1 Pass  1 fully in-core, NPsUse=  1.
+ Compute canonical integrals.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    165 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Spin components of T(2) and E(2):
+     alpha-alpha T2 =       0.4192926533D-02 E2=     -0.2630109372D-02
+     alpha-beta  T2 =       0.4324389502D-01 E2=     -0.2690800998D-01
+     beta-beta   T2 =       0.4192926533D-02 E2=     -0.2630109372D-02
+ The integrals were generated   1 times.
+ E2(B2PLYP) =    -0.3216822872D-01 E(B2PLYP) =    -0.40217794572194D+02
+ Leave Link  906 at Thu Nov 07 11:12:25 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (T) (T) (T)
+       Virtual   (A) (T) (T) (T) (T) (T) (T) (A) (T) (T) (T) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -10.52823  -0.80292  -0.45801  -0.45801  -0.45801
+ Alpha virt. eigenvalues --    0.21250   0.26564   0.26564   0.26564   0.78536
+ Alpha virt. eigenvalues --    0.78536   0.78536   1.17819   1.19459   1.19459
+ Alpha virt. eigenvalues --    1.19459   1.81058
+          Condensed to atoms (all electrons):
+               1          2          3          4          5
+     1  C    5.310020   0.370976   0.370976   0.370976   0.370976
+     2  H    0.370976   0.510088  -0.026515  -0.026515  -0.026515
+     3  H    0.370976  -0.026515   0.510088  -0.026515  -0.026515
+     4  H    0.370976  -0.026515  -0.026515   0.510088  -0.026515
+     5  H    0.370976  -0.026515  -0.026515  -0.026515   0.510088
+ Mulliken charges:
+               1
+     1  C   -0.793922
+     2  H    0.198480
+     3  H    0.198480
+     4  H    0.198480
+     5  H    0.198480
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C    0.000000
+ Electronic spatial extent (au):  <R**2>=             34.7598
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -8.2521   YY=             -8.2521   ZZ=             -8.2521
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.0000   YY=              0.0000   ZZ=              0.0000
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=              0.0000  XYY=              0.0000
+  XXY=              0.0000  XXZ=              0.0000  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=              0.0000  XYZ=              0.6859
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=            -14.8440 YYYY=            -14.8440 ZZZZ=            -14.8440 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -4.5291 XXZZ=             -4.5291 YYZZ=             -4.5291
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 1.368651844314D+01 E-N=-1.199505132239D+02  KE= 3.999316782235D+01
+ Symmetry A    KE= 3.420467566746D+01
+ Symmetry B1   KE= 1.929497384965D+00
+ Symmetry B2   KE= 1.929497384965D+00
+ Symmetry B3   KE= 1.929497384965D+00
+ Leave Link  601 at Thu Nov 07 11:12:25 2019, MaxMem=    33554432 cpu:         0.0
+ (Enter C:\G09W\l9999.exe)
+ 1|1|UNPC-DUMINDA-T480S|SP|RB2PLYP-FC|3-21G|C1H4|DRANA|07-Nov-2019|0||#
+ p b2plyp/3-21g geom=connectivity||Title Card Required||0,1|C,0,1.29707
+ 111,0.70606695,0.|H,0,1.65372554,-0.30274306,0.|H,0,1.65374395,1.21046
+ 514,0.8736515|H,0,1.65374395,1.21046514,-0.8736515|H,0,0.22707111,0.70
+ 608013,0.||Version=IA32W-G09RevD.01|State=1-A|HF=-40.1856263|MP2=-40.2
+ 177946|RMSD=1.070e-009|PG=T [O(C1),4C3(H1)]||@
+
+
+ TRUST EVERYONE, BUT CUT THE CARDS.
+ Job cpu time:       0 days  0 hours  0 minutes  1.0 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Thu Nov 07 11:12:25 2019.

--- a/arkane/data/UCCSDT_C_ATOM.LOG
+++ b/arkane/data/UCCSDT_C_ATOM.LOG
@@ -1,0 +1,364 @@
+ Entering Link 1 = C:\G09W\l1.exe PID=      1288.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  IA32W-G09RevD.01 24-Apr-2013
+                07-Nov-2019 
+ ******************************************
+ %chk=C:\Users\drana\Desktop\work\Scratch\G09\MarkG\Energy\G09\uccsdt_C_atom.chk
+ ----------------------------------
+ # uccsd(t)/3-21g geom=connectivity
+ ----------------------------------
+ 1/38=1,57=2/1;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=5,11=2,16=1,25=1,30=1,116=2/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 8/6=4,9=120000,10=1/1,4;
+ 9/5=7,14=2/13;
+ 6/7=2,8=2,9=2,10=2/1;
+ 99/5=1,9=1/99;
+ -------------------
+ Title Card Required
+ -------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 3
+ C                     1.0251    0.95711   0. 
+ 
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        1.025105    0.957113    0.000000
+ ---------------------------------------------------------------------
+ Stoichiometry    C(3)
+ Framework group  OH[O(C)]
+ Deg. of freedom     0
+ Full point group                 OH      NOp  48
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        0.000000    0.000000    0.000000
+ ---------------------------------------------------------------------
+ Standard basis: 3-21G (6D, 7F)
+ There are     3 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     3 symmetry adapted basis functions of AG  symmetry.
+ There are     0 symmetry adapted basis functions of B1G symmetry.
+ There are     0 symmetry adapted basis functions of B2G symmetry.
+ There are     0 symmetry adapted basis functions of B3G symmetry.
+ There are     0 symmetry adapted basis functions of AU  symmetry.
+ There are     2 symmetry adapted basis functions of B1U symmetry.
+ There are     2 symmetry adapted basis functions of B2U symmetry.
+ There are     2 symmetry adapted basis functions of B3U symmetry.
+     9 basis functions,    15 primitive gaussians,     9 cartesian basis functions
+     4 alpha electrons        2 beta electrons
+       nuclear repulsion energy         0.0000000000 Hartrees.
+ NAtoms=    1 NActive=    1 NUniq=    1 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    262144 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     9 RedAO= T EigKep=  6.75D-01  NBF=     3     0     0     0     0     2     2     2
+ NBsUse=     9 1.00D-06 EigRej= -1.00D+00 NBFU=     3     0     0     0     0     2     2     2
+ ExpMin= 1.96D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A1G) (A1G) (T1U) (T1U)
+       Virtual   (T1U) (T1U) (T1U) (T1U) (A1G)
+ Beta  Orbitals:
+       Occupied  (A1G) (A1G)
+       Virtual   (T1U) (T1U) (T1U) (T1U) (T1U) (T1U) (A1G)
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0000 S= 1.0000
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=822740.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ SCF Done:  E(UHF) =  -37.4810698326     A.U. after    6 cycles
+            NFock=  6  Conv=0.55D-08     -V/T= 2.0033
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0010 S= 1.0003
+ <L.S>= 0.000000000000E+00
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0010,   after     2.0000
+ ExpMin= 1.96D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV=-2 UseB2=F ITyADJ=14
+ ICtDFT= 12500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ Range of M.O.s used for correlation:     2     9
+ NBasis=     9 NAE=     4 NBE=     2 NFC=     1 NFV=     0
+ NROrb=      8 NOA=     3 NOB=     1 NVA=     5 NVB=     7
+ Semi-Direct transformation.
+ ModeAB=           2 MOrb=             3 LenV=      33458373
+ LASXX=           66 LTotXX=          66 LenRXX=          66
+ LTotAB=         132 MaxLAS=        1080 LenRXY=        1080
+ NonZer=        1368 LenScr=     1048064 LnRSAI=           0
+ LnScr1=           0 LExtra=           0 Total=      1049210
+ MaxDsk=          -1 SrtSym=           F ITran=            4
+ JobTyp=1 Pass  1:  I=   1 to   3.
+ (rs|ai) integrals will be sorted in core.
+ ModeAB=           2 MOrb=             1 LenV=      33458373
+ LASXX=           28 LTotXX=          28 LenRXX=         360
+ LTotAB=          20 MaxLAS=         360 LenRXY=          20
+ NonZer=         456 LenScr=     1048064 LnRSAI=           0
+ LnScr1=           0 LExtra=           0 Total=      1048444
+ MaxDsk=          -1 SrtSym=           F ITran=            4
+ JobTyp=2 Pass  1:  I=   1 to   1.
+ (rs|ai) integrals will be sorted in core.
+ Spin components of T(2) and E(2):
+     alpha-alpha T2 =       0.1539858699D-02 E2=     -0.4542240933D-02
+     alpha-beta  T2 =       0.8342095977D-02 E2=     -0.1907164950D-01
+     beta-beta   T2 =       0.0000000000D+00 E2=      0.0000000000D+00
+ ANorm=    0.1004928831D+01
+ E2 =    -0.2361389043D-01 EUMP2 =    -0.37504683723025D+02
+ (S**2,0)=  0.20010D+01           (S**2,1)=  0.20001D+01
+ E(PUHF)=      -0.37481383594D+02        E(PMP2)=      -0.37504849457D+02
+ Keep R2 and R3 ints in memory in symmetry-blocked form, NReq=802872.
+ Iterations=  50 Convergence= 0.100D-06
+ Iteration Nr.   1
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ E(PMP3)=      -0.37512313510D+02
+ MP4(R+Q)=  0.19195405D-03
+ E3=       -0.75521070D-02        EUMP3=      -0.37512235830D+02
+ E4(DQ)=   -0.27959200D-02        UMP4(DQ)=   -0.37515031750D+02
+ E4(SDQ)=  -0.28114103D-02        UMP4(SDQ)=  -0.37515047240D+02
+ DE(Corr)= -0.30974220E-01 E(Corr)=     -37.512044053    
+ NORM(A)=   0.10116679D+01
+ Iteration Nr.   2
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.34987698E-01 E(CORR)=     -37.516057530     Delta=-4.01D-03
+ NORM(A)=   0.10140179D+01
+ Iteration Nr.   3
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36028974E-01 E(CORR)=     -37.517098807     Delta=-1.04D-03
+ NORM(A)=   0.10142146D+01
+ Iteration Nr.   4
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36098709E-01 E(CORR)=     -37.517168542     Delta=-6.97D-05
+ NORM(A)=   0.10141609D+01
+ Iteration Nr.   5
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36075425E-01 E(CORR)=     -37.517145257     Delta= 2.33D-05
+ NORM(A)=   0.10141784D+01
+ Iteration Nr.   6
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36082625E-01 E(CORR)=     -37.517152457     Delta=-7.20D-06
+ NORM(A)=   0.10141757D+01
+ Iteration Nr.   7
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36081518E-01 E(CORR)=     -37.517151351     Delta= 1.11D-06
+ NORM(A)=   0.10141759D+01
+ Iteration Nr.   8
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36081594E-01 E(CORR)=     -37.517151426     Delta=-7.52D-08
+ NORM(A)=   0.10141759D+01
+ Dominant configurations:
+ ***********************
+ Spin Case        I    J    A    B          Value
+   ABAB           2    2    5    3      -0.136608D+00
+ Largest amplitude= 1.37D-01
+ Time for triples=        0.00 seconds.
+ T4(CCSD)= -0.30136292D-03
+ T5(CCSD)= -0.16795075D-05
+ CCSD(T)= -0.37517454469D+02
+
+ S**2, projected HF & approx projected MPn energies after annihilation of
+ unwanted spin states (see manual for definitions):
+
+ spins       (S**2,0) (S**2,1)    PUHF        PMP2        PMP3        PMP4
+ annihilated
+ s+1         2.00000  2.00000  -37.481384  -37.504849  -37.512314
+
+ Discarding MO integrals.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A1G) (A1G) (?A) (?A)
+       Virtual   (?A) (?A) (?A) (?A) (A1G)
+ Beta  Orbitals:
+       Occupied  (A1G) (A1G)
+       Virtual   (?A) (?A) (?A) (?A) (?A) (?A) (A1G)
+ Unable to determine electronic state:  an orbital has unidentified symmetry.
+ Alpha  occ. eigenvalues --  -11.27250  -0.81446  -0.42596  -0.42596
+ Alpha virt. eigenvalues --    0.05294   0.89798   0.89798   0.97612   1.24659
+  Beta  occ. eigenvalues --  -11.23139  -0.57527
+  Beta virt. eigenvalues --    0.10809   0.16273   0.16273   1.01164   1.06359
+  Beta virt. eigenvalues --    1.06359   1.33242
+          Condensed to atoms (all electrons):
+               1
+     1  C    6.000000
+          Atomic-Atomic Spin Densities.
+               1
+     1  C    2.000000
+ Mulliken charges and spin densities:
+               1          2
+     1  C    0.000000   2.000000
+ Sum of Mulliken charges =   0.00000   2.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  C    0.000000   2.000000
+ Electronic spatial extent (au):  <R**2>=             13.3032
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -4.7201   YY=             -6.5866   ZZ=             -6.5866
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.2443   YY=             -0.6222   ZZ=             -0.6222
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=              0.0000  XYY=              0.0000
+  XXY=              0.0000  XXZ=              0.0000  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -4.1347 YYYY=             -7.1820 ZZZZ=             -7.1820 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -1.8861 XXZZ=             -1.8861 YYZZ=             -2.3940
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 0.000000000000D+00 E-N=-8.757280191249D+01  KE= 3.735620893854D+01
+ Symmetry AG   KE= 3.487097636732D+01
+ Symmetry B1G  KE= 0.000000000000D+00
+ Symmetry B2G  KE= 0.000000000000D+00
+ Symmetry B3G  KE= 0.000000000000D+00
+ Symmetry AU   KE= 0.000000000000D+00
+ Symmetry B1U  KE= 1.242616285610D+00
+ Symmetry B2U  KE= 1.242616285610D+00
+ Symmetry B3U  KE= 4.658757089566D-33
+ 1|1|UNPC-DUMINDA-T480S|SP|UCCSD(T)-FC|3-21G|C1(3)|DRANA|07-Nov-2019|0|
+ |# uccsd(t)/3-21g geom=connectivity||Title Card Required||0,3|C,0,1.02
+ 510459,0.95711297,0.||Version=IA32W-G09RevD.01|HF=-37.4810698|MP2=-37.
+ 5046837|MP3=-37.5122358|MP4D=-37.5152237|MP4DQ=-37.5150318|PUHF=-37.48
+ 13836|PMP2-0=-37.5048495|PMP3-0=-37.5123135|MP4SDQ=-37.5150472|CCSD=-3
+ 7.5171514|CCSD(T)=-37.5174545|S2=2.000971|S2-1=2.000055|S2A=2.|RMSD=5.
+ 455e-009|PG=OH [O(C1)]||@
+
+
+ TIME IS NATURE'S WAY OF MAKING SURE EVERYTHING
+ DOESN'T HAPPEN AT ONCE.
+                     - WOODY ALLEN
+ Job cpu time:       0 days  0 hours  0 minutes  1.0 seconds.
+ File lengths (MBytes):  RWF=     14 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Thu Nov 07 11:18:37 2019.

--- a/arkane/data/UCCSD_C_ATOM.LOG
+++ b/arkane/data/UCCSD_C_ATOM.LOG
@@ -1,0 +1,359 @@
+ Entering Link 1 = C:\G09W\l1.exe PID=     24648.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  IA32W-G09RevD.01 24-Apr-2013
+                07-Nov-2019 
+ ******************************************
+ %chk=C:\Users\drana\Desktop\work\Scratch\G09\MarkG\Energy\G09\uccsd_C_atom.chk
+ -------------------------------
+ # uccsd/3-21g geom=connectivity
+ -------------------------------
+ 1/38=1,57=2/1;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=5,11=2,16=1,25=1,30=1,116=2/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 8/6=4,9=120000,10=1/1,4;
+ 9/5=7/13;
+ 6/7=2,8=2,9=2,10=2/1;
+ 99/5=1,9=1/99;
+ -------------------
+ Title Card Required
+ -------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 3
+ C                     1.0251    0.95711   0. 
+ 
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        1.025105    0.957113    0.000000
+ ---------------------------------------------------------------------
+ Stoichiometry    C(3)
+ Framework group  OH[O(C)]
+ Deg. of freedom     0
+ Full point group                 OH      NOp  48
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        0.000000    0.000000    0.000000
+ ---------------------------------------------------------------------
+ Standard basis: 3-21G (6D, 7F)
+ There are     3 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     3 symmetry adapted basis functions of AG  symmetry.
+ There are     0 symmetry adapted basis functions of B1G symmetry.
+ There are     0 symmetry adapted basis functions of B2G symmetry.
+ There are     0 symmetry adapted basis functions of B3G symmetry.
+ There are     0 symmetry adapted basis functions of AU  symmetry.
+ There are     2 symmetry adapted basis functions of B1U symmetry.
+ There are     2 symmetry adapted basis functions of B2U symmetry.
+ There are     2 symmetry adapted basis functions of B3U symmetry.
+     9 basis functions,    15 primitive gaussians,     9 cartesian basis functions
+     4 alpha electrons        2 beta electrons
+       nuclear repulsion energy         0.0000000000 Hartrees.
+ NAtoms=    1 NActive=    1 NUniq=    1 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    262144 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     9 RedAO= T EigKep=  6.75D-01  NBF=     3     0     0     0     0     2     2     2
+ NBsUse=     9 1.00D-06 EigRej= -1.00D+00 NBFU=     3     0     0     0     0     2     2     2
+ ExpMin= 1.96D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A1G) (A1G) (T1U) (T1U)
+       Virtual   (T1U) (T1U) (T1U) (T1U) (A1G)
+ Beta  Orbitals:
+       Occupied  (A1G) (A1G)
+       Virtual   (T1U) (T1U) (T1U) (T1U) (T1U) (T1U) (A1G)
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0000 S= 1.0000
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=822740.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ SCF Done:  E(UHF) =  -37.4810698326     A.U. after    6 cycles
+            NFock=  6  Conv=0.55D-08     -V/T= 2.0033
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0010 S= 1.0003
+ <L.S>= 0.000000000000E+00
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0010,   after     2.0000
+ ExpMin= 1.96D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV=-2 UseB2=F ITyADJ=14
+ ICtDFT= 12500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ Range of M.O.s used for correlation:     2     9
+ NBasis=     9 NAE=     4 NBE=     2 NFC=     1 NFV=     0
+ NROrb=      8 NOA=     3 NOB=     1 NVA=     5 NVB=     7
+ Semi-Direct transformation.
+ ModeAB=           2 MOrb=             3 LenV=      33458373
+ LASXX=           66 LTotXX=          66 LenRXX=          66
+ LTotAB=         132 MaxLAS=        1080 LenRXY=        1080
+ NonZer=        1368 LenScr=     1048064 LnRSAI=           0
+ LnScr1=           0 LExtra=           0 Total=      1049210
+ MaxDsk=          -1 SrtSym=           F ITran=            4
+ JobTyp=1 Pass  1:  I=   1 to   3.
+ (rs|ai) integrals will be sorted in core.
+ ModeAB=           2 MOrb=             1 LenV=      33458373
+ LASXX=           28 LTotXX=          28 LenRXX=         360
+ LTotAB=          20 MaxLAS=         360 LenRXY=          20
+ NonZer=         456 LenScr=     1048064 LnRSAI=           0
+ LnScr1=           0 LExtra=           0 Total=      1048444
+ MaxDsk=          -1 SrtSym=           F ITran=            4
+ JobTyp=2 Pass  1:  I=   1 to   1.
+ (rs|ai) integrals will be sorted in core.
+ Spin components of T(2) and E(2):
+     alpha-alpha T2 =       0.1539858699D-02 E2=     -0.4542240933D-02
+     alpha-beta  T2 =       0.8342095977D-02 E2=     -0.1907164950D-01
+     beta-beta   T2 =       0.0000000000D+00 E2=      0.0000000000D+00
+ ANorm=    0.1004928831D+01
+ E2 =    -0.2361389043D-01 EUMP2 =    -0.37504683723025D+02
+ (S**2,0)=  0.20010D+01           (S**2,1)=  0.20001D+01
+ E(PUHF)=      -0.37481383594D+02        E(PMP2)=      -0.37504849457D+02
+ Keep R2 and R3 ints in memory in symmetry-blocked form, NReq=802872.
+ Iterations=  50 Convergence= 0.100D-06
+ Iteration Nr.   1
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ E(PMP3)=      -0.37512313510D+02
+ MP4(R+Q)=  0.19195405D-03
+ E3=       -0.75521070D-02        EUMP3=      -0.37512235830D+02
+ E4(DQ)=   -0.27959200D-02        UMP4(DQ)=   -0.37515031750D+02
+ E4(SDQ)=  -0.28114103D-02        UMP4(SDQ)=  -0.37515047240D+02
+ DE(Corr)= -0.30974220E-01 E(Corr)=     -37.512044053    
+ NORM(A)=   0.10116679D+01
+ Iteration Nr.   2
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.34987698E-01 E(CORR)=     -37.516057530     Delta=-4.01D-03
+ NORM(A)=   0.10140179D+01
+ Iteration Nr.   3
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36028974E-01 E(CORR)=     -37.517098807     Delta=-1.04D-03
+ NORM(A)=   0.10142146D+01
+ Iteration Nr.   4
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36098709E-01 E(CORR)=     -37.517168542     Delta=-6.97D-05
+ NORM(A)=   0.10141609D+01
+ Iteration Nr.   5
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36075425E-01 E(CORR)=     -37.517145257     Delta= 2.33D-05
+ NORM(A)=   0.10141784D+01
+ Iteration Nr.   6
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36082625E-01 E(CORR)=     -37.517152457     Delta=-7.20D-06
+ NORM(A)=   0.10141757D+01
+ Iteration Nr.   7
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36081518E-01 E(CORR)=     -37.517151351     Delta= 1.11D-06
+ NORM(A)=   0.10141759D+01
+ Iteration Nr.   8
+ **********************
+ DD1Dir will call FoFMem   1 times, MxPair=        10
+ NAB=     3 NAA=     3 NBB=     0.
+ DE(Corr)= -0.36081594E-01 E(CORR)=     -37.517151426     Delta=-7.52D-08
+ NORM(A)=   0.10141759D+01
+ Dominant configurations:
+ ***********************
+ Spin Case        I    J    A    B          Value
+   ABAB           2    2    5    3      -0.136608D+00
+ Largest amplitude= 1.37D-01
+
+ S**2, projected HF & approx projected MPn energies after annihilation of
+ unwanted spin states (see manual for definitions):
+
+ spins       (S**2,0) (S**2,1)    PUHF        PMP2        PMP3        PMP4
+ annihilated
+ s+1         2.00000  2.00000  -37.481384  -37.504849  -37.512314
+
+ Discarding MO integrals.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A1G) (A1G) (?A) (?A)
+       Virtual   (?A) (?A) (?A) (?A) (A1G)
+ Beta  Orbitals:
+       Occupied  (A1G) (A1G)
+       Virtual   (?A) (?A) (?A) (?A) (?A) (?A) (A1G)
+ Unable to determine electronic state:  an orbital has unidentified symmetry.
+ Alpha  occ. eigenvalues --  -11.27250  -0.81446  -0.42596  -0.42596
+ Alpha virt. eigenvalues --    0.05294   0.89798   0.89798   0.97612   1.24659
+  Beta  occ. eigenvalues --  -11.23139  -0.57527
+  Beta virt. eigenvalues --    0.10809   0.16273   0.16273   1.01164   1.06359
+  Beta virt. eigenvalues --    1.06359   1.33242
+          Condensed to atoms (all electrons):
+               1
+     1  C    6.000000
+          Atomic-Atomic Spin Densities.
+               1
+     1  C    2.000000
+ Mulliken charges and spin densities:
+               1          2
+     1  C    0.000000   2.000000
+ Sum of Mulliken charges =   0.00000   2.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  C    0.000000   2.000000
+ Electronic spatial extent (au):  <R**2>=             13.3032
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -4.7201   YY=             -6.5866   ZZ=             -6.5866
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.2443   YY=             -0.6222   ZZ=             -0.6222
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=              0.0000  XYY=              0.0000
+  XXY=              0.0000  XXZ=              0.0000  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -4.1347 YYYY=             -7.1820 ZZZZ=             -7.1820 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -1.8861 XXZZ=             -1.8861 YYZZ=             -2.3940
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 0.000000000000D+00 E-N=-8.757280191249D+01  KE= 3.735620893854D+01
+ Symmetry AG   KE= 3.487097636732D+01
+ Symmetry B1G  KE= 0.000000000000D+00
+ Symmetry B2G  KE= 0.000000000000D+00
+ Symmetry B3G  KE= 0.000000000000D+00
+ Symmetry AU   KE= 0.000000000000D+00
+ Symmetry B1U  KE= 1.242616285610D+00
+ Symmetry B2U  KE= 1.242616285610D+00
+ Symmetry B3U  KE= 4.658757089566D-33
+ 1|1|UNPC-DUMINDA-T480S|SP|UCCSD-FC|3-21G|C1(3)|DRANA|07-Nov-2019|0||# 
+ uccsd/3-21g geom=connectivity||Title Card Required||0,3|C,0,1.02510459
+ ,0.95711297,0.||Version=IA32W-G09RevD.01|HF=-37.4810698|MP2=-37.504683
+ 7|MP3=-37.5122358|MP4D=-37.5152237|MP4DQ=-37.5150318|PUHF=-37.4813836|
+ PMP2-0=-37.5048495|PMP3-0=-37.5123135|MP4SDQ=-37.5150472|CCSD=-37.5171
+ 514|S2=2.000971|S2-1=2.000055|S2A=2.|RMSD=5.455e-009|PG=OH [O(C1)]||@
+
+
+ I am not a vegetarian because I love animals;
+ I am a vegetarian because I hate plants.
+                               -- A. Whitney Brown
+ Job cpu time:       0 days  0 hours  0 minutes  2.0 seconds.
+ File lengths (MBytes):  RWF=     14 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Thu Nov 07 16:40:06 2019.

--- a/arkane/data/UMP2_C_ATOM.LOG
+++ b/arkane/data/UMP2_C_ATOM.LOG
@@ -1,0 +1,274 @@
+ Entering Link 1 = C:\G09W\l1.exe PID=     24808.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  IA32W-G09RevD.01 24-Apr-2013
+                07-Nov-2019 
+ ******************************************
+ %chk=C:\Users\drana\Desktop\work\Scratch\G09\MarkG\Energy\G09\ump2_C_atom.chk
+ ------------------------------
+ # ump2/3-21g geom=connectivity
+ ------------------------------
+ 1/38=1,57=2/1;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=5,11=2,16=1,25=1,30=1,116=2/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 8/10=1/1;
+ 9/16=-3/6;
+ 6/7=2,8=2,9=2,10=2/1;
+ 99/5=1,9=1/99;
+ -------------------
+ Title Card Required
+ -------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 3
+ C                     1.0251    0.95711   0. 
+ 
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        1.025105    0.957113    0.000000
+ ---------------------------------------------------------------------
+ Stoichiometry    C(3)
+ Framework group  OH[O(C)]
+ Deg. of freedom     0
+ Full point group                 OH      NOp  48
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        0.000000    0.000000    0.000000
+ ---------------------------------------------------------------------
+ Standard basis: 3-21G (6D, 7F)
+ There are     3 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     0 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     3 symmetry adapted basis functions of AG  symmetry.
+ There are     0 symmetry adapted basis functions of B1G symmetry.
+ There are     0 symmetry adapted basis functions of B2G symmetry.
+ There are     0 symmetry adapted basis functions of B3G symmetry.
+ There are     0 symmetry adapted basis functions of AU  symmetry.
+ There are     2 symmetry adapted basis functions of B1U symmetry.
+ There are     2 symmetry adapted basis functions of B2U symmetry.
+ There are     2 symmetry adapted basis functions of B3U symmetry.
+     9 basis functions,    15 primitive gaussians,     9 cartesian basis functions
+     4 alpha electrons        2 beta electrons
+       nuclear repulsion energy         0.0000000000 Hartrees.
+ NAtoms=    1 NActive=    1 NUniq=    1 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    262144 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     9 RedAO= T EigKep=  6.75D-01  NBF=     3     0     0     0     0     2     2     2
+ NBsUse=     9 1.00D-06 EigRej= -1.00D+00 NBFU=     3     0     0     0     0     2     2     2
+ ExpMin= 1.96D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A1G) (A1G) (T1U) (T1U)
+       Virtual   (T1U) (T1U) (T1U) (T1U) (A1G)
+ Beta  Orbitals:
+       Occupied  (A1G) (A1G)
+       Virtual   (T1U) (T1U) (T1U) (T1U) (T1U) (T1U) (A1G)
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0000 S= 1.0000
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=822740.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ Density matrix breaks symmetry, PCut= 1.00D-07
+ Density has only Abelian symmetry.
+ SCF Done:  E(UHF) =  -37.4810698326     A.U. after    6 cycles
+            NFock=  6  Conv=0.55D-08     -V/T= 2.0033
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0010 S= 1.0003
+ <L.S>= 0.000000000000E+00
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0010,   after     2.0000
+ ExpMin= 1.96D-01 ExpMax= 1.72D+02 ExpMxC= 1.72D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV=-2 UseB2=F ITyADJ=14
+ ICtDFT= 12500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ Range of M.O.s used for correlation:     2     9
+ NBasis=     9 NAE=     4 NBE=     2 NFC=     1 NFV=     0
+ NROrb=      8 NOA=     3 NOB=     1 NVA=     5 NVB=     7
+ Fully in-core method, ICMem=     6005742.
+ JobTyp=2 Pass  1 fully in-core, NPsUse=  1.
+ Spin components of T(2) and E(2):
+     alpha-alpha T2 =       0.1539858699D-02 E2=     -0.4542240933D-02
+     alpha-beta  T2 =       0.8342095977D-02 E2=     -0.1907164950D-01
+     beta-beta   T2 =       0.0000000000D+00 E2=      0.0000000000D+00
+ (S**2,0)=  0.20010D+01           (S**2,1)=  0.20001D+01
+ E(PUHF)=      -0.37481383594D+02        E(PMP2)=      -0.37504849457D+02
+ ANorm=    0.1004928831D+01
+ E2 =    -0.2361389043D-01 EUMP2 =    -0.37504683723025D+02
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A1G) (A1G) (?A) (?A)
+       Virtual   (?A) (?A) (?A) (?A) (A1G)
+ Beta  Orbitals:
+       Occupied  (A1G) (A1G)
+       Virtual   (?A) (?A) (?A) (?A) (?A) (?A) (A1G)
+ Unable to determine electronic state:  an orbital has unidentified symmetry.
+ Alpha  occ. eigenvalues --  -11.27250  -0.81446  -0.42596  -0.42596
+ Alpha virt. eigenvalues --    0.05294   0.89798   0.89798   0.97612   1.24659
+  Beta  occ. eigenvalues --  -11.23139  -0.57527
+  Beta virt. eigenvalues --    0.10809   0.16273   0.16273   1.01164   1.06359
+  Beta virt. eigenvalues --    1.06359   1.33242
+          Condensed to atoms (all electrons):
+               1
+     1  C    6.000000
+          Atomic-Atomic Spin Densities.
+               1
+     1  C    2.000000
+ Mulliken charges and spin densities:
+               1          2
+     1  C    0.000000   2.000000
+ Sum of Mulliken charges =   0.00000   2.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  C    0.000000   2.000000
+ Electronic spatial extent (au):  <R**2>=             13.3032
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -4.7201   YY=             -6.5866   ZZ=             -6.5866
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.2443   YY=             -0.6222   ZZ=             -0.6222
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=              0.0000  XYY=              0.0000
+  XXY=              0.0000  XXZ=              0.0000  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -4.1347 YYYY=             -7.1820 ZZZZ=             -7.1820 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -1.8861 XXZZ=             -1.8861 YYZZ=             -2.3940
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 0.000000000000D+00 E-N=-8.757280191249D+01  KE= 3.735620893854D+01
+ Symmetry AG   KE= 3.487097636732D+01
+ Symmetry B1G  KE= 0.000000000000D+00
+ Symmetry B2G  KE= 0.000000000000D+00
+ Symmetry B3G  KE= 0.000000000000D+00
+ Symmetry AU   KE= 0.000000000000D+00
+ Symmetry B1U  KE= 1.242616285610D+00
+ Symmetry B2U  KE= 1.242616285610D+00
+ Symmetry B3U  KE= 4.658757089566D-33
+ 1|1|UNPC-DUMINDA-T480S|SP|UMP2-FC|3-21G|C1(3)|DRANA|07-Nov-2019|0||# u
+ mp2/3-21g geom=connectivity||Title Card Required||0,3|C,0,1.02510459,0
+ .95711297,0.||Version=IA32W-G09RevD.01|HF=-37.4810698|MP2=-37.5046837|
+ PUHF=-37.4813836|PMP2-0=-37.5048495|S2=2.000971|S2-1=2.000055|S2A=2.|R
+ MSD=5.455e-009|PG=OH [O(C1)]||@
+
+
+ I am not a vegetarian because I love animals;
+ I am a vegetarian because I hate plants.
+                               -- A. Whitney Brown
+ Job cpu time:       0 days  0 hours  0 minutes  1.0 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Thu Nov 07 16:40:29 2019.

--- a/arkane/gaussian.py
+++ b/arkane/gaussian.py
@@ -45,6 +45,7 @@ from arkane.common import check_conformer_energy, get_element_mass
 from arkane.exceptions import LogError
 from arkane.log import Log
 
+
 ################################################################################
 
 
@@ -212,7 +213,7 @@ class GaussianLog(Log):
                         elif 'Rotational constant (GHZ):' in line:
                             inertia = [float(line.split()[3])]
                             inertia[0] = constants.h / (8 * constants.pi * constants.pi * inertia[0] * 1e9) \
-                                * constants.Na * 1e23
+                                         * constants.Na * 1e23
                             rotation = LinearRotor(inertia=(inertia[0], "amu*angstrom^2"), symmetry=symmetry)
                             modes.append(rotation)
 
@@ -273,14 +274,17 @@ class GaussianLog(Log):
                 if 'SCF Done:' in line:
                     e_elect = float(line.split()[4]) * constants.E_h * constants.Na
                     elect_energy_source = 'SCF'
+                elif ' E2(' in line:
+                    e_elect = float(line.split()[-1].replace('D', 'E')) * constants.E_h * constants.Na
+                    elect_energy_source = 'doublehybrd or MP2'
                 elif 'MP2 =' in line:
-                    e_elect = float(line.split()[-1].replace('D','E')) * constants.E_h * constants.Na
+                    e_elect = float(line.split()[-1].replace('D', 'E')) * constants.E_h * constants.Na
                     elect_energy_source = 'MP2'
                 elif 'E(CORR)=' in line:
                     e_elect = float(line.split()[3]) * constants.E_h * constants.Na
                     elect_energy_source = 'CCSD'
-                elif 'CCSD(T)=' in line:
-                    e_elect = float(line.split()[1].replace('D','E')) * constants.E_h * constants.Na
+                elif 'CCSD(T)= ' in line:
+                    e_elect = float(line.split()[1].replace('D', 'E')) * constants.E_h * constants.Na
                     elect_energy_source = 'CCSD(T)'
                 elif 'CBS-QB3 (0 K)' in line:
                     e0_composite = float(line.split()[3]) * constants.E_h * constants.Na

--- a/arkane/gaussian.py
+++ b/arkane/gaussian.py
@@ -274,7 +274,7 @@ class GaussianLog(Log):
                 if 'SCF Done:' in line:
                     e_elect = float(line.split()[4]) * constants.E_h * constants.Na
                     elect_energy_source = 'SCF'
-                elif ' E2(' in line:
+                elif ' E2(' in line and ' E(' in line:
                     e_elect = float(line.split()[-1].replace('D', 'E')) * constants.E_h * constants.Na
                     elect_energy_source = 'doublehybrd or MP2'
                 elif 'MP2 =' in line:

--- a/arkane/gaussianTest.py
+++ b/arkane/gaussianTest.py
@@ -90,15 +90,18 @@ class GaussianTest(unittest.TestCase):
         log_mp2 = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'UMP2_C_ATOM.LOG'))
         log_ccsd = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'UCCSD_C_ATOM.LOG'))
         log_ccsdt = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'UCCSDT_C_ATOM.LOG'))
+        log_qb3 = GaussianLog(os.path.join(os.path.dirname(__file__), '../examples/arkane/species/C2H5/', 'ethyl_cbsqb3.log'))
 
         self.assertAlmostEqual(log_doublehybrid.load_energy() / constants.Na / constants.E_h, -0.40217794572194e+02,
-                               delta=1e-4)
+                               delta=1e-6)
         self.assertAlmostEqual(log_mp2.load_energy() / constants.Na / constants.E_h, -0.37504683723025e+02,
-                               delta=1e-4)
+                               delta=1e-6)
         self.assertAlmostEqual(log_ccsd.load_energy() / constants.Na / constants.E_h, -37.517151426,
-                               delta=1e-4)
+                               delta=1e-6)
         self.assertAlmostEqual(log_ccsdt.load_energy() / constants.Na / constants.E_h, -0.37517454469e+02,
-                               delta=1e-4)
+                               delta=1e-6)
+        self.assertAlmostEqual(log_qb3.load_energy() / constants.Na / constants.E_h, -79.029798,
+                               delta=1e-6)
 
     def test_load_oxygen_from_gaussian_log(self):
         """

--- a/arkane/gaussianTest.py
+++ b/arkane/gaussianTest.py
@@ -44,6 +44,7 @@ from arkane.gaussian import GaussianLog
 from arkane.statmech import determine_qm_software
 from arkane.exceptions import LogError
 
+
 ################################################################################
 
 
@@ -80,6 +81,24 @@ class GaussianTest(unittest.TestCase):
         self.assertAlmostEqual(e0 / constants.Na / constants.E_h, -78.467452, 4)
         self.assertEqual(conformer.spin_multiplicity, 1)
         self.assertEqual(conformer.optical_isomers, 1)
+
+    def test_gaussian_energies(self):
+        """
+        test parsing double hydride, MP2, CCSD, CCSD(T) form Gaussian log
+        """
+        log_doublehybrid = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'B2PLYP.LOG'))
+        log_mp2 = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'UMP2_C_ATOM.LOG'))
+        log_ccsd = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'UCCSD_C_ATOM.LOG'))
+        log_ccsdt = GaussianLog(os.path.join(os.path.dirname(__file__), 'data', 'UCCSDT_C_ATOM.LOG'))
+
+        self.assertAlmostEqual(log_doublehybrid.load_energy() / constants.Na / constants.E_h, -0.40217794572194e+02,
+                               delta=1e-4)
+        self.assertAlmostEqual(log_mp2.load_energy() / constants.Na / constants.E_h, -0.37504683723025e+02,
+                               delta=1e-4)
+        self.assertAlmostEqual(log_ccsd.load_energy() / constants.Na / constants.E_h, -37.517151426,
+                               delta=1e-4)
+        self.assertAlmostEqual(log_ccsdt.load_energy() / constants.Na / constants.E_h, -0.37517454469e+02,
+                               delta=1e-4)
 
     def test_load_oxygen_from_gaussian_log(self):
         """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Arkane parser for Gaussian does not parse MP2, double hybrid DFT, CCSD, CCSD(T) energies. Previous to this change, HF energy was appended as e0 or energies should be given manually in the Arkane input file.

### Description of Changes
CBS-QB3 calculation contains CCSD(T), MP2, and CCSD energies, therefore, new if statements were added before CBS-QB3. The elif statements were arranged in the order of appearance in the output file

### Testing
unit test added 

### Reviewer Tips
run a Gaussian calculation and check e0

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->