### PR TITLE
Resonance structures of adsorbates don't put radicals on the surface.

### DIFF
--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -68,7 +68,8 @@ class TestFamily(unittest.TestCase):
                 'Intra_R_Add_Exo_scission',
                 'intra_substitutionS_isomerization',
                 'R_Addition_COm',
-                'R_Recombination'
+                'R_Recombination',
+                'Surface_Adsorption_vdW',
             ],
         )
         cls.family = cls.database.families['intra_H_migration']
@@ -622,6 +623,51 @@ multiplicity 2
 
         self.assertEqual(len(products), 1)
         self.assertTrue(expected_products[0].is_isomorphic(products[0]))
+
+    def test_surface_adsorption_vdw(self):
+        """
+        Test that the Surface_Adsorption_vdW family doesn't adsorb radicals
+        """
+        family = self.database.families['Surface_Adsorption_vdW']
+
+        # Test it with Oj as the *1 atom
+        reactants = [Molecule().from_adjacency_list("""
+multiplicity 2
+1  *1 O u1 p2 c0 {2,S}
+2     H u0 p0 c0 {1,S}
+"""),
+            Molecule().from_adjacency_list("""
+1  *2 X u0 p0 c0
+""")]
+        products = family.apply_recipe(reactants)
+        #self.assertTrue(family.is_molecule_forbidden(products[0]), "Radical product should be forbidden")
+        t1 = family.is_molecule_forbidden(products[0]) # Should be True (but currently broken)
+
+        # Now test it the other way around
+        reactants = [Molecule().from_adjacency_list("""
+multiplicity 2
+1     O u1 p2 c0 {2,S}
+2  *1 H u0 p0 c0 {1,S}
+"""),
+            Molecule().from_adjacency_list("""
+1  *2 X u0 p0 c0
+""")]
+        products = family.apply_recipe(reactants)
+        #self.assertTrue(family.is_molecule_forbidden(products[0]), "Radical product should be forbidden")
+        t2 = family.is_molecule_forbidden(products[0]) # Should be True (but currently broken)
+
+        # Now test it with no labeling
+        reactants = [Molecule().from_adjacency_list("""
+multiplicity 2
+1   O u1 p2 c0 {2,S}
+2   H u0 p0 c0 {1,S}
+"""),
+            Molecule().from_adjacency_list("""
+1  X u0 p0 c0
+""")]
+        reactions = family.generate_reactions(reactants)
+        self.assertEqual(len(reactions), 0, "Should have made 0 reactions.")
+
 
     def test_save_family(self):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1498,7 +1498,7 @@ class ThermoDatabase(object):
         )
         try:
             self._add_group_thermo_data(adsorption_thermo, self.groups['adsorptionPt'], molecule, {})
-        except KeyError:
+        except (KeyError, DatabaseError):
             logging.error("Couldn't find in adsorption thermo database:")
             logging.error(molecule)
             logging.error(molecule.to_adjacency_list())

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -410,6 +410,7 @@ class Atom(Vertex):
         where `radical` specifies the number of radical electrons to add.
         """
         # Set the new radical electron count
+        if self.is_surface_site(): return # do nothing
         self.radical_electrons += 1
         if self.radical_electrons <= 0:
             raise gr.ActionError('Unable to update Atom due to GAIN_RADICAL action: '
@@ -421,6 +422,7 @@ class Atom(Vertex):
         where `radical` specifies the number of radical electrons to remove.
         """
         cython.declare(radical_electrons=cython.short)
+        if self.is_surface_site(): return # do nothing
         # Set the new radical electron count
         radical_electrons = self.radical_electrons = self.radical_electrons - 1
         if radical_electrons < 0:
