### PR TITLE
Minor: Updated files in /ipython/data/parse_source

### DIFF
--- a/ipython/data/parse_source/chem_annotated.inp
+++ b/ipython/data/parse_source/chem_annotated.inp
@@ -12,7 +12,10 @@ ELEMENTS
 	He
 	Si
 	S
+	F
 	Cl
+	Br
+	I
 	X /195.083/
 END
 
@@ -27,23 +30,22 @@ SPECIES
     C2H5(5)             ! C[CH2](5)
     H(6)                ! H(6)
     C2H4(9)             ! C=C(9)
-    H2(11)              ! H2(11)
+    H2(13)              ! H2(13)
     C2H3(14)            ! [CH]=C(14)
     C3H7(16)            ! [CH2]CC(16)
-    C#C(27)             ! C#C(27)
-    C4H7(29)            ! [CH2]CC=C(29)
-    C2H2(31)            ! [C]=C(31)
-    C3H5(32)            ! [CH]=CC(32)
-    C4H7(33)            ! [CH]=CCC(33)
-    C4H5(35)            ! [CH]=CC=C(35)
-    C4H7(41)            ! [CH2]C1CC1(41)
-    C4H6(42)            ! C=CC=C(42)
-    C4H6(43)            ! [CH2][CH]C=C(43)
-    C4H7(45)            ! C=C[CH]C(45)
-    C4H6(69)            ! C=C=CC(69)
-    C4H6(88)            ! C1=CCC1(88)
-    C4H5(144)           ! C=C=[C]C(144)
-    C4H5(185)           ! [CH2]C1C=C1(185)
+    C#C(28)             ! C#C(28)
+    C4H7(31)            ! [CH2]CC=C(31)
+    C4H6(33)            ! C=CC=C(33)
+    C2H2(35)            ! [C]=C(35)
+    C3H5(36)            ! [CH]=CC(36)
+    C4H7(37)            ! [CH]=CCC(37)
+    C4H5(40)            ! [CH]=CC=C(40)
+    C4H7(46)            ! [CH2]C1CC1(46)
+    C4H6(47)            ! [CH2][CH]C=C(47)
+    C4H7(49)            ! C=C[CH]C(49)
+    C4H6(111)           ! C=C=CC(111)
+    C4H6(186)           ! C1=CCC1(186)
+    C4H5(402)           ! [CH2]C1C=C1(402)
 END
 
 
@@ -112,7 +114,7 @@ C2H4(9)                 C   2H   4          G   100.000  5000.000  940.45      1
 -6.36221688E-08 2.31767197E-11 5.07746086E+03 4.04622760E+00                   4
 
 ! Thermo library: primaryThermoLibrary
-H2(11)                  H   2               G   100.000  5000.000 1959.08      1
+H2(13)                  H   2               G   100.000  5000.000 1959.08      1
  2.78816583E+00 5.87640942E-04 1.59010417E-07-5.52739026E-11 4.34310984E-15    2
 -5.96144270E+02 1.12732655E-01 3.43536412E+00 2.12710353E-04-2.78625043E-07    3
  3.40267167E-10-7.76031998E-14-1.03135984E+03-3.90841732E+00                   4
@@ -130,87 +132,81 @@ C3H7(16)                C   3H   7          G   100.000  5000.000  995.41      1
 -3.90848844E-08 1.43313303E-11 1.02284118E+04 1.24057873E+01                   4
 
 ! Thermo group additivity estimation: group(Ct-CtH) + group(Ct-CtH)
-C#C(27)                 C   2H   2          G   100.000  5000.000  888.63      1
+C#C(28)                 C   2H   2          G   100.000  5000.000  888.63      1
  5.76204511E+00 2.37158782E-03-1.49582699E-07-2.19154662E-11 2.21779207E-15    2
  2.50944501E+04-9.82608488E+00 3.03574736E+00 7.71239020E-03 2.53493006E-06    3
 -1.08133128E-08 5.50757058E-12 2.58526443E+04 4.54461297E+00                   4
 
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)CsHH) + group(Cs-CsHHH) + group(Cds-CdsCsH) + group(Cds-CdsHH) + radical(RCCJ)
-C4H7(29)                C   4H   7          G   100.000  5000.000 1000.95      1
+C4H7(31)                C   4H   7          G   100.000  5000.000 1000.95      1
  7.59479951E+00 2.06424593E-02-7.89782526E-06 1.45964270E-09-1.03413353E-13    2
  2.08073058E+04-1.19159668E+01 2.68059468E+00 2.10828055E-02 2.02114983E-05    3
 -3.64232761E-08 1.41440404E-11 2.27528020E+04 1.66009256E+01                   4
 
+! Thermo group additivity estimation: group(Cds-Cds(Cds-Cds)H) + group(Cds-Cds(Cds-Cds)H) + group(Cds-CdsHH) + group(Cds-CdsHH)
+C4H6(33)                C   4H   6          G   100.000  5000.000  940.95      1
+ 1.10823465E+01 1.17735303E-02-3.11414472E-06 5.37745823E-10-4.10623132E-14    2
+ 8.42127950E+03-3.51696040E+01 2.68205225E+00 1.69322825E-02 3.73648473E-05    3
+-6.26479964E-08 2.59146511E-11 1.13546018E+04 1.20324202E+01                   4
+
 ! Thermo group additivity estimation: group(Cds-CdsHH) + group(CdJ2_singlet-Cds)
-C2H2(31)                C   2H   2          G   100.000  5000.000 1423.26      1
+C2H2(35)                C   2H   2          G   100.000  5000.000 1423.26      1
  4.43041986E+00 4.87757420E-03-1.79374459E-06 3.04085410E-10-1.96652162E-14    2
  4.78744103E+04-1.67075241E-01 3.69251650E+00 6.06584723E-03-2.11277596E-06    3
  1.63533182E-11 1.07665581E-13 4.81741496E+04 3.96842354E+00                   4
 
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)HHH) + group(Cds-CdsCsH) + group(Cds-CdsHH) + radical(Cds_P)
-C3H5(32)                C   3H   5          G   100.000  5000.000  997.87      1
+C3H5(36)                C   3H   5          G   100.000  5000.000  997.87      1
  5.66465812E+00 1.44326998E-02-5.46743137E-06 1.00159120E-09-7.04869894E-14    2
  2.93871077E+04-4.48482420E+00 3.23409465E+00 1.18206723E-02 1.70311418E-05    3
 -2.64373876E-08 9.91250979E-12 3.04873059E+04 1.03182315E+01                   4
 
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)CsHH) + group(Cs-CsHHH) + group(Cds-CdsCsH) + group(Cds-CdsHH) + radical(Cds_P)
-C4H7(33)                C   4H   7          G   100.000  5000.000  999.92      1
+C4H7(37)                C   4H   7          G   100.000  5000.000  999.92      1
  8.06557472E+00 2.00625202E-02-7.60832471E-06 1.39784272E-09-9.86871188E-14    2
  2.57831993E+04-1.54387855E+01 2.56532733E+00 2.39244964E-02 1.38115950E-05    3
 -3.10269360E-08 1.25444431E-11 2.77900540E+04 1.56311184E+01                   4
 
 ! Thermo group additivity estimation: group(Cds-Cds(Cds-Cds)H) + group(Cds-Cds(Cds-Cds)H) + group(Cds-CdsHH) + group(Cds-CdsHH) + radical(Cds_P)
-C4H5(35)                C   4H   5          G   100.000  5000.000  935.58      1
+C4H5(40)                C   4H   5          G   100.000  5000.000  935.58      1
  1.13227703E+01 8.94049131E-03-2.08006868E-06 3.38974080E-10-2.61949890E-14    2
  3.83166548E+04-3.40911798E+01 2.61016310E+00 2.04314979E-02 2.07961080E-05    3
 -4.53910308E-08 2.00574491E-11 4.10742701E+04 1.33868405E+01                   4
 
 ! Thermo group additivity estimation: group(Cs-CsCsCsH) + group(Cs-CsCsHH) + group(Cs-CsCsHH) + group(Cs-CsHHH) + ring(Cyclopropane) + radical(Isobutyl)
-C4H7(41)                C   4H   7          G   100.000  5000.000  926.07      1
+C4H7(46)                C   4H   7          G   100.000  5000.000  926.07      1
  1.02346424E+01 1.41131644E-02-2.99925371E-06 4.56620522E-10-3.49799664E-14    2
  2.27933498E+04-2.92349187E+01 3.04736554E+00 5.45571385E-03 7.53308215E-05    3
 -1.02226599E-07 4.01828021E-11 2.58269388E+04 1.40791072E+01                   4
 
-! Thermo group additivity estimation: group(Cds-Cds(Cds-Cds)H) + group(Cds-Cds(Cds-Cds)H) + group(Cds-CdsHH) + group(Cds-CdsHH)
-C4H6(42)                C   4H   6          G   100.000  5000.000  940.95      1
- 1.10823465E+01 1.17735303E-02-3.11414472E-06 5.37745823E-10-4.10623132E-14    2
- 8.42127950E+03-3.51696040E+01 2.68205225E+00 1.69322825E-02 3.73648473E-05    3
--6.26479964E-08 2.59146511E-11 1.13546018E+04 1.20324202E+01                   4
-
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)HHH) + group(Cs-(Cds-Cds)HHH) + group(Cds-CdsCsH) + group(Cds-CdsCsH) + radical(Allyl_P) +
 ! radical(Allyl_P)
