### PR TITLE
Added a "symmetric top" rotor

### DIFF
--- a/arkane/ess/molpro.py
+++ b/arkane/ess/molpro.py
@@ -39,7 +39,13 @@ import os.path
 import numpy as np
 
 import rmgpy.constants as constants
-from rmgpy.statmech import IdealGasTranslation, NonlinearRotor, LinearRotor, HarmonicOscillator, Conformer
+from rmgpy.statmech import (Conformer,
+                            HarmonicOscillator,
+                            IdealGasTranslation,
+                            LinearRotor,
+                            NonlinearRotor,
+                            SphericalTopRotor,
+                            SymmetricTopRotor)
 
 from arkane.common import get_element_mass
 from arkane.exceptions import LogError
@@ -219,6 +225,7 @@ class MolproLog(ESSAdapter):
         modes = []
         unscaled_frequencies = []
         e0 = 0.0
+        I_tol = 0.01
         if optical_isomers is None or symmetry is None:
             _optical_isomers, _symmetry, _ = self.get_symmetry_properties()
             if optical_isomers is None:
@@ -279,7 +286,15 @@ class MolproLog(ESSAdapter):
                             for i in range(3):
                                 inertia[i] = constants.h / (8 * constants.pi * constants.pi * inertia[i] * 1e9) \
                                              * constants.Na * 1e23
-                            rotation = NonlinearRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
+                            if all([abs(inertia[i] - inertia[i + 1]) < I_tol for i in [0, 1]]):
+                                # all three moments of inertia are (nearly) equal, this is a "spherical top rotor"
+                                rotation = SphericalTopRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
+                            elif any([abs(inertia[i] - inertia[i + 1]) < I_tol for i in [0, 1]]):
+                                # two of the moments of inertia are (nearly) equal, this is a "symmetrical top rotor"
+                                rotation = SymmetricTopRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
+                            else:
+                                # none of the moments of inertia are (nearly) equal, this is an "asymmetric rotor"
+                                rotation = NonlinearRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry)
                             modes.append(rotation)
 
                         elif 'Rotational Constant' in line and line.split()[3] == '[GHz]':

--- a/arkane/thermo.py
+++ b/arkane/thermo.py
@@ -44,7 +44,7 @@ from rmgpy.exceptions import InputError
 from rmgpy.molecule import Molecule
 from rmgpy.molecule.util import get_element_count
 from rmgpy.species import Species
-from rmgpy.statmech.rotation import LinearRotor, NonlinearRotor
+from rmgpy.statmech.rotation import LinearRotor, NonlinearRotor, SphericalTopRotor, SymmetricTopRotor
 from rmgpy.thermo.wilhoit import Wilhoit
 
 from arkane.common import ArkaneSpecies, symbol_by_number
@@ -126,14 +126,16 @@ class ThermoJob(object):
         H298 += conformer.get_enthalpy(298.) + conformer.E0.value_si
         S298 += conformer.get_entropy(298.)
 
-        if not any([isinstance(mode, (LinearRotor, NonlinearRotor)) for mode in conformer.modes]):
-            # Monatomic species
+        if (species.mol is not None and len(species.mol[0].atoms) == 1) \
+                or not any([isinstance(mode, (LinearRotor, NonlinearRotor, SphericalTopRotor, SymmetricTopRotor))
+                            for mode in conformer.modes]):
+            # this is a monatomic species
             n_freq = 0
             n_rotors = 0
             Cp0 = 2.5 * constants.R
             CpInf = 2.5 * constants.R
         else:
-            # Polyatomic species
+            # this is a polyatomic species
             linear = True if isinstance(conformer.modes[1], LinearRotor) else False
             n_freq = len(conformer.modes[2].frequencies.value)
             n_rotors = len(conformer.modes[3:])

--- a/rmgpy/pdep/configuration.pyx
+++ b/rmgpy/pdep/configuration.pyx
@@ -395,7 +395,8 @@ cdef class Configuration(object):
                 b_list.append(float(j_rotor.rotationalConstant.value_si))
 
             for r0 in range(n_grains):
