### PR TITLE
BugFix: load_negative_frequency() undesired error behavior

### DIFF
--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -504,9 +504,10 @@ class GaussianLog(ESSAdapter):
 
         frequencies = [float(freq) for freq in frequencies]
         frequencies.sort()
-        frequency = [freq for freq in frequencies if freq < 0][0]
-        if frequency is None:
-            raise LogError('Unable to find imaginary frequency in Gaussian output file {0}'.format(self.path))
+        try:
+            frequency = [freq for freq in frequencies if freq < 0][0]
+        except IndexError:
+            raise LogError(f'Unable to find imaginary frequency in Gaussian output file {self.path}')
         return frequency
 
 register_ess_adapter("GaussianLog", GaussianLog)


### PR DESCRIPTION
Very minor. If no negative frequency, an error will be raised due to slice index 0 from an empty list, and `if frequency is None` will never happens.