### PR TITLE
Detect and handle NaNs in solve_ss_network

### DIFF
--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -454,6 +454,10 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                 c = c.astype(np.float64)
             except:  # fall back to raw flux analysis rather than solve steady state problem
                 return None
+        
+        if np.isnan(c).any():
+            return None
+        
         return c
 
     def remove_disconnected_reactions(self):


### PR DESCRIPTION
If the solution of the linear system gives NaNs originally the NaN got passed as the concentrations in the network breaking flux based network reduction. This small fix detects this case and returns None instead causing flux based network reduction to fall back to rate coefficient based methods in these cases. 

Input file with the issue this fixes is attached:  
[input.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/4172916/input.txt)
