### PR TITLE
Atom energy fitting

### DIFF
--- a/arkane/encorr/ae.py
+++ b/arkane/encorr/ae.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2020 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This module provides classes for fitting atom energies based on a very
+small, predetermined set of molecules.
+"""
+
+import importlib
+import json
+import logging
+from collections import Counter
+from typing import Dict, List
+
+import numpy as np
+from scipy.stats import distributions
+
+from rmgpy import constants
+from rmgpy.molecule import get_element, Molecule
+
+import arkane.encorr.data as data
+from arkane.encorr.reference import ReferenceDatabase
+
+# List of species labels that will be used for fitting (labels should match reference database)
+SPECIES_LABELS = [
+    'Dihydrogen',
+    'Dinitrogen',
+    'Dioxygen',
+    'Disulfur',
+    'Difluorine',
+    'Dichlorine',
+    'Dibromine',
+    'Hydrogen fluoride',
+    'Hydrogen chloride',
+    'Hydrogen bromide',
+    'Hydrogen sulfide',
+    'Water',
+    'Methane',
+    'Methyl',
+    'Ammonia',
+    'Chloromethane'
+]
+
+
+class AEJob:
+    """
+    A job for fitting atom energies.
+    """
+
+    def __init__(self,
+                 species_energies: Dict[str, float],
+                 level_of_theory: str = None,
+                 write_to_database: bool = False,
+                 overwrite: bool = False):
+        """
+        Initialize an AEJob instance.
+
+        Notes:
+            The species energies should be provided as a dictionary
+            containing the species labels as keys and their single-
+            point electronic energies in Hartree as values. The
+            energies should be calculated using the experimental
+            geometry provided for the species in the reference
+            database, and the zero-point energy should not be included
+            in the electronic energy.
+
+        Args:
+            species_energies: Dictionary of species labels with single-point electronic energies (Hartree).
+            level_of_theory: Dictionary key for saving atom energies to the database
+            write_to_database: Save the fitted atom energies directly to the RMG database.
+            overwrite: Overwrite atom energies in the RMG database if they already exist.
+        """
+        self.spcs_energies = species_energies
+        self.level_of_theory = level_of_theory
+        self.write_to_database = write_to_database
+        self.overwrite = overwrite
+        self.ae = AE(species_energies)
+
+    def execute(self, output_file: str = None):
+        """
+        Execute the atom energy job.
+
+        Args:
+            output_file: Write the fitted energies to this file.
+        """
+        if self.level_of_theory is None:
+            logging.info('Fitting atom energies')
+        else:
+            logging.info(f'Fitting atom energies for {self.level_of_theory}')
+        self.ae.fit()
+
+        if output_file is not None:
+            with open(output_file, 'a') as f:
+                if self.level_of_theory is not None:
+                    f.write(f'#  {self.level_of_theory}\n')
+                for element, energy in self.ae.atom_energies.items():
+                    f.write(f'# {element:2}: {energy:15.8f} +/- {self.ae.confidence_intervals[element]:.8f} Hartree\n')
+                f.writelines(self.ae.format_atom_energies(
+                    'atom_energies' if self.level_of_theory is None else self.level_of_theory))
+
+        if self.write_to_database:
+            if self.level_of_theory is None:
+                raise Exception('Level of theory is required for writing to database')
+            try:
+                self.ae.write_to_database(self.level_of_theory, overwrite=self.overwrite)
+            except ValueError as e:
+                logging.warning('Could not write atom energies to database. Captured error:')
+                logging.warning(str(e))
+
+
+class AE:
+    """
+    A class for fitting atom energies.
+    """
+
+    ref_data_src = 'CCCBDB'  # Use CCCBDB data
+    ref_data = None  # Dictionary of reference data entries
+
+    def __init__(self, species_energies: Dict[str, float]):
+        self.species_energies = species_energies  # Hartree
+        self.atom_energies = None
+        self.confidence_intervals = None
+
+    @classmethod
+    def _load_refdata(cls):
+        if cls.ref_data is None:
+            logging.info('Loading reference database')
+            db = ReferenceDatabase()
+            db.load()
+            cls.ref_data = {lbl: spc for lbl, spc in zip(SPECIES_LABELS, db.get_species_from_label(SPECIES_LABELS))}
+
+    def fit(self):
+        """
+        Fit atom energies using the provided species energies and
+        corresponding atomization energies from the reference data.
+        """
+        self._load_refdata()
+
+        mols = [
+            Molecule().from_adjacency_list(
+                self.ref_data[lbl].adjacency_list,
+                raise_atomtype_exception=False,
+                raise_charge_exception=False
+            ) for lbl in SPECIES_LABELS
+        ]
+        atom_counts = [Counter(atom.element.symbol for atom in mol.atoms) for mol in mols]
+        elements = sorted({element for ac in atom_counts for element in ac}, key=lambda s: get_element(s).number)
+        x = np.array([[ac[element] for element in elements] for ac in atom_counts])  # Nmols x Nelements
+
+        atomization_energies = np.array([
+            self.ref_data[lbl].reference_data[self.ref_data_src].atomization_energy.value_si
+            / constants.E_h / constants.Na for lbl in SPECIES_LABELS
+        ])
+        zpes = np.array([
+            self.ref_data[lbl].reference_data[self.ref_data_src].zpe.value_si
+            / constants.E_h / constants.Na for lbl in SPECIES_LABELS
+        ])
+        elec_energies = np.array([self.species_energies[lbl] for lbl in SPECIES_LABELS])  # Should already be in Hartree
+        y = atomization_energies + elec_energies + zpes
+
+        w = np.linalg.solve(x.T @ x, x.T @ y)
+        self.atom_energies = dict(zip(elements, w))
+
+        # Get confidence intervals
+        n = len(y)  # Ndata
+        k = len(w)  # Nparam
+        ypred = x @ w
+        sigma2 = np.sum((y - ypred)**2) / (n - k - 1)  # MSE
+        cov = sigma2 * np.linalg.inv(x.T @ x)  # covariance matrix
+        se = np.sqrt(np.diag(cov))  # standard error
+        alpha = 0.05  # 95% confidence level
+        tdist = distributions.t.ppf(1 - alpha/2, n - k - 1)  # student-t
+        ci = tdist * se  # confidence interval half-width
+        self.confidence_intervals = dict(zip(elements, ci))  # Parameter estimates are w +/- ci
+
+    def write_to_database(self, key: str, overwrite: bool = False, alternate_path: str = None):
+        """
+        Write atom energies to database.
+
+        Args:
+            key: Dictionary key to use for atom energies in database.
+            overwrite: Overwrite existing atom energies.
+            alternate_path: Write atom energies and existing database to this path instead.
+        """
+        if self.atom_energies is None:
+            raise ValueError('No atom energies available for writing')
+
+        data_path = data.quantum_corrections_path
+        with open(data_path) as f:
+            lines = f.readlines()
+
+        ae_formatted = self.format_atom_energies(key, indent=True)
+
+        # Add new atom energies to file without changing existing formatting
+        for i, line in enumerate(lines):
+            if 'atom_energies' in line:
+                if key in data.atom_energies:
+                    if overwrite:
+                        # Does not overwrite comments
+                        del_idx_start = del_idx_end = None
+                        for j, line2 in enumerate(lines[i:]):
+                            if key in line2:
+                                del_idx_start = i + j
+                                del_idx_end = None
+                            elif line2.rstrip() == '    },':  # Can't have a comment after final brace
+                                del_idx_end = i + j + 1
+                            if del_idx_start is not None and del_idx_end is not None:
+                                if (lines[del_idx_start - 1].lstrip().startswith('#')
+                                        or lines[del_idx_end + 1].lstrip().startswith('#')):
+                                    logging.warning('There may be left over comments from previous atom energies')
+                                lines[del_idx_start:del_idx_end] = ae_formatted
+                                break
+                    else:
+                        raise ValueError(f'{key} already exists. Set `overwrite` to True.')
+                else:
+                    lines[(i+1):(i+1)] = ['\n'] + ae_formatted
+                break
+
+        with open(data_path if alternate_path is None else alternate_path, 'w') as f:
+            f.writelines(lines)
+
+        # Reload data to update atom energy dictionary
+        if alternate_path is None:
+            importlib.reload(data)
+
+    def format_atom_energies(self, key: str, indent: bool = False) -> List[str]:
+        """
+        Obtain a list of nicely formatted atom energies suitable for
+        writelines.
+
+        Args:
+            key: Dictionary key to use for formatting dictionary.
+            indent: Indent each line.
+
+        Returns:
+            Formatted list of atom energies.
+        """
+        ae_formatted = json.dumps(self.atom_energies, indent=4).replace('"', "'").split('\n')
+        ae_formatted[0] = f'"{key}": ' + ae_formatted[0]
+        ae_formatted[-1] += ','
+        ae_formatted = [e + '\n' for e in ae_formatted]
+        if indent:
+            ae_formatted = ['    ' + e for e in ae_formatted]
+        return ae_formatted

--- a/arkane/encorr/bac.py
+++ b/arkane/encorr/bac.py
@@ -850,7 +850,7 @@ class BAC:
         if alternate_path is None:
             importlib.reload(data)
 
-    def format_bacs(self, indent=False):
+    def format_bacs(self, indent: bool = False) -> List[str]:
         """
         Obtain a list of nicely formatted BACs suitable for writelines.
 
