### PR TITLE
Arkane e0

### DIFF
--- a/arkane/encorr/corr.py
+++ b/arkane/encorr/corr.py
@@ -99,7 +99,7 @@ def get_atom_correction(model_chemistry, atoms, atom_energies=None):
     H doublet, C triplet, N quartet, O triplet, F doublet, Si triplet,
     P quartet, S triplet, Cl doublet, Br doublet, I doublet.
     """
-    corr = 0.0
+    corr = [0.0, 0.0]
     model_chemistry = model_chemistry.lower()
     # Step 1: Reference all energies to a model chemistry-independent
     # basis by subtracting out that model chemistry's atomic energies
@@ -111,7 +111,8 @@ def get_atom_correction(model_chemistry, atoms, atom_energies=None):
 
     for symbol, count in atoms.items():
         if symbol in atom_energies:
-            corr -= count * atom_energies[symbol] * 4.35974394e-18 * constants.Na  # Convert Hartree to J/mol
+            # Convert Hartree to J/mol
+            corr[0] -= count * atom_energies[symbol] * constants.E_h * constants.Na
         else:
             raise AtomEnergyCorrectionError(
                 'An energy correction for element "{}" is unavailable for model chemistry "{}".'
@@ -121,10 +122,12 @@ def get_atom_correction(model_chemistry, atoms, atom_energies=None):
             )
 
     # Step 2: Atom energy corrections to reach gas-phase reference state
-    atom_enthalpy_corrections = {symbol: data.atom_hf[symbol] - data.atom_thermal[symbol] for symbol in data.atom_hf}
+    atom_enthalpy_corrections = {symbol: (
+        data.atom_hf[symbol], data.atom_thermal[symbol]) for symbol in data.atom_hf}
     for symbol, count in atoms.items():
         if symbol in atom_enthalpy_corrections:
-            corr += count * atom_enthalpy_corrections[symbol] * 4184.0  # Convert kcal/mol to J/mol
+            corr[0] += count * atom_enthalpy_corrections[symbol][0] * 4184.0  # Convert kcal/mol to J/mol
+            corr[1] -= count * atom_enthalpy_corrections[symbol][1] * 4184.0  # Convert kcal/mol to J/mol
         else:
             raise AtomEnergyCorrectionError(
                 'Element "{}" is not yet supported in Arkane.'

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -483,7 +483,7 @@ class StatMechJob(object):
             else:
                 e_electronic *= constants.E_h * constants.Na  # convert Hartree/particle into J/mol
             if self.applyAtomEnergyCorrections:
-                atom_corrections = get_atom_correction(self.modelChemistry,
+                atom_corrections_0K, atom_corrections_298K  = get_atom_correction(self.modelChemistry,
                                                        atoms, self.atomEnergies)
 
             else:
@@ -497,7 +497,7 @@ class StatMechJob(object):
                                            multiplicity=conformer.spin_multiplicity)
             else:
                 bond_corrections = 0
-            e_electronic_with_corrections = e_electronic + atom_corrections + bond_corrections
+            e_electronic_with_corrections = e_electronic + atom_corrections_0K + bond_corrections
             # Get ZPE only for polyatomic species (monoatomic species don't have frequencies, so ZPE = 0)
             zpe = statmech_log.load_zero_point_energy() * zpe_scale_factor if len(number) > 1 else 0
             logging.debug('Scaled zero point energy (ZPE) is {0} J/mol'.format(zpe))
@@ -510,6 +510,7 @@ class StatMechJob(object):
             logging.debug('         E0 (0 K) = {0:g} kcal/mol'.format(e0 / 4184.))
 
         conformer.E0 = (e0 * 0.001, "kJ/mol")
+        self.species.props['atom_corrections_298K'] = atom_corrections_298K
 
         # If loading a transition state, also read the imaginary frequency
         if is_ts:

--- a/arkane/thermo.py
+++ b/arkane/thermo.py
@@ -123,7 +123,7 @@ class ThermoJob(object):
         conformer = self.species.conformer
         for i in range(Tlist.shape[0]):
             Cplist[i] += conformer.get_heat_capacity(Tlist[i])
-        H298 += conformer.get_enthalpy(298.) + conformer.E0.value_si
+        H298 += conformer.get_enthalpy(298.) + conformer.E0.value_si + self.species.props['atom_corrections_298K']
         S298 += conformer.get_entropy(298.)
 
         if not any([isinstance(mode, (LinearRotor, NonlinearRotor)) for mode in conformer.modes]):
@@ -157,6 +157,8 @@ class ThermoJob(object):
         else:
             species.thermo = wilhoit
 
+        species.thermo.E0 = conformer.E0
+
     def write_output(self, output_directory):
         """
         Save the results of the thermodynamics job to the `output.py` file located
@@ -168,8 +170,10 @@ class ThermoJob(object):
 
         with open(output_file, 'a') as f:
             f.write('# Thermodynamics for {0}:\n'.format(species.label))
+            H0 = species.conformer.E0.value_si / 4184
             H298 = species.get_thermo_data().get_enthalpy(298) / 4184.
             S298 = species.get_thermo_data().get_entropy(298) / 4.184
+            f.write('#   Enthalpy of formation (0 K)     = {0:9.3f} kcal/mol\n'.format(H0))
             f.write('#   Enthalpy of formation (298 K)   = {0:9.3f} kcal/mol\n'.format(H298))
             f.write('#   Entropy of formation (298 K)    = {0:9.3f} cal/(mol*K)\n'.format(S298))
             f.write('#    =========== =========== =========== =========== ===========\n')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Arkane incorrectly adds the atom thermal corrections (0->298K) to E0, so the output E0 is incorrect.

### Description of Changes
Separated atom corrections at 0K from the thermal correction.  Add in 0K correction to E0 in statmech, and add the atoms thermal correction to get H298 in Thermojob.

### Testing

### Reviewer Tips

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