-C4H6(43)                C   4H   6          G   100.000  5000.000  961.83      1
+C4H6(47)                C   4H   6          G   100.000  5000.000  961.83      1
  9.92849001E+00 1.51088208E-02-5.13560211E-06 9.43569819E-10-6.92734560E-14    2
  3.02829926E+04-2.74906163E+01 2.65638077E+00 1.89337507E-02 3.00987228E-05    3
 -5.20344307E-08 2.11232146E-11 3.29038799E+04 1.36624695E+01                   4
 
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)HHH) + group(Cs-(Cds-Cds)HHH) + group(Cds-CdsCsH) + group(Cds-CdsCsH) + radical(Allyl_P)
-C4H7(45)                C   4H   7          G   100.000  5000.000  998.56      1
+C4H7(49)                C   4H   7          G   100.000  5000.000  998.56      1
  7.82800811E+00 2.08400863E-02-7.96754424E-06 1.47337839E-09-1.04525635E-13    2
  1.26472412E+04-1.58820365E+01 2.64214371E+00 2.15952609E-02 2.09688717E-05    3
 -3.79216452E-08 1.47847719E-11 1.46809427E+04 1.41266132E+01                   4
 
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)HHH) + group(Cds-CdsCsH) + group(Cds-CdsHH) + group(Cdd-CdsCds)
-C4H6(69)                C   4H   6          G   100.000  5000.000 1063.05      1
+C4H6(111)               C   4H   6          G   100.000  5000.000 1063.05      1
  6.93544552E+00 1.97136368E-02-7.88231275E-06 1.45446865E-09-1.01396113E-13    2
  1.61162804E+04-1.12054239E+01 2.67091213E+00 2.38372295E-02 3.12253865E-06    3
 -1.59972758E-08 6.48389677E-12 1.76966515E+04 1.27978754E+01                   4
 
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)CsHH) + group(Cs-(Cds-Cds)CsHH) + group(Cds-CdsCsH) + group(Cds-CdsCsH) + ring(Cyclobutene)
-C4H6(88)                C   4H   6          G   100.000  5000.000  950.24      1
+C4H6(186)               C   4H   6          G   100.000  5000.000  950.24      1
  9.42741835E+00 1.39644294E-02-4.06892046E-06 7.75033524E-10-6.20421269E-14    2
  1.43343164E+04-2.81799733E+01 3.39621343E+00-3.43725308E-03 9.09465048E-05    3
 -1.13274520E-07 4.24110728E-11 1.74123946E+04 1.07743991E+01                   4
 
-! Thermo group additivity estimation: group(Cs-CtHHH) + group(Cs-CtHHH) + group(Ct-CtCs) + group(Ct-CtCs) + radical(Propargyl)
-C4H5(144)               C   4H   5          G   100.000  5000.000  942.37      1
- 6.33626737E+00 1.64827848E-02-5.56208397E-06 9.43126364E-10-6.35802263E-14    2
- 3.32941157E+04-6.00339957E+00 2.92156480E+00 1.88274652E-02 1.00444412E-05    3
--2.37783426E-08 1.01241167E-11 3.44771699E+04 1.31301921E+01                   4
-
 ! Thermo group additivity estimation: group(Cs-(Cds-Cds)(Cds-Cds)CsH) + group(Cs-CsHHH) + group(Cds-CdsCsH) + group(Cds-CdsCsH) + ring(Cyclopropene) +
 ! radical(Isobutyl)
-C4H5(185)               C   4H   5          G   100.000  5000.000  922.39      1
+C4H5(402)               C   4H   5          G   100.000  5000.000  922.39      1
  7.72013271E+00 1.42822671E-02-4.41414586E-06 7.16675938E-10-4.76705841E-14    2
  5.22310734E+04-1.47167968E+01 2.73381733E+00 2.27303683E-02 3.27346179E-06    3
 -2.03255440E-08 9.85275484E-12 5.37114183E+04 1.19746599E+01                   4
@@ -225,7 +221,7 @@ REACTIONS    KCAL/MOLE   MOLES
 ! Template reaction: R_Recombination
 ! Flux pairs: CH3(4), ethane(1); CH3(4), ethane(1); 
 ! Matched reaction 9 CH3 + CH3 <=> C2H6 in R_Recombination/training
-! This reaction matched rate rule [Root_N-1R->H_N-1CClNOSSi->N_N-1COS->O_1CS->C_N-1C-inRing]
+! This reaction matched rate rule [Root_N-1R->H_N-1CNOS->N_N-1COS->O_1CS->C_N-1C-inRing]
 ! family: R_Recombination
 CH3(4)+CH3(4)=ethane(1)                             9.450000e+14 -0.538    0.135    
 
@@ -241,16 +237,16 @@ CH3(4)+ethane(1)=CH4(3)+C2H5(5)                     3.500000e+01 3.440     10.38
 ! Template reaction: R_Recombination
 ! Flux pairs: C2H5(5), ethane(1); H(6), ethane(1); 
 ! Matched reaction 58 H + C2H5 <=> C2H6-2 in R_Recombination/training
-! This reaction matched rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_N-Sp-3R!H=2C_3R!H->C_Sp-3C-2C]
+! This reaction matched rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_N-Sp-3R!H=2CCNNOO_N-2CNO->O_3R!H->C_Sp-3C-2CN]
 ! family: R_Recombination
 H(6)+C2H5(5)=ethane(1)                              1.000000e+14 0.000     0.000    
 DUPLICATE
 
-! Reaction index: Chemkin #4; RMG #12
+! Reaction index: Chemkin #4; RMG #19
 ! Template reaction: R_Recombination
 ! Flux pairs: CH3(4), CH4(3); H(6), CH4(3); 
 ! Matched reaction 57 H + CH3 <=> CH4 in R_Recombination/training
-! This reaction matched rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C]
+! This reaction matched rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_N-2CNO->O]
 ! family: R_Recombination
 H(6)+CH3(4)=CH4(3)                                  1.930000e+14 0.000     0.270    
 
@@ -258,7 +254,7 @@ H(6)+CH3(4)=CH4(3)                                  1.930000e+14 0.000     0.270
 ! Template reaction: R_Recombination
 ! Flux pairs: H(6), ethane(1); C2H5(5), ethane(1); 
 ! Matched reaction 58 H + C2H5 <=> C2H6-2 in R_Recombination/training
-! This reaction matched rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_N-Sp-3R!H=2C_3R!H->C_Sp-3C-2C]
+! This reaction matched rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_N-Sp-3R!H=2CCNNOO_N-2CNO->O_3R!H->C_Sp-3C-2CN]
 ! family: R_Recombination
 H(6)+C2H5(5)=ethane(1)                              1.000000e+14 0.000     0.000    
 DUPLICATE
@@ -271,7 +267,7 @@ DUPLICATE
 ! family: R_Addition_MultipleBond
 H(6)+C2H4(9)=C2H5(5)                                4.620000e+08 1.640     1.010    
 
-! Reaction index: Chemkin #7; RMG #13
+! Reaction index: Chemkin #7; RMG #11
 ! Template reaction: Disproportionation
 ! Flux pairs: C2H5(5), C2H4(9); CH3(4), CH4(3); 
 ! Matched reaction 5 CH3 + C2H5 <=> CH4 + C2H4 in Disproportionation/training
@@ -279,7 +275,7 @@ H(6)+C2H4(9)=C2H5(5)                                4.620000e+08 1.640     1.010
 ! family: Disproportionation
 CH3(4)+C2H5(5)=CH4(3)+C2H4(9)                       6.570000e+14 -0.680    0.000    
 
-! Reaction index: Chemkin #8; RMG #17
+! Reaction index: Chemkin #8; RMG #15
 ! Template reaction: Disproportionation
 ! Flux pairs: C2H5(5), C2H4(9); C2H5(5), ethane(1); 
 ! Matched reaction 6 C2H5 + C2H5-2 <=> C2H6 + C2H4 in Disproportionation/training
@@ -289,35 +285,35 @@ C2H5(5)+C2H5(5)=C2H4(9)+ethane(1)                   6.900000e+13 -0.350    0.000
 
 ! Reaction index: Chemkin #9; RMG #20
 ! Template reaction: H_Abstraction
-! Flux pairs: H(6), H2(11); ethane(1), C2H5(5); 
+! Flux pairs: H(6), H2(13); ethane(1), C2H5(5); 
 ! Matched reaction 210 C2H6 + H <=> C2H5b + H2_p in H_Abstraction/training
 ! This reaction matched rate rule [C/H3/Cs\H3;H_rad]
 ! family: H_Abstraction
-H(6)+ethane(1)=H2(11)+C2H5(5)                       1.150000e+08 1.900     7.530    
+H(6)+ethane(1)=H2(13)+C2H5(5)                       1.150000e+08 1.900     7.530    
 
 ! Reaction index: Chemkin #10; RMG #22
 ! Template reaction: Disproportionation
-! Flux pairs: C2H5(5), C2H4(9); H(6), H2(11); 
+! Flux pairs: C2H5(5), C2H4(9); H(6), H2(13); 
 ! Matched reaction 4 H + C2H5 <=> H2 + C2H4 in Disproportionation/training
 ! This reaction matched rate rule [H_rad;Cmethyl_Csrad]
 ! family: Disproportionation
-H(6)+C2H5(5)=H2(11)+C2H4(9)                         1.083000e+13 0.000     0.000    
+H(6)+C2H5(5)=H2(13)+C2H4(9)                         1.083000e+13 0.000     0.000    
 
 ! Reaction index: Chemkin #11; RMG #25
 ! Template reaction: H_Abstraction