@@ -868,7 +868,7 @@ class BAC:
             bacs_formatted = ['    ' + e for e in bacs_formatted]
         return bacs_formatted
 
-    def save_correlation_mat(self, path, labels=None):
+    def save_correlation_mat(self, path: str, labels: List[str] = None):
         """
         Save a visual representation of the parameter correlation matrix.
 
@@ -920,7 +920,7 @@ class BAC:
         fig.savefig(path, dpi=600, bbox_inches='tight', pad_inches=0)
 
 
-def _covariance_to_correlation(cov):
+def _covariance_to_correlation(cov: np.ndarray) -> np.ndarray:
     """Convert (unscaled) covariance matrix to correlation matrix"""
     v = np.sqrt(np.diag(cov))
     corr = cov / np.outer(v, v)

--- a/arkane/encorr/reference.py
+++ b/arkane/encorr/reference.py
@@ -331,16 +331,22 @@ class ReferenceDataEntry(RMGObject):
     """
     A class for storing reference data for a specific species from a single source
     """
-    def __init__(self, thermo_data, atct_id=None):
+    def __init__(self, thermo_data=None, atct_id=None, atomization_energy=None, xyz_dict=None, zpe=None):
         """
 
         Args:
             thermo_data (rmgpy.thermo.ThermoData): Thermochemistry (Hf298, Cp, ...) from the reference for a species
             atct_id (str): ID number in the Active Thermochemical Tables if the source is ATcT
