### PR TITLE
Gav comments

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1966,13 +1966,21 @@ class ThermoDatabase(object):
             # Iterate over heavy (non-hydrogen) atoms
             if atom.is_non_hydrogen():
                 # Get initial thermo estimate from main group database
+                data_added = False
                 try:
-                    self._add_group_thermo_data(thermo_data, self.groups['group'], molecule, {'*': atom})
+                    data_added = self._add_group_thermo_data(thermo_data, self.groups['group'], molecule, {'*': atom})[1]
                 except KeyError:
                     logging.error("Couldn't find in main thermo database:")
                     logging.error(molecule)
                     logging.error(molecule.to_adjacency_list())
                     raise
+                if not data_added:
+                    neighbors = ''.join(sorted([atom2.atomtype.label for atom2 in atom.edges.keys()]))
+                    if thermo_data.comment:
+                        thermo_data.comment += f' + missing({atom.atomtype.label}-{neighbors})'
+                    else:
+                        thermo_data.comment = f'Thermo group additivity estimation: ' \
+                                              f'missing({atom.atomtype.label}-{neighbors})'
                 # Correct for gauche and 1,5- interactions
                 # Pair atom with its 1st and 2nd nonHydrogen neighbors, 
                 # Then match the pair with the entries in the database longDistanceInteraction_noncyclic.py

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -2314,6 +2314,9 @@ class ThermoDatabase(object):
         in the structure ``molecule``, and add it to the existing thermo data
         ``thermo_data``.
         The parameter ``atom`` is a dictionary of label-atom pairs like {'*',atom}
+
+        Returns:
+            tuple: The combined ThermoData object and a bool flag indicating whether new data was added to it.
         """
         node0 = database.descend_tree(molecule, atom, None)
         if node0 is None:
@@ -2357,9 +2360,11 @@ class ThermoDatabase(object):
         # print result[4:]
 
         if thermo_data is None:
-            return data
+            return data, False
         else:
-            return add_thermo_data(thermo_data, data, group_additivity=True)
+            if data.is_all_zeros():
+                return thermo_data, False
+            return add_thermo_data(thermo_data, data, group_additivity=True), True
 
     def _remove_group_thermo_data(self, thermo_data, database, molecule, atom):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1917,16 +1917,16 @@ class ThermoDatabase(object):
     def estimate_thermo_via_group_additivity(self, molecule):
         """
         Return the set of thermodynamic parameters corresponding to a given
-        :class:`Molecule` object `molecule` by estimation using the group
-        additivity values. If no group additivity values are loaded, a
-        :class:`DatabaseError` is raised.
-        
-        The entropy is not corrected for the symmetry of the molecule.
-        This should be done later by the calling function.
+        :class:`Molecule` object ``molecule`` using the group additivity values
+        method. If no group additivity values are loaded, a :class:`DatabaseError`
+        is raised.
+
+        The entropy is not corrected for the symmetry of the molecule,
+        this should be done later by the calling function.
         """
         # For thermo estimation we need the atoms to already be sorted because we
         # iterate over them; if the order changes during the iteration then we
-        # will probably not visit the right atoms, and so will get the thermo wrong
+        # will probably not visit the right atoms, and so will get the thermo wrong.
         molecule.sort_atoms()
 
         if molecule.is_radical():
@@ -1938,18 +1938,18 @@ class ThermoDatabase(object):
     def compute_group_additivity_thermo(self, molecule):
         """
         Return the set of thermodynamic parameters corresponding to a given
-        :class:`Molecule` object `molecule` by estimation using the group
-        additivity values. If no group additivity values are loaded, a
-        :class:`DatabaseError` is raised.
-        
-        The entropy is not corrected for the symmetry of the molecule.
-        This should be done later by the calling function.
+        :class:`Molecule` object ``molecule`` using the group additivity values
+        method. If no group additivity values are loaded, a :class:`DatabaseError`
+        is raised.
+
+        The entropy is not corrected for the symmetry of the molecule,
+        this should be done later by the calling function.
         """
 
         assert not molecule.is_radical(), "This method is only for saturated non-radical species."
         # For thermo estimation we need the atoms to already be sorted because we
         # iterate over them; if the order changes during the iteration then we
-        # will probably not visit the right atoms, and so will get the thermo wrong
+        # will probably not visit the right atoms, and so will get the thermo wrong.
         molecule.sort_atoms()
 
         # Create the ThermoData object
@@ -1961,7 +1961,7 @@ class ThermoDatabase(object):
         )
 
         cyclic = molecule.is_cyclic()
-        # Generate estimate of thermodynamics
+        # Generate estimates of the thermodynamics parameters
         for atom in molecule.atoms:
             # Iterate over heavy (non-hydrogen) atoms
             if atom.is_non_hydrogen():
@@ -2310,10 +2310,10 @@ class ThermoDatabase(object):
 
     def _add_group_thermo_data(self, thermo_data, database, molecule, atom):
         """
