### PR TITLE
Update canteramodel module name in Jupyter notebooks

### DIFF
--- a/ipython/cantera_sensitivity_comparison.ipynb
+++ b/ipython/cantera_sensitivity_comparison.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "from rmgpy.chemkin import load_chemkin_file\n",
     "from rmgpy.species import Species\n",
-    "from rmgpy.tools.canteraModel import Cantera, get_rmg_species_from_user_species\n",
+    "from rmgpy.tools.canteramodel import Cantera, get_rmg_species_from_user_species\n",
     "from rmgpy.tools.plot import SimulationPlot, ReactionSensitivityPlot, parse_csv_data\n",
     "from rmgpy.tools.simulate import run_simulation"
    ]

--- a/ipython/cantera_simulation.ipynb
+++ b/ipython/cantera_simulation.ipynb
@@ -16,7 +16,7 @@
     "from IPython.display import display, Image\n",
     "\n",
     "from rmgpy.chemkin import load_chemkin_file\n",
-    "from rmgpy.tools.canteraModel import Cantera, get_rmg_species_from_user_species\n",
+    "from rmgpy.tools.canteramodel import Cantera, get_rmg_species_from_user_species\n",
     "from rmgpy.species import Species"
    ]
   },

--- a/ipython/combustion_model_and_ignition_delay_demo.ipynb
+++ b/ipython/combustion_model_and_ignition_delay_demo.ipynb
@@ -224,7 +224,7 @@
    "outputs": [],
    "source": [
     "from rmgpy.chemkin import load_chemkin_file\n",
-    "from rmgpy.tools.canteraModel import Cantera, get_rmg_species_from_user_species\n",
+    "from rmgpy.tools.canteramodel import Cantera, get_rmg_species_from_user_species\n",
     "from rmgpy.species import Species\n",
     "import time\n",
     "\n",

--- a/ipython/local_uncertainty.ipynb
+++ b/ipython/local_uncertainty.ipynb
@@ -11,7 +11,7 @@
     "from IPython.display import display, Image\n",
     "\n",
     "from rmgpy.tools.uncertainty import Uncertainty, process_local_results\n",
-    "from rmgpy.tools.canteraModel import get_rmg_species_from_user_species\n",
+    "from rmgpy.tools.canteramodel import get_rmg_species_from_user_species\n",
     "from rmgpy.species import Species"
    ]
   },


### PR DESCRIPTION
`canteraModel` was renamed to `canteramodel` but this change did not make it into the Jupyter notebooks. This PR fixes that.