-! Flux pairs: H(6), H2(11); CH4(3), CH3(4); 
+! Flux pairs: H(6), H2(13); CH4(3), CH3(4); 
 ! Matched reaction 186 CH4b + H <=> CH3_p1 + H2_p in H_Abstraction/training
 ! This reaction matched rate rule [C_methane;H_rad]
 ! family: H_Abstraction
-H(6)+CH4(3)=H2(11)+CH3(4)                           4.100000e+03 3.156     8.755    
+H(6)+CH4(3)=H2(13)+CH3(4)                           4.100000e+03 3.156     8.755    
 
 ! Reaction index: Chemkin #12; RMG #26
 ! Template reaction: R_Recombination
-! Flux pairs: H(6), H2(11); H(6), H2(11); 
+! Flux pairs: H(6), H2(13); H(6), H2(13); 
 ! Matched reaction 56 H + H <=> H2 in R_Recombination/training
-! This reaction matched rate rule [Root_1R->H_N-2R-inRing_2R->H]
+! This reaction matched rate rule [Root_1R->H_N-2R->S_2CHNO->H]
 ! family: R_Recombination
-H(6)+H(6)=H2(11)                                    5.450000e+10 0.000     1.500    
+H(6)+H(6)=H2(13)                                    5.450000e+10 0.000     1.500    
 
 ! Reaction index: Chemkin #13; RMG #31
 ! Template reaction: R_Addition_MultipleBond
@@ -331,7 +327,7 @@ CH3(4)+C2H4(9)=C3H7(16)                             4.180000e+04 2.410     5.630
 ! Template reaction: R_Recombination
 ! Flux pairs: C2H3(14), C2H4(9); H(6), C2H4(9); 
 ! Matched reaction 60 H + C2H3 <=> C2H4 in R_Recombination/training
-! This reaction matched rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_Sp-3R!H=2C_3R!H->C]
+! This reaction matched rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_Sp-3R!H=2CCNNOO_N-3R!H->O]
 ! family: R_Recombination
 H(6)+C2H3(14)=C2H4(9)                               1.210000e+14 0.000     0.000    
 
@@ -353,13 +349,13 @@ C2H3(14)+ethane(1)=C2H4(9)+C2H5(5)                  1.080000e-03 4.550     3.500
 
 ! Reaction index: Chemkin #17; RMG #36
 ! Template reaction: H_Abstraction
-! Flux pairs: H(6), H2(11); C2H4(9), C2H3(14); 
+! Flux pairs: H(6), H2(13); C2H4(9), C2H3(14); 
 ! Matched reaction 217 C2H4 + H <=> C2H3_p + H2_p in H_Abstraction/training
 ! This reaction matched rate rule [Cd/H2/NonDeC;H_rad]
 ! family: H_Abstraction
-H(6)+C2H4(9)=H2(11)+C2H3(14)                        2.400000e+02 3.620     11.266   
+H(6)+C2H4(9)=H2(13)+C2H3(14)                        2.400000e+02 3.620     11.266   
 
-! Reaction index: Chemkin #18; RMG #39
+! Reaction index: Chemkin #18; RMG #38
 ! Template reaction: Disproportionation
 ! Flux pairs: C2H3(14), C2H4(9); C2H5(5), C2H4(9); 
 ! Matched reaction 11 C2H3-2 + C2H5 <=> C2H4-2 + C2H4 in Disproportionation/training
@@ -367,526 +363,502 @@ H(6)+C2H4(9)=H2(11)+C2H3(14)                        2.400000e+02 3.620     11.26
 ! family: Disproportionation
 C2H3(14)+C2H5(5)=C2H4(9)+C2H4(9)                    4.560000e+14 -0.700    0.000    
 
-! Reaction index: Chemkin #19; RMG #55
+! Reaction index: Chemkin #19; RMG #75
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C#C(27), C2H3(14); H(6), C2H3(14); 
+! Flux pairs: C#C(28), C2H3(14); H(6), C2H3(14); 
 ! Matched reaction 2697 H + C2H2 <=> C2H3-2 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Ct-H_Ct-H;HJ]
 ! family: R_Addition_MultipleBond
-H(6)+C#C(27)=C2H3(14)                               1.030000e+09 1.640     2.110    
+H(6)+C#C(28)=C2H3(14)                               1.030000e+09 1.640     2.110    
 
-! Reaction index: Chemkin #20; RMG #66
+! Reaction index: Chemkin #20; RMG #78
 ! Template reaction: Disproportionation
-! Flux pairs: C2H5(5), ethane(1); C2H3(14), C#C(27); 
-! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [C_rad/H2/Cs;Cds/H2_d_Crad]
-! Euclidian distance = 3.1622776601683795
-! Multiplied by reaction path degeneracy 2.0
-! family: Disproportionation
-C2H3(14)+C2H5(5)=C#C(27)+ethane(1)                  8.204641e+06 1.877     -1.115   
-
-! Reaction index: Chemkin #21; RMG #74
-! Template reaction: Disproportionation
-! Flux pairs: CH3(4), CH4(3); C2H3(14), C#C(27); 
+! Flux pairs: C2H3(14), C#C(28); CH3(4), CH4(3); 
 ! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [C_methyl;Cds/H2_d_Crad]
 ! Euclidian distance = 2.23606797749979
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-CH3(4)+C2H3(14)=CH4(3)+C#C(27)                      8.204641e+06 1.877     -1.115   
+CH3(4)+C2H3(14)=CH4(3)+C#C(28)                      8.204641e+06 1.877     -1.115   
 
-! Reaction index: Chemkin #22; RMG #77
+! Reaction index: Chemkin #21; RMG #83
 ! Template reaction: Disproportionation
-! Flux pairs: C2H3(14), C#C(27); C2H3(14), C2H4(9); 
-! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [Cd_pri_rad;Cds/H2_d_Crad]
-! Euclidian distance = 2.23606797749979
+! Flux pairs: C2H3(14), C#C(28); C2H5(5), ethane(1); 
+! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [C_rad/H2/Cs;Cds/H2_d_Crad]
+! Euclidian distance = 3.1622776601683795
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-C2H3(14)+C2H3(14)=C#C(27)+C2H4(9)                   8.204641e+06 1.877     -1.115   
+C2H3(14)+C2H5(5)=C#C(28)+ethane(1)                  8.204641e+06 1.877     -1.115   
 
-! Reaction index: Chemkin #23; RMG #79
+! Reaction index: Chemkin #22; RMG #90
 ! Template reaction: Disproportionation
-! Flux pairs: H(6), H2(11); C2H3(14), C#C(27); 
+! Flux pairs: C2H3(14), C#C(28); H(6), H2(13); 
 ! Estimated using template [H_rad;Cds/H2_d_Rrad] for rate rule [H_rad;Cds/H2_d_Crad]
 ! Euclidian distance = 1.0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-H(6)+C2H3(14)=H2(11)+C#C(27)                        6.788225e+08 1.500     -0.890   
+H(6)+C2H3(14)=H2(13)+C#C(28)                        6.788225e+08 1.500     -0.890   
 
-! Reaction index: Chemkin #24; RMG #65
+! Reaction index: Chemkin #23; RMG #106
+! Template reaction: Disproportionation
+! Flux pairs: C2H3(14), C#C(28); C2H3(14), C2H4(9); 
+! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [Cd_pri_rad;Cds/H2_d_Crad]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Disproportionation
+C2H3(14)+C2H3(14)=C#C(28)+C2H4(9)                   8.204641e+06 1.877     -1.115   
+
+! Reaction index: Chemkin #24; RMG #112
 ! Template reaction: Singlet_Carbene_Intra_Disproportionation
-! Flux pairs: C2H2(31), C#C(27); 
+! Flux pairs: C2H2(35), C#C(28); 
 ! Estimated using template [singletcarbene_CH;singletcarbene;CH] for rate rule [CdJ2=C;CdJ2;CdH2]
 ! Euclidian distance = 1.7320508075688772
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Singlet_Carbene_Intra_Disproportionation
-C2H2(31)=C#C(27)                                    1.599708e+13 -0.202    8.145    
+C2H2(35)=C#C(28)                                    1.599708e+13 -0.202    8.145    
 
-! Reaction index: Chemkin #25; RMG #62
+! Reaction index: Chemkin #25; RMG #95
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C2H3(14), C4H7(29); C2H4(9), C4H7(29); 
+! Flux pairs: C2H3(14), C4H7(31); C2H4(9), C4H7(31); 
 ! Matched reaction 234 C2H3 + C2H4 <=> C4H7-3 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Cds-HH_Cds-HH;CdsJ-H]
 ! family: R_Addition_MultipleBond
-C2H3(14)+C2H4(9)=C4H7(29)                           2.860000e+04 2.410     1.800    
+C2H3(14)+C2H4(9)=C4H7(31)                           2.860000e+04 2.410     1.800    
 
-! Reaction index: Chemkin #26; RMG #91
+! Reaction index: Chemkin #26; RMG #139
 ! Template reaction: Intra_R_Add_Exocyclic
-! Flux pairs: C4H7(29), C4H7(41); 
+! Flux pairs: C4H7(31), C4H7(46); 
 ! Matched reaction 335 C4H7 <=> C4H7-2 in Intra_R_Add_Exocyclic/training
 ! This reaction matched rate rule [R4_S_D;doublebond_intra_2H_pri;radadd_intra_cs2H]
 ! family: Intra_R_Add_Exocyclic
-C4H7(29)=C4H7(41)                                   6.320000e+08 0.970     8.900    
+C4H7(31)=C4H7(46)                                   6.320000e+08 0.970     8.900    
 
