### PR TITLE
Standardize model chemistry

### DIFF
--- a/arkane/common.py
+++ b/arkane/common.py
@@ -58,6 +58,7 @@ from rmgpy.statmech.vibration import HarmonicOscillator
 from rmgpy.thermo import NASA, Wilhoit, ThermoData, NASAPolynomial
 from rmgpy.transport import TransportData
 
+from arkane.modelchem import LevelOfTheory, CompositeLevelOfTheory
 from arkane.pdep import PressureDependenceJob
 
 ################################################################################
@@ -81,6 +82,8 @@ ARKANE_CLASS_DICT = {'ScalarQuantity': ScalarQuantity,
                      'NASAPolynomial': NASAPolynomial,
                      'ThermoData': ThermoData,
                      'np_array': np.array,
+                     'LevelOfTheory': LevelOfTheory,
+                     'CompositeLevelOfTheory': CompositeLevelOfTheory
                      }
 
 

--- a/arkane/commonTest.py
+++ b/arkane/commonTest.py
@@ -49,6 +49,7 @@ from arkane import Arkane, input
 from arkane.common import ArkaneSpecies, get_element_mass, get_center_of_mass, \
     get_moment_of_inertia_tensor, get_principal_moments_of_inertia
 from arkane.input import job_list
+from arkane.modelchem import LevelOfTheory
 from arkane.statmech import InputError, StatMechJob
 
 ################################################################################
@@ -229,7 +230,7 @@ class TestArkaneInput(unittest.TestCase):
     def setUp(cls):
         """Preparation for all unit tests in this class."""
         cls.directory = os.path.join(os.path.dirname(os.path.dirname(rmgpy.__file__)), 'examples', 'arkane')
-        cls.modelChemistry = "cbs-qb3"
+        cls.level_of_theory = LevelOfTheory("cbs-qb3")
         cls.frequencyScaleFactor = 0.99
         cls.useHinderedRotors = False
         cls.useBondCorrections = True
@@ -244,7 +245,7 @@ class TestArkaneInput(unittest.TestCase):
         """Test loading of statmech job from species input file."""
         job = job_list[-1]
         self.assertTrue(isinstance(job, StatMechJob))
-        job.modelChemistry = self.modelChemistry
+        job.level_of_theory = self.level_of_theory
         job.frequencyScaleFactor = self.frequencyScaleFactor
         job.includeHinderedRotors = self.useHinderedRotors
         job.applyBondEnergyCorrections = self.useBondCorrections
@@ -273,7 +274,7 @@ class TestArkaneInput(unittest.TestCase):
         """Test loading of statmech job from transition state input file."""
         job = job_list[-1]
         self.assertTrue(isinstance(job, StatMechJob))
-        job.modelChemistry = self.modelChemistry
+        job.level_of_theory = self.level_of_theory
         job.frequencyScaleFactor = self.frequencyScaleFactor
         job.includeHinderedRotors = self.useHinderedRotors
         job.applyBondEnergyCorrections = self.useBondCorrections
@@ -365,7 +366,7 @@ class TestArkaneSpecies(unittest.TestCase):
         self.assertAlmostEqual(arkane_spc.conformer.modes[2].frequencies.value_si[0], 830.38202, 4)  # HarmonicOsc.
         self.assertIsInstance(arkane_spc.energy_transfer_model, SingleExponentialDown)
         self.assertFalse(arkane_spc.is_ts)
-        self.assertEqual(arkane_spc.level_of_theory, 'cbs-qb3')
+        self.assertEqual(arkane_spc.level_of_theory, LevelOfTheory('cbs-qb3'))
         self.assertIsInstance(arkane_spc.thermo_data, ThermoData)
         self.assertTrue(arkane_spc.use_hindered_rotors)
         self.assertIsInstance(arkane_spc.chemkin_thermo_string, str)

--- a/arkane/data/species/reference_species_example.yml
+++ b/arkane/data/species/reference_species_example.yml
@@ -20,7 +20,7 @@ multiplicity: 2
 symmetry_number: 2.0
 RMG_version: 3.0.0
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
       - H
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 index: 149
 reference_data:
   ATcT:

--- a/arkane/encorr/aeTest.py
+++ b/arkane/encorr/aeTest.py
@@ -37,6 +37,7 @@ import tempfile
 import unittest
 
 from arkane.encorr.ae import AE, SPECIES_LABELS
+from arkane.modelchem import LevelOfTheory
 
 
 class TestAE(unittest.TestCase):
@@ -89,7 +90,7 @@ class TestAE(unittest.TestCase):
         self.ae.atom_energies = {'H': 1.0, 'C': 2.0}
         tmp_datafile_fd, tmp_datafile_path = tempfile.mkstemp(suffix='.py')
 
-        lot = 'wb97m-v/def2-tzvpd'
+        lot = LevelOfTheory(method='wb97m-v', basis='def2-tzvpd', software='Q-Chem')
         with self.assertRaises(ValueError) as e:
             self.ae.write_to_database(lot, alternate_path=tmp_datafile_path)
         self.assertIn('overwrite', str(e.exception))
@@ -101,13 +102,13 @@ class TestAE(unittest.TestCase):
         # Check that existing energies can be overwritten
         self.ae.write_to_database(lot, overwrite=True, alternate_path=tmp_datafile_path)
         spec.loader.exec_module(module)  # Load data as module
-        self.assertEqual(self.ae.atom_energies, module.atom_energies[lot])
+        self.assertEqual(self.ae.atom_energies, module.atom_energies[repr(lot)])
 
         # Check that new energies can be written
-        lot = 'test'
+        lot = LevelOfTheory('test')
         self.ae.write_to_database(lot, alternate_path=tmp_datafile_path)
         spec.loader.exec_module(module)  # Reload data module
-        self.assertEqual(self.ae.atom_energies, module.atom_energies[lot])
+        self.assertEqual(self.ae.atom_energies, module.atom_energies[repr(lot)])
 
         os.close(tmp_datafile_fd)
         os.remove(tmp_datafile_path)

--- a/arkane/encorr/corr.py
+++ b/arkane/encorr/corr.py
@@ -40,12 +40,13 @@ import rmgpy.constants as constants
 
 import arkane.encorr.data as data
 from arkane.encorr.bac import BAC
-from arkane.exceptions import AtomEnergyCorrectionError
+from arkane.exceptions import AtomEnergyCorrectionError, BondAdditivityCorrectionError
+from arkane.modelchem import LevelOfTheory, CompositeLevelOfTheory
 
 ################################################################################
 
 
