### PR TITLE
General Pdep Fixes

### DIFF
--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -411,8 +411,9 @@ class Network(object):
                         Q += np.sum(
                             self.dens_states[i, :, s] * (2 * j_list[s] + 1) * np.exp(-e_list / constants.R / T))
                     if Q == 0.:
-                        logging.warning('No density of states found for structure {1} in network {0}. '
-                                        'possibly a product witout any thermo.'.format(self.label, i))
+                        if not self.rmgmode:
+                            logging.warning('No density of states found for structure {1} in network {0}. '
+                                            'possibly a product witout any thermo.'.format(self.label, i))
                     else:
                         self.dens_states[i, :, :] /= Q
                 if np.isnan(self.dens_states).any():

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1465,7 +1465,9 @@ class CoreEdgeReactionModel:
             if not isNew:
                 logging.info("This library reaction was not new: {0}".format(rxn))
             elif self.pressure_dependence and rxn.elementary_high_p and rxn.is_unimolecular() \
-                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius):
+                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius) and \
+                    (self.pressure_dependence.maximum_atoms is None or self.pressure_dependence.maximum_atoms >= \
+                     sum([len(spec.molecule[0].atoms) for spec in r.reactants])):
                 # This unimolecular library reaction is flagged as `elementary_high_p` and has Arrhenius type kinetics.
                 # We should calculate a pressure-dependent rate for it
                 if len(rxn.reactants) == 1:
@@ -1562,7 +1564,9 @@ class CoreEdgeReactionModel:
             if not isNew:
                 logging.info("This library reaction was not new: {0}".format(rxn))
             elif self.pressure_dependence and rxn.elementary_high_p and rxn.is_unimolecular() \
-                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius):
+                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius) and \
+                    (self.pressure_dependence.maximum_atoms is None or self.pressure_dependence.maximum_atoms >= \
+                     sum([len(spec.molecule[0].atoms) for spec in r.reactants])):
                 # This unimolecular library reaction is flagged as `elementary_high_p` and has Arrhenius type kinetics.
                 # We should calculate a pressure-dependent rate for it
                 if len(rxn.reactants) == 1:
@@ -1603,7 +1607,9 @@ class CoreEdgeReactionModel:
             # Instead, we remove the comment below if the reaction is moved to
             # the core later in the mechanism generation
             if not (self.pressure_dependence and rxn.elementary_high_p and rxn.is_unimolecular()
-                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius)):
+                    and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius) and \
+                    (self.pressure_dependence.maximum_atoms is None or self.pressure_dependence.maximum_atoms >= \
+                     sum([len(spec.molecule[0].atoms) for spec in r.reactants]))):
                 # Don't add to the edge library reactions that were already processed
                 self.add_reaction_to_edge(rxn)
 

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -497,10 +497,11 @@ cdef class ReactionSystem(DASx):
                 try:
                     i = self.get_species_index(spec)
                 except KeyError:
-                    # spec is probably in the edge, hence is not a key in the species_index dictionary.
-                    # Sicne network_indices is only used to identify the number of reactants, set the
-                    # corresponding value to be different than `-1`.
-                    i = -2
+                    self.network_indices[j, :] = [-1,-1,-1]
+                    break
+                if i >= self.num_core_species: #an edge species is in source
+                    self.network_indices[j, :] = [-1,-1,-1]
+                    break
                 self.network_indices[j, l] = i
 
     @cython.boundscheck(False)

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -493,7 +493,7 @@ cdef class ReactionSystem(DASx):
 
         for j, network in enumerate(pdep_networks):
             self.network_leak_coefficients[j] = network.get_leak_coefficient(self.T.value_si, self.P.value_si)
-            for l, spec in enumerate(network.source):
+            for k, spec in enumerate(network.source):
                 try:
                     i = self.get_species_index(spec)
                 except KeyError:
@@ -502,7 +502,7 @@ cdef class ReactionSystem(DASx):
                 if i >= self.num_core_species: #an edge species is in source
                     self.network_indices[j, :] = [-1,-1,-1]
                     break
