### PR TITLE
Added an option to save atom order when adding atom labels for a template reaction

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1116,11 +1116,11 @@ class Molecule(Graph):
         for index, vertex in enumerate(self.vertices):
             vertex.sorting_label = index
 
-    def update(self, log_species=True, raise_atomtype_exception=True):
+    def update(self, log_species=True, raise_atomtype_exception=True, sort_atoms=True):
         """
         Update connectivity values, atom types of atoms.
-        Update multiplicity, and sort atoms using the new
-        connectivity values.
+        Update multiplicity, and sort atoms (if ``sort_atoms`` is ``True``)
+        using the new connectivity values.
         """
 
         for atom in self.atoms:
@@ -1128,7 +1128,8 @@ class Molecule(Graph):
 
         self.update_atomtypes(log_species=log_species, raise_exception=raise_atomtype_exception)
         self.update_multiplicity()
-        self.sort_atoms()
+        if sort_atoms:
+            self.sort_atoms()
         self.identify_ring_membership()
 
     def get_formula(self):

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -38,7 +38,6 @@ cimport numpy as np
 ################################################################################
 
 cdef class Reaction:
-    
     cdef public int index
     cdef public str label
     cdef public list reactants
@@ -59,19 +58,19 @@ cdef class Reaction:
     cdef public bint is_forward
     cdef public bint allow_max_rate_violation
     cdef public object rank
-    
+
     cpdef bint is_isomerization(self)
 
     cpdef bint is_dissociation(self)
 
     cpdef bint is_association(self)
-    
+
     cpdef bint is_unimolecular(self)
 
     cpdef bint is_surface_reaction(self)
 
     cpdef bint has_template(self, list reactants, list products)
-    
+
     cpdef bint matches_species(self, list reactants, list products=?)
 
     cpdef bint is_isomorphic(self, Reaction other, bint either_direction=?, bint check_identical=?,
@@ -114,12 +113,14 @@ cdef class Reaction:
 
     cpdef bint can_tst(self) except -2
 
-    cpdef calculate_microcanonical_rate_coefficient(self, np.ndarray e_list, np.ndarray j_list, np.ndarray reac_dens_states, np.ndarray prod_dens_states=?, double T=?)
+    cpdef calculate_microcanonical_rate_coefficient(self, np.ndarray e_list, np.ndarray j_list,
+                                                    np.ndarray reac_dens_states, np.ndarray prod_dens_states=?,
+                                                    double T=?)
 
     cpdef bint is_balanced(self)
-    
+
     cpdef generate_pairs(self)
-    
+
     cpdef copy(self)
 
     cpdef ensure_species(self, bint reactant_resonance=?, bint product_resonance=?)

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -74,8 +74,9 @@ cdef class Reaction:
     
     cpdef bint matches_species(self, list reactants, list products=?)
 
-    cpdef bint is_isomorphic(self, Reaction other, bint either_direction=?, bint check_identical=?, bint check_only_label=?,
-                            bint check_template_rxn_products=?, bint generate_initial_map=?, bint strict=?) except -2
+    cpdef bint is_isomorphic(self, Reaction other, bint either_direction=?, bint check_identical=?,
+                             bint check_only_label=?, bint check_template_rxn_products=?, bint generate_initial_map=?,
+                             bint strict=?, bint save_order=?) except -2
 
     cpdef double get_enthalpy_of_reaction(self, double T)
 
@@ -131,4 +132,5 @@ cdef class Reaction:
 
     cpdef get_mean_sigma_and_epsilon(self, bint reverse=?)
 
-cpdef bint same_species_lists(list list1, list list2, bint check_identical=?, bint only_check_label=?, bint generate_initial_map=?, bint strict=?) except -2
+cpdef bint same_species_lists(list list1, list list2, bint check_identical=?, bint only_check_label=?,
+                              bint generate_initial_map=?, bint strict=?, bint save_order=?) except -2

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -432,7 +432,7 @@ class Reaction:
             return False
 
     def is_isomorphic(self, other, either_direction=True, check_identical=False, check_only_label=False,
-                      check_template_rxn_products=False, generate_initial_map=False, strict=True):
+                      check_template_rxn_products=False, generate_initial_map=False, strict=True, save_order=False):
         """
         Return ``True`` if this reaction is the same as the `other` reaction,
         or ``False`` if they are different. The comparison involves comparing
@@ -448,6 +448,7 @@ class Reaction:
                                                           (used when we know the reactants are identical, i.e. in generating reactions)
             generate_initial_map (bool, optional):        if ``True``, initialize map by pairing atoms with same labels
             strict (bool, optional):                      if ``False``, perform isomorphism ignoring electrons
+            save_order (bool, optional):                  if ``True``, perform isomorphism saving atom order
         """
         if check_template_rxn_products:
             try:
@@ -460,21 +461,24 @@ class Reaction:
                                       check_identical=check_identical,
                                       only_check_label=check_only_label,
                                       generate_initial_map=generate_initial_map,
-                                      strict=strict)
+                                      strict=strict,
+                                      save_order=save_order)
 
         # Compare reactants to reactants
         forward_reactants_match = same_species_lists(self.reactants, other.reactants,
                                                      check_identical=check_identical,
                                                      only_check_label=check_only_label,
                                                      generate_initial_map=generate_initial_map,
-                                                     strict=strict)
+                                                     strict=strict,
+                                                     save_order=save_order)
 
         # Compare products to products
         forward_products_match = same_species_lists(self.products, other.products,
                                                     check_identical=check_identical,
                                                     only_check_label=check_only_label,
                                                     generate_initial_map=generate_initial_map,
-                                                    strict=strict)
+                                                    strict=strict,
+                                                    save_order=save_order)
 
         # Compare specific_collider to specific_collider
         collider_match = (self.specific_collider == other.specific_collider)