-! Reaction index: Chemkin #27; RMG #73
+! Reaction index: Chemkin #27; RMG #119
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C2H5(5), C4H7(33); C#C(27), C4H7(33); 
+! Flux pairs: C2H5(5), C4H7(37); C#C(28), C4H7(37); 
 ! Matched reaction 2254 C2H2 + C2H5 <=> C4H7-6 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Ct-H_Ct-H;CsJ-CsHH]
 ! family: R_Addition_MultipleBond
-C#C(27)+C2H5(5)=C4H7(33)                            1.360000e+04 2.410     6.200    
+C#C(28)+C2H5(5)=C4H7(37)                            1.360000e+04 2.410     6.200    
 
-! Reaction index: Chemkin #28; RMG #99
+! Reaction index: Chemkin #28; RMG #147
 ! Template reaction: intra_H_migration
-! Flux pairs: C4H7(33), C4H7(29); 
+! Flux pairs: C4H7(37), C4H7(31); 
 ! Estimated using template [R4H_DSS;Cd_rad_out_singleH;Cs_H_out] for rate rule [R4H_DSS;Cd_rad_out_singleH;Cs_H_out_2H]
 ! Euclidian distance = 1.0
 ! Multiplied by reaction path degeneracy 3.0
 ! family: intra_H_migration
-C4H7(33)=C4H7(29)                                   1.113000e+05 2.230     10.590   
+C4H7(37)=C4H7(31)                                   1.113000e+05 2.230     10.590   
 
-! Reaction index: Chemkin #29; RMG #97
+! Reaction index: Chemkin #29; RMG #145
 ! Template reaction: intra_H_migration
-! Flux pairs: C4H7(29), C4H7(45); 
+! Flux pairs: C4H7(31), C4H7(49); 
 ! Matched reaction 84 C:CC[CH2] <=> C:C[CH]C in intra_H_migration/training
 ! This reaction matched rate rule [R2H_S;C_rad_out_2H;Cs_H_out_H/Cd]
 ! family: intra_H_migration
-C4H7(29)=C4H7(45)                                   1.720000e+06 1.990     27.200   
+C4H7(31)=C4H7(49)                                   1.720000e+06 1.990     27.200   
 
-! Reaction index: Chemkin #30; RMG #146
+! Reaction index: Chemkin #30; RMG #343
 ! Template reaction: intra_H_migration
-! Flux pairs: C4H7(33), C4H7(45); 
+! Flux pairs: C4H7(37), C4H7(49); 
 ! Matched reaction 194 C4H7-4 <=> C4H7-5 in intra_H_migration/training
 ! This reaction matched rate rule [R3H_DS;Cd_rad_out_singleH;Cs_H_out_H/NonDeC]
 ! family: intra_H_migration
-C4H7(33)=C4H7(45)                                   1.846000e+10 0.740     34.700   
+C4H7(37)=C4H7(49)                                   1.846000e+10 0.740     34.700   
 
-! Reaction index: Chemkin #31; RMG #92
+! Reaction index: Chemkin #31; RMG #110
+! Template reaction: R_Recombination
+! Flux pairs: C2H3(14), C4H6(33); C2H3(14), C4H6(33); 
+! Matched reaction 89 C2H3 + C2H3 <=> C4H6-4 in R_Recombination/training
+! This reaction matched rate rule [Root_N-1R->H_N-1CNOS->N_N-1COS->O_1CS->C_N-1C-inRing_Ext-2R-R_N-Sp-3R!H-2R_N-3R!H->O_N-Sp-3CCSS#2R_Ext-1C-R]
+! family: R_Recombination
+C2H3(14)+C2H3(14)=C4H6(33)                          3.615000e+13 0.000     0.000    
+
+! Reaction index: Chemkin #32; RMG #140
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C4H6(42), C4H7(29); H(6), C4H7(29); 
+! Flux pairs: C4H6(33), C4H7(31); H(6), C4H7(31); 
 ! Matched reaction 2580 H + C4H6-2 <=> C4H7-11 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Cds-CdH_Cds-HH;HJ]
 ! family: R_Addition_MultipleBond
-H(6)+C4H6(42)=C4H7(29)                              3.240000e+08 1.640     2.400    
+H(6)+C4H6(33)=C4H7(31)                              3.240000e+08 1.640     2.400    
 
