### PR TITLE
Minor: add solvation correction in species.thermo.comment

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -886,6 +886,7 @@ class SolvationDatabase(object):
                     pass
 
         solute_data = self.remove_h_bonding(saturated_struct, added_to_radicals, added_to_pairs, solute_data)
+        solute_data.comment = solute_data.comment[:-3]
 
         return solute_data
 
@@ -933,7 +934,7 @@ class SolvationDatabase(object):
         solute_data.E += data.E
         solute_data.L += data.L
         solute_data.A += data.A
-        solute_data.comment += comment + "+"
+        solute_data.comment += comment + " + "
 
         return solute_data
 

--- a/rmgpy/thermo/thermoengine.py
+++ b/rmgpy/thermo/thermoengine.py
@@ -68,6 +68,7 @@ def process_thermo_data(spc, thermo0, thermo_class=NASA, solvent_name=''):
         # correction is added to the entropy and enthalpy
         wilhoit.S0.value_si = (wilhoit.S0.value_si + solvation_correction.entropy)
         wilhoit.H0.value_si = (wilhoit.H0.value_si + solvation_correction.enthalpy)
+        wilhoit.comment += ' + Solvation correction with {} as solvent and solute estimated using {}'.format(solvent_name, solute_data.comment)
 
     # Compute E0 by extrapolation to 0 K
     if spc.conformer is None:


### PR DESCRIPTION
### Motivation or Problem
I think it would be nice to know if the species's thermo has been corrected with solvation correction of which solvent.

### Description of Changes
I add the solvation correction comment in the attribute species.thermo.comment in the method get_thermo_data() for class Species.

### Testing
Tested locally with benzene as solvant. The result looks like: `Thermo group additivity estimation: group(Cs-CsCsHH) + group(Cs-CsCsHH) + group(Cs-CbCsHH) + group(Cs-CbCsHH) + group(Cb-Cs) + group(Cb-Cs) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + group(Cb-H) + ring(Benzene) + ring(Benzene) + radical(Benzyl_S) + radical(Benzyl_S) Solvation correction with benzene as solvent.`