@@ -490,14 +494,16 @@ class Reaction:
                                                      check_identical=check_identical,
                                                      only_check_label=check_only_label,
                                                      generate_initial_map=generate_initial_map,
-                                                     strict=strict)
+                                                     strict=strict,
+                                                     save_order=save_order)
 
         # Compare products to reactants
         reverse_products_match = same_species_lists(self.products, other.reactants,
                                                     check_identical=check_identical,
                                                     only_check_label=check_only_label,
                                                     generate_initial_map=generate_initial_map,
-                                                    strict=strict)
+                                                    strict=strict,
+                                                    save_order=save_order)
 
         # should have already returned if it matches forwards, or we're not allowed to match backwards
         return reverse_reactants_match and reverse_products_match and collider_match
@@ -1350,7 +1356,7 @@ class Reaction:
 
 
 def same_species_lists(list1, list2, check_identical=False, only_check_label=False, generate_initial_map=False,
-                       strict=True):
+                       strict=True, save_order=False):
     """
     This method compares whether two lists of species or molecules are the same,
     given the comparison options provided. It is used for the `is_same` method
@@ -1363,19 +1369,21 @@ def same_species_lists(list1, list2, check_identical=False, only_check_label=Fal
         only_check_label (bool, optional):     if ``True``, only compare the label attribute of each species
         generate_initial_map (bool, optional): if ``True``, initialize map by pairing atoms with same labels
         strict (bool, optional):               if ``False``, perform isomorphism ignoring electrons
+        save_order (bool, optional):           if ``True``, perform isomorphism saving atom order
 
     Returns:
         ``True`` if the lists are the same and ``False`` otherwise
     """
 
     def same(object1, object2, _check_identical=check_identical, _only_check_label=only_check_label,
-             _generate_initial_map=generate_initial_map, _strict=strict):
+             _generate_initial_map=generate_initial_map, _strict=strict, save_order=save_order):
         if _only_check_label:
             return str(object1) == str(object2)
         elif _check_identical:
             return object1.is_identical(object2, strict=_strict)
         else:
-            return object1.is_isomorphic(object2, generate_initial_map=_generate_initial_map, strict=_strict)
+            return object1.is_isomorphic(object2, generate_initial_map=_generate_initial_map,
+                                         strict=_strict, save_order=save_order)
 
     if len(list1) == len(list2) == 1:
         if same(list1[0], list2[0]):

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -71,7 +71,7 @@ class PseudoSpecies(object):
     def __str__(self):
         return self.label
 
-    def is_isomorphic(self, other, generate_initial_map=False, strict=True):
+    def is_isomorphic(self, other, generate_initial_map=False, strict=True, save_order=False):
         return self.label.lower() == other.label.lower()
 
 

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -59,7 +59,7 @@ cdef class Species:
 
     cpdef generate_resonance_structures(self, bint keep_isomorphic=?, bint filter_structures=?)
     
-    cpdef bint is_isomorphic(self, other, bint generate_initial_map=?, bint strict=?) except -2
+    cpdef bint is_isomorphic(self, other, bint generate_initial_map=?, bint save_order=?, bint strict=?) except -2
 
     cpdef bint is_identical(self, other, bint strict=?) except -2
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -276,23 +276,26 @@ class Species(object):
             self.molecule = self.molecule[0].generate_resonance_structures(keep_isomorphic=keep_isomorphic,
                                                                            filter_structures=filter_structures)
 
-    def is_isomorphic(self, other, generate_initial_map=False, strict=True):
+    def is_isomorphic(self, other, generate_initial_map=False, save_order=False, strict=True):
         """
         Return ``True`` if the species is isomorphic to `other`, which can be
         either a :class:`Molecule` object or a :class:`Species` object.
 
         Args:
             generate_initial_map (bool, optional): If ``True``, make initial map by matching labeled atoms
-            strict (bool, optional):             If ``False``, perform isomorphism ignoring electrons.
+            save_order (bool, optional):           if ``True``, reset atom order after performing atom isomorphism
+            strict (bool, optional):               If ``False``, perform isomorphism ignoring electrons.
         """
         if isinstance(other, Molecule):
             for molecule in self.molecule:
-                if molecule.is_isomorphic(other, generate_initial_map=generate_initial_map, strict=strict):
+                if molecule.is_isomorphic(other, generate_initial_map=generate_initial_map,
+                                          save_order=save_order, strict=strict):
                     return True
         elif isinstance(other, Species):
             for molecule1 in self.molecule:
                 for molecule2 in other.molecule:
-                    if molecule1.is_isomorphic(molecule2, generate_initial_map=generate_initial_map, strict=strict):
+                    if molecule1.is_isomorphic(molecule2, generate_initial_map=generate_initial_map,
+                                               save_order=save_order, strict=strict):
                         return True
         else:
             raise ValueError('Unexpected value "{0!r}" for other parameter;'


### PR DESCRIPTION
### Motivation or Problem
The Family.add_atom_labels_for_reaction() method may be used for 3D TS guess generation outside RMG. However, currently, it does not preserve the atom order of the original molecule (tracked down to a `struc.update()` call under `apply_recipe()`)

### Description of Changes
A `save_order` attribute was added to `KineticsFamily`.