-! Reaction index: Chemkin #32; RMG #160
-! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C4H6(42), C4H7(45); H(6), C4H7(45); 
-! Matched reaction 2544 H + C4H6 <=> C4H7-9 in R_Addition_MultipleBond/training
-! This reaction matched rate rule [Cds-HH_Cds-CdH;HJ]
-! family: R_Addition_MultipleBond
-H(6)+C4H6(42)=C4H7(45)                              4.620000e+08 1.640     -0.470   
-
-! Reaction index: Chemkin #33; RMG #213
-! Template reaction: R_Recombination
-! Flux pairs: C2H3(14), C4H6(42); C2H3(14), C4H6(42); 
-! Matched reaction 89 C2H3 + C2H3 <=> C4H6-4 in R_Recombination/training
-! This reaction matched rate rule [Root_N-1R->H_N-1CClNOSSi->N_N-1COS->O_1CS->C_N-1C-inRing_Ext-2R-R_N-Sp-3R!H-2R_N-3R!H->O_N-Sp-3CCSS#2R_Ext-1C-R]
-! family: R_Recombination
-C2H3(14)+C2H3(14)=C4H6(42)                          3.615000e+13 0.000     0.000    
-
-! Reaction index: Chemkin #34; RMG #218
+! Reaction index: Chemkin #33; RMG #151
 ! Template reaction: Disproportionation
-! Flux pairs: C2H5(5), ethane(1); C4H7(29), C4H6(42); 
-! Estimated using template [C_rad/H2/Cs;Cpri_Rrad] for rate rule [C_rad/H2/Cs;C/H2/Cd_Csrad]
-! Euclidian distance = 3.0
-! Multiplied by reaction path degeneracy 2.0
-! family: Disproportionation
-C2H5(5)+C4H7(29)=ethane(1)+C4H6(42)                 2.900000e+12 0.000     0.000    
-
-! Reaction index: Chemkin #35; RMG #219
-! Template reaction: Disproportionation
-! Estimated using template [C_rad/H2/Cs;Cmethyl_Csrad] for rate rule [C_rad/H2/Cs;Cmethyl_Csrad/H/Cd]
-! Euclidian distance = 1.0
-! Multiplied by reaction path degeneracy 3.0
-! family: Disproportionation
-C2H5(5)+C4H7(45)=ethane(1)+C4H6(42)                 6.900000e+13 -0.350    0.000    
-
-! Reaction index: Chemkin #36; RMG #234
-! Template reaction: Disproportionation
-! Flux pairs: CH3(4), CH4(3); C4H7(29), C4H6(42); 
+! Flux pairs: C4H7(31), C4H6(33); CH3(4), CH4(3); 
 ! Estimated using template [Y_rad_birad_trirad_quadrad;C/H2/Cd_Csrad] for rate rule [C_methyl;C/H2/Cd_Csrad]
 ! Euclidian distance = 3.0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-CH3(4)+C4H7(29)=CH4(3)+C4H6(42)                     2.000000e+10 0.000     0.000    
+CH3(4)+C4H7(31)=CH4(3)+C4H6(33)                     2.000000e+10 0.000     0.000    
 
-! Reaction index: Chemkin #37; RMG #235
+! Reaction index: Chemkin #34; RMG #161
 ! Template reaction: Disproportionation
-! Estimated using template [Cs_rad;Cmethyl_Csrad/H/Cd] for rate rule [C_methyl;Cmethyl_Csrad/H/Cd]
-! Euclidian distance = 1.0
-! Multiplied by reaction path degeneracy 3.0
-! family: Disproportionation
-CH3(4)+C4H7(45)=CH4(3)+C4H6(42)                     1.500000e+11 0.000     0.000    
-
-! Reaction index: Chemkin #38; RMG #243
-! Template reaction: Disproportionation
-! Flux pairs: C2H3(14), C4H6(42); C4H7(29), C2H4(9); 
-! Estimated using average of templates [Y_rad_birad_trirad_quadrad;C/H2/Cd_Csrad] + [Cd_pri_rad;Cpri_Rrad] for rate rule [Cd_pri_rad;C/H2/Cd_Csrad]
+! Flux pairs: C4H7(31), C4H6(33); C2H5(5), ethane(1); 
+! Estimated using template [C_rad/H2/Cs;Cpri_Rrad] for rate rule [C_rad/H2/Cs;C/H2/Cd_Csrad]
 ! Euclidian distance = 3.0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-C2H3(14)+C4H7(29)=C2H4(9)+C4H6(42)                  2.200000e+11 0.000     0.000    
+C2H5(5)+C4H7(31)=ethane(1)+C4H6(33)                 2.900000e+12 0.000     0.000    
 
-! Reaction index: Chemkin #39; RMG #244
+! Reaction index: Chemkin #35; RMG #177
 ! Template reaction: Disproportionation
-! Estimated using template [Cd_pri_rad;Cmethyl_Csrad] for rate rule [Cd_pri_rad;Cmethyl_Csrad/H/Cd]
-! Euclidian distance = 1.0
-! Multiplied by reaction path degeneracy 3.0
-! family: Disproportionation
-C2H3(14)+C4H7(45)=C2H4(9)+C4H6(42)                  4.560000e+14 -0.700    0.000    
-
-! Reaction index: Chemkin #40; RMG #247
-! Template reaction: Disproportionation
-! Flux pairs: H(6), H2(11); C4H7(29), C4H6(42); 
+! Flux pairs: C4H7(31), C4H6(33); H(6), H2(13); 
 ! Estimated using template [Y_rad_birad_trirad_quadrad;C/H2/Cd_Csrad] for rate rule [H_rad;C/H2/Cd_Csrad]
 ! Euclidian distance = 2.0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-H(6)+C4H7(29)=H2(11)+C4H6(42)                       2.000000e+10 0.000     0.000    
+H(6)+C4H7(31)=H2(13)+C4H6(33)                       2.000000e+10 0.000     0.000    
 
-! Reaction index: Chemkin #41; RMG #248
+! Reaction index: Chemkin #36; RMG #213
 ! Template reaction: Disproportionation
+! Flux pairs: C4H7(31), C4H6(33); C2H3(14), C2H4(9); 
+! Estimated using average of templates [Y_rad_birad_trirad_quadrad;C/H2/Cd_Csrad] + [Cd_pri_rad;Cpri_Rrad] for rate rule [Cd_pri_rad;C/H2/Cd_Csrad]
+! Euclidian distance = 3.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Disproportionation
+C2H3(14)+C4H7(31)=C2H4(9)+C4H6(33)                  2.200000e+11 0.000     0.000    
+
+! Reaction index: Chemkin #37; RMG #465
+! Template reaction: R_Addition_MultipleBond
+! Flux pairs: C4H6(33), C4H7(49); H(6), C4H7(49); 
+! Matched reaction 2544 H + C4H6 <=> C4H7-9 in R_Addition_MultipleBond/training
+! This reaction matched rate rule [Cds-HH_Cds-CdH;HJ]
+! family: R_Addition_MultipleBond
+H(6)+C4H6(33)=C4H7(49)                              4.620000e+08 1.640     -0.470   
+
+! Reaction index: Chemkin #38; RMG #481
+! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(33); CH3(4), CH4(3); 
+! Estimated using template [Cs_rad;Cmethyl_Csrad/H/Cd] for rate rule [C_methyl;Cmethyl_Csrad/H/Cd]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Disproportionation
+CH3(4)+C4H7(49)=CH4(3)+C4H6(33)                     1.500000e+11 0.000     0.000    
+
+! Reaction index: Chemkin #39; RMG #498
+! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(33); C2H5(5), ethane(1); 
+! Estimated using template [C_rad/H2/Cs;Cmethyl_Csrad] for rate rule [C_rad/H2/Cs;Cmethyl_Csrad/H/Cd]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Disproportionation
+C2H5(5)+C4H7(49)=ethane(1)+C4H6(33)                 6.900000e+13 -0.350    0.000    
+
+! Reaction index: Chemkin #40; RMG #516
+! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(33); H(6), H2(13); 
 ! Estimated using average of templates [Y_rad;Cmethyl_Csrad/H/Cd] + [H_rad;Cmethyl_Csrad] for rate rule [H_rad;Cmethyl_Csrad/H/Cd]
 ! Euclidian distance = 1.0
 ! Multiplied by reaction path degeneracy 3.0
 ! family: Disproportionation
-H(6)+C4H7(45)=H2(11)+C4H6(42)                       1.274559e+12 0.000     0.000    
+H(6)+C4H7(49)=H2(13)+C4H6(33)                       1.274559e+12 0.000     0.000    
 
-! Reaction index: Chemkin #42; RMG #209
+! Reaction index: Chemkin #41; RMG #578
+! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(33); C2H3(14), C2H4(9); 
+! Estimated using template [Cd_pri_rad;Cmethyl_Csrad] for rate rule [Cd_pri_rad;Cmethyl_Csrad/H/Cd]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Disproportionation
+C2H3(14)+C4H7(49)=C2H4(9)+C4H6(33)                  4.560000e+14 -0.700    0.000    
+
+! Reaction index: Chemkin #42; RMG #737
 ! Template reaction: Intra_2+2_cycloaddition_Cd
-! Flux pairs: C4H6(42), C4H6(88); 
+! Flux pairs: C4H6(33), C4H6(186); 
 ! Estimated using template [1,3-butadiene_backbone;C=C_1;C=C_2] for rate rule [1,3-butadiene_backbone;CdH2_1;CdH2_2]
 ! Euclidian distance = 1.4142135623730951
 ! family: Intra_2+2_cycloaddition_Cd
-C4H6(42)=C4H6(88)                                   4.999980e+11 0.056     29.257   
+C4H6(33)=C4H6(186)                                  4.999980e+11 0.056     29.257   
 
-! Reaction index: Chemkin #43; RMG #94
+! Reaction index: Chemkin #43; RMG #142
 ! Template reaction: R_Recombination
-! Flux pairs: C4H6(43), C4H7(29); H(6), C4H7(29); 
-! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_N-
-! Sp-3R!H=2C_3R!H->C_Sp-3C-2C_Ext-3C-R_Sp-4R!H=3C_N-3C-inRing
-!     Total Standard Deviation in ln(k): 11.5401827615
-! Exact match found for rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_N-
-! Sp-3R!H=2C_3R!H->C_Sp-3C-2C_Ext-3C-R_Sp-4R!H=3C_N-3C-inRing]
+! Flux pairs: C4H6(47), C4H7(31); H(6), C4H7(31); 
+! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_N-Sp-3R!H=2CCNNOO_N-2CNO->O_Ext-2CN-R
+!     Total Standard Deviation in ln(k): 2.14551182899
+! Exact match found for rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_N-Sp-3R!H=2CCNNOO_N-2CNO->O_Ext-2CN-R]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: R_Recombination
-H(6)+C4H6(43)=C4H7(29)                              3.251960e+13 0.255     0.000    
+H(6)+C4H6(47)=C4H7(31)                              3.532740e+13 0.153     0.000    
 
-! Reaction index: Chemkin #44; RMG #107
+! Reaction index: Chemkin #44; RMG #189
 ! Template reaction: Disproportionation
 ! From training reaction 5 used for Y_rad;Cmethyl_Csrad
 ! Exact match found for rate rule [Y_rad;Cmethyl_Csrad]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 6.0
 ! family: Disproportionation
-C2H5(5)+C4H6(43)=C2H4(9)+C4H7(29)                   1.314000e+15 -0.680    0.000    
+C2H5(5)+C4H6(47)=C2H4(9)+C4H7(31)                   1.314000e+15 -0.680    0.000    
 
-! Reaction index: Chemkin #45; RMG #120
+! Reaction index: Chemkin #45; RMG #235
 ! Template reaction: Disproportionation
 ! Estimated using average of templates [Y_rad_birad_trirad_quadrad;Cds/H2_d_Crad] + [Y_rad;Cds/H2_d_Rrad] for rate rule [Y_rad;Cds/H2_d_Crad]
 ! Euclidian distance = 1.0
 ! Multiplied by reaction path degeneracy 4.0
 ! family: Disproportionation
-C2H3(14)+C4H6(43)=C#C(27)+C4H7(29)                  4.131060e+11 0.309     1.097    
+C2H3(14)+C4H6(47)=C#C(28)+C4H7(31)                  4.131060e+11 0.309     1.097    
 
-! Reaction index: Chemkin #46; RMG #154
+! Reaction index: Chemkin #46; RMG #459
 ! Template reaction: R_Recombination
-! Flux pairs: C4H6(43), C4H7(45); H(6), C4H7(45); 
-! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_N-
-! Sp-3R!H=2C_3R!H->C_Sp-3C-2C_Ext-3C-R_Sp-4R!H=3C_N-3C-inRing
+! Flux pairs: C4H6(47), C4H7(49); H(6), C4H7(49); 
+! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_N-
+! Sp-3R!H=2CCNNOO_N-2CNO->O_3R!H->C_Sp-3C-2CN_Ext-3C-R_Sp-4R!H=3C_N-3C-inRing
 !     Total Standard Deviation in ln(k): 11.5401827615
-! Exact match found for rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_N-
-! Sp-3R!H=2C_3R!H->C_Sp-3C-2C_Ext-3C-R_Sp-4R!H=3C_N-3C-inRing]
+! Exact match found for rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_N-
+! Sp-3R!H=2CCNNOO_N-2CNO->O_3R!H->C_Sp-3C-2CN_Ext-3C-R_Sp-4R!H=3C_N-3C-inRing]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: R_Recombination
-H(6)+C4H6(43)=C4H7(45)                              3.251960e+13 0.255     0.000    
+H(6)+C4H6(47)=C4H7(49)                              3.251960e+13 0.255     0.000    
 
-! Reaction index: Chemkin #47; RMG #179
+! Reaction index: Chemkin #47; RMG #524
 ! Template reaction: Disproportionation
 ! From training reaction 7 used for C_rad/H2/Cd;Cmethyl_Csrad
 ! Exact match found for rate rule [C_rad/H2/Cd;Cmethyl_Csrad]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 6.0
 ! family: Disproportionation
-C2H5(5)+C4H6(43)=C2H4(9)+C4H7(45)                   1.374000e+14 -0.350    -0.130   
+C2H5(5)+C4H6(47)=C2H4(9)+C4H7(49)                   1.374000e+14 -0.350    -0.130   
 
-! Reaction index: Chemkin #48; RMG #200
+! Reaction index: Chemkin #48; RMG #590
 ! Template reaction: Disproportionation
 ! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [C_rad/H2/Cd;Cds/H2_d_Crad]
 ! Euclidian distance = 3.1622776601683795
 ! Multiplied by reaction path degeneracy 4.0
 ! family: Disproportionation
