### PR TITLE
Reverse recipes should be in reverse order

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -243,7 +243,7 @@ class ReactionRecipe(object):
         of the reaction that this is the recipe for.
         """
         other = ReactionRecipe()
-        for action in self.actions:
+        for action in reversed(self.actions):  # Play the reverse recipe in the reverse order
             if action[0] == 'CHANGE_BOND':
                 other.add_action(['CHANGE_BOND', action[1], str(-int(action[2])), action[3]])
             elif action[0] == 'FORM_BOND':


### PR DESCRIPTION
This is a duplicate of PR #1827, but only contains the relevant commits.

I found that when generating reverse templates, the action list would go in the same order as the forward, and this would cause issues when making and breaking multiple bonds.

```    ['FORM_BOND', '*1', 1, '*2'],
    ['CHANGE_BOND', '*1', 1, '*2'],
    ['CHANGE_BOND', '*2', -1, '*3'],
    ['BREAK_BOND', '*2', 1, '*3'],
    ['FORM_BOND', '*3', 1, '*4'],
    ['CHANGE_BOND', '*3', 1, '*4']
```
This change fixes this template's reverse recipe.