### PR TITLE
Create the dense Hamiltonian and use np.linalg.eigh to find eigenvalues

### DIFF
--- a/arkane/pdepTest.py
+++ b/arkane/pdepTest.py
@@ -104,7 +104,7 @@ class ArkaneTest(unittest.TestCase):
             reaction_list = read_reactions_block(chem, dictionary)
         rxn = reaction_list[0]
         self.assertIsInstance(rxn.kinetics, Chebyshev)
-        self.assertAlmostEquals(rxn.kinetics.get_rate_coefficient(1000.0, 1.0), 88.88253229631246)
+        self.assertAlmostEquals(rxn.kinetics.get_rate_coefficient(1000.0, 1.0), 88.9003516559412)
 
         files = [f for f in os.listdir(os.path.join(self.directory, 'sensitivity', ''))
                  if os.path.isfile(os.path.join(self.directory, 'sensitivity', f))]
@@ -116,7 +116,7 @@ class ArkaneTest(unittest.TestCase):
                 if '1000.0' in line:
                     break
         sa_coeff = line.split()[-2]
-        self.assertEquals(float(sa_coeff), -8.23e-6)
+        self.assertEquals(float(sa_coeff), -8.21e-6)
 
     @classmethod
     def tearDown(cls):


### PR DESCRIPTION
### Motivation or Problem
A potential solution for #1843. In initial testing, we have found that using np.linalg.eigh to calculate the eigenvalues from the dense Hamiltonian appears to give consistent results across different platforms. Further testing is needed to confirm this. If this is the case then this PR will close the issue. 

### Description of Changes

- Convert banded Hamiltonian into dense Hamiltonian. Only the lower triangle and main diagonal elements are constructed, which is all np.linalg.eigh needs.

- Use replace scipy.linalg.eig_banded with np.linalg.eigh

### Testing
Verify that this passes on the newest Travis worker version