-        Determine the group additivity thermodynamic data for the atom `atom`
-        in the structure `structure`, and add it to the existing thermo data
-        `thermo_data`.
-        The parameter `atom` is a dictionary of label-atom pairs like {'*',atom}
+        Determine the group additivity thermodynamic data for the atom ``atom``
+        in the structure ``molecule``, and add it to the existing thermo data
+        ``thermo_data``.
+        The parameter ``atom`` is a dictionary of label-atom pairs like {'*',atom}
         """
         node0 = database.descend_tree(molecule, atom, None)
         if node0 is None:
@@ -2327,7 +2327,7 @@ class ThermoDatabase(object):
             node = node.parent
         if node is None:
             raise DatabaseError('Unable to determine thermo parameters for {0}: no data for node {1} or '
-                                'any of its ancestors.'.format(molecule, node0) )
+                                'any of its ancestors.'.format(molecule, node0))
 
         data = node.data
         comment = node.label
@@ -2345,7 +2345,7 @@ class ThermoDatabase(object):
                     comment = entry.label
                     break
             else:
-                raise DatabaseError("Node {0} points to a non-existant group called {1} in database: "
+                raise DatabaseError("Node {0} points to a non-existing group called {1} in database: "
                                     "{2}".format(node.label, data, database.label))
         data.comment = '{0}({1})'.format(database.label, comment)
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -606,6 +606,14 @@ multiplicity 2
         self.assertIn('group additivity', thermo_gav.comment, 'Thermo not found from GAV, test purpose not fulfilled.')
         self.assertIn('polycyclic(s2_6_6_naphthalene)', thermo_gav.comment)
 
+    def test_identifying_missing_group(self):
+        """Test identifying a missing GAV group"""
+        # this test should be updated once data is added to the missing group
+        spc = Species(smiles='CN(C)CCCN1C2=CC=CC=C2CCC3=CC=CC=C31')
+        spc.generate_resonance_structures()
+        thermo_gav = self.database.get_thermo_data_from_groups(spc)
+        self.assertIn('missing(N3s-CbCbCs)', thermo_gav.comment)
+
 
 class TestThermoAccuracy(unittest.TestCase):
     """

--- a/rmgpy/thermo/thermodata.pxd
+++ b/rmgpy/thermo/thermodata.pxd
@@ -50,3 +50,5 @@ cdef class ThermoData(HeatCapacityModel):
     cpdef Wilhoit to_wilhoit(self, object B=?)
 
     cpdef NASA to_nasa(self, double Tmin, double Tmax, double Tint, bint fixedTint=?, bint weighting=?, int continuity=?)
+
+    cpdef bint is_all_zeros(self)

--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -402,3 +402,21 @@ cdef class ThermoData(HeatCapacityModel):
         :class:`NASAPolynomial` objects.
         """
         return self.to_wilhoit().to_nasa(Tmin, Tmax, Tint, fixedTint, weighting, continuity)
+
+    cpdef bint is_all_zeros(self):
+        """
+        Check whether a ThermoData object has all zero values, e.g.: 
+        
+            ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "J/(mol*K)"),
+                H298=(0.0, "kJ/mol"),
+                S298=(0.0, "J/(mol*K)"),
+            )
+    
+        Returns:
+            bool: Whether all values are zeroes or not.
+        """
+        if self.H298.value_si == 0.0 and self.S298.value_si == 0.0 and all([cp == 0.0 for cp in self.Cpdata.value_si]):
+            return True
+        return False

--- a/rmgpy/thermo/thermodataTest.py
+++ b/rmgpy/thermo/thermodataTest.py
@@ -256,3 +256,41 @@ class TestThermoData(unittest.TestCase):
         self.assertEqual(self.thermodata.E0.units, thermodata.E0.units)
         self.assertEqual(self.thermodata.label, thermodata.label)
         self.assertEqual(self.thermodata.comment, thermodata.comment)
+
+    def test_is_all_zeros(self):
+        """Test whether a ThermoData object has all zero values"""
+        td1 = ThermoData(
+            Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+            Cpdata=([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "J/(mol*K)"),
+            H298=(0.0, "kJ/mol"),
+            S298=(0.0, "J/(mol*K)"),
+        )
+        td2 = ThermoData(
+            Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+            Cpdata=([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "J/(mol*K)"),
+            H298=(3.0, "kJ/mol"),
+            S298=(0.0, "J/(mol*K)"),
+        )
+        td3 = ThermoData(
+            Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+            Cpdata=([0.0, 0.0, 8.0, 0.0, 0.0, 0.0, 0.0], "J/(mol*K)"),
+            H298=(0.0, "kJ/mol"),
+            S298=(0.0, "J/(mol*K)"),
+        )
+        td4 = ThermoData(
+            Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+            Cpdata=([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "J/(mol*K)"),
+            H298=(0.0, "kJ/mol"),
+            S298=(5.0, "J/(mol*K)"),
+        )
+        td5 = ThermoData(
+            Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+            Cpdata=([0.0, 78.0, 0.0, 0.0, 0.0, 0.0, 0.0], "J/(mol*K)"),
+            H298=(3.0, "kJ/mol"),
+            S298=(7.0, "J/(mol*K)"),
+        )
+        self.assertTrue(td1.is_all_zeros())
+        self.assertFalse(td2.is_all_zeros())
+        self.assertFalse(td3.is_all_zeros())
+        self.assertFalse(td4.is_all_zeros())
+        self.assertFalse(td5.is_all_zeros())


### PR DESCRIPTION
fixes #1877

### Motivation or Problem
We'd like to add metadata to GAV when a group is empty or missing.

### Description of Changes
- Added an `is_all_zeros` method to `ThermoData`
- Add a `missing(<group>)` comment to GAV ThermoData when relevant

### Testing
tests were added

### Reviewer Tips
generate GAV thermo for the molecule in the test or for the molecules in #1877, look at the thermo data comment
