### PR TITLE
Tweak the AtomTypeError error message.

### DIFF
--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -752,10 +752,10 @@ def get_atomtype(atom, bonds):
         else:
             return specific_atom_type
     else:
-        single, _, r_double, o_double, s_double, triple, quadruple, benzene, lone_pairs, charge = mol_feature_list
+        single, all_double, r_double, o_double, s_double, triple, quadruple, benzene, lone_pairs, charge = mol_feature_list
 
         raise AtomTypeError(
             f'Unable to determine atom type for atom {atom}, which has {single:d} single bonds, '
-            f'{r_double:d} double bonds to C, {o_double:d} double bonds to O, {s_double:d} double '
-            f'bonds to S, {triple:d} triple bonds, {quadruple:d} quadruple bonds, {benzene:d} '
-            f'benzene bonds, {lone_pairs:d} lone pairs, and {charge:d} charge.')
+            f'{all_double:d} double bonds ({o_double:d} to O, {s_double:d} to S, '
+            f'{r_double:d} others), {triple:d} triple bonds, {quadruple:d} quadruple bonds, '
+            f'{benzene:d} benzene bonds, {lone_pairs:d} lone pairs, and {charge:+d} charge.')


### PR DESCRIPTION
### Motivation or Problem
Closes #1957. 
Thanks to @xiaoruiDong for pointing to the problem.

### Description of Changes
Changed the error message to be less misleading when you have double bonds to N or X.

### Testing
Small change. Tested it on the broken adjacency list described in #1957 and it reports the much more accurate and helpful `AtomTypeError: Unable to determine atom type for atom O-, which has 1 single bonds, 1 double bonds (0 to O, 0 to S, 1 others), 0 triple bonds, 0 quadruple bonds, 0 benzene bonds, 2 lone pairs, and -1 charge.`. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
