### PR TITLE
BugFix: Make rank 1 accuracy 0.2 kcal/mol instead of 0 kcal/mol

### DIFF
--- a/rmgpy/kinetics/uncertainties.pyx
+++ b/rmgpy/kinetics/uncertainties.pyx
@@ -67,7 +67,7 @@ cdef class RateUncertainty(object):
         """
         return np.sqrt(self.var * 2.0 / np.pi) + abs(self.mu)
 
-rank_accuracy_map = {1: (0.0, 'kcal/mol'),
+rank_accuracy_map = {1: (0.2, 'kcal/mol'),
                      2: (0.5, 'kcal/mol'),
                      3: (1.0, 'kcal/mol'),
                      4: (1.5, 'kcal/mol'),


### PR DESCRIPTION
If rank 1 accuracy = 0, then in situations where training reactions are all from literature (rank 1), as the case for some newly added families, division by zero would occur when fitting ArrheniusBM model (cf. fit_to_reactions in arrhenius.pyx)

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Estimated uncertainty in line 623 arrhenius.pyx is 0 if all training reactions in a family have rank 1. This will then lead to division by zero error during automatic tree generation. This PR provides a fix by changing the estimation for rank 1 from 0 to 0.2 kcal/mol to avoid overflow as suggested by @mjohnson541 

### Description of Changes
Estimated rank 1 accuracy in the `rank_accuracy_map` is changed to 0.2 kcal/mol instead of 0.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
