### PR TITLE
Fix chemkin file duplicate flags

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -2150,7 +2150,7 @@ def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicat
         f.write('\n')
     f.write('END\n\n')
     f.close()
-    logging.info("Chemkin file contains {0} reactions.".format(_chemkin_reaction_count))
+    logging.info("Chemkin surface file contains {0} reactions.".format(_chemkin_reaction_count))
     _chemkin_reaction_count = None
 
 

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1969,8 +1969,8 @@ def mark_duplicate_reaction(test_reaction, reaction_list):
             # duplicates of one another.
             # RHW question: why can't TemplateReaction be duplicate of LibraryReaction, in Chemkin terms? I guess it shouldn't happen in RMG.
             continue
-        same_dir_match = (reaction1.reactants == reaction2.reactants and reaction1.products == reaction2.products)
-        opposite_dir_match = (reaction1.products == reaction2.reactants and reaction1.reactants == reaction2.products)
+        same_dir_match = (sorted(reaction1.reactants) == sorted(reaction2.reactants) and sorted(reaction1.products) == sorted(reaction2.products))
+        opposite_dir_match = (sorted(reaction1.products) == sorted(reaction2.reactants) and sorted(reaction1.reactants) == sorted(reaction2.products))
         if (same_dir_match or opposite_dir_match) and (reaction1.specific_collider == reaction2.specific_collider):
             if reaction1.duplicate and reaction2.duplicate:
                 if reaction1.kinetics.is_pressure_dependent() != reaction2.kinetics.is_pressure_dependent():

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1975,16 +1975,16 @@ def mark_duplicate_reaction(test_reaction, reaction_list):
             if reaction1.duplicate and reaction2.duplicate:
                 if reaction1.kinetics.is_pressure_dependent() != reaction2.kinetics.is_pressure_dependent():
                     # Reactions with mixed pressure dependence do not need to be marked duplicate in Chemkin
-                    logging.warning('Marked reaction {0} as not duplicate because of mixed pressure dependence '
-                                    'for saving to Chemkin file.'.format(reaction1))
-                    reaction1.duplicate = False
-                    reaction2.duplicate = False
+                    logging.warning('Reaction {0} is marked as duplicate but for Chemkin file it '
+                                    'doesn\'t need to be because of mixed pressure dependence'
+                                    '.'.format(reaction1))
+                    # But leave it alone in case it's a DUPLICATE of some _other_ reaction.
                 elif opposite_dir_match and not reaction1.reversible and not reaction2.reversible:
                     # Irreversible reactions in opposite directions do not need to be marked duplicate in Chemkin
