### PR TITLE
ND Hindered Rotor Improvements

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -58,6 +58,7 @@ from rmgpy.statmech.vibration import HarmonicOscillator
 from rmgpy.thermo.nasa import NASAPolynomial, NASA
 from rmgpy.thermo.thermodata import ThermoData
 from rmgpy.thermo.wilhoit import Wilhoit
+from rmgpy.kinetics.uncertainties import RateUncertainty
 from rmgpy.transport import TransportData
 from rmgpy.util import as_list
 
@@ -567,6 +568,7 @@ def load_input_file(path):
         'SingleExponentialDown': SingleExponentialDown,
         # Kinetics
         'Arrhenius': Arrhenius,
+        'RateUncertainty' : RateUncertainty,
         # Statistical mechanics
         'IdealGasTranslation': IdealGasTranslation,
         'LinearRotor': LinearRotor,

--- a/examples/arkane/species/Toulene_Hindered_Rotor_SemiClassicalND/toluene_HinderedRotor.py
+++ b/examples/arkane/species/Toulene_Hindered_Rotor_SemiClassicalND/toluene_HinderedRotor.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+bonds = {
+    'C-C': 4,
+    'C-H': 8,
+    'C=C': 3,
+}
+
+externalSymmetry = 1
+
+spinMultiplicity = 1
+
+opticalIsomers = 1
 
 energy = {
     'CBS-QB3': Log('TolueneEnergy.log')

--- a/rmgpy/statmech/conformer.pyx
+++ b/rmgpy/statmech/conformer.pyx
@@ -384,7 +384,8 @@ cdef class Conformer(RMGObject):
         elif pivots[0] in top1 and pivots[1] in top1:
             raise ValueError('Both pivot atoms included in top; you must specify only one pivot atom that belongs'
                              ' with the specified top.')
-
+        elif 0 in top1:
+            raise ValueError('Top must be one indexed, top1: {}'.format(top1))
         # Enumerate atoms in other top
         top2 = [i + 1 for i in range(n_atoms) if i + 1 not in top1]
 

--- a/rmgpy/statmech/ndTorsions.py
+++ b/rmgpy/statmech/ndTorsions.py
@@ -31,6 +31,7 @@ import logging
 import os
 import os.path
 import subprocess
+import itertools
 
 import numdifftools as nd
 import numpy as np
@@ -597,12 +598,22 @@ class HinderedRotorClassicalND(Mode):
         """
         calculate the classical/semiclassical partition function at a given temperature
         """
-        rngs = [(0.0, 2.0 * np.pi) for x in range(len(self.pivots))]
 
         def f(*phis):
             return self.rootD(*phis) * np.exp(-self.V(*phis) / (constants.R * T))
-
-        intg = inte.nquad(f, ranges=rngs)[0]
+        
+        rphis = np.linspace(0, 2.0*np.pi, 30)
+        Imat = np.zeros([len(rphis) for i in range(len(self.pivots))])
+        it = itertools.product(*[list(range(len(rphis))) for i in range(len(self.pivots))])
+        
+        for coords in it:
+            Imat[coords] = f(*rphis[np.array(coords)])
+        
+        for i in range(len(self.pivots)):
+            Imat = inte.simps(Imat, rphis)
+            
+        intg = Imat
+        
         Q = intg * (2.0 * np.pi * constants.kB * T / constants.h**2) ** (len(self.pivots) / 2.0) / np.prod(self.sigmas)
 
         if self.semiclassical:
@@ -612,7 +623,6 @@ class HinderedRotorClassicalND(Mode):
             x = constants.h * freqs / (constants.kB * T)
             out = x / (1.0 - np.exp(-x))
             Q *= np.prod(out)
-
         return Q
 
     def get_partition_function(self, T):

--- a/rmgpy/statmech/ndTorsions.py
+++ b/rmgpy/statmech/ndTorsions.py
@@ -576,12 +576,9 @@ class HinderedRotorClassicalND(Mode):
         generate splines for the first and second derivatives of the partition function
         """
         N = len(self.pivots)
-        if N > 2:
+        if N > 1:
             self.V = interpolate.LinearNDInterpolator(self.phis, self.Es)
             self.rootD = interpolate.LinearNDInterpolator(self.phis, self.rootDs)
-        elif N == 2:
-            self.V = interpolate.SmoothBivariateSpline(self.phis[:, 0], self.phis[:, 1], self.Es)
-            self.rootD = interpolate.SmoothBivariateSpline(self.phis[:, 0], self.phis[:, 1], self.rootDs)
         else:
             self.V = interpolate.CubicSpline(self.phis, self.Es)
             self.rootD = interpolate.CubicSpline(self.phis, self.rootDs)

--- a/rmgpy/statmech/ndTorsionsTest.py
+++ b/rmgpy/statmech/ndTorsionsTest.py
@@ -114,7 +114,7 @@ class TestHinderedRotorClassicalND(unittest.TestCase):
         self.hdnd.read_scan()
         self.assertAlmostEqual(self.hdnd.Es[0], 20.048316823666962, 4)
         self.hdnd.fit()
-        self.assertAlmostEqual(self.hdnd.calc_partition_function(300.0), 2.85254214434672, 5)
+        self.assertAlmostEqual(self.hdnd.calc_partition_function(300.0), 2.8524691948593133, 5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This has a number of numerical improvements for the calculation of ND classical and semiclassical hindered rotor partition functions.  I've removed use of SmoothBivarateSpline interpolation as this resulted in some negative fitted internal reduced moment of inertia values and I've fixed issues with the integration routine.

Also includes miscellaneous Arkane improvements: lets Arkane deal with RateUncertainty objects, makes the semiclassicalND rotors example consistent with the other Toulene examples, and adds a error trigger in internal reduced moment of inertia calculations that prevents use of 0-indexed atom numbers that result in all kinds of weird outputs from the function. 