### PR TITLE
Liquid test improvements

### DIFF
--- a/arkane/explorer.py
+++ b/arkane/explorer.py
@@ -321,9 +321,10 @@ class ExplorerJob(object):
             self.pdepjob.network = network
 
             if len(self.networks) > 1:
-                s1, s2 = output_file.split(".")
+                root, file_name = os.path.split(output_file)
+                s1, s2 = file_name.split(".")
                 ind = str(self.networks.index(network))
-                stot = s1 + "{}.".format(ind) + s2
+                stot = os.path.join(root, s1 + "{}.".format(ind) + s2)
             else:
                 stot = output_file
 

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -105,6 +105,8 @@ class LiquidReactorCheck(unittest.TestCase):
 
         cls.T = 1000
 
+        cls.file_dir = os.path.join(os.path.dirname(rmgpy.__file__), 'solver', 'files', 'liquid_phase_constSPC')
+
     def test_compute_flux(self):
         """
         Test the liquid batch reactor with a simple kinetic model. 
@@ -415,11 +417,7 @@ class LiquidReactorCheck(unittest.TestCase):
         From input file reading to information storage in liquid reactor object.
         """
         rmg = RMG()
-        rmg.input_file = os.path.join(os.path.dirname(rmgpy.__file__),
-                                      'solver',
-                                      'files',
-                                      'liquid_phase_constSPC',
-                                      'input.py')
+        rmg.input_file = os.path.join(self.file_dir, 'input.py')
         rmg.initialize()
 
         for index, reactionSystem in enumerate(rmg.reaction_systems):
@@ -482,3 +480,5 @@ class LiquidReactorCheck(unittest.TestCase):
 
         import rmgpy.data.rmg
         rmgpy.data.rmg.database = None
+
+        os.remove(os.path.join(cls.file_dir, 'restart_from_seed.py'))

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -48,7 +48,8 @@ from rmgpy.thermo import ThermoData
 
 class LiquidReactorCheck(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """
         Here we choose a kinetic model consisting of the hydrogen abstraction
         reaction CH4 + C2H5 <=> CH3 + C2H6.
@@ -60,7 +61,7 @@ class LiquidReactorCheck(unittest.TestCase):
         rmgpy.data.rmg.database = None
 
         Tlist = [300, 400, 500, 600, 800, 1000, 1500]
-        self.CH4 = Species(
+        cls.CH4 = Species(
             molecule=[Molecule().from_smiles("C")],
             thermo=ThermoData(
                 Tdata=(Tlist, "K"),
@@ -68,7 +69,7 @@ class LiquidReactorCheck(unittest.TestCase):
                 H298=(-17.714, "kcal/mol"),
                 S298=(44.472, "cal/(mol*K)"))
         )
-        self.CH3 = Species(
+        cls.CH3 = Species(
             molecule=[Molecule().from_smiles("[CH3]")],
             thermo=ThermoData(
                 Tdata=(Tlist, "K"),
@@ -76,7 +77,7 @@ class LiquidReactorCheck(unittest.TestCase):
                 H298=(9.357, "kcal/mol"),
                 S298=(45.174, "cal/(mol*K)"))
         )
-        self.C2H6 = Species(
+        cls.C2H6 = Species(
             molecule=[Molecule().from_smiles("CC")],
             thermo=ThermoData(
                 Tdata=(Tlist, "K"),
@@ -84,7 +85,7 @@ class LiquidReactorCheck(unittest.TestCase):
                 H298=(-19.521, "kcal/mol"),
                 S298=(54.799, "cal/(mol*K)"))
         )
-        self.C2H5 = Species(
+        cls.C2H5 = Species(
             molecule=[Molecule().from_smiles("C[CH2]")],
             thermo=ThermoData(
                 Tdata=(Tlist, "K"),
@@ -93,7 +94,7 @@ class LiquidReactorCheck(unittest.TestCase):
                 S298=(56.687, "cal/(mol*K)"))
         )
 
-        self.H2 = Species(
+        cls.H2 = Species(
             molecule=[Molecule().from_smiles("[H][H]")],
             thermo=ThermoData(
                 Tdata=(Tlist, "K"),
@@ -102,7 +103,7 @@ class LiquidReactorCheck(unittest.TestCase):
                 S298=(31.23, "cal/(mol*K)"))
         )
 
-        self.T = 1000
+        cls.T = 1000
 
     def test_compute_flux(self):
         """
@@ -470,7 +471,8 @@ class LiquidReactorCheck(unittest.TestCase):
                              "Core species rate has to be equal to 0 for species hold constant. "
                              "Here it is equal to {0}".format(rxn_system.core_species_rates[0]))
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """
         Reset the database & liquid parameters for solution
         """

--- a/rmgpy/solver/liquidTest.py
+++ b/rmgpy/solver/liquidTest.py
@@ -32,7 +32,6 @@ import unittest
 
 import numpy as np
 
-import rmgpy
 from rmgpy.kinetics import Arrhenius
 from rmgpy.molecule import Molecule
 from rmgpy.reaction import Reaction

--- a/rmgpy/tools/generatereactionsTest.py
+++ b/rmgpy/tools/generatereactionsTest.py
@@ -54,6 +54,7 @@ class GenerateReactionsTest(unittest.TestCase):
         self.assertIsNotNone(rmg.reaction_model.output_reaction_list)
 
         shutil.rmtree(os.path.join(folder, 'pdep'))
+        os.remove(os.path.join(folder, 'restart_from_seed.py'))
 
     def test_duplicate_reaction(self):
         """
@@ -88,6 +89,7 @@ class GenerateReactionsTest(unittest.TestCase):
         self.assertEquals(count, 1)
 
         shutil.rmtree(os.path.join(folder, 'pdep'))
+        os.remove(os.path.join(folder, 'restart_from_seed.py'))
 
     def test_library_reaction_enters_core(self):
         """
@@ -126,6 +128,7 @@ class GenerateReactionsTest(unittest.TestCase):
         # Assert that the core only has 1 reaction
         self.assertEquals(len(rmg.reaction_model.core.reactions), 1)
         shutil.rmtree(os.path.join(folder, 'pdep'))
+        os.remove(os.path.join(folder, 'restart_from_seed.py'))
 
     def setUp(self):
         import rmgpy.data.rmg


### PR DESCRIPTION
Gets rid of the liquidTest restart file that is generated by the unit tests. Also uses the setUpClass method, which is what is actually desired here.
