### PR TITLE
Debugged global uncertainty analysis

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -816,7 +816,7 @@ def uncertainty(localAnalysis=False, globalAnalysis=False, uncorrelated=True, co
         'correlated': correlated,
         'localnum': localNumber,
         'globalnum': globalNumber,
-        'time': terminationTime,
+        'time': Quantity(terminationTime) if terminationTime else terminationTime,
         'pcetime': pceRunTime,
         'pcetol': pceErrorTol,
         'pceevals': pceMaxEvals,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -1130,10 +1130,17 @@ class RMG(util.Subject):
 
                                     
                             Tlist = ([reaction_system.sens_conditions['T']], 'K')
-                            Plist = ([reaction_system.sens_conditions['P']], 'Pa')
+                            try:
+                                Plist = ([reaction_system.sens_conditions['P']], 'Pa')
+                            except KeyError:
+                                #LiquidReactor
+                                Plist = ([1e8], 'Pa')
+                                logging.warning('Using 1e8 Pa as the reaction system pressure to approximate liquid phase density.')
+
                             mol_frac_list = [reaction_system.sens_conditions.copy()]
                             del mol_frac_list[0]['T']
-                            del mol_frac_list[0]['P']
+                            if 'P' in mol_frac_list[0]:
+                                del mol_frac_list[0]['P']
 
                             # Set up Cantera reactor
                             job = Cantera(species_list=uncertainty.species_list, reaction_list=uncertainty.reaction_list,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -61,7 +61,7 @@ from rmgpy.data.base import Entry
 from rmgpy.data.kinetics.family import TemplateReaction
 from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 from rmgpy.data.rmg import RMGDatabase
-from rmgpy.exceptions import ForbiddenStructureException, DatabaseError, CoreError
+from rmgpy.exceptions import ForbiddenStructureException, DatabaseError, CoreError, InputError
 from rmgpy.kinetics.diffusionLimited import diffusion_limiter
 from rmgpy.kinetics import ThirdBody
 from rmgpy.molecule import Molecule
@@ -1121,7 +1121,14 @@ class RMG(util.Subject):
                                     time_criteria = ([criteria.time.value], criteria.time.units)
                                     break
                             else:
-                                time_criteria = self.uncertainty['time']
+                                if self.uncertainty['time']:
+                                    time_criteria = ([self.uncertainty['time'].value], self.uncertainty['time'].units)
+                                else:
+                                    raise InputError('If terminationTime was not specified in the reactor options block, it'
+                                                    'must be specified in the uncertainty options block for global uncertainty'
+                                                    'analysis.')
+
+                                    
                             Tlist = ([reaction_system.sens_conditions['T']], 'K')
                             Plist = ([reaction_system.sens_conditions['P']], 'Pa')
                             mol_frac_list = [reaction_system.sens_conditions.copy()]


### PR DESCRIPTION
### Motivation or Problem
1. Currently global uncertainty analysis throws an KeyError message for liquid reactor because it tries to access `reaction_system.sens_conditions['P']` and `del mol_frac_list[0]['P']` in `rmgpy/rmg/main.py/RMG.run_uncertainty_analysis()`. 
2.  Currently, if terminationTime is not assigned in the reactor options block,  `rmgpy/rmg/main.py/RMG.run_uncertainty_analysis()` assigns the `time_criteria` to be `self.uncertainty['time']`. However, if terminationTime is also not provided in the uncertainty options block, `self.uncertainty['time']` would be None and causes an AttributeError. It is desirable for RMG to throw meaningful InputError here. 

### Description of Changes
I assigned `Plist = ([1e8],'Pa')` for liquid reactor, which uses `self.P = 1e5 #kPa` in liquid.pyx. I also added an informative InputError for terminationTime.

### Testing
I performed global uncertainty analysis by adding the uncertainty options block to the toy model provided in `examples/rmg/liquid_phase_constSPC/input.py`. The results seem normal.
