### PR TITLE
fixed the solvation GAV heuristic

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -702,32 +702,14 @@ class SolvationDatabase(object):
         additivity method. If no group additivity values are loaded, a
         :class:`DatabaseError` is raised.
         
-        It averages (linearly) over the desciptors for each Molecule (resonance isomer)
-        in the Species.
+        It estimates the solute data for the first item in the species's
+        molecule list because it is the most stable resonance structure found
+        by gas-phase thermo estimate.
         """
-        solute_data = SoluteData(0.0, 0.0, 0.0, 0.0, 0.0)
-        count = 0
-        comments = []
-        for molecule in species.molecule:
-            molecule.clear_labeled_atoms()
-            molecule.update_atomtypes()
-            sdata = self.estimate_solute_via_group_additivity(molecule)
-            solute_data.S += sdata.S
-            solute_data.B += sdata.B
-            solute_data.E += sdata.E
-            solute_data.L += sdata.L
-            solute_data.A += sdata.A
-            count += 1
-            comments.append(sdata.comment)
-
-        solute_data.S /= count
-        solute_data.B /= count
-        solute_data.E /= count
-        solute_data.L /= count
-        solute_data.A /= count
-
-        # Print groups that are used for debugging purposes
-        solute_data.comment = "Average of {0}".format(" and ".join(comments))
+        molecule = species.molecule[0]
+        molecule.clear_labeled_atoms()
+        molecule.update_atomtypes()
+        solute_data = self.estimate_solute_via_group_additivity(molecule)
 
         return solute_data
 

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -120,6 +120,28 @@ class TestSoluteDatabase(TestCase):
             self.assertAlmostEqual(solute_data.L, L, places=2)
             self.assertAlmostEqual(solute_data.A, A, places=2)
 
+    def test_solute_with_resonance_structures(self):
+        """
+        Test we can estimate Abraham solute parameters correctly using group contributions
+        for the solute species with resonance structures.
+        """
+        smiles = "CC1=CC=CC=C1N"
+        species = Species(smiles=smiles)
+        species.generate_resonance_structures()
+        solute_data = self.database.get_solute_data(species)
+        solvent_data = self.database.get_solvent_data('water')
+        solvation_correction = self.database.get_solvation_correction(solute_data, solvent_data)
+        dGsolv_spc = solvation_correction.gibbs / 1000
+        for mol in species.molecule:
+            spc = Species(molecule=[mol])
+            solute_data = self.database.get_solute_data_from_groups(spc)
+            solvation_correction = self.database.get_solvation_correction(solute_data, solvent_data)
+            dGsolv_mol = solvation_correction.gibbs / 1000
+            if mol == species.molecule[0]:
+                self.assertEqual(dGsolv_spc, dGsolv_mol)
+            else:
+                self.assertNotAlmostEqual(dGsolv_spc, dGsolv_mol)
+
     def test_lone_pair_solute_generation(self):
         """Test we can obtain solute parameters via group additivity for a molecule with lone pairs"""
         molecule = Molecule().from_adjacency_list(

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -112,8 +112,8 @@ class TestSoluteDatabase(TestCase):
         ]
 
         for name, smiles, S, B, E, L, A, V in self.testCases:
-            species = Species(molecule=[Molecule(smiles=smiles)])
-            solute_data = self.database.get_solute_data_from_groups(Species(molecule=[species.molecule[0]]))
+            species = Species(smiles=smiles)
+            solute_data = self.database.get_solute_data_from_groups(species)
             self.assertAlmostEqual(solute_data.S, S, places=2)
             self.assertAlmostEqual(solute_data.B, B, places=2)
             self.assertAlmostEqual(solute_data.E, E, places=2)


### PR DESCRIPTION
### Motivation or Problem
Solvation group additivity was estimating solute data by averaging over all molecules in species.molecule list (so it was averaging over all resonance structure). However, when the solvation solute groups were fitted from the experimental values, they were fitted using the SMILES of the most stable resonance structure in gas phase. Therefore, averaging over all resonance structures is not a correct way. Instead, it should be estimating solute data from only the most stable structure found by gas-phase. 

Extra Note:
Once might be concerned that the most stable resonance structure might change in liquid phase. But the change in the resonance structures when a species is solvated is already reflected in the experimental solvation energies, which are measured for a certain species in general, not for its particular resonance structures. Since we fitted the solute group to these experimental solvation energies using the SMILES of the most stable gas phase resonance structures, we should be consistent with using the same SMILES when we estimate the solute data.

### Description of Changes
In `def get_solute_data_from_groups`, instead of iterating over all molecules and averaging, it only calculates the solute data for the first item in the molecule list,  `species.molecule[0]` as it is the SMILES of the most stable gas phase resonance structure found.

### Testing
I did not add any test since the unittest for `get_solute_data_from_groups` already exists.
I can add more unittests if necessary.

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