-                if e_list[r0] >= E0: break
+                if e_list[r0] >= E0:
+                    break
 
             if len(b_list) == 1:
                 b1 = b_list[0] * 11.962  # cm^-1 to J/mol
@@ -403,7 +404,8 @@ cdef class Configuration(object):
                     for s in range(n_j):
                         j1 = j_list[s]
                         e = e_list[r] - E0 - b1 * j1 * (j1 + 1)
-                        if e < 0: break
+                        if e < 0:
+                            break
                         dens_states[r,s] = (2 * j1 + 1) * exp(f(e)) * d_j
 
             elif len(b_list) == 2:

--- a/rmgpy/statmech/__init__.py
+++ b/rmgpy/statmech/__init__.py
@@ -32,7 +32,7 @@ initialize imports
 """
 
 from rmgpy.statmech.conformer import Conformer
-from rmgpy.statmech.rotation import KRotor, LinearRotor, NonlinearRotor, Rotation, SphericalTopRotor
+from rmgpy.statmech.rotation import KRotor, LinearRotor, NonlinearRotor, Rotation, SphericalTopRotor, SymmetricTopRotor
 from rmgpy.statmech.torsion import HinderedRotor, Torsion
 from rmgpy.statmech.translation import IdealGasTranslation, Translation
 from rmgpy.statmech.vibration import HarmonicOscillator, Vibration

--- a/rmgpy/statmech/conformer.pyx
+++ b/rmgpy/statmech/conformer.pyx
@@ -44,11 +44,12 @@ cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
 from rmgpy.exceptions import StatmechError
 from rmgpy.statmech.mode cimport Mode
-from rmgpy.statmech.rotation cimport LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor
+from rmgpy.statmech.rotation cimport LinearRotor, NonlinearRotor, KRotor, SphericalTopRotor, SymmetricTopRotor
 from rmgpy.statmech.torsion cimport HinderedRotor
 from rmgpy.statmech.translation cimport IdealGasTranslation
 
 ################################################################################
+
 
 cdef class Conformer(RMGObject):
     """
@@ -266,6 +267,8 @@ cdef class Conformer(RMGObject):
             elif type(mode) == KRotor:
                 n += 1
             elif type(mode) == SphericalTopRotor:
+                n += 3
+            elif type(mode) == SymmetricTopRotor:
                 n += 3
             elif hasattr(mode, 'dof'):
                 n += mode.dof

--- a/rmgpy/statmech/rotation.pxd
+++ b/rmgpy/statmech/rotation.pxd
@@ -123,3 +123,31 @@ cdef class SphericalTopRotor(Rotation):
     cpdef np.ndarray get_sum_of_states(self, np.ndarray e_list, np.ndarray sum_states_0=?)
     
     cpdef np.ndarray get_density_of_states(self, np.ndarray e_list, np.ndarray dens_states_0=?)
+
+################################################################################
+
+cdef class SymmetricTopRotor(Rotation):
+
+    cdef public ArrayQuantity _inertia
+
+    cpdef double get_IA(self) except -1
+
+    cpdef double get_IC(self) except -1
+
+    cpdef double get_level_energy(self, int J) except -1
+
+    cpdef double get_K_level_energy(self, int J, double T) except -1
+
+    cpdef int get_level_degeneracy(self, int J) except -1
+
+    cpdef double get_partition_function(self, double T) except -1
+
+    cpdef double get_heat_capacity(self, double T) except -100000000
+
+    cpdef double get_enthalpy(self, double T) except 100000000
+
+    cpdef double get_entropy(self, double T) except -100000000
+
+    cpdef np.ndarray get_sum_of_states(self, np.ndarray e_list, np.ndarray sum_states_0=?)
+
+    cpdef np.ndarray get_density_of_states(self, np.ndarray e_list, np.ndarray dens_states_0=?)

