### PR TITLE
Reference concentration for surface species when calculating Kc

### DIFF
--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -83,7 +83,7 @@ cdef class Reaction:
 
     cpdef double get_free_energy_of_reaction(self, double T)
 
-    cpdef double get_equilibrium_constant(self, double T, str type=?)
+    cpdef double get_equilibrium_constant(self, double T, str type=?, double surface_site_density=?)
 
     cpdef np.ndarray get_enthalpies_of_reaction(self, np.ndarray Tlist)
 

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -258,6 +258,17 @@ class TestSurfaceReaction(unittest.TestCase):
 
         self.assertEqual(self.rxn1s.generate_reverse_rate_coefficient().A.units, 'm^2/(mol*s)')
 
+    def test_equilibrium_constant_surface_kc(self):
+        """
+        Test the Reaction.get_equilibrium_constant() method for Kc of a surface reaction.
+        """
+        Tlist = numpy.arange(400.0, 1600.0, 200.0, numpy.float64)
+        Kclist0 = [15375.20186, 1.566753, 0.017772, 0.0013485,
+                   0.000263180, 8.73504e-05]
+        Kclist = self.rxn1s.get_equilibrium_constants(Tlist, type='Kc')
+        for i in range(len(Tlist)):
+            self.assertAlmostEqual(Kclist[i] / Kclist0[i], 1.0, 4)
+
 class TestReaction(unittest.TestCase):
     """
     Contains unit tests of the Reaction class.

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -404,6 +404,7 @@ class TestReaction(unittest.TestCase):
         # CC(=O)O[O]
         acetylperoxy = Species(
             label='acetylperoxy',
+            molecule=[Molecule(smiles='CC(=O)O[O]')],
             thermo=Wilhoit(Cp0=(4.0 * constants.R, "J/(mol*K)"), CpInf=(21.0 * constants.R, "J/(mol*K)"), a0=-3.95,
                            a1=9.26, a2=-15.6, a3=8.55, B=(500.0, "K"), H0=(-6.151e+04, "J/mol"),
                            S0=(-790.2, "J/(mol*K)")),
@@ -412,6 +413,7 @@ class TestReaction(unittest.TestCase):
         # C[C]=O
         acetyl = Species(
             label='acetyl',
+            molecule=[Molecule(smiles='C[C]=O')],
             thermo=Wilhoit(Cp0=(4.0 * constants.R, "J/(mol*K)"), CpInf=(15.5 * constants.R, "J/(mol*K)"), a0=0.2541,
                            a1=-0.4712, a2=-4.434, a3=2.25, B=(500.0, "K"), H0=(-1.439e+05, "J/mol"),
                            S0=(-524.6, "J/(mol*K)")),
@@ -420,6 +422,7 @@ class TestReaction(unittest.TestCase):
         # [O][O]
         oxygen = Species(
             label='oxygen',
+            molecule=[Molecule(smiles='[O][O]')],
             thermo=Wilhoit(Cp0=(3.5 * constants.R, "J/(mol*K)"), CpInf=(4.5 * constants.R, "J/(mol*K)"), a0=-0.9324,
                            a1=26.18, a2=-70.47, a3=44.12, B=(500.0, "K"), H0=(1.453e+04, "J/mol"),
                            S0=(-12.19, "J/(mol*K)")),
@@ -577,6 +580,12 @@ class TestReaction(unittest.TestCase):
         Kclist = self.reaction2.get_equilibrium_constants(Tlist, type='Kc')
         for i in range(len(Tlist)):
             self.assertAlmostEqual(Kclist[i] / Kclist0[i], 1.0, 4)
+
+        rxn2_copy = self.reaction2.copy()
+        rxn2_copy.reactants[0].molecule = []
+        Kclist_2 = rxn2_copy.get_equilibrium_constants(Tlist, type='Kc')
+        for i in range(len(Tlist)):
+            self.assertAlmostEqual(Kclist[i] / Kclist_2[i], 1.0, 4)
 
     def test_equilibrium_constant_kp(self):
         """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This is related to issue https://github.com/ReactionMechanismGenerator/RMG-Py/issues/1937
We currently assume ideal gas mixture to determine Kc.  We should be using different reference concentrations for gas and surface species.  

### Description of Changes
Use reference concentration of (surface site density) for surface site species and ideal gas (P/RT) for gas species.  That way, gas concentration scales with temperature and surface species concentration is independent of temperature.  Therefore, we use the change in mols of gas in the reaction to determine Kc (instead of len(reactants) - len(products)).  However, the species object needs a molecule to determine its phase (if it contains surface site), so I added a try and except for this.

### Testing
I added unit test for determining Kc for a surface reaction. I also modified the gas Kc test to test reactions with species that contain and don't contain a molecule.

### Reviewer Tips
I don't really like my try and except block.  I'm interested in suggestions to improve this.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