-                self.network_indices[j, l] = i
+                self.network_indices[j, k] = i
 
     @cython.boundscheck(False)
     cpdef get_layering_indices(self):

--- a/rmgpy/solver/liquid.pyx
+++ b/rmgpy/solver/liquid.pyx
@@ -348,14 +348,17 @@ cdef class LiquidReactor(ReactionSystem):
                         if third >= num_core_species: edge_species_rates[third - num_core_species] += reaction_rate
 
         for j in range(inet.shape[0]):
-            k = knet[j]
-            if inet[j, 1] == -1:  # only one reactant
-                reaction_rate = k * C[inet[j, 0]]
-            elif inet[j, 2] == -1:  # only two reactants
-                reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]]
-            else:  # three reactants
-                reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]] * C[inet[j, 2]]
-            network_leak_rates[j] = reaction_rate
+            if inet[j, 0] != -1: #all source species are in the core
+                k = knet[j]
+                if inet[j, 1] == -1:  # only one reactant
+                    reaction_rate = k * C[inet[j, 0]]
+                elif inet[j, 2] == -1:  # only two reactants
+                    reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]]
+                else:  # three reactants
+                    reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]] * C[inet[j, 2]]
+                    network_leak_rates[j] = reaction_rate
+            else:
+                network_leak_rates[j] = 0.0
 
         # chatelak: Same as in Java, core species rate = 0 if declared as constant
         if self.const_spc_indices is not None:

--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -512,14 +512,17 @@ cdef class SimpleReactor(ReactionSystem):
                         if third >= num_core_species: edge_species_rates[third - num_core_species] += reaction_rate
 
         for j in range(inet.shape[0]):
-            k = knet[j]
-            if inet[j, 1] == -1:  # only one reactant
-                reaction_rate = k * C[inet[j, 0]]
-            elif inet[j, 2] == -1:  # only two reactants
-                reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]]
-            else:  # three reactants
-                reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]] * C[inet[j, 2]]
-            network_leak_rates[j] = reaction_rate
+            if inet[j, 0] != -1: #all source species are in the core
+                k = knet[j]
+                if inet[j, 1] == -1:  # only one reactant
+                    reaction_rate = k * C[inet[j, 0]]
+                elif inet[j, 2] == -1:  # only two reactants
+                    reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]]
+                else:  # three reactants
+                    reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]] * C[inet[j, 2]]
+                network_leak_rates[j] = reaction_rate
+            else:
+                network_leak_rates[j] = 0.0
 
         if self.const_spc_indices is not None:
             for spc_index in self.const_spc_indices:

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -465,14 +465,17 @@ cdef class SurfaceReactor(ReactionSystem):
                         if third >= num_core_species: edge_species_rates[third - num_core_species] += reaction_rate
 
         for j in range(inet.shape[0]):
-            k = knet[j]
-            if inet[j, 1] == -1:  # only one reactant
-                reaction_rate = k * C[inet[j, 0]]
-            elif inet[j, 2] == -1:  # only two reactants
-                reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]]
-            else:  # three reactants!! (really?)
-                reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]] * C[inet[j, 2]]
-            network_leak_rates[j] = reaction_rate
+            if inet[j, 0] != -1: #all source species are in the core
+                k = knet[j]
+                if inet[j, 1] == -1:  # only one reactant
+                    reaction_rate = k * C[inet[j, 0]]
+                elif inet[j, 2] == -1:  # only two reactants
+                    reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]]
+                else:  # three reactants
+                    reaction_rate = k * C[inet[j, 0]] * C[inet[j, 1]] * C[inet[j, 2]]
+                    network_leak_rates[j] = reaction_rate
+            else:
+                network_leak_rates[j] = 0.0
 
         self.core_species_concentrations = core_species_concentrations
         self.core_species_rates = core_species_rates


### PR DESCRIPTION
This fixes #1905 and #1911.  The first is fixed by not displaying the warning when the network is in rmgmode. The second is fixed by detecting when the source of a network is not entirely in the core and setting the leak rate to zero in those cases.  