### PR TITLE
Update required version of rdkit to avoid severe memory leaks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
   - python >=3.7
   - pyyaml
   - quantities
-  - rdkit >=2018
+  - rdkit >=2019.09.1.0
   - scikit-learn
   - scipy
   - symmetry


### PR DESCRIPTION
### Motivation or Problem
Significant memory leaks have been observed when using an rmg_env containing rdkit version 2019.03.4.0 as referenced in issue #1850. The issue is documented on the rdkit page [https://github.com/rdkit/rdkit/issues/2639](https://github.com/rdkit/rdkit/issues/2639) 

Memory leaks are not observed when using a more recent rdkit version of 2019.09.1.0 (and it looks like they've already released a version 2019.09.2.0)

### Description of Changes
Updated the minimum required version number for rdkit in the environment.yml file

### Testing
I used this environment.yml file to create an rmg_env. Doing `conda list rdkit` produced the following output, confirming that the change is implemented correctly

```
# Name                    Version                   Build  Channel
rdkit                     2019.09.2.0      py37h65625ec_1    rdkit
```





