### PR TITLE
BugFix: use str(freq_level) to get frequency scale factor from dict

### DIFF
--- a/arkane/encorr/corr.py
+++ b/arkane/encorr/corr.py
@@ -236,10 +236,10 @@ def assign_frequency_scale_factor(level_of_theory: Union[LevelOfTheory, Composit
         return 1
     freq_level = getattr(level_of_theory, 'freq', level_of_theory)
     try:
-        scaling_factor = data.freq_dict[freq_level]
+        scaling_factor = data.freq_dict[str(freq_level)]
     except KeyError:
         try:
-            scaling_factor = data.freq_dict[freq_level.simple()]
+            scaling_factor = data.freq_dict[str(freq_level.simple())]
         except KeyError:
             scaling_factor = 1
         else:


### PR DESCRIPTION
### Motivation or Problem
The keys of data.freq_dict are strings, but freq_level is an object. This mismatch results in KeyError, and subsequently gave a wrong frequency scale factor of 1 for model chemistries exist in the database.  

This bug also caused ARC to crash as it incorrectly informs ARC about the frequency scale factor. Related to https://github.com/ReactionMechanismGenerator/ARC/pull/398

Execute the following in a Jupiter notebook will reveal the bug:

from arkane.encorr.corr import assign_frequency_scale_factor
from arkane.modelchem import LevelOfTheory
import arkane.encorr.data as data

lot = LevelOfTheory(method='b3lyp',basis='6311+g(3df,2p)',software='gaussian')
assign_frequency_scale_factor(lot)

Output: WARNING:root:No frequency scaling factor found for LevelOfTheory(method='b3lyp',basis='6311+g(3df,2p)',software='gaussian'). Assuming a value of unity. This will affect the partition function and all quantities derived from it  (thermo quantities and rate coefficients).
>>> 1

### Description of Changes
Convert freq_level to string before using it as a key.

### Testing
After the change, repeat the above example code in the Jupiter notebook gave the correct frequency scale factor of 0.967.