-C2H3(14)+C4H6(43)=C#C(27)+C4H7(45)                  1.640928e+07 1.877     -1.115   
+C2H3(14)+C4H6(47)=C#C(28)+C4H7(49)                  1.640928e+07 1.877     -1.115   
 
-! Reaction index: Chemkin #49; RMG #275
+! Reaction index: Chemkin #49; RMG #800
+! Template reaction: Disproportionation
+! Estimated using template [Y_rad_birad_trirad_quadrad;C/H2/Cd_Csrad] for rate rule [Y_rad;C/H2/Cd_Csrad]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 4.0
+! family: Disproportionation
+C4H6(47)+C4H7(31)=C4H6(33)+C4H7(31)                 4.000000e+10 0.000     0.000    
+
+! Reaction index: Chemkin #50; RMG #801
+! Template reaction: Disproportionation
+! Estimated using an average for rate rule [Y_rad;Cmethyl_Csrad/H/Cd]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 6.0
+! family: Disproportionation
+C4H6(47)+C4H7(49)=C4H6(33)+C4H7(31)                 3.000000e+11 0.000     0.000    
+
+! Reaction index: Chemkin #51; RMG #845
 ! Template reaction: Disproportionation
 ! Estimated using template [C_rad/H2/Cd;Cpri_Rrad] for rate rule [C_rad/H2/Cd;C/H2/Cd_Csrad]
 ! Euclidian distance = 3.0
 ! Multiplied by reaction path degeneracy 4.0
 ! family: Disproportionation
-C4H6(43)+C4H7(29)=C4H6(42)+C4H7(45)                 5.800000e+12 0.000     -0.130   
+C4H6(47)+C4H7(31)=C4H6(33)+C4H7(49)                 5.800000e+12 0.000     -0.130   
 
-! Reaction index: Chemkin #50; RMG #276
+! Reaction index: Chemkin #52; RMG #846
 ! Template reaction: Disproportionation
 ! Estimated using template [C_rad/H2/Cd;Cmethyl_Csrad] for rate rule [C_rad/H2/Cd;Cmethyl_Csrad/H/Cd]
 ! Euclidian distance = 1.0
 ! Multiplied by reaction path degeneracy 6.0
 ! family: Disproportionation
-C4H6(43)+C4H7(45)=C4H6(42)+C4H7(45)                 1.374000e+14 -0.350    -0.130   
+C4H6(47)+C4H7(49)=C4H6(33)+C4H7(49)                 1.374000e+14 -0.350    -0.130   
 
-! Reaction index: Chemkin #51; RMG #312
+! Reaction index: Chemkin #53; RMG #878
 ! Template reaction: Birad_recombination
-! Flux pairs: C4H6(43), C4H6(88); 
+! Flux pairs: C4H6(47), C4H6(186); 
 ! Estimated using template [R4;C_rad_out_2H;Cpri_rad_out_2H] for rate rule [R4_SDS;C_rad_out_2H;Cpri_rad_out_2H]
 ! Euclidian distance = 1.0
 ! family: Birad_recombination
-C4H6(43)=C4H6(88)                                   1.620000e+12 -0.305    1.980    
+C4H6(47)=C4H6(186)                                  1.620000e+12 -0.305    1.980    
 
-! Reaction index: Chemkin #52; RMG #348
+! Reaction index: Chemkin #54; RMG #987
 ! Template reaction: 1,2-Birad_to_alkene
-! Flux pairs: C4H6(43), C4H6(42); 
+! Flux pairs: C4H6(47), C4H6(33); 
 ! Matched reaction 5 C4H6 => C4H6-2 in 1,2-Birad_to_alkene/training
 ! This reaction matched rate rule [Y_12_01]
 ! family: 1,2-Birad_to_alkene
-C4H6(43)=>C4H6(42)                                  5.010000e+07 0.000     0.000    
+C4H6(47)=>C4H6(33)                                  5.010000e+07 0.000     0.000    
 
-! Reaction index: Chemkin #53; RMG #152
+! Reaction index: Chemkin #55; RMG #457
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C4H6(69), C4H7(45); H(6), C4H7(45); 
+! Flux pairs: C4H6(111), C4H7(49); H(6), C4H7(49); 
 ! Matched reaction 2714 H + C4H6-4 <=> C4H7-13 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Ca_Cds-HH;HJ]
 ! family: R_Addition_MultipleBond
-H(6)+C4H6(69)=C4H7(45)                              5.460000e+08 1.640     3.780    
+H(6)+C4H6(111)=C4H7(49)                             5.460000e+08 1.640     3.780    
 
-! Reaction index: Chemkin #54; RMG #342
-! Template reaction: Intra_Disproportionation
-! Flux pairs: C4H6(43), C4H6(69); 
-! Estimated using an average for rate rule [R3radExo;Y_rad;XH_Rrad]
-! Euclidian distance = 0
-! Multiplied by reaction path degeneracy 2.0
-! family: Intra_Disproportionation
-C4H6(43)=C4H6(69)                                   1.487400e+09 1.045     15.153   
-
-! Reaction index: Chemkin #55; RMG #367
+! Reaction index: Chemkin #56; RMG #472
 ! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(111); CH3(4), CH4(3); 
+! Estimated using template [Cs_rad;Cdpri_Csrad] for rate rule [C_methyl;Cdpri_Csrad]
+! Euclidian distance = 1.0
+! family: Disproportionation
+CH3(4)+C4H7(49)=CH4(3)+C4H6(111)                    3.354068e+12 0.000     6.000    
+
+! Reaction index: Chemkin #57; RMG #486
+! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(111); C2H5(5), ethane(1); 
 ! From training reaction 47 used for C_rad/H2/Cs;Cdpri_Csrad
 ! Exact match found for rate rule [C_rad/H2/Cs;Cdpri_Csrad]
 ! Euclidian distance = 0
 ! family: Disproportionation
-C2H5(5)+C4H7(45)=ethane(1)+C4H6(69)                 9.640000e+11 0.000     6.000    
+C2H5(5)+C4H7(49)=ethane(1)+C4H6(111)                9.640000e+11 0.000     6.000    
 
-! Reaction index: Chemkin #56; RMG #370
+! Reaction index: Chemkin #58; RMG #510
 ! Template reaction: Disproportionation
-! Estimated using template [Cs_rad;Cdpri_Csrad] for rate rule [C_methyl;Cdpri_Csrad]
+! Flux pairs: C4H7(49), C4H6(111); H(6), H2(13); 
+! Estimated using template [Y_rad;Cdpri_Csrad] for rate rule [H_rad;Cdpri_Csrad]
 ! Euclidian distance = 1.0
 ! family: Disproportionation
-CH3(4)+C4H7(45)=CH4(3)+C4H6(69)                     3.354068e+12 0.000     6.000    
+H(6)+C4H7(49)=H2(13)+C4H6(111)                      3.010000e+12 0.000     6.000    
 
-! Reaction index: Chemkin #57; RMG #376
+! Reaction index: Chemkin #59; RMG #562
 ! Template reaction: Disproportionation
+! Flux pairs: C4H7(49), C4H6(111); C2H3(14), C2H4(9); 
 ! From training reaction 51 used for Cd_pri_rad;Cdpri_Csrad
 ! Exact match found for rate rule [Cd_pri_rad;Cdpri_Csrad]
 ! Euclidian distance = 0
 ! family: Disproportionation
-C2H3(14)+C4H7(45)=C2H4(9)+C4H6(69)                  2.410000e+12 0.000     6.000    
+C2H3(14)+C4H7(49)=C2H4(9)+C4H6(111)                 2.410000e+12 0.000     6.000    
 
-! Reaction index: Chemkin #58; RMG #382
-! Template reaction: Disproportionation
-! Estimated using template [Y_rad;Cdpri_Csrad] for rate rule [H_rad;Cdpri_Csrad]
-! Euclidian distance = 1.0
-! family: Disproportionation
-H(6)+C4H7(45)=H2(11)+C4H6(69)                       3.010000e+12 0.000     6.000    
-
-! Reaction index: Chemkin #59; RMG #361
-! Template reaction: R_Recombination
-! Flux pairs: C4H5(144), C4H6(69); H(6), C4H6(69); 
-! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_Sp-3R!H=2C_Ext-2C-R_Ext-3R!H-R
-!     Total Standard Deviation in ln(k): 11.5401827615
-! Exact match found for rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_Sp-3R!H=2C_Ext-2C-R_Ext-3R!H-R]
+! Reaction index: Chemkin #60; RMG #981
+! Template reaction: Intra_Disproportionation
+! Flux pairs: C4H6(47), C4H6(111); 
+! Estimated using an average for rate rule [R3radExo;Y_rad;XH_Rrad]
 ! Euclidian distance = 0
-! family: R_Recombination
-H(6)+C4H5(144)=C4H6(69)                             1.554090e+97 -24.703   0.000    
+! Multiplied by reaction path degeneracy 2.0
+! family: Intra_Disproportionation
+C4H6(47)=C4H6(111)                                  1.487400e+09 1.045     15.153   
 
-! Reaction index: Chemkin #60; RMG #378
+! Reaction index: Chemkin #61; RMG #1124
 ! Template reaction: Disproportionation
