### PR TITLE
BAC options

### DIFF
--- a/arkane/encorr/dataTest.py
+++ b/arkane/encorr/dataTest.py
@@ -347,6 +347,44 @@ class TestFuncs(unittest.TestCase):
         dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY)
         self.assertIsInstance(dataset, BACDataset)
 
+        # Test excluding elements
+        elements = 'N'
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, exclude_elements=elements)
+        for d in dataset:
+            self.assertFalse(elements in d.spc.formula)
+        elements = ['N', 'O']
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, exclude_elements=elements)
+        for d in dataset:
+            self.assertFalse(any(e in d.spc.formula for e in elements))
+
+        # Test specifying charge
+        charges = 'negative'
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, charge=charges)
+        for d in dataset:
+            self.assertTrue(d.spc.charge < 0)
+        charges = 1
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, charge=charges)
+        for d in dataset:
+            self.assertTrue(d.spc.charge == 1)
+        charges = ['positive', 'neutral']
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, charge=charges)
+        for d in dataset:
+            self.assertTrue(d.spc.charge >= 0)
+        charges = [-1, 'positive']
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, charge=charges)
+        for d in dataset:
+            self.assertTrue(d.spc.charge > 0 or d.spc.charge == -1)
+
+        # Test specifying multiplicity
+        multiplicities = 2
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, multiplicity=multiplicities)
+        for d in dataset:
+            self.assertTrue(d.spc.multiplicity == 2)
+        multiplicities = [2, 3]
+        dataset = extract_dataset(DATABASE, MODEL_CHEMISTRY, multiplicity=multiplicities)
+        for d in dataset:
+            self.assertTrue(d.spc.multiplicity in {2, 3})
+
     def test_geo_to_mol(self):
         """
         Test that a geometry can be converted to an RMG molecule.

--- a/arkane/input.py
+++ b/arkane/input.py
@@ -509,8 +509,9 @@ def explorer(source, explore_tol=0.01, energy_tol=np.inf, flux_tol=0.0, bathGas=
     job_list.append(job)
 
 
-def bac(model_chemistry, bac_type='p', train_names='main', weighted=False,
-        write_to_database=False, overwrite=False,
+def bac(model_chemistry, bac_type='p', train_names='main',
+        exclude_elements=None, charge='all', multiplicity='all',
+        weighted=False, write_to_database=False, overwrite=False,
         fit_mol_corr=True, global_opt=True, global_opt_iter=10):
     """Generate a BAC job"""
     global job_list
@@ -518,6 +519,9 @@ def bac(model_chemistry, bac_type='p', train_names='main', weighted=False,
         model_chemistry,
         bac_type=bac_type,
         db_names=train_names,
+        exclude_elements=exclude_elements,
+        charge=charge,
+        multiplicity=multiplicity,
         weighted=weighted,
         write_to_database=write_to_database,
         overwrite=overwrite,

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -1062,19 +1062,22 @@ fits one parameter for each bond type, and Melius-type (Anantharaman and Melius,
 which fits three parameters per atom type and an optional molecular parameter. Each BAC fitting calculation must be
 specified using a ``bac()`` function, which accepts the following parameters:
 
-====================== ==================== =========================================================================================
-Parameter              Required?            Description
-====================== ==================== =========================================================================================
-``model_chemistry``    Yes                  Calculated data will be extracted from the reference database using this model chemistry
-``bac_type``           No                   BAC type: 'p' for Petersson (default), 'm' for Melius
-``train_name``         No                   Names of training data folders in the RMG database (default: 'main')
-``weighted``           No                   Weight the data to diversify substructures (default: False)
-``write_to_database``  No                   Write the BACs to the database (default: False)
-``overwrite``          No                   If BACs already exist, overwrite them (default: False)
-``fit_mol_corr``       No                   Fit the optional molecular correction term (Melius only, default: True)
-``global_opt``         No                   Perform a global optimization (Melius only, default: True)
-``global_opt_iter``    No                   Number of global optimization iterations (Melius only, default: 10)
-====================== ==================== =========================================================================================
+====================== ============ =============================================================================================================================
+Parameter              Required?    Description
+====================== ============ =============================================================================================================================
+``model_chemistry``    Yes          Calculated data will be extracted from the reference database using this model chemistry
+``bac_type``           No           BAC type: 'p' for Petersson (default), 'm' for Melius
+``train_names``        No           Names of training data folders in the RMG database (default: 'main')
+``exclude_elements``   No           Exclude molecules with the elements in this list from the training data (default: None)
+``charge``             No           Set the allowed charges ('neutral', 'positive', 'negative', or integers) for molecules in the training data (default: 'all')
+``multiplicity``       No           Set the allowed multiplicities for molecules in the training data (default: 'all')
+``weighted``           No           Weight the data to diversify substructures (default: False)
+``write_to_database``  No           Write the BACs to the database (default: False)
+``overwrite``          No           If BACs already exist, overwrite them (default: False)
+``fit_mol_corr``       No           Fit the optional molecular correction term (Melius only, default: True)
+``global_opt``         No           Perform a global optimization (Melius only, default: True)
+``global_opt_iter``    No           Number of global optimization iterations (Melius only, default: 10)
+====================== ============ =============================================================================================================================
 
 
 Examples


### PR DESCRIPTION
Allows excluding elements, specifying charge, and specifying multiplicity for training set molecules used for BAC fitting. Added some new unit tests as well, and tested a BAC Arkane job with some of the new settings.