--- a/rmgpy/statmech/rotation.pyx
+++ b/rmgpy/statmech/rotation.pyx
@@ -97,7 +97,7 @@ cdef inline double get_rotational_constant_energy(double inertia) except -1:
     Return the value of the rotational constant in energy units (J/mol)
     corresponding to the given moment of `inertia` in kg*m^2.
     """
-    return constants.hbar * constants.hbar / (2. * inertia) * constants.Na
+    return constants.hbar ** 2 / (2. * inertia) * constants.Na
 
 ################################################################################
 
@@ -162,12 +162,12 @@ cdef class LinearRotor(Rotation):
         """The rotational constant of the rotor."""
         def __get__(self):
             cdef double I = self._inertia.value_si
-            cdef double B = constants.h / (8 * constants.pi * constants.pi * I) / (constants.c * 100.)
+            cdef double B = constants.h / (8 * constants.pi ** 2 * I) / (constants.c * 100.)
             return quantity.Quantity(B, "cm^-1")
         def __set__(self, B):
             cdef double I
             B = quantity.Frequency(B)
-            I = constants.h / (8 * constants.pi * constants.pi * (B.value_si * constants.c * 100.))
+            I = constants.h / (8 * constants.pi ** 2 * (B.value_si * constants.c * 100.))
             self._inertia = quantity.ScalarQuantity(I / (constants.amu * 1e-20), "amu*angstrom^2")
 
     cpdef double get_level_energy(self, int J) except -1:
@@ -336,12 +336,12 @@ cdef class NonlinearRotor(Rotation):
         """The rotational constant of the rotor."""
         def __get__(self):
             cdef np.ndarray I = self._inertia.value_si
-            cdef np.ndarray B = constants.h / (8 * constants.pi * constants.pi * I) / (constants.c * 100.)
+            cdef np.ndarray B = constants.h / (8 * constants.pi ** 2 * I) / (constants.c * 100.)
             return quantity.Quantity(B, "cm^-1")
         def __set__(self, B):
             cdef np.ndarray I
             B = quantity.Frequency(B)
-            I = constants.h / (8 * constants.pi * constants.pi * (B.value_si * constants.c * 100.))
+            I = constants.h / (8 * constants.pi ** 2 * (B.value_si * constants.c * 100.))
             self._inertia = quantity.ArrayQuantity(I / (constants.amu * 1e-20), "amu*angstrom^2")
 
     cdef np.ndarray get_rotational_constant_energy(self):
@@ -453,6 +453,7 @@ cdef class NonlinearRotor(Rotation):
 
 ################################################################################
 
+
 cdef class KRotor(Rotation):
     """
     A statistical mechanical model of an active K-rotor (a one-dimensional
@@ -514,19 +515,19 @@ cdef class KRotor(Rotation):
         """The rotational constant of the rotor."""
         def __get__(self):
             cdef double I = self._inertia.value_si
-            cdef double B = constants.h / (8 * constants.pi * constants.pi * I) / (constants.c * 100.)
+            cdef double B = constants.h / (8 * constants.pi ** 2 * I) / (constants.c * 100.)
             return quantity.Quantity(B, "cm^-1")
         def __set__(self, B):
             cdef double I
             B = quantity.Frequency(B)
-            I = constants.h / (8 * constants.pi * constants.pi * (B.value_si * constants.c * 100.))
+            I = constants.h / (8 * constants.pi ** 2 * (B.value_si * constants.c * 100.))
             self._inertia = quantity.ScalarQuantity(I / (constants.amu * 1e-20), "amu*angstrom^2")
 
     cpdef double get_level_energy(self, int J) except -1:
         """
         Return the energy of level `J` in kJ/mol.
         """
-        return get_rotational_constant_energy(self.inertia.value_si) * J * J
+        return get_rotational_constant_energy(self.inertia.value_si) * J ** 2
 
     cpdef int get_level_degeneracy(self, int J) except -1:
         """
@@ -628,10 +629,11 @@ cdef class KRotor(Rotation):
 
 ################################################################################
 
+
 cdef class SphericalTopRotor(Rotation):
     """
     A statistical mechanical model of a three-dimensional rigid rotor with a
-    single rotational constant: a spherical top. The attributes are:
+    single rotational constant: a spherical top (e.g., CH4). The attributes are:
     
     ======================== ===================================================
     Attribute                Description
@@ -689,12 +691,12 @@ cdef class SphericalTopRotor(Rotation):
         """The rotational constant of the rotor."""
         def __get__(self):
             cdef double I = self._inertia.value_si
-            cdef double B = constants.h / (8 * constants.pi * constants.pi * I) / (constants.c * 100.)
+            cdef double B = constants.h / (8 * constants.pi ** 2 * I) / (constants.c * 100.)
             return quantity.Quantity(B, "cm^-1")
         def __set__(self, B):
             cdef double I
             B = quantity.Frequency(B)
-            I = constants.h / (8 * constants.pi * constants.pi * (B.value_si * constants.c * 100.))
+            I = constants.h / (8 * constants.pi ** 2 * (B.value_si * constants.c * 100.))
             self._inertia = quantity.ScalarQuantity(I / (constants.amu * 1e-20), "amu*angstrom^2")
 
     cpdef double get_level_energy(self, int J) except -1:
@@ -707,7 +709,7 @@ cdef class SphericalTopRotor(Rotation):
         """
         Return the degeneracy of level `J`.
         """
-        return (2 * J + 1) * (2 * J + 1)
+        return (2 * J + 1) ** 2
 
     cpdef double get_partition_function(self, double T) except -1:
         """
@@ -720,7 +722,7 @@ cdef class SphericalTopRotor(Rotation):
         else:
             B = get_rotational_constant_energy(self._inertia.value_si)
             theta = constants.R * T / B
-            Q = sqrt(theta * theta * theta * constants.pi) / self.symmetry
+            Q = sqrt(theta ** 3 * constants.pi) / self.symmetry
         return Q
 
     cpdef double get_heat_capacity(self, double T) except -100000000:

--- a/rmgpy/statmech/rotationTest.py
+++ b/rmgpy/statmech/rotationTest.py
@@ -36,7 +36,7 @@ import unittest
 import numpy as np
 
 import rmgpy.constants as constants
-from rmgpy.statmech.rotation import KRotor, LinearRotor, NonlinearRotor, SphericalTopRotor
+from rmgpy.statmech.rotation import KRotor, LinearRotor, NonlinearRotor, SphericalTopRotor, SymmetricTopRotor
 
 ################################################################################
 
@@ -862,5 +862,240 @@ class TestSphericalTopRotor(unittest.TestCase):
         mode = pickle.loads(pickle.dumps(self.mode, -1))
         self.assertAlmostEqual(self.mode.inertia.value, mode.inertia.value, 6)
         self.assertEqual(self.mode.inertia.units, mode.inertia.units)
+        self.assertEqual(self.mode.symmetry, mode.symmetry)
+        self.assertEqual(self.mode.quantum, mode.quantum)
+
+################################################################################
+
+
+class TestSymmetricTopRotor(unittest.TestCase):
+    """
+    Contains unit tests of the SymmetricTopRotor class.
+    """
+
+    def setUp(self):
+        """
+        A function run before each unit test in this class.
+        """
+        self.inertia = np.array([3.196, 3.197, 20.07])
+        self.symmetry = 2
+        self.quantum = False
+        self.mode = SymmetricTopRotor(
+            inertia=(self.inertia, "amu*angstrom^2"),
+            symmetry=self.symmetry,
+            quantum=self.quantum,
+        )
+
+    def test_get_rotationalConstant(self):
+        """
+        Test getting the SymmetricTopRotor.rotationalConstant property.
+        """
+        b_exp = np.array([4.93635, 1.0125, 0.839942])
+        b_act = self.mode.rotationalConstant.value_si
+        for b0, b in zip(b_exp, b_act):
+            self.assertAlmostEqual(b0, b, 4)
+
+    def test_set_rotationalConstant(self):
+        """
+        Test setting the SymmetricTopRotor.rotationalConstant property.
+        """
+        B = self.mode.rotationalConstant
+        B.value_si *= 2
+        self.mode.rotationalConstant = B
+        Iexp = 0.5 * self.inertia
+        Iact = self.mode.inertia.value_si * constants.Na * 1e23
+        for I0, I in zip(Iexp, Iact):
+            self.assertAlmostEqual(I0, I, 4)
+
+    def test_get_level_energy(self):
+        """
+        Test the SymmetricTopRotor.get_level_energy() method.
+        """
+        b = self.mode.rotationalConstant.value_si * constants.h * constants.c * 100. * constants.Na
+        for j in range(0, 100):
+            e_exp = b * j * (j + 1)
+            e_act = self.mode.get_level_energy(j)
+            if j == 0:
+                self.assertEqual(e_act, 0)
+            else:
+                for e0, e in zip(e_exp, e_act):
+                    self.assertAlmostEqual(e0, e, delta=1e-4 * e_exp)
+
+    def test_get_level_degeneracy(self):
+        """
+        Test the SymmetricTopRotor.get_level_degeneracy() method.
+        """
+        for j in range(0, 100):
+            g_exp = (2 * j + 1) ** 2
+            g_act = self.mode.get_level_degeneracy(j)
+            self.assertEqual(g_exp, g_act)
+
+    def test_get_partition_function_classical(self):
+        """
+        Test the SymmetricTopRotor.get_partition_function() method for a classical rotor.
+        """
+        self.mode.quantum = False
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1552.74, 3340.97, 9449.69, 17360.2, 26727.8])
+        for t, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.get_partition_function(t)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_partition_function_quantum(self):
+        """
+        Test the SymmetricTopRotor.get_partition_function() method for a quantum rotor.
+        """
+        self.mode.quantum = True
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        q_exp_list = np.array([1555.42, 3344.42, 9454.57, 17366.2, 26734.7])
+        for t, q_exp in zip(t_list, q_exp_list):
+            q_act = self.mode.get_partition_function(t)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-4 * q_exp)
+
+    def test_get_heat_capacity_classical(self):
+        """
+        Test the SymmetricTopRotor.get_heat_capacity() method using a classical rotor.
+        """
+        self.mode.quantum = False
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
+        for t, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.get_heat_capacity(t)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_heat_capacity_quantum(self):
+        """
+        Test the SymmetricTopRotor.get_heat_capacity() method using a quantum rotor.
+        """
+        self.mode.quantum = True
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        cv_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R
+        for t, cv_exp in zip(t_list, cv_exp_list):
+            cv_act = self.mode.get_heat_capacity(t)
+            self.assertAlmostEqual(cv_exp, cv_act, delta=1e-4 * cv_exp)
+
+    def test_get_enthalpy_classical(self):
+        """
+        Test the SymmetricTopRotor.get_enthalpy() method using a classical rotor.
+        """
+        self.mode.quantum = False
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        h_exp_list = np.array([1.5, 1.5, 1.5, 1.5, 1.5]) * constants.R * t_list
+        for t, h_exp in zip(t_list, h_exp_list):
+            h_act = self.mode.get_enthalpy(t)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_enthalpy_quantum(self):
+        """
+        Test the SymmetricTopRotor.get_enthalpy() method using a quantum rotor.
+        """
+        self.mode.quantum = True
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        Hexplist = np.array([1.49828, 1.49897, 1.49948, 1.49966, 1.49974]) * constants.R * t_list
+        for t, h_exp in zip(t_list, Hexplist):
+            h_act = self.mode.get_enthalpy(t)
+            self.assertAlmostEqual(h_exp, h_act, delta=1e-4 * h_exp)
+
+    def test_get_entropy_classical(self):
+        """
+        Test the SymmetricTopRotor.get_entropy() method using a classical rotor.
+        """
+        self.mode.quantum = False
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([8.84778, 9.61402, 10.6537, 11.2619, 11.6935]) * constants.R
+        for t, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.get_entropy(t)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_entropy_quantum(self):
+        """
+        Test the SymmetricTopRotor.get_entropy() method using a quantum rotor.
+        """
+        self.mode.quantum = True
+        t_list = np.array([300, 500, 1000, 1500, 2000])
+        s_exp_list = np.array([8.84778, 9.61402, 10.6537, 11.2619, 11.6935]) * constants.R
+        for t, s_exp in zip(t_list, s_exp_list):
+            s_act = self.mode.get_entropy(t)
+            self.assertAlmostEqual(s_exp, s_act, delta=1e-4 * s_exp)
+
+    def test_get_sum_of_states_classical(self):
+        """
+        Test the SymmetricTopRotor.get_sum_of_states() method using a classical rotor.
+        """
+        self.mode.quantum = False
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        dens_states = self.mode.get_density_of_states(e_list)
+        sum_states = self.mode.get_sum_of_states(e_list)
+        for n in range(20, len(e_list)):
+            self.assertAlmostEqual(np.sum(dens_states[0:n+1]) / sum_states[n], 1.0, 1)
+
+    def test_get_sum_of_states_quantum(self):
+        """
+        Test the SymmetricTopRotor.get_sum_of_states() method using a quantum rotor.
+        """
+        self.mode.quantum = True
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        dens_states = self.mode.get_density_of_states(e_list)
+        sum_states = self.mode.get_sum_of_states(e_list)
+        for n in range(1, len(e_list)):
+            self.assertAlmostEqual(np.sum(dens_states[0: n + 1]) / sum_states[n], 1.0, 3)
+
+    def test_get_density_of_states_classical(self):
+        """
+        Test the SymmetricTopRotor.get_density_of_states() method using a classical rotor.
+        """
+        self.mode.quantum = False
+        t_list = np.array([300, 400, 500])
+        e_list = np.arange(0, 2000 * 11.96, 1.0 * 11.96)
+        for t in t_list:
+            dens_states = self.mode.get_density_of_states(e_list)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / t))
+            q_exp = self.mode.get_partition_function(t)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
+
+        # self.mode.quantum = False
+        # Elist = np.arange(0, 1000 * 11.96, 1 * 11.96)
+        # densStates = self.mode.getDensityOfStates(Elist)
+        # T = 100
+        # Qact = np.sum(densStates * np.exp(-Elist / constants.R / T))
+        # Qexp = self.mode.getPartitionFunction(T)
+        # self.assertAlmostEqual(Qexp, Qact, delta=1e-2 * Qexp)
+
+    def test_get_density_of_states_quantum(self):
+        """
+        Test the SymmetricTopRotor.get_density_of_states() method using a quantum rotor.
+        """
+        self.mode.quantum = True
+        t_list = np.array([300, 400, 500])
+        e_list = np.arange(0, 4000*11.96, 2.0 * 11.96)
+        for t in t_list:
+            dens_states = self.mode.get_density_of_states(e_list)
+            q_act = np.sum(dens_states * np.exp(-e_list / constants.R / t))
+            q_exp = self.mode.get_partition_function(t)
+            self.assertAlmostEqual(q_exp, q_act, delta=1e-2 * q_exp)
+
+    def test_repr(self):
+        """
+        Test that a SymmetricTopRotor object can be reconstructed from its
+        repr() output with no loss of information.
+        """
+        mode = None
+        exec(f'mode = {self.mode!r}')
+        for self_mode, mode in zip(self.mode.inertia, mode.inertia):
+            self.assertAlmostEqual(self_mode.value, mode.value, 6)
+            self.assertEqual(self_mode.units, mode.units)
+        self.assertEqual(self.mode.symmetry, mode.symmetry)
+        self.assertEqual(self.mode.quantum, mode.quantum)
+
+    def test_pickle(self):
+        """
+        Test that a SymmetricTopRotor object can be pickled and unpickled
+        with no loss of information.
+        """
+        import cPickle
+        mode = cPickle.loads(cPickle.dumps(self.mode, -1))
+        for self_mode, mode in zip(self.mode.inertia, mode.inertia):
+            self.assertAlmostEqual(self_mode.value, mode.value, 6)
+            self.assertEqual(self_mode.units, mode.units)
         self.assertEqual(self.mode.symmetry, mode.symmetry)
         self.assertEqual(self.mode.quantum, mode.quantum)

--- a/rmgpy/statmech/schrodinger.pxd
+++ b/rmgpy/statmech/schrodinger.pxd
@@ -29,14 +29,20 @@ cimport numpy as np
 
 ################################################################################
 
-cpdef double get_partition_function(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except -1
+cpdef double get_partition_function(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?,
+                                    qka_energy=?, qkc_energy=?) except -1
 
-cpdef double get_heat_capacity(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except -100000000
+cpdef double get_heat_capacity(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?,
+                               qka_energy=?, qkc_energy=?) except -100000000
 
-cpdef double get_enthalpy(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except 100000000
+cpdef double get_enthalpy(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?,
+                          qka_energy=?, qkc_energy=?) except 100000000
 
-cpdef double get_entropy(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?) except -100000000
+cpdef double get_entropy(double T, energy, degeneracy=?, int n0=?, int nmax=?, double tol=?,
+                         qka_energy=?, qkc_energy=?) except -100000000
 
-cpdef np.ndarray get_sum_of_states(np.ndarray e_list, energy, degeneracy=?, int n0=?, np.ndarray sum_states_0=?)
+cpdef np.ndarray get_sum_of_states(np.ndarray e_list, energy, degeneracy=?, int n0=?, np.ndarray sum_states_0=?,
+                                   qka_energy=?, qkc_energy=?, )
 
-cpdef np.ndarray get_density_of_states(np.ndarray e_list, energy, degeneracy=?, int n0=?, np.ndarray dens_states_0=?)
+cpdef np.ndarray get_density_of_states(np.ndarray e_list, energy, degeneracy=?, int n0=?, np.ndarray dens_states_0=?,
+                                       qka_energy=?, qkc_energy=?)

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -53,6 +53,7 @@ RCOND = -1 if int(np.__version__.split('.')[1]) < 14 else None
 
 ################################################################################
 
+
 cdef class Torsion(Mode):
     """
     A base class for all torsional degrees of freedom. The attributes are:
@@ -66,7 +67,7 @@ cdef class Torsion(Mode):
 
     In the majority of chemical applications, the torsional energy levels are
     mostly close together compared to :math:`k_\\mathrm{B} T`, which makes the
-    torsional motion well-approximated by a semiclassical treatment. 
+    torsional motion well-approximated by a semiclassical treatment.
     """
 
     def __init__(self, symmetry=1, quantum=False):
@@ -97,6 +98,7 @@ cdef class Torsion(Mode):
         self.__init__(**kwargs)
 
 ################################################################################
+
 
 cdef class HinderedRotor(Torsion):
     """
@@ -197,7 +199,7 @@ cdef class HinderedRotor(Torsion):
         """
         Return the value of the rotational constant in J/mol.
         """
-        return constants.hbar * constants.hbar / (2 * self._inertia.value_si) * constants.Na
+        return constants.hbar ** 2 / (2 * self._inertia.value_si) * constants.Na
 
     cpdef double get_frequency(self) except -1:
         """
@@ -214,7 +216,7 @@ cdef class HinderedRotor(Torsion):
             fourier = self._fourier.value_si
             V0 = 0.0
             for k in range(fourier.shape[1]):
-                V0 -= fourier[0, k] * (k + 1) * (k + 1)
+                V0 -= fourier[0, k] * (k + 1) ** 2
             V0 /= constants.Na
             if V0 < 0:
                 raise NegativeBarrierException("Hindered rotor barrier height is less than 0 \n     Try running Arkane"
@@ -593,12 +595,15 @@ cdef class HinderedRotor(Torsion):
 
         return self
 
+
 cdef class FreeRotor(Torsion):
     """
     A statistical mechanical model of a one-dimensional hindered rotor.  
-    Based on Pfaendtner et al. 2007.  
+    Based on J. Pfaendtner, X. Yu, L.J. Broadbelt, Theoretical Chemistry Accounts 2007, 118, 881,
+    DOI: 10.1007/s00214-007-0376-5
+
     The attributes are:
-    
+
     ======================== ===================================================
     Attribute                Description
     ======================== ===================================================
@@ -621,8 +626,7 @@ cdef class FreeRotor(Torsion):
 
     def __repr__(self):
         """
-        Return a string representation that can be used to reconstruct the
-        FreeRotor object.
+        Return a string representation that can be used to reconstruct the FreeRotor object.
         """
         result = 'FreeRotor(inertia={0!r}, symmetry={1:d}'.format(self.inertia, self.symmetry)
         result += ')'
@@ -695,7 +699,7 @@ cdef class FreeRotor(Torsion):
         """
         Return the sum of states :math:`N(E)` at the specified energies `e_list`
         in J/mol above the ground state. 
-        formula from
+        formula from:
         Forst 1995 Journal of Computational Chemistry, Vol. 17, No. 8 954-961 (1996)
         """
         if sum_states_0:

--- a/rmgpy/statmech/translation.pyx
+++ b/rmgpy/statmech/translation.pyx
@@ -45,6 +45,7 @@ cimport rmgpy.statmech.schrodinger as schrodinger
 
 ################################################################################
 
+
 cdef class Translation(Mode):
     """
     A base class for all vibrational degrees of freedom. The attributes are:
@@ -55,15 +56,16 @@ cdef class Translation(Mode):
     `quantum`                ``True`` to use the quantum mechanical model, ``False`` to use the classical model
     ======================== ===================================================
 
-    In the majority of chemical applications, the vibrational energy levels are
-    widely spaced compared to :math:`k_\\mathrm{B} T`, which makes a quantum
-    mechanical treatment required.
+    In the majority of chemical applications, the translational energy levels are
+    much smaller than :math:`k_\\mathrm{B} T`, which makes a classical
+    mechanical treatment adequate.
     """
 
     def __init__(self, quantum=True):
         Mode.__init__(self, quantum)
 
 ################################################################################
+
 
 cdef class IdealGasTranslation(Translation):
     """
@@ -123,7 +125,7 @@ cdef class IdealGasTranslation(Translation):
             raise NotImplementedError('Quantum mechanical model not yet implemented for IdealGasTranslation.')
         else:
             mass = self._mass.value_si
-            qt = ((2 * constants.pi * mass) / (constants.h * constants.h)) ** 1.5 / 101325.
+            qt = ((2 * constants.pi * mass) / (constants.h ** 2)) ** 1.5 / 101325.  # assume P = 1 atm = 101325 Pa
             Q = qt * (constants.kB * T) ** 2.5
         return Q
 
@@ -179,7 +181,7 @@ cdef class IdealGasTranslation(Translation):
         else:
             mass = self._mass.value_si
             e_list = e_list / constants.Na
-            qt = ((2 * constants.pi * mass) / (constants.h * constants.h)) ** 1.5 / 101325.
+            qt = ((2 * constants.pi * mass) / (constants.h ** 2)) ** 1.5 / 101325.
             sum_states = qt * e_list ** 2.5 / (sqrt(constants.pi) * 15.0 / 8.0)
         return sum_states
 
@@ -198,7 +200,7 @@ cdef class IdealGasTranslation(Translation):
             mass = self._mass.value_si
             e_list = e_list / constants.Na
             dE = e_list[1] - e_list[0]
-            qt = ((2 * constants.pi * mass) / (constants.h * constants.h)) ** 1.5 / 101325.
+            qt = ((2 * constants.pi * mass) / (constants.h ** 2)) ** 1.5 / 101325.
             dens_states = qt * e_list ** 1.5 / (sqrt(constants.pi) * 0.75) * dE
             if dens_states_0 is not None:
                 dens_states = schrodinger.convolve(dens_states_0, dens_states)


### PR DESCRIPTION
### Motivation or Problem
So far Arkane treated species as either linear or non-linear ("asymmetric top"). Although RMG's statmech had functionality to treat "spherical top" rotors, it wasn't used when parsing ESS output files (it is used only if a user explicitly specifies it in the input file).

### Description of Changes
First a "spherical top" rotor was added. Here we also make Arkane identify the correct rotor using the parsed or computed rotational constants.

Nomenclature:
- Spherical Top rotor: A species with all three rotational constants equal (e.g., CH4).
- Symmetric Top rotor: A species with only two of the three rotational constants equal (e.g., NH3).
- Asymmetric Top rotor: A (non linear) species with three unique rotational constants. In RMG this is called a `NonlinearRotor`, we might want to consider renaming it to `AsymmetricRotor` (not renamed in this PR).