### PR TITLE
Allow colons and periods in chemkin species names

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1557,7 +1557,7 @@ def get_species_identifier(species):
     if species.index == -1:
         # No index present -- probably not in RMG job
         # In this case just return the label (if the right size)
-        if len(label) > 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#]+', label):
+        if len(label) > 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#.:\[\]]+', label):
             if len(label) <= 10:
                 return label
             elif len(label) <= 15:
@@ -1577,8 +1577,8 @@ def get_species_identifier(species):
         # (at the expense of the current label or formula if need be)
 
         # First try to use the label and index
-        # The label can only contain alphanumeric characters, and -()*#_,
-        if len(label) > 0 and species.index >= 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#]+', label):
+        # The label can only contain alphanumeric characters, and -()*#_,.:[]
+        if len(label) > 0 and species.index >= 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#.:\[\]]+', label):
             name = '{0}({1:d})'.format(label, species.index)
             if len(name) <= 10:
                 return name


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
When trying to import a chemkin file from NIST, we choked on a species called `CHF:CF2` because RMG does not expect chemkin species labels to contain colons.


### Description of Changes
Added `:` to the regular expression used to check valid species labels before returning them.
Also found a commit from ages ago where we did the same thing for periods, for some other chemkin file. I added that commit to this PR. Then I found the model also had `[` and `]` in the species names, so I added those.

### Testing
I will cross my fingers and let travis run the unit tests.

### Reviewer Tips
Hopefully any other parts of code that parse strings using regular expressions (or worse, `split()`) are well written and tested.

### Note
We are still, in fact, too restrictive to parse all valid Chemkin names. For example see some of the pathological names that Cantera checks for in https://github.com/Cantera/cantera/blob/master/test/data/species-names.inp
which contains `(Parens)  @#$%^-2  co:lons: [xy2]*{.}  plus+ eq=uals plus trans_butene co`