+            atomization_energy (rmgpy.quantity.ScalarQuantity): Atomization energy at zero Kelvin
+            xyz_dict (dict): An ARC style xyz dictionary for the cartesian coordinates
+            zpe (rmgpy.quantity.ScalarQuantity): Zero-point energy
         """
         super().__init__()
         self.thermo_data = thermo_data
         self.atct_id = atct_id
+        self.atomization_energy = atomization_energy
+        self.xyz_dict = xyz_dict
+        self.zpe = zpe
 
     def __repr__(self):
         return str(self.as_dict())

--- a/arkane/encorr/reference.py
+++ b/arkane/encorr/reference.py
@@ -296,15 +296,16 @@ class ReferenceSpecies(ArkaneSpecies):
         """
         if self.preferred_reference is not None:
             preferred_source = self.preferred_reference
-        else:  # Choose the source that has the smallest uncertainty
-            sources = list(self.reference_data.keys())
-            data = list(self.reference_data.values())
-            preferred_source = sources[0]  # If all else fails, use the first source as the preferred one
-            uncertainty = data[0].thermo_data.H298.uncertainty_si
-            for i, entry in enumerate(data):
-                if 0 < entry.thermo_data.H298.uncertainty_si < uncertainty:
-                    uncertainty = entry.thermo_data.H298.uncertainty_si
-                    preferred_source = sources[i]
+        else:
+            data_w_thermo = {s: d for s, d in self.reference_data.items() if d.thermo_data is not None}
+            data_w_thermo_unc = {s: d for s, d in data_w_thermo.items() if d.thermo_data.H298.uncertainty_si > 0}
+            if data_w_thermo_unc:  # Use source with smallest uncertainty
+                preferred_source = min(data_w_thermo_unc,
+                                       key=lambda s: data_w_thermo_unc[s].thermo_data.H298.uncertainty_si)
+            elif data_w_thermo:  # Use first source with thermo data
+                preferred_source = list(data_w_thermo.keys())[0]
+            else:  # If all else fails, use the first source, even if it doesn't have thermo
+                preferred_source = list(self.reference_data.keys())[0]
 
         return preferred_source
 

--- a/arkane/input.py
+++ b/arkane/input.py
@@ -63,6 +63,7 @@ from rmgpy.transport import TransportData
 from rmgpy.util import as_list
 
 from arkane.common import is_pdep
+from arkane.encorr.ae import AEJob
 from arkane.encorr.bac import BACJob
 from arkane.encorr.corr import assign_frequency_scale_factor
 from arkane.explorer import ExplorerJob