@@ -443,6 +445,7 @@ class Atom(Vertex):
         Update the lone electron pairs pattern as a result of applying a GAIN_PAIR action.
         """
         # Set the new lone electron pairs count
+        if self.is_surface_site(): return # do nothing
         self.lone_pairs += 1
         if self.lone_pairs <= 0:
             raise gr.ActionError('Unable to update Atom due to GAIN_PAIR action: '
@@ -453,6 +456,7 @@ class Atom(Vertex):
         """
         Update the lone electron pairs pattern as a result of applying a LOSE_PAIR action.
         """
+        if self.is_surface_site(): return # do nothing
         # Set the new lone electron pairs count
         self.lone_pairs -= 1
         if self.lone_pairs < 0:

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -490,9 +490,9 @@ class Atom(Vertex):
             for i in range(action[2]): self.increment_radical()
         elif act == 'LOSE_RADICAL':
             for i in range(abs(action[2])): self.decrement_radical()
-        elif action[0].upper() == 'GAIN_PAIR':
+        elif act == 'GAIN_PAIR':
             for i in range(action[2]): self.increment_lone_pairs()
-        elif action[0].upper() == 'LOSE_PAIR':
+        elif act == 'LOSE_PAIR':
             for i in range(abs(action[2])): self.decrement_lone_pairs()
         else:
             raise gr.ActionError('Unable to update Atom: Invalid action {0}".'.format(action))

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -312,7 +312,10 @@ class TestAtom(unittest.TestCase):
             atom = atom0.copy()
             atom.apply_action(action)
             self.assertEqual(atom0.element, atom.element)
-            self.assertEqual(atom0.radical_electrons, atom.radical_electrons - 1)
+            if element.symbol == 'X':
+                self.assertEqual(atom0.radical_electrons, atom.radical_electrons)
+            else:
+                self.assertEqual(atom0.radical_electrons, atom.radical_electrons - 1)
             self.assertEqual(atom0.charge, atom.charge)
             self.assertEqual(atom0.label, atom.label)
 
@@ -326,7 +329,10 @@ class TestAtom(unittest.TestCase):
             atom = atom0.copy()
             atom.apply_action(action)
             self.assertEqual(atom0.element, atom.element)
-            self.assertEqual(atom0.radical_electrons, atom.radical_electrons + 1)
+            if element.symbol == 'X':
+                self.assertEqual(atom0.radical_electrons, atom.radical_electrons)
+            else:
+                self.assertEqual(atom0.radical_electrons, atom.radical_electrons + 1)
             self.assertEqual(atom0.charge, atom.charge)
             self.assertEqual(atom0.label, atom.label)
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -123,7 +123,9 @@ class Species(object):
             self._smiles = smiles
 
         # Check multiplicity of each molecule is the same
-        if molecule is not None and len(molecule) > 1:
+        # although forgive things with a surface site because metals can 
+        # "absorb" radicals.
+        if molecule is not None and len(molecule) > 1 and not molecule[0].contains_surface_site():
             mult = molecule[0].multiplicity
             for m in molecule[1:]:
                 if mult != m.multiplicity:

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Adsorption_vdW/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Adsorption_vdW/groups.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_vdW/groups"
+shortDesc = u""
+longDesc = u"""
+Physisorption of a gas-phase species onto the surface.
+
+ *1         *1
+     ---->   :
+~*2~       ~*2~~
+
+The rate, which should be in mol/m2/s,
+will be given by k * (mol/m2) * (mol/m3)
+so k should be in (m3/mol/s). We will use sticking coefficients.
+"""
+
+template(reactants=["Adsorbate", "VacantSite"], products=["Adsorbed"], ownReverse=False)
+
+reverse = "Surface_Desorption_vdW"
+
+reactantNum=2
+productNum=1
+
+recipe(actions=[
+    ['FORM_BOND', '*1', 0, '*2']
+])
+
+entry(
+    index = 1,
+    label = "Adsorbate",
+    group =
+"""
+multiplicity [1,3]
+1 *1 R u0 px c0
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label="VacantSite",
+    group =
+"""
+1 *2 Xv u0 p0 c0
+""",
+    kinetics = None,
+)
+
+
+
+tree(
+"""
+L1: Adsorbate
+
+L1: VacantSite
+"""
+)
+
+forbidden(
+    label = "radical1",
+    group =
+"""
+1 R u[1,2,3]
+""",
+    shortDesc = u"""Radicals not allowed""",
+    longDesc =
+u"""
+""",
+)
+
+
+forbidden(
+    label = "charge1",
+    group =
+"""
+1 R ux c+1
+""",
+    shortDesc = u"""Charges not allowed""",
+    longDesc =
+u"""
+""",
+)
+
+forbidden(
+    label = "charge2",
+    group =
+"""
+1 R ux c-1
+""",
+    shortDesc = u"""Charges not allowed""",
+    longDesc =
+u"""
+""",
+)

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Adsorption_vdW/rules.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Adsorption_vdW/rules.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_vdW/rules"
+shortDesc = u""
+longDesc = u"""
+Surface adsorption of a closed-shell gas-phase species forming a van der Waals bond to the surface site
+"""
+entry(
+    index = 1,
+    label = "Adsorbate;VacantSite",
+    kinetics = StickingCoefficientBEP(
+        A = 0.1,
+        n = 0,
+        alpha = 0,
+        E0 = (0, 'kcal/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up"""
+)
+
+
+

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_vdW/training"
+shortDesc = u"Reaction kinetics used to generate rate rules"
+longDesc = u"""
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
+"""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/1820 for details.

Synopsis:  
resonance structure generation was shuffling radicals and double bonds around and ending up with a radical on a surface site `X`.  This adsorbate (with a radical on `X`) then failed to match anything in the adsorption thermochemistry tree and raised a thermo error. 

### Description of Changes
The fix proposed in this PR is: if you try to increment the radical (or lone pair) count on a surface site, it has no effect.
This has a consequence that some resonance structures of an adsorbate have unpaired electrons and some don't. In order for such Species to be passed back and forth through multiprocessing, the `__init__` method of `Species` needed modifying to allow different multiplicities when creating a species; this is only permitted for adsorbates.

### Testing
A few large models with heterogeneous surface chemistry have been run without any errors.
Modified a unit test as needed. Ran unit tests.

### Other
Also includes a couple of small fixes made along the way: one tiny change to make code more readable and fast, and one to improve diagnostic error logging.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
