### PR TITLE
Do resonance structure generation less often.

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -208,10 +208,6 @@ def ensure_independent_atom_ids(input_species, resonance=True):
                 species.generate_resonance_structures(keep_isomorphic=True)
             if len(unreactive_mol_list):
                 species.molecule.extend(unreactive_mol_list)
-    elif resonance:
-        # IDs are already independent, generate resonance structures if needed
-        for species in input_species:
-            species.generate_resonance_structures(keep_isomorphic=True)
 
 
 def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kinetics_database=None,


### PR DESCRIPTION
### Motivation or Problem
This addresses https://github.com/ReactionMechanismGenerator/RMG-Py/issues/1963 so read that issue for context.

### Description of Changes
The change in this PR stops a lot of calls to `generate_resonance_structures`.
I'm not entirely sure some of it wasn't being counted on by something, but I am hoping that by making this pull request, the automated tests will tell us if it changes the outcome. 

Now the method `ensure_independent_atom_ids` only generates
resonance structures if doing so is needed to ensure independent
atom ids, and not as a side effect on all species it is called with.

I believe that if some code was relying on resonance structures to be generated
that code should instead explicitly call `generate_resonance_structures`, and that can be added to this PR.
The method name `ensure_independent_atom_ids` doesn't suggest it generates all resonance structures, and methods that are called one thing but relied on to do another are a code smell.

Before this change, resonances structures were generated a lot,
because `ensure_independent_atom_ids` is called a lot. Hopefully this speeds things up. Do the automated tests also check runtimes?

If we *do* need to generate resonance structures more than this to ensure we get all reactions, maybe we can call it from somewhere else so it gets done only once for each species.

### Testing
I already ran the unit test suite, which passes. Hoping the automated regression tests will be informative.
