### PR TITLE
Include Gaussian 16 executable

### DIFF
--- a/rmgpy/qm/gaussian.py
+++ b/rmgpy/qm/gaussian.py
@@ -51,7 +51,7 @@ class Gaussian:
     inputFileExtension = '.gjf'
     outputFileExtension = '.log'
 
-    executablesToTry = ('g09', 'g03')
+    executablesToTry = ('g16', 'g09', 'g03')
 
     for exe in executablesToTry:
         try:


### PR DESCRIPTION
Allows local unit tests to pass when run on servers with Gaussian

### Motivation or Problem
When I am checking out a new branch of RMG-Py on a server, it is re-assuring to see that all of the unit tests pass. Recently though I ran into an issue where one of the unit tests for Gaussian in the qm module ran (it only runs if Gaussian is detected) but could not pass because g16 was not listed as a possible executable. This is a very minor change for this reason, but could be important if people want to use QMTP on a server with Gaussian 16.