### PR TITLE
Enable fitting and reversing of negative reaction rates.

### DIFF
--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -151,6 +151,16 @@ cdef class Arrhenius(KineticsModel):
         """
         import scipy.stats
         import scipy.linalg
+        if not all(np.isfinite(klist)):
+            raise  ValueError("Rates must all be finite, not inf or NaN")
+        if any(klist<0):
+            if not all(klist<0):
+                raise ValueError("Rates must all be positive or all be negative.")
+            rate_sign_multiplier = -1
+            klist = -1 * klist
+        else:
+            rate_sign_multiplier = 1
+
         assert len(Tlist) == len(klist), "length of temperatures and rates must be the same"
         if len(Tlist) < 3 + three_params:
             raise KineticsError('Not enough degrees of freedom to fit this Arrhenius expression')
@@ -182,7 +192,7 @@ cdef class Arrhenius(KineticsModel):
             x = np.array([x[0], 0, x[1]])
             cov = np.array([[cov[0, 0], 0, cov[0, 1]], [0, 0, 0], [cov[1, 0], 0, cov[1, 1]]])
 
-        self.A = (exp(x[0]), kunits)
+        self.A = (rate_sign_multiplier * exp(x[0]), kunits)
         self.n = x[1]
         self.Ea = (x[2] * 0.001, "kJ/mol")
         self.T0 = (T0, "K")

--- a/rmgpy/kinetics/arrheniusTest.py
+++ b/rmgpy/kinetics/arrheniusTest.py
@@ -158,6 +158,21 @@ class TestArrhenius(unittest.TestCase):
         self.assertAlmostEqual(arrhenius.Ea.value_si, self.arrhenius.Ea.value_si, 2)
         self.assertAlmostEqual(arrhenius.T0.value_si, self.arrhenius.T0.value_si, 4)
 
+    def test_fit_to_negative_data(self):
+        """
+        Test the Arrhenius.fit_to_data() method on negative rates
+        """
+        Tdata = np.array([300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500])
+        kdata = np.array([-1 * self.arrhenius.get_rate_coefficient(T) for T in Tdata])
+        arrhenius = Arrhenius().fit_to_data(Tdata, kdata, kunits="m^3/(mol*s)")
+        self.assertEqual(float(self.arrhenius.T0.value_si), 1)
+        for T, k in zip(Tdata, kdata):
+            self.assertAlmostEqual(k, arrhenius.get_rate_coefficient(T), delta=1e-6 * abs(k))
+        self.assertAlmostEqual(arrhenius.A.value_si, -1 * self.arrhenius.A.value_si, delta=1e0)
+        self.assertAlmostEqual(arrhenius.n.value_si, self.arrhenius.n.value_si, 1, 4)
+        self.assertAlmostEqual(arrhenius.Ea.value_si, self.arrhenius.Ea.value_si, 2)
+        self.assertAlmostEqual(arrhenius.T0.value_si, self.arrhenius.T0.value_si, 4)
+
     def test_pickle(self):
         """
         Test that an Arrhenius object can be pickled and unpickled with no loss

--- a/rmgpy/kinetics/arrheniusTest.py
+++ b/rmgpy/kinetics/arrheniusTest.py
@@ -1020,3 +1020,36 @@ class TestMultiPDepArrhenius(unittest.TestCase):
         for T, kexp in zip(Tlist, k0list):
             kact = self.kinetics.get_rate_coefficient(T, 1e5)
             self.assertAlmostEqual(2 * kexp, kact, delta=1e-6 * kexp)
