### PR TITLE
Correct hindered rotor spacing with missing values

### DIFF
--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -353,9 +353,11 @@ class GaussianLog(Log):
         rigid_scan = False
 
         vlist = []  # The array of potentials at each scan angle
-
+        angle = []  # The corresponding angles for each scan
         # Parse the Gaussian log file, extracting the energies of each
         # optimized conformer in the scan
+        scan_number, failed_scans = 0, 0
+        scan_angle = self._load_scan_angle() * np.pi / 180  # convert to radians
         with open(self.path, 'r') as f:
             line = f.readline()
             while line != '':
@@ -373,18 +375,31 @@ class GaussianLog(Log):
                     # rigid scans will only not optimize, so just append every time it finds an energy.
                     if rigid_scan:
                         vlist.append(energy)
+                        angle.append(scan_angle * scan_number)
+                        scan_number += 1
                 # We want to keep the values of energy that come most recently before
                 # the line containing "Optimization completed", since it refers
                 # to the optimized geometry
                 if 'Optimization completed' in line:
                     vlist.append(energy)
+                    angle.append(scan_angle * scan_number)
+                    scan_number += 1
+                if 'Optimization stopped' in line:
+                    # failed to converge, skipping and warning
+                    scan_number += 1
+                    failed_scans += 1
                 line = f.readline()
 
         # give warning in case this assumption is not true
         if rigid_scan:
             print('   Assuming', os.path.basename(self.path), 'is the output from a rigid scan...')
-
+        if failed_scans:
+            logging.warning('{0} failed optimizations for scan located at {1}'.format(failed_scans, self.path))
+        if scan_number != self._load_number_scans() + 1:  # + 1 since Gaussian runs an additional scan at end.
+            logging.warning('Read {0} scan energies located in {2}. Expected {1} from input. Scan job may not '
+                            'have completed.'.format(scan_number, self._load_number_scans() + 1, self.path))
         vlist = np.array(vlist, np.float64)
+        angle = np.array(angle, np.float64)
         # check to see if the scanlog indicates that a one of your reacting species may not be
         # the lowest energy conformer
         check_conformer_energy(vlist, self.path)
@@ -396,11 +411,7 @@ class GaussianLog(Log):
 
         if opt_freq:
             vlist = vlist[:-1]
-
-        # Determine the set of dihedral angles corresponding to the loaded energies
-        # This assumes that you start at 0.0, finish at 360.0, and take
-        # constant step sizes in between
-        angle = np.arange(0.0, 2 * math.pi + 0.00001, 2 * math.pi / (len(vlist) - 1), np.float64)
+            angle = angle[:-1]
 
         return vlist, angle
 

--- a/arkane/ess/gaussianTest.py
+++ b/arkane/ess/gaussianTest.py
@@ -215,6 +215,17 @@ class GaussianLogTest(unittest.TestCase):
             log.load_conformer()
         self.assertTrue(f'The Gaussian job in {file_path} did not converge.' in str(log_error.exception))
 
+    def test_gap_in_scan(self):
+        """
+        Ensures when an error occurs in the hindered rotors, proper distribution occurs
+        """
+        # load gaussian log with 10 degree separations, which has a failed optimization
+        log = GaussianLog(os.path.join(self.data_path, 'isobutanolQOOH_scan.log'))
+        with self.assertLogs(level=30):  # warnings only
+            angles = log.load_scan_energies()[1]
+        self.assertAlmostEqual(angles[1], 10. * np.pi / 180)
+        self.assertAlmostEqual(angles[-1], 2 * np.pi)
+
     def test_load_scan_with_freq(self):
         """
         Ensures that the length of enegies with hr scans and freq calc is correct

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -570,32 +570,16 @@ cdef class HinderedRotor(Torsion):
     cpdef fit_cosine_potential_to_data(self, np.ndarray angle, np.ndarray V):
         """
         Fit the given angles in radians and corresponding potential energies in
-        J/mol to the cosine potential. For best results, the angle should 
-        begin at zero and end at :math:`2 \pi`, with the minimum energy
-        conformation having a potential of zero be placed at zero angle. The
-        fit is attempted at several possible values of the symmetry number in
-        order to determine which one is correct.
+        J/mol to the cosine potential. The symmetry value of the object should
+        already bet set. You can use arkane.statmech.determine_rotor_symmetry
+        to get the symmetry value.
         """
-        cdef double barrier, barr, num, den
-        cdef int symmetry, symm
+        cdef double num, den
 
-        # We fit at integral symmetry numbers in the range [1, 9]
-        # The best fit will have the maximum barrier height
-        symmetry = 0
-        barrier = 0.0
-        for symm in range(1, 10):
-            num = np.sum(V * (1 - np.cos(symm * angle)))
-            den = np.sum((1 - np.cos(symm * angle)) ** 2)
-            barr = 2 * num / den
-            if barr > barrier:
-                symmetry = symm
-                barrier = barr
-
+        num = np.sum(V * (1 - np.cos(self.symmetry * angle)))
+        den = np.sum((1 - np.cos(self.symmetry * angle)) ** 2)
+        self.barrier = (2 * num / den, 'J/mol')
         self.fourier = None
-        self.barrier = (barrier * 0.001, "kJ/mol")
-        self.symmetry = symmetry
-
-        return self
 
 cdef class FreeRotor(Torsion):
     """

--- a/rmgpy/statmech/torsionTest.py
+++ b/rmgpy/statmech/torsionTest.py
@@ -495,6 +495,25 @@ class TestHinderedRotor(unittest.TestCase):
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)
 
+    def test_fit_cosine_potential_to_data(self):
+        """
+        Test that cosine fit works in difficult cases.
+
+        Data come from an unfinished methyl rotor scan where only 120 degrees
+        was completed.
+        """
+        hr = self.mode
+        original_symmetry = hr.symmetry
+        angles = np.array([250, 260, 270, 280, 290, 300, 310, 320, 330, 340, 350, 360]) / 180 * np.pi
+        energies = np.array([394, 2093, 4658, 7488, 9765, 10847, 10350, 8473, 5817, 3092, 1001, 0])
+        hr.fit_cosine_potential_to_data(angles, energies)
+        # fitting the potential should not change the symmetry
+        self.assertEqual(original_symmetry, hr.symmetry)
+        # fitted barrier height should be within one kJ of highest value
+        self.assertAlmostEqual(hr.barrier.value_si, energies.max(), -3)
+        # no fourier fitting should exist
+        self.assertIsNone(hr.fourier)
+
 ################################################################################
 
 


### PR DESCRIPTION
Previously, missing values were ignored in GaussianLog, leading
to potential errors in hindered rotor assessments. For example, if only 21 out of the 37 scans completed, the GaussianLog object would set them at equal spacing of 18 degrees (instead of 10 degrees with gaps for missing data. 

This PR modifies the `load_scan_energies` method to explicitly track failed optimizations and ensures the angles
are correct, so Arkane can accurately fit the data. The code will output a warning for a failed optimization
so the user can better identify issues.

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Testing
I wrote a unittest for this change, and tested it on my isobutanol work. 

### Reviewer Tips
Determine if the unittest is correct. If you have it, rerun an arkane job with this to see if you have any missing values (this can be checked outside RMG by searching for `Optimization stopped`). You can look at the output hindered_rotor_data.csv to check the values used. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
