### PR TITLE
Add A units for trimolecular reactions in ArrheniusBM model fits

### DIFF
--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -650,10 +650,9 @@ cdef class ArrheniusBM(KineticsModel):
         A = np.exp(lnA)
 
         # fill in parameters
-        if len(rxns[0].reactants) == 1:
-            self.A = (A, 's^-1')
-        elif len(rxns[0].reactants) == 2:
-            self.A = (A, 'm^3/(mol*s)')
+        A_units = ['', 's^-1', 'm^3/(mol*s)', 'm^6/(mol^2*s)']
+        order = len(rxns[0].reactants)
+        self.A = (A, A_units[order])
 
         self.n = n
         self.w0 = (w0, 'J/mol')


### PR DESCRIPTION
Now output correct units for trimolecular reactions

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
`A` unit for a trimolecular reaction was not correctly assigned. 

### Description of Changes
Updated unit dictionary, now supports a trimolecular reaction.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