@@ -509,6 +510,18 @@ def explorer(source, explore_tol=0.01, energy_tol=np.inf, flux_tol=0.0, bathGas=
     job_list.append(job)
 
 
+def ae(species_energies, level_of_theory=None, write_to_database=False, overwrite=False):
+    """Generate an atom energy job"""
+    global job_list
+    job = AEJob(
+        species_energies,
+        level_of_theory=level_of_theory,
+        write_to_database=write_to_database,
+        overwrite=overwrite
+    )
+    job_list.append(job)
+
+
 def bac(model_chemistry, bac_type='p', train_names='main',
         exclude_elements=None, charge='all', multiplicity='all',
         weighted=False, write_to_database=False, overwrite=False,
@@ -622,6 +635,7 @@ def load_input_file(path):
         'pressureDependence': pressureDependence,
         'explorer': explorer,
         'bac': bac,
+        'ae': ae,
         # Miscellaneous
         'SMILES': SMILES,
         'adjacencyList': adjacencyList,

--- a/arkane/input.py
+++ b/arkane/input.py
@@ -538,7 +538,9 @@ def SMILES(smiles):
 
 def adjacencyList(adj):
     """Make a Molecule object from an adjacency list"""
-    return Molecule().from_adjacency_list(adj)
+    return Molecule().from_adjacency_list(adj,
+                                          raise_atomtype_exception=False,
+                                          raise_charge_exception=False)
 
 
 def InChI(inchi):

--- a/arkane/main.py
+++ b/arkane/main.py
@@ -55,6 +55,7 @@ from rmgpy.data.kinetics.library import KineticsLibrary
 from rmgpy.exceptions import InputError
 
 from arkane.common import is_pdep
+from arkane.encorr.ae import AEJob
 from arkane.encorr.bac import BACJob
 from arkane.explorer import ExplorerJob
 from arkane.input import load_input_file
@@ -219,6 +220,8 @@ class Arkane(object):
             if isinstance(job, BACJob):
                 job.execute(output_directory=self.output_directory, plot=self.plot, jobnum=bacjob_num)
                 bacjob_num += 1
+            if isinstance(job, AEJob):
+                job.execute(output_file=output_file)
 
         with open(chemkin_file, 'a') as f:
             f.write('\n')

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -1053,6 +1053,25 @@ for all network reactions (both directions if reversible) at all requested condi
 automatically generated per network reaction, showing the semi-normalized sensitivity coefficients at all conditions.
 
 
+Atom Energy Fitting
+==================================
+
+Atom energies can be fitted using a small selection of species (see ``SPECIES_LABELS`` in ``arkane/encorr/ae.py``). To
+do this, the single-point electronic energies calculated using the experimental geometries from the reference database
+of each of the species should be provided as a dictionary of the species labels and their energies in Hartree.
+Zero-point energies should not be included in the electronic energies. Each atom energy fitting calculation must be
+specified using a ``ae()`` function, which accepts the following parameters:
+
+====================== ==================== =========================================================================================
+Parameter              Required?            Description
+====================== ==================== =========================================================================================
+``species_energies``   Yes                  Dictionary of species labels and single-point energies
+``level_of_theory``    No                   Level of theory used as key if writing to the database dictionary
+``write_to_database``  No                   Write the atom energies to the database; requires ``level_of_theory`` (default: False)
+``overwrite``          No                   If atom energies already exist, overwrite them (default: False)
+====================== ==================== =========================================================================================
+
+
 Bond Additivity Correction Fitting
 ==================================
 


### PR DESCRIPTION
### Motivation or Problem
We should fit atom energies so that levels of theory that produce incorrect atom energies can be used to compute thermochemistry.

### Description of Changes
Added `AE` and `AEJob` classes that require a dictionary of species labels with single-point electronic energies (computed using the experimental geometries available in the reference database). For example,
```python
species_energies = {
    'Dihydrogen': -1.1607014438,
    'Dinitrogen': -109.5502634582,
    'Dioxygen': -150.3479925723,
    'Disulfur': -796.325655201,
    ...
}
```
The list of species that has to be provided is available in `SPECIES_LABELS` in `arkane/encorr/ae.py`. Atom energies can be fitted by using the `ae()` function in Arkane input files as described in the updated documentation. Corresponding database PR is ReactionMechanismGenerator/RMG-database#415.

### Testing
Added unit tests and checked that it works well for wB97M-V.

### Reviewer Tips
Check the logic of the linear regression and maybe run an Arkane job to fit energies.