-! Estimated using template [Cd_rad;Cmethyl_Csrad] for rate rule [Cd_rad/NonDeC;Cmethyl_Csrad]
-! Euclidian distance = 2.0
-! Multiplied by reaction path degeneracy 3.0
-! family: Disproportionation
-C2H5(5)+C4H5(144)=C2H4(9)+C4H6(69)                  4.560000e+14 -0.700    0.000    
-
-! Reaction index: Chemkin #61; RMG #390
-! Template reaction: Disproportionation
-! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [Cd_rad/NonDeC;Cds/H2_d_Crad]
-! Euclidian distance = 3.1622776601683795
+! Flux pairs: C4H7(49), C4H6(111); C4H6(47), C4H7(49); 
+! From training reaction 48 used for C_rad/H2/Cd;Cdpri_Csrad
+! Exact match found for rate rule [C_rad/H2/Cd;Cdpri_Csrad]
+! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-C2H3(14)+C4H5(144)=C#C(27)+C4H6(69)                 8.204641e+06 1.877     -1.115   
+C4H6(47)+C4H7(49)=C4H6(111)+C4H7(49)                1.686000e+11 0.000     6.000    
 
-! Reaction index: Chemkin #62; RMG #407
+! Reaction index: Chemkin #62; RMG #1140
 ! Template reaction: Disproportionation
-! Estimated using template [Cd_rad;Cpri_Rrad] for rate rule [Cd_rad/NonDeC;C/H2/Cd_Csrad]
-! Euclidian distance = 3.605551275463989
+! Flux pairs: C4H7(49), C4H6(111); C4H6(47), C4H7(31); 
+! From training reaction 46 used for Y_rad;Cdpri_Csrad
+! Exact match found for rate rule [Y_rad;Cdpri_Csrad]
+! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-C4H5(144)+C4H7(29)=C4H6(69)+C4H6(42)                2.420000e+12 0.000     0.000    
+C4H6(47)+C4H7(49)=C4H6(111)+C4H7(31)                6.020000e+12 0.000     6.000    
 
-! Reaction index: Chemkin #63; RMG #410
-! Template reaction: Disproportionation
-! Estimated using template [Cd_rad;Cmethyl_Csrad] for rate rule [Cd_rad/NonDeC;Cmethyl_Csrad/H/Cd]
-! Euclidian distance = 2.23606797749979
-! Multiplied by reaction path degeneracy 3.0
-! family: Disproportionation
-C4H5(144)+C4H7(45)=C4H6(69)+C4H6(42)                4.560000e+14 -0.700    0.000    
-
-! Reaction index: Chemkin #64; RMG #425
-! Template reaction: H_Abstraction
-! Flux pairs: C4H6(69), C4H5(144); C2H5(5), ethane(1); 
-! Estimated using an average for rate rule [Cd_allenic;C_rad/H2/Cs\H3]
-! Euclidian distance = 0
-! family: H_Abstraction
-C2H5(5)+C4H6(69)=ethane(1)+C4H5(144)                5.450000e-03 4.340     5.900    
-
-! Reaction index: Chemkin #65; RMG #436
-! Template reaction: H_Abstraction
-! Flux pairs: C4H6(69), C4H5(144); C2H3(14), C2H4(9); 
-! Estimated using an average for rate rule [Cd_allenic;Cd_Cd\H2_pri_rad]
-! Euclidian distance = 0
-! family: H_Abstraction
-C2H3(14)+C4H6(69)=C2H4(9)+C4H5(144)                 4.170000e-02 4.340     1.000    
-
-! Reaction index: Chemkin #66; RMG #442
-! Template reaction: H_Abstraction
-! Flux pairs: C4H6(69), C4H5(144); H(6), H2(11); 
-! Estimated using an average for rate rule [Cd_allenic;H_rad]
-! Euclidian distance = 0
-! family: H_Abstraction
-H(6)+C4H6(69)=H2(11)+C4H5(144)                      3.532500e+00 3.852     3.502    
-
-! Reaction index: Chemkin #67; RMG #69
+! Reaction index: Chemkin #63; RMG #115
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: CH3(4), C3H5(32); C#C(27), C3H5(32); 
+! Flux pairs: CH3(4), C3H5(36); C#C(28), C3H5(36); 
 ! Matched reaction 2253 C2H2 + CH3 <=> C3H5-2 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Ct-H_Ct-H;CsJ-HHH]
 ! family: R_Addition_MultipleBond
-CH3(4)+C#C(27)=C3H5(32)                             1.338000e+05 2.410     6.770    
+CH3(4)+C#C(28)=C3H5(36)                             1.338000e+05 2.410     6.770    
 
-! Reaction index: Chemkin #68; RMG #84
+! Reaction index: Chemkin #64; RMG #132
 ! Template reaction: R_Addition_MultipleBond
-! Flux pairs: C2H3(14), C4H5(35); C#C(27), C4H5(35); 
+! Flux pairs: C2H3(14), C4H5(40); C#C(28), C4H5(40); 
 ! Matched reaction 196 C2H2 + C2H3 <=> C4H5-8 in R_Addition_MultipleBond/training
 ! This reaction matched rate rule [Ct-H_Ct-H;CdsJ-H]
 ! family: R_Addition_MultipleBond
-C#C(27)+C2H3(14)=C4H5(35)                           1.168000e+07 1.997     5.452    
+C#C(28)+C2H3(14)=C4H5(40)                           1.168000e+07 1.997     5.452    
 
-! Reaction index: Chemkin #69; RMG #215
+! Reaction index: Chemkin #65; RMG #742
 ! Template reaction: R_Recombination
-! Flux pairs: C4H5(35), C4H6(42); H(6), C4H6(42); 
-! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_Sp-3R!H=2C_3R!H->C
-!     Total Standard Deviation in ln(k): 6.83519320067
-! Exact match found for rate rule [Root_1R->H_N-2R-inRing_N-2R->H_N-2CNOS->S_2CNO->C_Ext-2C-R_Sp-3R!H=2C_3R!H->C]
+! Flux pairs: C4H5(40), C4H6(33); H(6), C4H6(33); 
+! BM rule fitted to 2 training reactions at node Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_Sp-3R!H=2CCNNOO_N-3R!H->O
+!     Total Standard Deviation in ln(k): 7.13613102162
+! Exact match found for rate rule [Root_1R->H_N-2R->S_N-2CHNO->H_N-2CNO-inRing_Ext-2CNO-R_Sp-3R!H=2CCNNOO_N-3R!H->O]
 ! Euclidian distance = 0
 ! family: R_Recombination
-H(6)+C4H5(35)=C4H6(42)                              9.988280e+13 0.006     0.000    
+H(6)+C4H5(40)=C4H6(33)                              8.156660e+18 -1.493    0.000    
 
-! Reaction index: Chemkin #70; RMG #223
+! Reaction index: Chemkin #66; RMG #748
 ! Template reaction: H_Abstraction
-! Flux pairs: CH3(4), CH4(3); C4H6(42), C4H5(35); 
+! Flux pairs: CH3(4), CH4(3); C4H6(33), C4H5(40); 
 ! From training reaction 1567 used for Cd/H2/NonDeC;C_methyl
 ! Exact match found for rate rule [Cd/H2/NonDeC;C_methyl]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 4.0
 ! family: H_Abstraction
-CH3(4)+C4H6(42)=CH4(3)+C4H5(35)                     3.432000e-02 4.340     20.710   
+CH3(4)+C4H6(33)=CH4(3)+C4H5(40)                     3.432000e-02 4.340     20.710   
 
-! Reaction index: Chemkin #71; RMG #231
+! Reaction index: Chemkin #67; RMG #756
 ! Template reaction: H_Abstraction
-! Flux pairs: C2H5(5), ethane(1); C4H6(42), C4H5(35); 
+! Flux pairs: C2H5(5), ethane(1); C4H6(33), C4H5(40); 
 ! From training reaction 344 used for Cd/H2/NonDeC;C_rad/H2/Cs\H3
 ! Exact match found for rate rule [Cd/H2/NonDeC;C_rad/H2/Cs\H3]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 4.0
 ! family: H_Abstraction
-C2H5(5)+C4H6(42)=ethane(1)+C4H5(35)                 6.320000e+02 3.130     18.000   
+C2H5(5)+C4H6(33)=ethane(1)+C4H5(40)                 6.320000e+02 3.130     18.000   
 
-! Reaction index: Chemkin #72; RMG #237
+! Reaction index: Chemkin #68; RMG #760
 ! Template reaction: H_Abstraction
-! Flux pairs: H(6), H2(11); C4H6(42), C4H5(35); 
+! Flux pairs: H(6), H2(13); C4H6(33), C4H5(40); 
 ! From training reaction 217 used for Cd/H2/NonDeC;H_rad
 ! Exact match found for rate rule [Cd/H2/NonDeC;H_rad]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 4.0
 ! family: H_Abstraction
-H(6)+C4H6(42)=H2(11)+C4H5(35)                       2.400000e+02 3.620     11.266   
+H(6)+C4H6(33)=H2(13)+C4H5(40)                       2.400000e+02 3.620     11.266   
 
-! Reaction index: Chemkin #73; RMG #246
+! Reaction index: Chemkin #69; RMG #765
 ! Template reaction: Disproportionation
 ! From training reaction 11 used for Cd_pri_rad;Cmethyl_Csrad
 ! Exact match found for rate rule [Cd_pri_rad;Cmethyl_Csrad]
 ! Euclidian distance = 0
 ! Multiplied by reaction path degeneracy 3.0
 ! family: Disproportionation
-C2H5(5)+C4H5(35)=C2H4(9)+C4H6(42)                   4.560000e+14 -0.700    0.000    
+C2H5(5)+C4H5(40)=C2H4(9)+C4H6(33)                   4.560000e+14 -0.700    0.000    
 
