### PR TITLE
Adding in a new database test to check all surface training reactions are useable

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1957,14 +1957,15 @@ class KineticsFamily(Database):
             molecules_a = reactants[0]
             molecules_b = reactants[1]
 
-            # ToDo: try to remove this hard-coding of reaction family name..
             if 'adsorption' in self.label.lower() and forward:
-                if 'Surface_Dual_Adsorption_vdW' is self.label and forward:
-                    pass
-                elif molecules_a[0].contains_surface_site() and molecules_b[0].contains_surface_site():
-                    # Can't adsorb something that's already adsorbed.
-                    # Both reactants either contain or are a surface site.
-                    return []
+                if molecules_a[0].contains_surface_site() and molecules_b[0].contains_surface_site():
+                    if 'vdw' in self.label.lower():
+                        # can adsorb vdW species to the surface, so continue on
+                        pass
+                    else:
+                        # Can't adsorb something that's already adsorbed.
+                        # Both reactants either contain or are a surface site.
+                        return []
 
             # Iterate over all resonance isomers of the reactant
             for molecule_a in molecules_a:

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -116,6 +116,14 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
             self.compat_func_name = test_name
             yield test, family_name
 
+            # tests for surface families
+            if 'surface' in family_name.lower():
+                test = lambda x: self.kinetics_check_surface_training_reactions_can_be_used(family_name)
+                test_name = "Kinetics surface family {0}: entries can be used to generate rate rules?".format(family_name)
+                test.description = test_name
+                self.compat_func_name = test_name
+                yield test, family_name
+
             # these families have some sort of difficulty which prevents us from testing accessibility right now
             difficult_families = ['Diels_alder_addition', 'Intra_R_Add_Exocyclic', 'Intra_R_Add_Endocyclic']
             generated_trees = ["R_Recombination"]
@@ -320,6 +328,11 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
             yield test, group_name
 
     # These are the actual tests, that don't start with a "test_" name:
+    def kinetics_check_surface_training_reactions_can_be_used(self, family_name):
+        """Test that surface training reactions can be averaged and used for generating rate rules"""
+        family = self.database.kinetics.families[family_name]
+        family.add_rules_from_training(thermo_database=self.database.thermo)
+
     def kinetics_check_correct_number_of_nodes_in_rules(self, family_name):
         """
         This test ensures that each rate rule contains the proper number of nodes according to the family it originates.


### PR DESCRIPTION
### Motivation or Problem
This is related to #1881, when I found that adding training reactions to the database would pass all database tests but then fail when used to generate rate rules when trying to run rmg.  This adds a check to catch these problem training reactions.
This also removes the hard-coded family work around, introduced in e8e292875bb412c8690b0a0584d2dc31c700d5b9

### Description of Changes
I have added a new kinetics check called `kinetics_check_surface_training_reactions_can_be_used` that checks all surface family training reactions.
I have changed the hard coded family exception to work for any family that has both reactants vdW bonded to the surface

### Testing
All tests pass!
