### PR TITLE
Debugged liquid phase range based reactor

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -523,7 +523,8 @@ class RMG(util.Subject):
 
             # Set solvent viscosity for reaction filtering
             for reaction_system in self.reaction_systems:
-                reaction_system.viscosity = solvent_data.get_solvent_viscosity(reaction_system.T.value_si)
+                if reaction_system.T:
+                    reaction_system.viscosity = solvent_data.get_solvent_viscosity(reaction_system.T.value_si)
 
         try:
             self.walltime = kwargs['walltime']
@@ -783,6 +784,14 @@ class RMG(util.Subject):
                     for p in range(reaction_system.n_sims):
                         reactor_done = True
                         objects_to_enlarge = []
+
+                        conditions = self.rmg_memories[index].get_cond()
+                        if conditions and self.solvent:
+                            T = conditions['T']
+                            # Set solvent viscosity
+                            solvent_data = self.database.solvation.get_solvent_data(self.solvent)
+                            reaction_system.viscosity = solvent_data.get_solvent_viscosity(T)
+
                         self.reaction_system = reaction_system
                         # Conduct simulation
                         logging.info('Conducting simulation of reaction system %s...' % (index + 1))


### PR DESCRIPTION
### Motivation or Problem
Range based reactor didn't work for liquid phase before. It's because RMG used `reaction_system.T` to calculate viscosity for liquid phase. However, `reaction_system.T` is `None` when the input T is a list (range). 

### Description of Changes
I modified the code such that RMG will check whether `reaction_system.T` exists. If so, viscosity will be calculated when the model is initialized (i.e. not range based). If not, then viscosity will be calculated in each run of `n_sims` with the corresponding T stored in the condition dictionary from `rmg_memories.get_cond()`. `diffusion_limiter` is still enabled in the initiation stage, no matter the liquid phase job is range based or not.

### Testing
I tested with an old liquid reactor input file. It works now. Output seems reasonable.