### PR TITLE
Unit fix for reverse rate constants with surface species

### DIFF
--- a/rmgpy/kinetics/model.pxd
+++ b/rmgpy/kinetics/model.pxd
@@ -32,7 +32,7 @@ from rmgpy.kinetics.uncertainties cimport RateUncertainty
 
 ################################################################################
 
-cpdef str get_rate_coefficient_units_from_reaction_order(order)
+cpdef str get_rate_coefficient_units_from_reaction_order(n_gas, n_surf=?)
 
 cpdef int get_reaction_order_from_rate_coefficient_units(kunits) except -1
 

--- a/rmgpy/kinetics/model.pyx
+++ b/rmgpy/kinetics/model.pyx
@@ -41,27 +41,41 @@ from rmgpy.molecule import Molecule
 
 ################################################################################
 
-cpdef str get_rate_coefficient_units_from_reaction_order(order):
+cpdef str get_rate_coefficient_units_from_reaction_order(n_gas, n_surf=0):
     """
-    Given a reaction `order`, return the corresponding SI units of the rate
+    Given a reaction `order` with `n_gas` and `n_surf` species, 
+    return the corresponding SI units of the rate
     coefficient. These are the units that rate coefficients are stored in
     internally, as well as the units of the rate coefficient obtained using
     the ``simplified`` attribute of a :class:`Quantity` object that represents
     a rate coefficient. Raises a :class:`ValueError` if the units could not be
     determined.
     """
-    if order == 0:
-        kunits = 'mol/(m^3*s)'
-    elif order == 1:
-        kunits = 's^-1'
-    elif order == 2:
-        kunits = 'm^3/(mol*s)'
-    elif order == 3:
-        kunits = 'm^6/(mol^2*s)'
-    elif order == 4:
-        kunits = 'm^9/(mol^3*s)'
+
+    if n_surf == 0: # Volume units
+        if n_gas == 0: kunits = 'mol/(m^3*s)'
+        elif n_gas == 1: kunits = 's^-1'
+        elif n_gas == 2: kunits = 'm^3/(mol*s)'
+        elif n_gas == 3: kunits = 'm^6/(mol^2*s)'
+        elif n_gas == 4: kunits = 'm^9/(mol^3*s)'
+    elif n_surf == 1: # Area Units
+        if n_gas == 0: kunits = 's^-1'
+        elif n_gas == 1: kunits = 'm^3/(mol*s)'
+        elif n_gas == 2: kunits = 'm^6/(mol^2*s)'
+        elif n_gas == 3: kunits = 'm^9/(mol^3*s)'
+    elif n_surf == 2: # Area Units 
+        if n_gas == 0: kunits = 'm^2/(mol*s)'
+        elif n_gas == 1: kunits = 'm^5/(mol^2*s)'
+        elif n_gas == 2: kunits = 'm^8/(mol^3*s)'
+        elif n_gas == 3: kunits = 'm^11/(mol^4*s)'
+    elif n_surf == 3: # Area Units 
+        if n_gas == 0: kunits = 'm^4/(mol^2*s)' 
+        elif n_gas == 1: kunits = 'm^7/(mol^3*s)'
+        elif n_gas == 2: kunits = 'm^10/(mol^4*s)'
+        elif n_gas == 3: kunits = 'm^13/(mol^5*s)'
     else:
-        raise ValueError('Invalid reaction order {0}.'.format(order))
+        raise ValueError('Invalid reaction order of {0} gas {1} surface species.'.format(n_gas,n_surf))
+    
     return kunits
 
 cpdef int get_reaction_order_from_rate_coefficient_units(kunits) except -1:

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -144,24 +144,24 @@ class TestSurfaceReaction(unittest.TestCase):
 
         s_h2 = Species(
             molecule=[m_h2],
-            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500],
+            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000],
                                      "K"),
                               Cpdata=([6.955, 6.955, 6.956, 6.961, 7.003,
-                                       7.103, 7.502], "cal/(mol*K)"),
+                                       7.103, 7.502, 8.17], "cal/(mol*K)"),
                               H298=(0, "kcal/mol"),
                               S298=(31.129, "cal/(mol*K)")))
         s_x = Species(
             molecule=[m_x],
-            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500],
+            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000],
                                      "K"),
-                              Cpdata=([0., 0., 0., 0., 0., 0., 0.], "cal/(mol*K)"),
+                              Cpdata=([0., 0., 0., 0., 0., 0., 0., 0.], "cal/(mol*K)"),
                               H298=(0.0, "kcal/mol"),
                               S298=(0.0, "cal/(mol*K)")))
         s_hx = Species(
             molecule=[m_hx],
-            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500],
+            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000],
                                      "K"),
-                              Cpdata=([1.50, 2.58, 3.40, 4.00, 4.73, 5.13, 5.57], "cal/(mol*K)"),
+                              Cpdata=([1.50, 2.58, 3.40, 4.00, 4.73, 5.13, 5.57, 5.82], "cal/(mol*K)"),
                               H298=(-11.26, "kcal/mol"),
                               S298=(0.44, "cal/(mol*K)")))
 
@@ -254,6 +254,9 @@ class TestSurfaceReaction(unittest.TestCase):
                                numpy.log10(target),
                                places=0)
 
+    def test_get_rate_coefficient_units_from_reaction_order(self):
+
+        self.assertEqual(self.rxn1s.generate_reverse_rate_coefficient().A.units, 'm^2/(mol*s)')
 
 class TestReaction(unittest.TestCase):
     """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Units for reverse rate constants are in volume units for surface reactions, but they should be in area units.  For example, for the reaction `H2 + X + X <--> H-X + H-X`, rmg assigns units of `m^3/(mol*s)` to the reverse rate constant kr, but since H-X is in area units (mol/m^2), the rate r=kr[H-X][H-X] would have units `mol/(m*s)`.  

### Description of Changes
Modified the `get_rate_coefficient_units_from_reaction_order` to consider the number of gas and surface species, and assign the units accordingly.

### Testing
Added a unit test for `H2 + X + X <--> H-X + H-X` to make sure we get `m^2/(mol*s)` units for the reverse rate constant. 


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
