### PR TITLE
Avoid SMILES translation errors for reference species

### DIFF
--- a/arkane/encorr/reference.py
+++ b/arkane/encorr/reference.py
@@ -60,7 +60,7 @@ class ReferenceSpecies(ArkaneSpecies):
     selections for use in isodesmic reaction calculations
     """
 
-    def __init__(self, species=None, smiles=None, adjacency_list=None, inchi=None, reference_data=None,
+    def __init__(self, species=None, smiles=None, adjacency_list=None, inchi=None, inchi_key=None, reference_data=None,
                  calculated_data=None, preferred_reference=None, index=None, label=None, cas_number=None,
                  symmetry_number=None, default_xyz_chemistry=None, **kwargs):
         """
@@ -71,6 +71,7 @@ class ReferenceSpecies(ArkaneSpecies):
             smiles (str): SMILES string representing the reference species
             adjacency_list (str): An RMG adjacency list representation of the reference species
             inchi (str): InChI string representing the reference species
+            inchi_key (str): InChI key hash of the InChI string
             reference_data (dict): Formatted as {'source_string': ReferenceDataEntry, ...}
             calculated_data (dict): Formatted as {'model_chemistry': CalculatedDataEntry, ...}
             preferred_reference (str): The source string key for the reference data to use for isodesmic reactions
@@ -110,6 +111,12 @@ class ReferenceSpecies(ArkaneSpecies):
         # Alter the symmetry number calculated by RMG to the one provided by the user
         if symmetry_number:
             self.symmetry_number = symmetry_number
+
+        # Reset to the provided identifiers to avoid translation errors. Note that `''` should not be a valid identifier
+        self.smiles = smiles or self.smiles
+        self.adjacency_list = adjacency_list or self.adjacency_list
+        self.inchi = inchi or self.inchi
+        self.inchi_key = inchi_key or self.inchi_key
 
     def __repr__(self):
         if self.index:


### PR DESCRIPTION
### Motivation or Problem
If you load and then immediately save the reference database, some items in the database change, including SMILES strings, InChI strings/keys, and floating point errors for ScalarQuantity objects, even though the user made no changes to the files.

This PR fixes the issues related to the identifiers by resetting these attributes in the __init__ method if they were supplied (as they would be when loading the database). This avoids the translation errors that occur when creating the species in the call to the super class ArkaneSpecies.

This PR does NOT fix the issues with the floating point errors. It is noteworthy that these errors only occur inside of ScalarQuantity objects. The root cause of this is that quantities with non-SI units are first converted to SI units (ScalarQuantity.value is just a property that reads/updates value_si), and this arithmetic leads to floating point errors when converting back to the non-SI unit when saving the database. I tired implementing a fix for this by refactoring our quantity code so that we don't convert to SI units until needed, but this would involve a major refactoring of our quantities module (the current limiting factor is that we need a way to update the value property if the user changes the units, but this is difficult because the units are there own class). 

### Testing
I tested loading and saving the database, and only floating point error changes occurred.