+
+    def test_generate_reverse_rate_coefficient(self):
+        """
+        Test ability to reverse a reaction rate.
+
+        This is a real example from an imported chemkin file.
+        """
+        from rmgpy.species import Species
+        from rmgpy.molecule import Molecule
+        from rmgpy.data.kinetics import LibraryReaction
+        from rmgpy.thermo import NASA, NASAPolynomial
+        test_reaction = LibraryReaction(reactants=[Species(label="C2H3", thermo=NASA(polynomials=[NASAPolynomial(coeffs=[3.12502,0.00235137,2.36803e-05,-3.35092e-08,1.39444e-11,34524.3,8.81538], Tmin=(200,"K"), Tmax=(1000,"K")), NASAPolynomial(coeffs=[4.37211,0.00746869,-2.64716e-06,4.22753e-10,-2.44958e-14,33805.2,0.428772], Tmin=(1000,"K"), Tmax=(6000,"K"))], Tmin=(200,"K"), Tmax=(6000,"K"), E0=(285.696,"kJ/mol"), Cp0=(33.2579,"J/mol/K"), CpInf=(108.088,"J/mol/K"), comment="""ATcT3E\nC2H3 <g> ATcT ver. 1.122, DHf298 = 296.91 ± 0.33 kJ/mol - fit JAN17"""), molecule=[Molecule(smiles="[CH]=C")], molecular_weight=(27.0452,"amu")), 
+                                                  Species(label="CH2O", thermo=NASA(polynomials=[NASAPolynomial(coeffs=[4.77187,-0.00976266,3.70122e-05,-3.76922e-08,1.31327e-11,-14379.8,0.696586], Tmin=(200,"K"), Tmax=(1000,"K")), NASAPolynomial(coeffs=[2.91333,0.0067004,-2.55521e-06,4.27795e-10,-2.44073e-14,-14462.2,7.43823], Tmin=(1000,"K"), Tmax=(6000,"K"))], Tmin=(200,"K"), Tmax=(6000,"K"), E0=(-119.527,"kJ/mol"), Cp0=(33.2579,"J/mol/K"), CpInf=(83.1447,"J/mol/K"), comment="""ATcT3E\nH2CO <g> ATcT ver. 1.122, DHf298 = -109.188 ± 0.099 kJ/mol - fit JAN17"""), molecule=[Molecule(smiles="C=O")], molecular_weight=(30.026,"amu"))], 
+                                        products=[Species(label="C2H4", thermo=NASA(polynomials=[NASAPolynomial(coeffs=[3.65151,-0.00535067,5.16486e-05,-6.36869e-08,2.50743e-11,5114.51,5.38561], Tmin=(200,"K"), Tmax=(1000,"K")), NASAPolynomial(coeffs=[4.14446,0.0102648,-3.61247e-06,5.74009e-10,-3.39296e-14,4190.59,-1.14778], Tmin=(1000,"K"), Tmax=(6000,"K"))], Tmin=(200,"K"), Tmax=(6000,"K"), E0=(42.06,"kJ/mol"), Cp0=(33.2579,"J/mol/K"), CpInf=(133.032,"J/mol/K"), comment="""ATcT3E\nC2H4 <g> ATcT ver. 1.122, DHf298 = 52.45 ± 0.13 kJ/mol - fit JAN17"""), molecule=[Molecule(smiles="C=C")], molecular_weight=(28.0532,"amu")), 
+                                                  Species(label="HCO", thermo=NASA(polynomials=[NASAPolynomial(coeffs=[3.97075,-0.00149122,9.54042e-06,-8.8272e-09,2.67645e-12,3842.03,4.4466], Tmin=(200,"K"), Tmax=(1000,"K")), NASAPolynomial(coeffs=[3.85781,0.00264114,-7.44177e-07,1.23313e-10,-8.88959e-15,3616.43,3.92451], Tmin=(1000,"K"), Tmax=(6000,"K"))], Tmin=(200,"K"), Tmax=(6000,"K"), E0=(32.0237,"kJ/mol"), Cp0=(33.2579,"J/mol/K"), CpInf=(58.2013,"J/mol/K"), comment="""HCO <g> ATcT ver. 1.122, DHf298 = 41.803 ± 0.099 kJ/mol - fit JAN17"""), molecule=[Molecule(smiles="[CH]=O")], molecular_weight=(29.018,"amu"))], 
+                                        kinetics=MultiPDepArrhenius(arrhenius=[PDepArrhenius(pressures=([0.001,0.01,0.1,1,10,100,1000],"atm"), 
+                                                                                             arrhenius=[Arrhenius(A=(1.1e+07,"cm^3/(mol*s)"), n=1.09, Ea=(1807,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(2.5e+07,"cm^3/(mol*s)"), n=0.993, Ea=(1995,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(2.5e+08,"cm^3/(mol*s)"), n=0.704, Ea=(2596,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(1.4e+10,"cm^3/(mol*s)"), n=0.209, Ea=(3934,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(3.5e+13,"cm^3/(mol*s)"), n=-0.726, Ea=(6944,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(3.3e+14,"cm^3/(mol*s)"), n=-0.866, Ea=(10966,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(17,"cm^3/(mol*s)"), n=3.17, Ea=(9400,"cal/mol"), T0=(1,"K"))]), 
+                                                                               PDepArrhenius(pressures=([0.001,0.01,0.1,1,10,100,1000],"atm"), 
+                                                                                             arrhenius=[Arrhenius(A=(-2.3e+16,"cm^3/(mol*s)"), n=-1.269, Ea=(20617,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(-5.2e+16,"cm^3/(mol*s)"), n=-1.366, Ea=(20805,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(-1.5e+18,"cm^3/(mol*s)"), n=-1.769, Ea=(22524,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(-8.5e+19,"cm^3/(mol*s)"), n=-2.264, Ea=(23862,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(-4.4e+23,"cm^3/(mol*s)"), n=-3.278, Ea=(27795,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(-4.2e+24,"cm^3/(mol*s)"), n=-3.418, Ea=(31817,"cal/mol"), T0=(1,"K")), 
+                                                                                                        Arrhenius(A=(-2.1e+11,"cm^3/(mol*s)"), n=0.618, Ea=(30251,"cal/mol"), T0=(1,"K"))])
+                                                                                                    ]), duplicate=True)
+        test_reaction.generate_reverse_rate_coefficient()


### PR DESCRIPTION
### Motivation or Problem
Sometimes people represent a complex rate expression as the sum of Arrhenius, or sum of PDepArrhenius terms, one or more of which is negative. Although an overall negative rate expression is not allowed, one part of the sum may be. 
When generating reverse rate expressions, these multiple sum type expressions are reversed one part at a time. The function to generate a reverse rate expression for an individual Arrhenius expression does so by evaluating the rate at some array of temperatures, calculating the reverses (from the equilibrium constants) then  doing least squares regression to fit a new Arrhenius. But that last step involves taking logarithms of the rates, which leads to `nan` if they're negative, which then messes up the least squares regression.

This was the underlying cause of #1833 (not problems in my LAPACK implementation, as originally suspected)

### Description of Changes
If trying to fit a negative rate, negate it then fit it then negate the A factor.
Also ensure that all k(T) have the same sign, and are all finite.
Also added a couple of unit tests, that would fail without this fix.

### Testing
Unit tests have been added.
(The second one doesn't really test the result, just tries not to crash. But it used to crash)

