### PR TITLE
Make reordering and reindexing of entries optional when saving database

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -322,7 +322,7 @@ class Database(object):
                 f.write(species_dict[label].molecule[0].to_adjacency_list(label=label, remove_h=False))
                 f.write('\n')
 
-    def save(self, path):
+    def save(self, path, reindex=True):
         """
         Save the current database to the file at location `path` on disk. 
         """
@@ -330,14 +330,18 @@ class Database(object):
             os.makedirs(os.path.dirname(path))
         except OSError:
             pass
-        entries = self.get_entries_to_save()
+        if reindex is True:
+            entries = self.get_entries_to_save()
+        else:
+            entries = self.entries.values()
+
 
         f = codecs.open(path, 'w', 'utf-8')
         f.write('#!/usr/bin/env python\n')
         f.write('# encoding: utf-8\n\n')
         f.write('name = "{0}"\n'.format(self.name))
-        f.write('shortDesc = "{0}"\n'.format(self.short_desc))
-        f.write('longDesc = """\n')
+        f.write('shortDesc = u"{0}"\n'.format(self.short_desc))
+        f.write('longDesc = u"""\n')
         f.write(self.long_desc.strip() + '\n')
         f.write('"""\n')
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -123,14 +123,17 @@ def save_entry(f, entry):
             f.write('        CpInf = {0!r},\n'.format(entry.data.CpInf))
         f.write('    ),\n')
     else:
-        f.write('    thermo = {0!r},\n'.format(entry.data))
+        if entry.data:
+            f.write('    thermo = u{0!r},\n'.format(entry.data))
+        else:
+            f.write('    thermo = {0!r},\n'.format(entry.data))
 
     if entry.reference is not None:
         f.write('    reference = {0!r},\n'.format(entry.reference))
     if entry.reference_type != "":
         f.write('    referenceType = "{0}",\n'.format(entry.reference_type))
-    f.write(f'    shortDesc = """{entry.short_desc.strip()}""",\n')
-    f.write(f'    longDesc = \n"""\n{entry.long_desc.strip()}\n""",\n')
+    f.write(f'    shortDesc = u"""{entry.short_desc.strip()}""",\n')
+    f.write(f'    longDesc = \nu"""\n{entry.long_desc.strip()}\n""",\n')
     if entry.rank:
         f.write("    rank = {0},\n".format(entry.rank))
 


### PR DESCRIPTION
### Motivation or Problem
When loading and saving the database, the entries are automatically re-ordered and re-indexed using the `get_entries_to_save` function.  While it is nice to have this option, sometimes we do not want to reorder and reindex when adding new entries because the entire file may be rewritten in the git commit history.

### Description of Changes
This PR makes the reordering and reindexing optional when saving.

### Testing
I used this branch when saving the thermo groups in PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/414.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