-def get_energy_correction(model_chemistry: str,
+def get_energy_correction(level_of_theory: Union[LevelOfTheory, CompositeLevelOfTheory],
                           atoms: Dict[str, int],
                           bonds: Dict[str, int],
                           coords: np.ndarray,
@@ -57,12 +58,12 @@ def get_energy_correction(model_chemistry: str,
                           bac_type: str = 'p') -> float:
     """
     Calculate a correction to the electronic energy obtained from a
-    quantum chemistry calculation at a given model chemistry such that
+    quantum chemistry calculation at a given level of theory such that
     it is consistent with the normal gas-phase reference states.
     Optionally, correct the energy using bond additivity corrections.
 
     Args:
-        model_chemistry: The model chemistry, typically specified as method/basis.
+        level_of_theory: The level of theory.
         atoms: A dictionary of element symbols with their associated counts.
         bonds: A dictionary of bond types (e.g., 'C=O') with their associated counts.
         coords: A Numpy array of Cartesian molecular coordinates.
@@ -78,25 +79,26 @@ def get_energy_correction(model_chemistry: str,
     """
     logging.warning('get_energy_correction has be deprecated, use get_atom_correction '
                     'and get_bac instead')
-    model_chemistry = model_chemistry.lower()
 
     corr = 0.0
     if apply_atom_corrections:
-        corr += get_atom_correction(model_chemistry, atoms, atom_energies=atom_energies)
+        corr += get_atom_correction(level_of_theory, atoms, atom_energies=atom_energies)
     if apply_bac:
-        corr += get_bac(model_chemistry, bonds, coords, nums, bac_type=bac_type, multiplicity=multiplicity)
+        corr += get_bac(level_of_theory, bonds, coords, nums, bac_type=bac_type, multiplicity=multiplicity)
 
     return corr
 
 
-def get_atom_correction(model_chemistry: str, atoms: Dict[str, int], atom_energies: Dict[str, float] = None) -> float:
+def get_atom_correction(level_of_theory: Union[LevelOfTheory, CompositeLevelOfTheory],
+                        atoms: Dict[str, int],
+                        atom_energies: Dict[str, float] = None) -> float:
     """
     Calculate a correction to the electronic energy obtained from a
-    quantum chemistry calculation at a given model chemistry such that
+    quantum chemistry calculation at a given level of theory such that
     it is consistent with the normal gas-phase reference states.
 
     Args:
-        model_chemistry: The model chemistry, typically specified as method/basis.
+        level_of_theory: The level of theory.
         atoms: A dictionary of element symbols with their associated counts.
         atom_energies: A dictionary of element symbols with their associated atomic energies in Hartree.
 
@@ -108,21 +110,27 @@ def get_atom_correction(model_chemistry: str, atoms: Dict[str, int], atom_energi
     P quartet, S triplet, Cl doublet, Br doublet, I doublet.
     """
     corr = 0.0
-    model_chemistry = model_chemistry.lower()
-    # Step 1: Reference all energies to a model chemistry-independent
-    # basis by subtracting out that model chemistry's atomic energies
+    # Step 1: Reference all energies to a level of theory-independent
+    # basis by subtracting out that level of theory's atomic energies
     if atom_energies is None:
+        energy_level = getattr(level_of_theory, 'energy', level_of_theory)
         try:
-            atom_energies = data.atom_energies[model_chemistry]
+            atom_energies = data.atom_energies[energy_level]
         except KeyError:
-            raise AtomEnergyCorrectionError(f'Missing atom energies for model chemistry {model_chemistry}')
+            try:
+                atom_energies = data.atom_energies[energy_level.simple()]
+            except KeyError:
+                raise AtomEnergyCorrectionError(f'Missing atom energies for {energy_level}')
+            else:
+                logging.warning(f'No exact atom energy match found for {energy_level}.'
+                                f' Using {energy_level.simple()} instead.')
 
     for symbol, count in atoms.items():
         if symbol in atom_energies:
             corr -= count * atom_energies[symbol] * 4.35974394e-18 * constants.Na  # Convert Hartree to J/mol
         else:
             raise AtomEnergyCorrectionError(
-                f'An energy correction for element "{symbol}" is unavailable for model chemistry "{model_chemistry}".'
+                f'An energy correction for element "{symbol}" is unavailable for {level_of_theory}.'
                 ' Turn off atom corrections if only running a kinetics jobs'
                 ' or supply a dictionary of atom energies'
                 ' as `atomEnergies` in the input file.'
@@ -137,13 +145,13 @@ def get_atom_correction(model_chemistry: str, atoms: Dict[str, int], atom_energi
             raise AtomEnergyCorrectionError(
                 f'Element "{symbol}" is not yet supported in Arkane.'
                 ' To include it, add its experimental heat of formation in the atom_hf'
-                ' and atom_thermal dictionaries in arkane/encorr/data.py'
+                ' and atom_thermal dictionaries in input/quantum_corrections/data.py in the RMG database.'
             )
 
     return corr
 
 
-def get_bac(model_chemistry: str,
+def get_bac(level_of_theory: Union[LevelOfTheory, CompositeLevelOfTheory],
             bonds: Dict[str, int],
             coords: np.ndarray,
             nums: Iterable[int],
@@ -161,7 +169,7 @@ def get_bac(model_chemistry: str,
     in `coords` and array of atomic numbers of atoms as well as the structure's multiplicity.
 
     Args:
-        model_chemistry: The model chemistry, typically specified as method/basis.
+        level_of_theory: The level of theory.
         bonds: A dictionary of bond types (e.g., 'C=O') with their associated counts.
         coords: A Numpy array of Cartesian molecular coordinates.
         nums: A sequence of atomic numbers.
@@ -171,14 +179,44 @@ def get_bac(model_chemistry: str,
     Returns:
         The bond correction to the electronic energy in J/mol.
     """
-    model_chemistry = model_chemistry.lower()
-    bac = BAC(model_chemistry, bac_type=bac_type)
-    return bac.get_correction(bonds=bonds, coords=coords, nums=nums, multiplicity=multiplicity).value_si
+    def _get_bac(_lot):
+        """Helper function to get BACs"""
+        bac = BAC(_lot, bac_type=bac_type)
+        return bac.get_correction(bonds=bonds, coords=coords, nums=nums, multiplicity=multiplicity).value_si
+
+    # Try to match each of these levels of theory, but issue warning if full level of theory cannot be matched
+    lots_to_attempt = [
+        level_of_theory,  # Full level of theory
+        level_of_theory.simple()  # Only method and basis
+    ]
+    if isinstance(level_of_theory, CompositeLevelOfTheory):
+        lots_to_attempt.extend([
+            level_of_theory.energy,  # Full energy level
+            level_of_theory.energy.simple()  # Energy level with only method and basis
+        ])
+    for lot in lots_to_attempt:
+        try:
+            corr = _get_bac(lot)
+        except BondAdditivityCorrectionError as e:
+            if lot is not lots_to_attempt[-1]:
+                continue
+            else:
+                if 'BAC parameters' in str(e):
+                    bac_type_str = 'Melius' if bac_type == 'm' else 'Petersson'
+                    raise BondAdditivityCorrectionError(
+                        f'Missing {bac_type_str}-type BAC parameters for {level_of_theory}'
+                    )
+                else:
+                    raise
+        else:
+            if lot is not lots_to_attempt[0]:
+                logging.warning(f'No exact BAC match found for {level_of_theory}. Using {lot} instead.')
+            return corr
 
 
-def assign_frequency_scale_factor(freq_level: str) -> Union[int, float]:
+def assign_frequency_scale_factor(level_of_theory: Union[LevelOfTheory, CompositeLevelOfTheory]) -> Union[int, float]:
     """
-    Assign the frequency scaling factor according to the model chemistry.
+    Assign the frequency scaling factor according to the level of theory.
     Refer to https://comp.chem.umn.edu/freqscale/index.html for future updates of these factors
 
     Sources:
@@ -189,19 +227,31 @@ def assign_frequency_scale_factor(freq_level: str) -> Union[int, float]:
         [5] J.A. Montgomery, M.J. Frisch, J. Chem. Phys. 1999, 110, 2822–2827, DOI: 10.1063/1.477924
 
     Args:
-        freq_level (str, unicode): The frequency level of theory.
+        level_of_theory (LevelOfTheory, CompositeLevelOfTheory): The level of theory.
 
     Returns:
         float: The frequency scaling factor (1 by default).
     """
-    scaling_factor = data.freq_dict.get(freq_level.lower(), 1)
+    if level_of_theory is None:
+        return 1
+    freq_level = getattr(level_of_theory, 'freq', level_of_theory)
+    try:
+        scaling_factor = data.freq_dict[freq_level]
+    except KeyError:
+        try:
+            scaling_factor = data.freq_dict[freq_level.simple()]
+        except KeyError:
+            scaling_factor = 1
+        else:
+            logging.warning(f'No exact frequency scaling factor match found for {freq_level}.'
+                            f' Using {freq_level.simple()} instead.')
     if scaling_factor == 1:
         logging.warning(
-            f'No frequency scaling factor found for model chemistry {freq_level}. Assuming a value of unity.'
+            f'No frequency scaling factor found for {freq_level}. Assuming a value of unity.'
             ' This will affect the partition function and all quantities derived from it '
             ' (thermo quantities and rate coefficients).')
     else:
         logging.info(
-            f'Assigned a frequency scale factor of {scaling_factor} for the frequency level of theory {freq_level}'
+            f'Assigned a frequency scale factor of {scaling_factor} for {level_of_theory}'
         )
     return scaling_factor

--- a/arkane/encorr/dataTest.py
+++ b/arkane/encorr/dataTest.py
@@ -39,15 +39,48 @@ import pybel
 
 from rmgpy.molecule import Molecule as RMGMolecule
 
+import arkane.encorr.data as data
 from arkane.encorr.data import (Molecule, Stats, BACDatapoint, DatasetProperty, BACDataset,
                                 extract_dataset, geo_to_mol, _pybel_to_rmg)
 from arkane.encorr.reference import ReferenceDatabase
 from arkane.exceptions import BondAdditivityCorrectionError
-from arkane.modelchem import LevelOfTheory
+from arkane.modelchem import LOT, LevelOfTheory
 
 DATABASE = ReferenceDatabase()
 DATABASE.load()
 LEVEL_OF_THEORY = LevelOfTheory(method='wb97m-v', basis='def2-tzvpd', software='qchem')
+
+
+class TestDataLoading(unittest.TestCase):
+    """
+    A class for testing that the quantum correction data is loaded
+    correctly from the RMG database.
+    """
+
+    def test_contains_data(self):
+        """
+        Test that the necessary dictionaries are available.
+        """
+        self.assertTrue(hasattr(data, 'atom_hf'))
+        self.assertTrue(hasattr(data, 'atom_thermal'))
+        self.assertTrue(hasattr(data, 'SOC'))
+        self.assertTrue(hasattr(data, 'atom_energies'))
+        self.assertTrue(hasattr(data, 'pbac'))
+        self.assertTrue(hasattr(data, 'mbac'))
+        self.assertTrue(hasattr(data, 'freq_dict'))
+
+    def test_level_of_theory(self):
+        """
+        Test that level of theory objects were created.
+        """
+        for lot in data.atom_energies.keys():
+            self.assertIsInstance(lot, LOT)
+        for lot in data.pbac.keys():
+            self.assertIsInstance(lot, LOT)
+        for lot in data.mbac.keys():
+            self.assertIsInstance(lot, LOT)
+        for lot in data.freq_dict.keys():
+            self.assertIsInstance(lot, LOT)
 
 
 class TestMolecule(unittest.TestCase):

--- a/arkane/encorr/isodesmic.py
+++ b/arkane/encorr/isodesmic.py
@@ -51,6 +51,8 @@ import numpy as np
 from rmgpy.molecule import Molecule
 from rmgpy.quantity import ScalarQuantity
 
+from arkane.modelchem import LOT
+
 # Optional Imports
 try:
     import pyomo.environ as pyo
@@ -61,13 +63,13 @@ except ImportError:
 class ErrorCancelingSpecies:
     """Class for target and known (reference) species participating in an error canceling reaction"""
 
-    def __init__(self, molecule, low_level_hf298, model_chemistry, high_level_hf298=None, source=None):
+    def __init__(self, molecule, low_level_hf298, level_of_theory, high_level_hf298=None, source=None):
         """
 
         Args:
             molecule (Molecule): The RMG Molecule object with connectivity information
             low_level_hf298 (ScalarQuantity): evaluated using a lower level of theory (e.g. DFT)
-            model_chemistry (str): Level of theory used to calculate the low level thermo
+            level_of_theory ((Composite)LevelOfTheory): Level of theory used to calculate the low level thermo
             high_level_hf298 (ScalarQuantity, optional): evaluated using experimental data
                 or a high level of theory that is serving as the "reference" for the isodesmic calculation
             source (str): Literature source from which the high level data was taken
@@ -78,11 +80,11 @@ class ErrorCancelingSpecies:
             raise ValueError(f'ErrorCancelingSpecies molecule attribute must be an rmgpy Molecule object. Instead a '
                              f'{type(molecule)} object was given')
 
-        if isinstance(model_chemistry, str):
-            self.model_chemistry = model_chemistry
+        if isinstance(level_of_theory, LOT):
+            self.level_of_theory = level_of_theory
         else:
-            raise ValueError(f'The model chemistry string used to calculate the low level Hf298 must be provided '
-                             f'consistency checks. Instead, a {type(model_chemistry)} object was given')
+            raise ValueError(f'The level of theory used to calculate the low level Hf298 must be provided '
+                             f'for consistency checks. Instead, a {type(level_of_theory)} object was given')
 
         if not isinstance(low_level_hf298, ScalarQuantity):
             if isinstance(low_level_hf298, tuple):
@@ -125,13 +127,13 @@ class ErrorCancelingReaction:
         """
 
         self.target = target
-        self.model_chemistry = self.target.model_chemistry
+        self.level_of_theory = self.target.level_of_theory
 
-        # Perform a consistency check that all species are using the same model chemistry
+        # Perform a consistency check that all species are using the same level of theory
         for spcs in species.keys():
-            if spcs.model_chemistry != self.model_chemistry:
-                raise ValueError(f'Species {spcs} has model chemistry {spcs.model_chemistry}, which does not match the '
-                                 f'model chemistry of the reaction of {self.model_chemistry}')
+            if spcs.level_of_theory != self.level_of_theory:
+                raise ValueError(f'Species {spcs} has level of theory {spcs.level_of_theory}, which does not match the '
+                                 f'level of theory of the reaction of {self.level_of_theory}')
 
         # Does not include the target, which is handled separately.
         self.species = species

--- a/arkane/encorr/referenceTest.py
+++ b/arkane/encorr/referenceTest.py
@@ -37,6 +37,7 @@ import unittest
 import shutil
 
 from arkane.encorr.isodesmic import ErrorCancelingSpecies
+from arkane.modelchem import LevelOfTheory
 from arkane.encorr.reference import ReferenceSpecies, ReferenceDataEntry, CalculatedDataEntry, ReferenceDatabase
 from rmgpy.species import Species
 from rmgpy.thermo import ThermoData
@@ -173,9 +174,9 @@ class TestReferenceDatabase(unittest.TestCase):
         # Finally, remove the testing directory
         shutil.rmtree(testing_dir)
 
-    def test_extract_model_chemistry(self):
+    def test_extract_level_of_theory(self):
         """
-        Test that a given model chemistry can be extracted from the reference set database
+        Test that a given level of theory can be extracted from the reference set database
         """
         # Create a quick example database
         ref_data_1 = ReferenceDataEntry(ThermoData(H298=(100, 'kJ/mol', '+|-', 2)))
@@ -186,21 +187,23 @@ class TestReferenceDatabase(unittest.TestCase):
 
         ethane = ReferenceSpecies(smiles='CC',
                                   reference_data={'precise': ref_data_1, 'less_precise': ref_data_2},
-                                  calculated_data={'good_chem': calc_data_1, 'bad_chem': calc_data_2},
+                                  calculated_data={LevelOfTheory('good_chem'): calc_data_1,
+                                                   LevelOfTheory('bad_chem'): calc_data_2},
                                   preferred_reference='less_precise')
 
         propane = ReferenceSpecies(smiles='CCC',
                                    reference_data={'precise': ref_data_1, 'less_precise': ref_data_2},
-                                   calculated_data={'good_chem': calc_data_1, 'bad_chem': calc_data_2})
+                                   calculated_data={LevelOfTheory('good_chem'): calc_data_1,
+                                                    LevelOfTheory('bad_chem'): calc_data_2})
 
         butane = ReferenceSpecies(smiles='CCCC',
                                   reference_data={'precise': ref_data_1, 'less_precise': ref_data_2},
-                                  calculated_data={'bad_chem': calc_data_2})
+                                  calculated_data={LevelOfTheory('bad_chem'): calc_data_2})
 
         database = ReferenceDatabase()
         database.reference_sets = {'testing_1': [ethane, butane], 'testing_2': [propane]}
 
-        model_chem_list = database.extract_model_chemistry('good_chem')
+        model_chem_list = database.extract_level_of_theory(LevelOfTheory('good_chem'))
         self.assertEqual(len(model_chem_list), 2)
         self.assertIsInstance(model_chem_list[0], ErrorCancelingSpecies)
 
@@ -217,10 +220,10 @@ class TestReferenceDatabase(unittest.TestCase):
 
     def test_list_available_chemistry(self):
         """
-        Test that a set of available model chemistries can be return for the reference database
+        Test that a set of available levels of theory can be return for the reference database
         """
-        model_chemistry_list = self.database.list_available_chemistry()
-        self.assertIn('wb97m-v/def2-tzvpd', model_chemistry_list)
+        level_of_theory_list = self.database.list_available_chemistry()
+        self.assertIn(LevelOfTheory(method='wb97m-v', basis='def2-tzvpd', software='qchem'), level_of_theory_list)
 
     def test_get_species_from_index(self):
         """

--- a/arkane/ess/adapter.py
+++ b/arkane/ess/adapter.py
@@ -127,6 +127,13 @@ class ESSAdapter(ABC):
         """
         pass
 
+    def get_software(self):
+        """
+        Return the name of the software. Should correspond to the class
+        name without 'Log'.
+        """
+        return self.__class__.__name__.replace('Log', '')
+
     def get_D1_diagnostic(self):
         """
         Returns the D1 diagnostic from output log.

--- a/arkane/input.py
+++ b/arkane/input.py
@@ -68,6 +68,7 @@ from arkane.encorr.bac import BACJob
 from arkane.encorr.corr import assign_frequency_scale_factor
 from arkane.explorer import ExplorerJob
 from arkane.kinetics import KineticsJob
+from arkane.modelchem import LevelOfTheory, CompositeLevelOfTheory
 from arkane.pdep import PressureDependenceJob
 from arkane.statmech import StatMechJob
 from arkane.thermo import ThermoJob
@@ -522,14 +523,14 @@ def ae(species_energies, level_of_theory=None, write_to_database=False, overwrit
     job_list.append(job)
 
 
-def bac(model_chemistry, bac_type='p', train_names='main',
+def bac(level_of_theory, bac_type='p', train_names='main',
         exclude_elements=None, charge='all', multiplicity='all',
         weighted=False, write_to_database=False, overwrite=False,
         fit_mol_corr=True, global_opt=True, global_opt_iter=10):
     """Generate a BAC job"""
     global job_list
     job = BACJob(
-        model_chemistry,
+        level_of_theory,
         bac_type=bac_type,
         db_names=train_names,
         exclude_elements=exclude_elements,
@@ -640,6 +641,8 @@ def load_input_file(path):
         'SMILES': SMILES,
         'adjacencyList': adjacencyList,
         'InChI': InChI,
+        'LevelOfTheory': LevelOfTheory,
+        'CompositeLevelOfTheory': CompositeLevelOfTheory,
     }
 
     load_necessary_databases()

--- a/arkane/main.py
+++ b/arkane/main.py
@@ -158,7 +158,7 @@ class Arkane(object):
         """
         self.input_file = input_file
         self.job_list, self.reaction_dict, self.species_dict, self.transition_state_dict, self.network_dict, \
-            self.model_chemistry = load_input_file(self.input_file)
+            self.level_of_theory = load_input_file(self.input_file)
         logging.info('')
         return self.job_list
 
@@ -306,8 +306,8 @@ class Arkane(object):
                         if all([len(species.molecule) for species in reaction.reactants + reaction.products]):
                             reactions.append(reaction)
             lib_path = os.path.join(self.output_directory, 'RMG_libraries')
-            model_chemistry = f' at the {self.model_chemistry} level of theory' if self.model_chemistry else ''
-            lib_long_desc = f'Calculated using Arkane v{__version__}{model_chemistry}.'
+            level_of_theory = f' using {self.level_of_theory}' if self.level_of_theory is not None else ''
+            lib_long_desc = f'Calculated using Arkane v{__version__}{level_of_theory}.'
             save_thermo_lib(species_list=species, path=lib_path, name='thermo', lib_long_desc=lib_long_desc)
             save_kinetics_lib(rxn_list=reactions, path=lib_path, name='kinetics', lib_long_desc=lib_long_desc)
 

--- a/arkane/modelchem.py
+++ b/arkane/modelchem.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2020 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+Model chemistry standardization module
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, Field, fields, MISSING, replace
+from typing import Iterable, Union
+
+from rmgpy.rmgobject import RMGObject
+
+
+@dataclass(frozen=True)
+class LOT(RMGObject):
+    """
+    Base class for quantum chemistry settings.
+    """
+    def _is_default(self, f: Field) -> bool:
+        """Check if field is set to its default value"""
+        if f.default is not MISSING:
+            if f.default is None:  # Check using 'is'
+                return True if getattr(self, f.name) is None else False
+            else:
+                return True if getattr(self, f.name) == f.default else False
+        else:
+            return False
+
+    def __repr__(self) -> str:
+        """
+        Don't include attributes that are set to their default values,
+        and don't include spaces.
+        """
+        r = (self.__class__.__qualname__ + '('
+             + ','.join(f"{f.name}={getattr(self, f.name)!r}" for f in fields(self) if not self._is_default(f))
+             + ')')
+        return r.replace(' ', '')
+
+    def update(self, **kwargs) -> LOT:
+        """
+        Return a new instance with updated attributes.
+
+        Args:
+            kwargs: Keyword arguments specifying attributes and their new values.
+
+        Returns:
+            New instance of same type.
+        """
+        return replace(self, **kwargs)
+
+
+@dataclass(repr=False, frozen=True)  # repr=False uses parent repr; frozen makes instances quasi-immutable and hashable
+class LevelOfTheory(LOT):
+    """
+    Uniquely defines the settings used for a quantum calculation.
+
+    Attributes:
+        method: Quantum chemistry method.
+        basis: Basis set.
+        auxiliary_basis: Auxiliary basis set for correlated methods.
+        cabs: Complementary auxiliary basis set for F12 calculations.
+        software: Quantum chemistry software.
+        software_version: Quantum chemistry software version.
+        solvent: Solvent.
+        solvation_method: Solvation method.
+        args: Tuple of additional arguments provided to the software.
+    """
+    method: str
+    basis: str = None
+    auxiliary_basis: str = None
+    cabs: str = None
+    software: str = None
+    software_version: Union[int, float, str] = None
+    solvent: str = None
+    solvation_method: str = None
+    args: Union[str, Iterable[str]] = None
+
+    def __post_init__(self):
+        """
+        Standardize attribute values.
+
+        __post_init__ should allow mutating attributes of frozen
+        instances, but it doesn't, so use object.__setattr__ to get
+        around that issue.
+        """
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                if attr == 'software':
+                    std_fn = get_software_id
+                elif attr == 'args':  # Standardize and sort args to make unique; convert to tuple
+                    def std_fn(args):
+                        args = (args,) if isinstance(args, str) else args
+                        return tuple(sorted(standardize_name(a) for a in args))
+                else:
+                    std_fn = standardize_name
+                object.__setattr__(self, attr, std_fn(val))
+
+    def simple(self) -> LevelOfTheory:
+        """
+        Convert to level of theory containing only method and basis.
+
+        Returns:
+            New instance with only method and basis attributes set.
+        """
+        return LevelOfTheory(method=self.method, basis=self.basis)
+
+    def to_model_chem(self) -> str:
+        """
+        Return model chemistry containing method and basis.
+
+        Returns:
+            Model chemistry string.
+        """
+        if self.basis is None:
+            return self.method
+        else:
+            return f'{self.method}/{self.basis}'
+
+
+@dataclass(repr=False, frozen=True)
+class CompositeLevelOfTheory(LOT):
+    """
+    Uniquely defines the settings used for a combination of frequency
+    and single-point energy quantum calculations.
+
+    Notes:
+        Assumes that the geometry optimization was performed using the
+        same settings as the frequency calculation.
+        CBS-QB3 and similar methods are technically composite methods,
+        but they should use the LevelOfTheory interface instead because
+        they are specified using a single method.
+
+    Attributes:
+        freq: Settings for the frequency calculation.
+        energy: Settings for the single-point energy calculation.
+    """
+    freq: LevelOfTheory
+    energy: LevelOfTheory
+
+    def simple(self) -> CompositeLevelOfTheory:
+        """
+        Convert to composite level of theory containing only methods
+        and bases.
+
+        Returns:
+            New instance with only method and basis attributes set.
+        """
+        return CompositeLevelOfTheory(freq=self.freq.simple(), energy=self.energy.simple())
+
+    def to_model_chem(self) -> str:
+        """
+        Return model chemistry containing methods and bases.
+
+        Returns:
+            Model chemistry string.
+        """
+        return f'{self.energy.to_model_chem()}//{self.freq.to_model_chem()}'
+
+
+def _to_lot_helper(model_chem: str, **kwargs) -> LevelOfTheory:
+    """Convert non-composite level of theory"""
+    try:
+        method, basis = model_chem.split('/')
+    except ValueError:  # no explicit basis
+        return LevelOfTheory(method=model_chem, **kwargs)
+    else:
+        return LevelOfTheory(method=method, basis=basis, **kwargs)
+
+
+def model_chem_to_lot(model_chem: str,
+                      freq_settings: dict = None,
+                      energy_settings: dict = None,
+                      **kwargs) -> Union[LevelOfTheory, CompositeLevelOfTheory]:
+    """
+    Convert model chemistry to standardized level of theory object.
+
+    Notes:
+        If `model_chem` only contains one level of theory, either
+        settings dictionary can be used with `freq_settings` being
+        preferred if both are provided.
+        Additional settings can also be provided with `kwargs` which
+        are applied to all levels of theory.
+
+    Args:
+        model_chem: Model chemistry string.
+        freq_settings: Additional parameters for frequency level of theory.
+        energy_settings: Additional parameters for energy level of theory.
+        kwargs: Additional parameters applied to all levels of theory.
+
+    Returns:
+        LevelOfTheory or CompositeLevelOfTheory instance.
+    """
+    if freq_settings is None:
+        freq_settings = {}
+    if energy_settings is None:
+        energy_settings = {}
+
+    try:
+        energy, freq = model_chem.split('//')
+    except ValueError:  # No energy level
+        _settings = freq_settings or energy_settings
+        return _to_lot_helper(model_chem, **_settings, **kwargs)
+    else:
+        return CompositeLevelOfTheory(
+            freq=_to_lot_helper(freq, **freq_settings, **kwargs),
+            energy=_to_lot_helper(energy, **energy_settings, **kwargs)
+        )
+
+
+def str_to_lot(s: str) -> Union[LevelOfTheory, CompositeLevelOfTheory]:
+    """
+    Convert string to standardized level of theory object.
+
+    Args:
+        s: String representation of object.
+
+    Returns:
+        LevelOfTheory or CompositeLevelOfTheory instance.
+    """
+    return eval(s, {'__builtins__': None},
+                {'LevelOfTheory': LevelOfTheory, 'CompositeLevelOfTheory': CompositeLevelOfTheory})
+
+
+def standardize_name(name: str) -> str:
+    """Remove spaces, hyphens, and make lowercase"""
+    if isinstance(name, str):
+        return name.replace('-', '').replace(' ', '').lower()
+    else:
+        return name
+
+
+# Map from multiple names for a software to a single standard identifier
+# No need for hyphens, spaces, or capitalization in the possible names
+_valid_software_names = {
+    'gaussian': ('gaussian', 'gaussian16', 'gaussian09', 'gaussian03',
+                 'gau', 'gau16', 'gau09', 'gau03',
+                 'g16', 'g09', 'g03'),
+    'qchem': ('qchem',),
+    'molpro': ('molpro',),
+    'orca': ('orca',),
+    'terachem': ('terachem',),
+    'mopac': ('mopac',)
+}
+_software_ids = {_name: _id for _id, _names in _valid_software_names.items() for _name in _names}
+
+
+def get_software_id(name: str) -> str:
+    """
+    Given a name for a quantum chemistry software, return its standard
+    identifier.
+
+    Args:
+        name: Commonly used name of software.
+
+    Returns:
+        Unique software identifier.
+    """
+    try:
+        return _software_ids[standardize_name(name)]
+    except KeyError:
+        raise ValueError(f'"{name}" is an invalid quantum chemistry software')

--- a/arkane/modelchemTest.py
+++ b/arkane/modelchemTest.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2020 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This script contains unit tests for the :mod:`arkane.modelchem` module.
+"""
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from arkane.modelchem import (LOT, LevelOfTheory, CompositeLevelOfTheory,
+                              model_chem_to_lot, str_to_lot, get_software_id)
+
+# Instances for use in tests
+FREQ = LevelOfTheory(
+    method='wB97X-D',
+    basis='def2-TZVP',
+    software='Gaussian 16',
+    args='very-tight'
+)
+ENERGY = LevelOfTheory(
+    method='DLPNO-CCSD(T)-F12',
+    basis='def2-TZVP',
+    software='Orca'
+)
+COMPOSITE = CompositeLevelOfTheory(
+    freq=FREQ,
+    energy=ENERGY
+)
+
+# Representations corresponding to instances
+FREQ_REPR = "LevelOfTheory(method='wb97xd',basis='def2tzvp',software='gaussian',args=('verytight',))"
+ENERGY_REPR = "LevelOfTheory(method='dlpnoccsd(t)f12',basis='def2tzvp',software='orca')"
+COMPOSITE_REPR = f"CompositeLevelOfTheory(freq={FREQ_REPR},energy={ENERGY_REPR})"
+
+# Dictionaries corresponding to instances
+FREQ_DICT = {
+    'class': 'LevelOfTheory',
+    'method': 'wb97xd',
+    'basis': 'def2tzvp',
+    'software': 'gaussian',
+    'args': ['verytight']  # This is a list instead of tuple because that's what YAML files expect
+}
+ENERGY_DICT = {
+    'class': 'LevelOfTheory',
+    'method': 'dlpnoccsd(t)f12',
+    'basis': 'def2tzvp',
+    'software': 'orca',
+}
+COMPOSITE_DICT = {
+    'class': 'CompositeLevelOfTheory',
+    'freq': FREQ_DICT,
+    'energy': ENERGY_DICT
+}
+
+# Model chemistries corresponding to instances
+FREQ_MODELCHEM = 'wb97xd/def2tzvp'
+ENERGY_MODELCHEM = 'dlpnoccsd(t)f12/def2tzvp'
+COMPOSITE_MODELCHEM = f'{ENERGY_MODELCHEM}//{FREQ_MODELCHEM}'
+
+
+class TestLevelOfTheory(unittest.TestCase):
+    """
+    A class for testing that the LevelOfTheory class functions properly.
+    """
+
+    def test_attrs(self):
+        """
+        Test that instance behaves correctly.
+        """
+        self.assertEqual(FREQ.method, 'wb97xd')
+        self.assertEqual(FREQ.basis, 'def2tzvp')
+        self.assertEqual(FREQ.software, 'gaussian')
+        self.assertTupleEqual(FREQ.args, ('verytight',))
+        with self.assertRaises(FrozenInstanceError):
+            FREQ.method = ''
+
+        self.assertEqual(repr(FREQ), FREQ_REPR)
+        self.assertEqual(repr(ENERGY), ENERGY_REPR)
+
+        with self.assertRaises(ValueError):
+            _ = LevelOfTheory(method=FREQ.method)
+        lot = LevelOfTheory(method=FREQ.method, software=FREQ.software)
+        self.assertIsNone(lot.basis)
+        self.assertIsNone(lot.auxiliary_basis)
+        self.assertIsNone(lot.cabs)
+        self.assertIsNone(lot.software_version)
+        self.assertIsNone(lot.solvent)
+        self.assertIsNone(lot.solvation_method)
+        self.assertIsNone(lot.args)
+
+        self.assertIsInstance(FREQ, LOT)
+
+    def test_comparison(self):
+        """
+        Test comparisons between instances.
+        """
+        self.assertIsInstance(hash(FREQ), int)
+        self.assertNotEqual(FREQ, ENERGY)
+        with self.assertRaises(TypeError):
+            _ = ENERGY > FREQ
+
+        # Test args in different order
+        lot1 = LevelOfTheory('method', args=('arg1', 'arg2'))
+        lot2 = LevelOfTheory('method', args=('arg2', 'arg1'))
+        self.assertEqual(lot1, lot2)
+
+    def test_simple(self):
+        """
+        Test that simple level of theory can be obtained.
+        """
+        lot = FREQ.simple()
+        self.assertIsNot(lot, FREQ)
+        self.assertEqual(lot.method, FREQ.method)
+        self.assertEqual(lot.basis, FREQ.basis)
+        self.assertEqual(lot.software, FREQ.software)
+        for attr, val in lot.__dict__.items():
+            if attr not in {'method', 'basis', 'software'}:
+                self.assertIsNone(val)
+
+    def test_to_model_chem(self):
+        """
+        Test conversion to model chemistry.
+        """
+        self.assertEqual(FREQ.to_model_chem(), FREQ_MODELCHEM)
+        self.assertEqual(ENERGY.to_model_chem(), ENERGY_MODELCHEM)
+
+        lot = LevelOfTheory(
+            method='CBS-QB3',
+            software='g16'
+        )
+        self.assertEqual(lot.to_model_chem(), 'cbsqb3')
+
+    def test_update(self):
+        """
+        Test updating attributes.
+        """
+        lot = FREQ.update(software='Q-Chem')
+        self.assertIsNot(lot, FREQ)
+        self.assertEqual(lot.software, 'qchem')
+        with self.assertRaises(TypeError):
+            FREQ.update(test='test')
+
+    def test_as_dict(self):
+        """
+        Test conversion to dictionary.
+        """
+        self.assertDictEqual(FREQ.as_dict(), FREQ_DICT)
+        self.assertDictEqual(ENERGY.as_dict(), ENERGY_DICT)
+
+
+class TestCompositeLevelOfTheory(unittest.TestCase):
+    """
+    A class for testing that the CompositeLevelOfTheory class functions properly.
+    """
+
+    def test_attrs(self):
+        """
+        Test that instance behaves correctly.
+        """
+        self.assertIs(COMPOSITE.freq, FREQ)
+        self.assertIs(COMPOSITE.energy, ENERGY)
+        self.assertEqual(repr(COMPOSITE), COMPOSITE_REPR)
+        with self.assertRaises(FrozenInstanceError):
+            COMPOSITE.energy = ''
+
+        self.assertIsInstance(COMPOSITE, LOT)
+
+    def test_comparison(self):
+        """
+        Test comparisons between instances.
+        """
+        other = CompositeLevelOfTheory(freq=ENERGY, energy=FREQ)
+        self.assertIsInstance(hash(COMPOSITE), int)
+        self.assertNotEqual(COMPOSITE, other)
+        with self.assertRaises(TypeError):
+            _ = COMPOSITE > other
+
+    def test_simple(self):
+        """
+        Test that simple level of theory can be obtained.
+        """
+        lot = COMPOSITE.simple()
+        self.assertIsNot(lot, COMPOSITE)
+        self.assertEqual(lot.freq.method, COMPOSITE.freq.method)
+        self.assertEqual(lot.freq.basis, COMPOSITE.freq.basis)
+        self.assertEqual(lot.freq.software, COMPOSITE.freq.software)
+        self.assertEqual(lot.energy.method, COMPOSITE.energy.method)
+        self.assertEqual(lot.energy.basis, COMPOSITE.energy.basis)
+        for attr, val in lot.freq.__dict__.items():
+            if attr not in {'method', 'basis', 'software'}:
+                self.assertIsNone(val)
+        for attr, val in lot.energy.__dict__.items():
+            if attr not in {'method', 'basis'}:
+                self.assertIsNone(val)
+
+    def test_to_model_chem(self):
+        """
+        Test conversion to model chemistry.
+        """
+        self.assertEqual(COMPOSITE.to_model_chem(), COMPOSITE_MODELCHEM)
+
+    def test_as_dict(self):
+        """
+        Test conversion to dictionary.
+        """
+        self.assertDictEqual(COMPOSITE.as_dict(), COMPOSITE_DICT)
+
+
+class TestFuncs(unittest.TestCase):
+    """
+    A class for testing that the functions in the modelchem module work.
+    """
+
+    def test_model_chem_to_lot(self):
+        """
+        Test model chemistry to quantum calculation settings conversion.
+        """
+        self.assertEqual(
+            model_chem_to_lot(FREQ_MODELCHEM, software='gaussian', args='verytight'),
+            FREQ
+        )
+        self.assertEqual(
+            model_chem_to_lot(FREQ_MODELCHEM,
+                              freq_settings={'software': 'gaussian', 'args': 'verytight'}),
+            FREQ
+        )
+        self.assertEqual(
+            model_chem_to_lot(FREQ_MODELCHEM,
+                              freq_settings={'software': 'gaussian', 'args': 'verytight'},
+                              energy_settings={'unused setting': None}),
+            FREQ
+        )
+        self.assertEqual(
+            model_chem_to_lot(ENERGY_MODELCHEM, energy_settings={'software': 'orca'}),
+            ENERGY
+        )
+        self.assertEqual(
+            model_chem_to_lot(COMPOSITE_MODELCHEM,
+                              freq_settings={'software': 'gaussian', 'args': 'verytight'},
+                              energy_settings={'software': 'orca'}),
+            COMPOSITE
+        )
+
+    def test_str_to_lot(self):
+        """
+        Test key to quantum calculation settings conversion.
+        """
+        self.assertEqual(str_to_lot(FREQ_REPR), FREQ)
+        self.assertEqual(str_to_lot(ENERGY_REPR), ENERGY)
+        self.assertEqual(str_to_lot(COMPOSITE_REPR), COMPOSITE)
+
+    def test_get_software_id(self):
+        """
+        Test standardized software identifiers.
+        """
+        test_names = ['gaussian', 'Gaussian 09', 'g-16', 'Gau  03']
+        for name in test_names:
+            self.assertEqual(get_software_id(name), 'gaussian')
+
+        test_names = ['qchem', 'QChem', 'Q-Chem']
+        for name in test_names:
+            self.assertEqual(get_software_id(name), 'qchem')
+
+        test_names = ['molpro', 'Molpro', 'MOLPRO']
+        for name in test_names:
+            self.assertEqual(get_software_id(name), 'molpro')
+
+        test_names = ['orca', 'Orca', 'ORCA']
+        for name in test_names:
+            self.assertEqual(get_software_id(name), 'orca')
+
+        test_names = ['terachem', 'Terachem', 'TeraChem', 'Tera-Chem', 'Tera Chem']
+        for name in test_names:
+            self.assertEqual(get_software_id(name), 'terachem')
+
+        with self.assertRaises(ValueError):
+            get_software_id('g')
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arkane/statmechTest.py
+++ b/arkane/statmechTest.py
@@ -41,6 +41,7 @@ from rmgpy.exceptions import InputError
 
 from arkane import Arkane
 from arkane.ess.qchem import QChemLog
+from arkane.modelchem import LevelOfTheory
 from arkane.statmech import StatMechJob, determine_rotor_symmetry, is_linear
 
 ################################################################################
@@ -188,7 +189,7 @@ rotors = [HinderedRotor(scanLog=Log('{scan}'), pivots=[1, 2], top=[1, 3], symmet
         h2o2 = Species(label='H2O2', smiles='OO')
         self.assertIsNone(h2o2.conformer)
         statmech_job = StatMechJob(species=h2o2, path=h2o2_path)
-        statmech_job.modelChemistry = 'b3lyp/6-311+g(3df,2p)'
+        statmech_job.level_of_theory = LevelOfTheory('b3lyp', '6-311+g(3df,2p)')
         statmech_job.load(pdep=False, plot=False)
         self.assertAlmostEqual(h2o2.conformer.E0.value_si, -146031.49933673252)
         os.remove(h2o2_path)

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -20,8 +20,6 @@ computations:
 Component                   Description
 =========================== ============================================================================================
 ``modelChemistry``          Level of theory from quantum chemical calculations, see ``Model Chemistry`` table below
-``levelOfTheory``           Level of theory, free text format (only used for archiving). Suggested format:
-                            ``energy_method/basis_set//geometry_method/basis_set, rotors at rotor_method/basis_set``
 ``author``                  Author's name. Used when saving statistical mechanics properties as a .yml file.
 ``atomEnergies``            Dictionary of atomic energies at ``modelChemistry`` level
 ``frequencyScaleFactor``    A factor by which to scale all frequencies
@@ -54,11 +52,37 @@ Component                   Description
 
 Model Chemistry
 ===============
-
 The first item in the input file should be a ``modelChemistry`` assignment with a string describing the model
 chemistry. The ``modelChemistry`` could either be in a `single point // frequency` format, e.g.,
 `CCSD(T)-F12a/aug-cc-pVTZ//B3LYP/6-311++G(3df,3pd)`, just the `single point`, e.g., `CCSD(T)-F12a/aug-cc-pVTZ`,
 or a composite method, e.g., `CBS-QB3`.
+
+Alternatively, ``modelChemistry`` can be specified using a ``LevelOfTheory`` or ``CompositeLevelOfTheory`` object. The
+basic syntax for ``LevelOfTheory`` is::
+
+    LevelOfTheory(
+        method='B3LYP',
+        basis='6-311++G(3df,3pd)'
+    )
+
+See ``arkane/modelchem.py`` for additional options (e.g., software, solvent). Note that the software generally does not
+have to be specified because it is inferred from the provided quantum chemistry logs. An example
+``CompositeLevelOfTheory`` is given by::
+
+    CompositeLevelOfTheory(
+        freq=LevelOfTheory(
+            method='B3LYP',
+            basis='6-311++G(3df,3pd)'
+        )
+        energy=LevelOfTheory(
+            method='CCSD(T)-F12',
+            basis='aug-cc-pVTZ'
+        )
+    )
+
+There are some methods that require the software to be specified. Currently, it is not possible to infer the software
+for such methods directly from the log files because Arkane requires the software prior to reading the log files. The
+methods for which this is the case are listed in the RMG-database in ``input/quantum_corrections/lot_constraints.yml``.
 
 Arkane uses the single point level to adjust the computed energies to the usual gas-phase reference
 states by applying atom and spin-orbit coupling energy corrections. Additionally, bond additivity corrections OR
@@ -1084,7 +1108,7 @@ specified using a ``bac()`` function, which accepts the following parameters:
 ====================== ============ =============================================================================================================================
 Parameter              Required?    Description
 ====================== ============ =============================================================================================================================
-``model_chemistry``    Yes          Calculated data will be extracted from the reference database using this model chemistry
+``level_of_theory``    Yes          Calculated data will be extracted from the reference database using this level of theory
 ``bac_type``           No           BAC type: 'p' for Petersson (default), 'm' for Melius
 ``train_names``        No           Names of training data folders in the RMG database (default: 'main')
 ``exclude_elements``   No           Exclude molecules with the elements in this list from the training data (default: None)

--- a/examples/arkane/bac/wb97m-v_def2-tzvpd/input.py
+++ b/examples/arkane/bac/wb97m-v_def2-tzvpd/input.py
@@ -1,8 +1,14 @@
 title = 'Bond additivity correction fitting for wB97M-V/def2-TZVPD level of theory'
 
+lot = LevelOfTheory(
+    method='wB97M-V',
+    basis='def2-TZVPD',
+    software='Q-Chem'
+)
+
 # Petersson-type
 bac(
-    model_chemistry='wb97m-v/def2-tzvpd',
+    level_of_theory=lot,
     bac_type='p',  # Petersson
     weighted=True,
     write_to_database=False,
@@ -11,7 +17,7 @@ bac(
 
 # Melius-type
 bac(
-    model_chemistry='wb97m-v/def2-tzvpd',
+    level_of_theory=lot,
     bac_type='m',  # Melius
     write_to_database=False,
     overwrite=False,

--- a/examples/arkane/species/Pentyl_isodesmic/input.py
+++ b/examples/arkane/species/Pentyl_isodesmic/input.py
@@ -5,7 +5,11 @@
 This input file shows how to calculate the thermochemistry of a species using isodesmic reactions in Arkane
 """
 title = 'Isodesmic Example'
-modelChemistry = 'wb97m-v/def2-tzvpd'
+modelChemistry = LevelOfTheory(
+    method='wb97m-v',
+    basis='def2-tzvpd',
+    software='qchem'
+)
 
 # Setting `useIsodesmicReactions` to True will also force useAtomCorrections to True and useBondCorrections to False
 useIsodesmicReactions = True

--- a/rmgpy/rmgobjectTest.py
+++ b/rmgpy/rmgobjectTest.py
@@ -32,6 +32,7 @@ This script contains unit tests of the :mod:`rmgobject` module.
 """
 
 import unittest
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -399,6 +400,22 @@ class TestExpandAndMakeFromDictionaries(unittest.TestCase):
         Test that numpy arrays can be recreated from their dictionary representation
         """
         self.assertTrue(np.array_equal(recursive_make_object(self.np_dict, self.class_dictionary), self.np_array))
+
+    def test_hashable_class_key_creation(self):
+        """
+        Test that dictionaries with hashable class instances as keys can be recreated
+        """
+        @dataclass(frozen=True)
+        class Data:
+            arg: str
+
+        input_dict = {"Data(arg='test')": 'test'}
+        class_dictionary = {'Data': Data}
+        key, val = list(recursive_make_object(input_dict, class_dictionary).items())[0]
+
+        self.assertIsInstance(key, Data)
+        self.assertEqual(key, Data('test'))
+        self.assertEqual(val, 'test')
 
 
 ################################################################################


### PR DESCRIPTION
### Motivation or Problem
Model chemistry definitions in Arkane are not unique because changes in software and options can lead to different results. The goal is to standardize the representation in Arkane and in the RMG database by defining detailed and unique levels of theory to identify the settings used in quantum chemistry calculations.

### Description of Changes
Implements two new classes, `LevelOfTheory` and `CompositeLevelOfTheory`, which are used by Arkane internally instead of model chemistry strings. Arkane input files can still be specified using the `modelChemistry` syntax, but using the new level of theory objects is now also possible. Arkane will first try to find an exact match for the specified level of theory in the RMG database (including options like software, solvation, and additional arguments) but will fall back to just matching method and basis if an exact match is not possible (and will print a warning if this is the case).

The corresponding database PR ReactionMechanismGenerator/RMG-database#409 updates the database to also use the new level of theory objects. This required some changes to `RMGObject` to enable using hashable objects as dictionary/YAML keys.

### Testing and Reviewer Suggestions
Unit tests were adapted and should pass. Make some Arkane input files using the new syntax and check that it works as expected.