-! Reaction index: Chemkin #74; RMG #256
+! Reaction index: Chemkin #70; RMG #783
 ! Template reaction: H_Abstraction
-! Flux pairs: C2H3(14), C2H4(9); C4H6(42), C4H5(35); 
+! Flux pairs: C2H3(14), C2H4(9); C4H6(33), C4H5(40); 
 ! Matched reaction 177 C4H6-3 + C2H3 <=> C2H4 + C4H5 in H_Abstraction/training
 ! This reaction matched rate rule [Cd/H2/NonDeC;Cd_Cd\H2_pri_rad]
 ! family: H_Abstraction
-C2H3(14)+C4H6(42)=C2H4(9)+C4H5(35)                  3.437000e-04 4.732     6.579    
+C2H3(14)+C4H6(33)=C2H4(9)+C4H5(40)                  3.437000e-04 4.732     6.579    
 
-! Reaction index: Chemkin #75; RMG #265
+! Reaction index: Chemkin #71; RMG #792
 ! Template reaction: Disproportionation
 ! Estimated using template [Y_rad;Cds/H2_d_Rrad] for rate rule [Cd_pri_rad;Cds/H2_d_Crad]
 ! Euclidian distance = 2.23606797749979
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-C2H3(14)+C4H5(35)=C#C(27)+C4H6(42)                  8.204641e+06 1.877     -1.115   
+C2H3(14)+C4H5(40)=C#C(28)+C4H6(33)                  8.204641e+06 1.877     -1.115   
 
-! Reaction index: Chemkin #76; RMG #309
+! Reaction index: Chemkin #72; RMG #875
 ! Template reaction: Disproportionation
 ! Estimated using average of templates [Y_rad_birad_trirad_quadrad;C/H2/Cd_Csrad] + [Cd_pri_rad;Cpri_Rrad] for rate rule [Cd_pri_rad;C/H2/Cd_Csrad]
 ! Euclidian distance = 3.0
 ! Multiplied by reaction path degeneracy 2.0
 ! family: Disproportionation
-C4H5(35)+C4H7(29)=C4H6(42)+C4H6(42)                 2.200000e+11 0.000     0.000    
+C4H5(40)+C4H7(31)=C4H6(33)+C4H6(33)                 2.200000e+11 0.000     0.000    
 
-! Reaction index: Chemkin #77; RMG #310
+! Reaction index: Chemkin #73; RMG #876
 ! Template reaction: Disproportionation
 ! Estimated using template [Cd_pri_rad;Cmethyl_Csrad] for rate rule [Cd_pri_rad;Cmethyl_Csrad/H/Cd]
 ! Euclidian distance = 1.0
 ! Multiplied by reaction path degeneracy 3.0
 ! family: Disproportionation
-C4H5(35)+C4H7(45)=C4H6(42)+C4H6(42)                 4.560000e+14 -0.700    0.000    
+C4H5(40)+C4H7(49)=C4H6(33)+C4H6(33)                 4.560000e+14 -0.700    0.000    
 
-! Reaction index: Chemkin #78; RMG #405
+! Reaction index: Chemkin #74; RMG #1408
 ! Template reaction: Disproportionation
 ! From training reaction 51 used for Cd_pri_rad;Cdpri_Csrad
 ! Exact match found for rate rule [Cd_pri_rad;Cdpri_Csrad]
 ! Euclidian distance = 0
 ! family: Disproportionation
-C4H5(35)+C4H7(45)=C4H6(69)+C4H6(42)                 2.410000e+12 0.000     6.000    
+C4H5(40)+C4H7(49)=C4H6(111)+C4H6(33)                2.410000e+12 0.000     6.000    
 
-! Reaction index: Chemkin #79; RMG #466
+! Reaction index: Chemkin #75; RMG #1668
 ! Template reaction: Intra_R_Add_Exocyclic
-! Flux pairs: C4H5(35), C4H5(185); 
+! Flux pairs: C4H5(40), C4H5(402); 
 ! From training reaction 14 used for R4_D_D;doublebond_intra_2H_pri;radadd_intra_cdsingleH
 ! Exact match found for rate rule [R4_D_D;doublebond_intra_2H_pri;radadd_intra_cdsingleH]
 ! Euclidian distance = 0
 ! family: Intra_R_Add_Exocyclic
-C4H5(35)=C4H5(185)                                  2.540000e+10 0.690     25.170   
+C4H5(40)=C4H5(402)                                  2.540000e+10 0.690     25.170   
 
 END
 

--- a/ipython/data/parse_source/species_dictionary.txt
+++ b/ipython/data/parse_source/species_dictionary.txt
@@ -57,7 +57,7 @@ C2H4(9)
 5 H u0 p0 c0 {2,S}
 6 H u0 p0 c0 {2,S}
 
-H2(11)
+H2(13)
 1 H u0 p0 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
@@ -82,19 +82,19 @@ multiplicity 2
 4 H u0 p0 c0 {1,S}
 5 H u0 p0 c0 {2,S}
 
-C#C(27)
+C#C(28)
 1 C u0 p0 c0 {2,T} {3,S}
 2 C u0 p0 c0 {1,T} {4,S}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {2,S}
 
-C2H2(31)
+C2H2(35)
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
 2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 
-C4H7(29)
+C4H7(31)
 multiplicity 2
 1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
 2  C u0 p0 c0 {1,S} {4,D} {7,S}
@@ -108,7 +108,7 @@ multiplicity 2
 10 H u0 p0 c0 {4,S}
 11 H u0 p0 c0 {4,S}
 
-C4H7(41)
+C4H7(46)
 multiplicity 2
 1  C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
 2  C u0 p0 c0 {1,S} {3,S} {6,S} {7,S}
@@ -122,7 +122,7 @@ multiplicity 2
 10 H u0 p0 c0 {4,S}
 11 H u0 p0 c0 {4,S}
 
-C4H7(33)
+C4H7(37)
 multiplicity 2
 1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
 2  C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
@@ -136,7 +136,7 @@ multiplicity 2
 10 H u0 p0 c0 {3,S}
 11 H u0 p0 c0 {4,S}
 
-C4H7(45)
+C4H7(49)
 multiplicity 2
 1  C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
 2  C u0 p0 c0 {1,S} {3,D} {8,S}
@@ -150,7 +150,7 @@ multiplicity 2
 10 H u0 p0 c0 {4,S}
 11 H u0 p0 c0 {4,S}
 
-C4H6(42)
+C4H6(33)
 1  C u0 p0 c0 {2,S} {3,D} {5,S}
 2  C u0 p0 c0 {1,S} {4,D} {6,S}
 3  C u0 p0 c0 {1,D} {7,S} {8,S}
@@ -162,7 +162,7 @@ C4H6(42)
 9  H u0 p0 c0 {4,S}
 10 H u0 p0 c0 {4,S}
 
-C4H6(88)
+C4H6(186)
 1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
 2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
 3  C u0 p0 c0 {1,S} {4,D} {9,S}
@@ -174,7 +174,7 @@ C4H6(88)
 9  H u0 p0 c0 {3,S}
 10 H u0 p0 c0 {4,S}
 
-C4H6(43)
+C4H6(47)
 multiplicity 3
 1  C u0 p0 c0 {2,D} {3,S} {5,S}
 2  C u0 p0 c0 {1,D} {4,S} {6,S}
@@ -187,7 +187,7 @@ multiplicity 3
 9  H u0 p0 c0 {4,S}
 10 H u0 p0 c0 {4,S}
 
-C4H6(69)
+C4H6(111)
 1  C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
 2  C u0 p0 c0 {1,S} {4,D} {8,S}
 3  C u0 p0 c0 {4,D} {9,S} {10,S}
@@ -199,19 +199,7 @@ C4H6(69)
 9  H u0 p0 c0 {3,S}
 10 H u0 p0 c0 {3,S}
 
-C4H5(144)
-multiplicity 2
-1 C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
-2 C u1 p0 c0 {4,S} {8,S} {9,S}
-3 C u0 p0 c0 {1,S} {4,T}
-4 C u0 p0 c0 {2,S} {3,T}
-5 H u0 p0 c0 {1,S}
-6 H u0 p0 c0 {1,S}
-7 H u0 p0 c0 {1,S}
-8 H u0 p0 c0 {2,S}
-9 H u0 p0 c0 {2,S}
-
-C3H5(32)
+C3H5(36)
 multiplicity 2
 1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
 2 C u0 p0 c0 {1,S} {3,D} {7,S}
@@ -222,7 +210,7 @@ multiplicity 2
 7 H u0 p0 c0 {2,S}
 8 H u0 p0 c0 {3,S}
 
-C4H5(35)
+C4H5(40)
 multiplicity 2
 1 C u0 p0 c0 {2,S} {3,D} {5,S}
 2 C u0 p0 c0 {1,S} {4,D} {6,S}
@@ -234,7 +222,7 @@ multiplicity 2
 8 H u0 p0 c0 {3,S}
 9 H u0 p0 c0 {4,S}
 
-C4H5(185)
+C4H5(402)
 multiplicity 2
 1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
 2 C u0 p0 c0 {1,S} {3,D} {6,S}


### PR DESCRIPTION
This is a minor modification.

### Motivation or Problem
The reaction templates commented in the original chen_annotated.inp is no longer valid since PR #334 tree generation for R_recombination. 

### Description of Changes
I ran a RMG simulation with the original input.py and update the chem_annotated.inp and species_dictionary.

### Testing
I ran the three uncertainty related jupyter notebook. All can load the new files successfully.
