### PR TITLE
Warn the user if the RMG environment is not activated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,28 +57,28 @@ decython:
 	find . -name *.so ! \( -name _statmech.so -o -name quantity.so -o -regex '.*rmgpy/solver/.*' \) -exec rm -f '{}' \;
 	find . -name *.pyc -exec rm -f '{}' \;
 
-test-all:
+test-all: check
 ifneq ($(OS),Windows_NT)
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
 endif
 	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy arkane
 
-test test-unittests:
+test test-unittests: check
 ifneq ($(OS),Windows_NT)
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
 endif
 	nosetests --nocapture --nologcapture --all-modules -A 'not functional' --verbose --with-coverage --cover-inclusive --cover-erase --cover-html --cover-html-dir=testing/coverage --exe rmgpy arkane
 
-test-functional:
+test-functional: check
 ifneq ($(OS),Windows_NT)
 	mkdir -p testing/coverage
 	rm -rf testing/coverage/*
 endif
 	nosetests --nologcapture --all-modules -A 'functional' --verbose --exe rmgpy arkane
 
-test-database:
+test-database: check
 	nosetests --nocapture --nologcapture --verbose --detailed-errors testing/databaseTest.py
 
 eg0: all

--- a/utilities.py
+++ b/utilities.py
@@ -44,6 +44,7 @@ def check_dependencies():
     """
     Checks for and locates major dependencies that RMG requires.
     """
+    check_env()
     print('\nChecking vital dependencies...\n')
     print('{0:<15}{1:<15}{2}'.format('Package', 'Version', 'Location'))
 
@@ -195,6 +196,18 @@ def _check_symmetry():
             location = subprocess.check_output('which symmetry', shell=True)
 
         print('{0:<15}{1:<15}{2}'.format('symmetry', version, location.strip().decode()))
+
+
+def check_env():
+    env = os.environ['CONDA_DEFAULT_ENV']
+    if env == 'base':
+        print('\n\n\nWARNING: It appears that conda is still in the `base` environment. Please make sure that the RMG '
+              'environment is activated by running the following command before proceeding: '
+              '`conda activate rmg_env`\n\n\n')
+    elif env != 'rmg_env':
+        print('\nWarning: The current conda environment is not `rmg_env`. If this is in error, please make sure that '
+              'the RMG environment is activated by running the following command before proceeding: '
+              '`conda activate rmg_env`\n')
 
 
 def check_pydas():


### PR DESCRIPTION
### Motivation or Problem
It is a very common mistake for even experienced RMG developers to make to forget to activate their RMG environment before working with RMG. While experienced users can quickly figure out what went wrong, we should print out dialog that helps the user fix this issue whenever we detect that the conda environment is not correct so that new users can overcome this issue quickly.

### Description of Changes
We already had a utility for checking that vital dependencies could be found, so I just made sure that this code is always called whenever we run any of the unit tests like `make test`. 

Further, I added a method that specifically checks the name of the environment to make sure that this all checks out.

### Testing
I have tested running `make test` with and without my environment activated and it appears to work as expected

### Note to Reviewer
When checking the environment, I have two messages: one for if the environment is "base" and one for if the environment is simply not named "rmg_env". My intention with this was that "base" is almost certainly wrong, and we shouldn't even bother proceeding further, while for any other name it is possible that the user simply named their environment differently.

However, I currently did not make it such that "base" prevents the tests from running further. Therefore, I think I either need to consolidate the two messages, or implement this blocking for "base". Let me know which one you prefer.

Also, let me know if my formatting was too excessive for the warning statement (i.e. too many "\n").
