### PR TITLE
Fix indexing while merging models

### DIFF
--- a/rmgpy/tools/mergemodels.py
+++ b/rmgpy/tools/mergemodels.py
@@ -166,16 +166,11 @@ def combine_models(models):
     print('The merged model has {0:d} species and {1:d} reactions'
           ''.format(len(final_model.species), len(final_model.reactions)))
 
-    # ensure no species with same name and index
-    label_index_dict = {}
-    for s in final_model.species:
-        if s.label not in label_index_dict:
-            label_index_dict[s.label] = [s.index]
-        else:
-            if s.index in label_index_dict[s.label]:
-                # obtained a duplicate
-                s.index = max(label_index_dict[s.label]) + 1
-                print("Reindexed {0} due to dublicate labels and index".format(s.label))
-            label_index_dict[s.label].append(s.index)
+    # reindex the unique species (to avoid name conflicts on save)
+    speciesIndex = 0
+    for spec in final_model.species:
+        if spec.label not in ['Ar', 'N2', 'Ne', 'He']:
+            spec.index = speciesIndex + 1
+            speciesIndex += 1
 
     return final_model

--- a/rmgpy/tools/mergemodelsTest.py
+++ b/rmgpy/tools/mergemodelsTest.py
@@ -53,16 +53,7 @@ class MergeModelsTest(unittest.TestCase):
         # make sure all species are included
         self.assertEqual(len(species), 15)
 
-        # make sure indexes are not unnecessarily redone
-        for s in species:
-            if s.label == 'CH2O':
-                self.assertEqual(s.index, 150)
-            elif s.label == 'CH3':
-                self.assertEqual(s.index, -1)
-            elif s.label == 'C3H7':
-                self.assertEqual(s.index, 14)
-
-        # make sure indexes are redone when there is a conflict
+        # make sure indexes are redone by checking a random species
         h_index = False
         for s in species:
             if s.label == 'H':


### PR DESCRIPTION
### Motivation or Problem
The script mergeModels.py fails to guarantee unique indices, which prevents the merged models from being simulated or restarted as described in issue #1932. 

### Description of Changes
mergemodels.py was reverted back to how it was before PR #1649. The motivation of PR #1649  was to avoid changing chemkin or cantera names at the expense of not ensuring unique indices. 

### Testing
An unnecessary check was removed from mergemodelsTest.py. All unittests passed locally. 
