### PR TITLE
Read all Chebyshev coefficients from Chemkin files

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -224,6 +224,9 @@ def read_kinetics_entry(entry, species_dict, Aunits, Eunits):
                 raise ChemkinError('Missing TCHEB line for reaction {0}'.format(reaction))
             if chebyshev.Pmin is None or chebyshev.Pmax is None:
                 raise ChemkinError('Missing PCHEB line for reaction {0}'.format(reaction))
+            if len(kinetics['chebyshev coefficients']) != (chebyshev.degreeT * chebyshev.degreeP):
+                raise ChemkinError('Wrong number of Chebyshev coefficients '
+                    'for reaction {0}'.format(reaction))
             index = 0
             for t in range(chebyshev.degreeT):
                 for p in range(chebyshev.degreeP):
@@ -519,6 +522,9 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
             chebyshev.degreeT = int(float(tokens2[0].strip()))
             chebyshev.degreeP = int(float(tokens2[1].strip()))
             chebyshev.coeffs = np.zeros((chebyshev.degreeT, chebyshev.degreeP), np.float64)
+            # There may be some coefficients on this first line
+            kinetics['chebyshev coefficients'].extend(
+                [float(t.strip()) for t in tokens2[2:]])
         else:
             tokens2 = tokens[1].split()
             kinetics['chebyshev coefficients'].extend(


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Some chemkin files, like those published with
https://doi.org/10.1016/j.combustflame.2019.04.040.
put some of their Chebyshev coefficients on the first line immediately after declaring the order of the polynomials, like this:

```
O2+A1CH2=OH+A1CHO                                       1.0000e+00    0.000         0.00
 TCHEB/ 300.0 4000.0 /
 PCHEB/ 0.0132 232.0000 /
 CHEB/ 8 4 3.32750 -0.0203970 -0.00742560 -0.00160600  /
 CHEB/ 4.63780 0.0305250 0.0124980 0.00157280 -0.578460 -0.0199920  /
 CHEB/ -0.00488330 -0.000692790 -0.465680 0.00426740 0.00237970 8.65490e-05  /
 CHEB/ -0.309580 0.00107990 0.000855640 0.000952210 -0.159150 -0.000427600  /
 CHEB/ -0.000454890 -0.000143740 -0.0667800 -0.000709740 -0.000378320 -0.000119820  /
 CHEB/ -0.00356040 0.000891270 0.000485330 0.000204740  /
```

instead of something like

```
O2+A1CH2=OH+A1CHO                                       1.0000e+00    0.000         0.00
 TCHEB/ 300.0 4000.0 /
 PCHEB/ 0.0132 232.0000 /
 CHEB/ 8 4  /
 CHEB/ 3.32750 -0.0203970 -0.00742560 -0.00160600 4.63780 0.0305250  /
 CHEB/ 0.0124980 0.00157280 -0.578460 -0.0199920 -0.00488330 /
 CHEB/  -0.000692790 -0.465680 0.00426740 0.00237970 8.65490e-05  /
 CHEB/ -0.309580 0.00107990 0.000855640 0.000952210 -0.159150 -0.000427600  /
 CHEB/ -0.000454890 -0.000143740 -0.0667800 -0.000709740 -0.000378320  /
 CHEB/  -0.000119820 -0.00356040 0.000891270 0.000485330 0.000204740  /
```


### Description of Changes
RMG used to assume that the first line only contains
the orders, and all the coefficients appeared on subsequent
lines. This commit fixes that assumption, and also adds 
a check that the right number of coefficients have been read.
Also added a test that we got the right number of coefficients; it raises a `ChemkinError` if it doesn't.

### Testing
Tested we can parse the Chebyshev expressions in the Chemkin files published with
https://doi.org/10.1016/j.combustflame.2019.04.040.