-                    logging.warning('Marked reaction {0} as not duplicate because they are irreversible '
-                                    'in opposite directions for saving to Chemkin file.'.format(reaction1))
-                    reaction1.duplicate = False
-                    reaction2.duplicate = False
+                    logging.warning('Reaction {0} is marked as duplicate but for Chemkin file it '
+                                    'doesn\'t need to be because they are irreversible '
+                                    'in opposite directions.'.format(reaction1))
+                    # But leave it alone in case it's a DUPLICATE of some _other_ reaction.
             else:
                 if (reaction1.kinetics.is_pressure_dependent() == reaction2.kinetics.is_pressure_dependent()
                         and ((reaction1.reversible and reaction2.reversible)

--- a/test/rmgpy/chemkinTest.py
+++ b/test/rmgpy/chemkinTest.py
@@ -30,6 +30,7 @@
 import os
 
 from unittest import mock
+from external.wip import work_in_progress
 
 import rmgpy
 from rmgpy.chemkin import (
@@ -503,6 +504,21 @@ class ChemkinTest:
 
         assert duplicate_flags == expected_flags
 
+    @work_in_progress
+    def test_unmark_duplicate_reactions(self):
+        """Test that we can properly REMOVE duplicate reaction flags for Chemkin."""
+
+        """
+        We can't do this properly yet. 
+        See https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1856
+        """
+        s1 = Species().from_smiles('CC')
+        s2 = Species().from_smiles('[CH3]')
+        s3 = Species().from_smiles('[OH]')
+        s4 = Species().from_smiles('C[CH2]')
+        s5 = Species().from_smiles('O')
+        s6 = Species().from_smiles('[H]')
+    
         # Try initializing with duplicate=True
         reaction_list = [
             Reaction(reactants=[s1], products=[s2, s2], duplicate=True, kinetics=Arrhenius()),
@@ -548,6 +564,8 @@ class ChemkinTest:
                 reversible=False,
             ),
         ]
+
+        expected_flags = [True, True, False, False, True, True, False, False]
 
         mark_duplicate_reactions(reaction_list)
         duplicate_flags = [rxn.duplicate for rxn in reaction_list]

--- a/test/rmgpy/chemkinTest.py
+++ b/test/rmgpy/chemkinTest.py
@@ -30,7 +30,6 @@
 import os
 
 from unittest import mock
-from external.wip import work_in_progress
 
 import rmgpy
 from rmgpy.chemkin import (
@@ -504,7 +503,7 @@ class ChemkinTest:
 
         assert duplicate_flags == expected_flags
 
-    @work_in_progress
+    @pytest.mark.skip(reason="WIP")
     def test_unmark_duplicate_reactions(self):
         """Test that we can properly REMOVE duplicate reaction flags for Chemkin."""
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem 1

#1823 and #1336 describe problems with Chemkin files having unmarked duplicate reactions, which then causes problems in Cantera.
The very first example in #1336 I can't explain, but nobody can reproduce that behavior anyway.

All the other examples have the property that either the reactants or the products are in a different order., eg. one reaction is `A + B = C + D` and the undetected duplicate is either `A + B = D + C` or `B + A = C + D`.
The function `chemkin.mark_duplicate_reaction` was not sorting the reactants or products before comparing the lists.

### Description of Changes 1
The main change is sorting the reactants and products before comparing them.
This should address #1823 and #1336.

But there's another duplicate flag problem addressed here too.

### Motivation or Problem 2

The reaction library `NOx2018` has the reaction `HCCO + OH <=> HCOH + CO` described as three duplicate reactions:
```
entry(
    index = 461,
    label = "HCCO + OH <=> HCOH + CO",
    degeneracy = 1,
    duplicate = True,
    kinetics = PDepArrhenius(
        pressures = ([1, 10, 100], 'atm'),
        arrhenius = [
            Arrhenius(A=(3e+16, 'cm^3/(mol*s)'), n=-0.935, Ea=(659, 'cal/mol'), T0=(1, 'K')),
            Arrhenius(
                A = (1.1e+18, 'cm^3/(mol*s)'),
                n = -1.392,
                Ea = (1395, 'cal/mol'),
                T0 = (1, 'K'),
            ),
            Arrhenius(
                A = (3.2e+18, 'cm^3/(mol*s)'),
                n = -1.523,
                Ea = (1627, 'cal/mol'),
                T0 = (1, 'K'),
            ),
        ],
    ),
)

entry(
    index = 462,
    label = "HCCO + OH <=> HCOH + CO",
    degeneracy = 1,
    duplicate = True,
    kinetics = PDepArrhenius(
        pressures = ([1, 10, 100], 'atm'),
        arrhenius = [
            Arrhenius(
                A = (8.7e+19, 'cm^3/(mol*s)'),
                n = -1.792,
                Ea = (5994, 'cal/mol'),
                T0 = (1, 'K'),
            ),
            Arrhenius(
                A = (3.5e+22, 'cm^3/(mol*s)'),
                n = -2.475,
                Ea = (9163, 'cal/mol'),
                T0 = (1, 'K'),
            ),
            Arrhenius(
                A = (1.3e+24, 'cm^3/(mol*s)'),
                n = -2.902,
                Ea = (10522, 'cal/mol'),
                T0 = (1, 'K'),
            ),
        ],
    ),
)

entry(
    index = 463,
    label = "HCCO + OH <=> HCOH + CO",
    degeneracy = 1,
    duplicate = True,
    kinetics = Arrhenius(A=(2.9e+12, 'cm^3/(mol*s)'), n=0.37, Ea=(-24, 'cal/mol'), T0=(1, 'K')),
)
```

I think this in accurate representation of the mess in the published Chemkin file:
```
HCCO+OH=HCOH+CO	                     3.0E16  -0.935     659 ! 1 atm
PLOG / 1                             3.0E16  -0.935     659/ !refit to avoid convergence problems
!PLOG / 1                             2.8E13   0.090     -20/
PLOG / 10                            1.1E18  -1.392    1395/
!PLOG / 10                            5.7E12   0.310    -232/
PLOG / 100                           3.2E18   -1.523   1627/
!PLOG / 100                           3.8E13   0.050      70/
! Xiong et al., Combust. Flame 161 (2014) 885�897
! assuming 3-HCOH=1-HCOH=HCOH
DUPLICATE
HCCO+OH=HCOH+CO		             8.7E19  -1.792    5994 ! 1 atm 
PLOG / 1                             8.7E19  -1.792    5994/ !Average (max) fitting error: 0.7% (3.8%) over T of 250--3000 [K] 
!PLOG / 1                            -1.4E15  -0.280   10792/
PLOG / 10                            3.5E22  -2.475    9163/ !Average (max) fitting error: 0.8% (3.2%) over T of 400--3000 [K] 
!PLOG / 10                           -2.9E11   0.720    5000/
PLOG / 100                           1.3E24   -2.902  10522/     !Average (max) fitting error: 0.9% (3.6%) over T of 400--3000 [K] 
!PLOG / 100                          -6.8E13   0.100   10302/
! Xiong et al., Combust. Flame 161 (2014) 885�897
! assuming 3-HCOH=1-HCOH=HCOH
DUPLICATE
!
HCCO+OH=HCOH+CO	                     2.9E12   0.370     -24	
! Xiong et al., Combust. Flame 161 (2014) 885�897
! assuming 3-HCOH=1-HCOH=HCOH
DUPLICATE
```

But the algorithm to detect and remove un-necessary DUPLICATE markers is over-zealous.
Because non-pdep and pdep reactions usually do not need to be marked as duplicates, it removes the duplicate markers. eg.
> Adding species HCOH(44) to model core
> Warning: Marked reaction OH(20) + HCCO(67) <=> CO(11) + HCOH(44) as not duplicate because of mixed pressure dependence for saving to Chemkin file.

However, there are two pdep reactions, and so the marker should remain. 

### Description of Changes 2
It now just logs a warning that the DUPLICATE flag may be redundant, but leaves it in place. Hopefully these are only marked as duplicates appropriately anyway.


### Testing
I ran the existing unit tests. I'm currently re-building a large model that revealed these errors. I will know soon whether they went away.

