### PR TITLE
Add family.auto_generated check in Arkane

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -122,7 +122,8 @@ def database(thermoLibraries=None, transportLibraries=None, reactionLibraries=No
     )
 
     for family in rmg_database.kinetics.families.values():  # load training
-        family.add_rules_from_training(thermo_database=rmg_database.thermo)
+        if not family.auto_generated:
+            family.add_rules_from_training(thermo_database=rmg_database.thermo)
 
     for family in rmg_database.kinetics.families.values():
         family.fill_rules_by_averaging_up(verbose=True)


### PR DESCRIPTION
### Motivation or Problem
arkane.inpuy doesn't have the same fix that rmgpy.main does, i.e. skipping add_rules_from_training if the tree is auto-generated.

### Description of Changes
Added a check that if family.auto_generated is True, Arkane will skip add_rules_from_training.

### Testing
Tested with test_arkane_examples in inputTest.py locally and it passed.