### PR TITLE
BAC cross-validation

### DIFF
--- a/arkane/encorr/bac.py
+++ b/arkane/encorr/bac.py
@@ -140,6 +140,8 @@ class BACJob:
         with open(output_file2, 'w') as f:
             writer = csv.writer(f)
             writer.writerow([
+                'Index',
+                'Label',
                 'Smiles',
                 'InChI',
                 'Formula',
@@ -152,6 +154,8 @@ class BACJob:
             ])
             for d in self.bac.dataset:
                 writer.writerow([
+                    d.spc.index,
+                    d.spc.label,
                     d.spc.smiles,
                     d.spc.inchi,
                     d.spc.formula,

--- a/arkane/encorr/bac.py
+++ b/arkane/encorr/bac.py
@@ -584,6 +584,8 @@ class BAC:
     def fit(self,
             weighted: bool = False,
             db_names: Union[str, List[str]] = 'main',
+            idxs: Union[Sequence[int], Set[int], int] = None,
+            exclude_idxs: Union[Sequence[int], Set[int], int] = None,
             exclude_elements: Union[Sequence[str], Set[str], str] = None,
             charge: Union[Sequence[Union[str, int]], Set[Union[str, int]], str, int] = 'all',
             multiplicity: Union[Sequence[int], Set[int], int, str] = 'all',
@@ -596,6 +598,8 @@ class BAC:
         Args:
             weighted: Perform weighted least squares by balancing training data.
             db_names: Optionally specify database names to train on (defaults to main).
+            idxs: Only include reference species with these indices in the training data.
+            exclude_idxs: Exclude reference species with these indices from the training data.
             exclude_elements: Molecules with any of the elements in this sequence are excluded from training data.
             charge: Allowable charges for molecules in training data.
             multiplicity: Allowable multiplicites for molecules in training data.
@@ -605,6 +609,7 @@ class BAC:
         self.database_key = self.load_database(names=db_names)
 
         self.dataset = extract_dataset(self.ref_databases[self.database_key], self.level_of_theory,
+                                       idxs=idxs, exclude_idxs=exclude_idxs,
                                        exclude_elements=exclude_elements, charge=charge, multiplicity=multiplicity)
         if len(self.dataset) == 0:
             raise BondAdditivityCorrectionError(f'No species available for {self.level_of_theory}')

--- a/arkane/encorr/bacTest.py
+++ b/arkane/encorr/bacTest.py
@@ -44,7 +44,7 @@ from rmgpy import settings
 from rmgpy.molecule import Molecule
 from rmgpy.quantity import ScalarQuantity
 
-from arkane.encorr.bac import BAC
+from arkane.encorr.bac import BAC, CrossVal
 from arkane.encorr.data import BACDataset, BOND_SYMBOLS, _pybel_to_rmg
 from arkane.encorr.reference import ReferenceDatabase
 from arkane.exceptions import BondAdditivityCorrectionError
@@ -274,6 +274,46 @@ class TestBAC(unittest.TestCase):
             tmp_corr_path = os.path.join(tmpdirname, 'corr.pdf')
             self.bac.save_correlation_mat(tmp_corr_path)
             self.assertTrue(os.path.exists(tmp_corr_path))
+
+
+class TestCrossVal(unittest.TestCase):
+    """
+    A class for testing that the CrossVal class functions properly.
+    """
+
+    def setUp(self):
+        lot = LevelOfTheory(method='wB97M-V', basis='def2-TZVPD', software='Q-Chem')
+        self.cross_val = CrossVal(lot)
+
+    def test_init(self):
+        """
+        Test that CrossVal is initialized correctly.
+        """
+        self.assertIsInstance(self.cross_val.level_of_theory, LevelOfTheory)
+        self.assertEqual(self.cross_val.bac_type, 'p')
+        self.assertEqual(self.cross_val.val_type, 'leaveoneout')
+        self.assertIsNone(self.cross_val.dataset)
+        self.assertIsNone(self.cross_val.bacs)
+
+    def test_leave_one_out(self):
+        """
+        Test leave-one-out cross-validation.
+        """
+        idxs = [19, 94, 191]
+        self.cross_val.val_type = 'Leave one out'
+        self.cross_val.fit(idxs=idxs)
+
+        self.assertIsInstance(self.cross_val.dataset, BACDataset)
+        self.assertEqual(len(self.cross_val.dataset), 3)
+        self.assertIsNotNone(self.cross_val.dataset.bac_data)
+        self.assertEqual(len(self.cross_val.bacs), 3)
+
+        train_folds = [[19, 94], [19, 191], [94, 191]]
+        for i, bac in enumerate(self.cross_val.bacs):
+            self.assertIsInstance(bac, BAC)
+            self.assertEqual(len(bac.dataset), 2)
+            for d in bac.dataset:
+                self.assertNotEqual(d.spc.index, train_folds[i])
 
 
 if __name__ == '__main__':

--- a/arkane/encorr/data.py
+++ b/arkane/encorr/data.py
@@ -340,6 +340,8 @@ class BACDataset:
 
 def extract_dataset(ref_database: ReferenceDatabase,
                     level_of_theory: Union[LevelOfTheory, CompositeLevelOfTheory],
+                    idxs: Union[Sequence[int], Set[int], int] = None,
+                    exclude_idxs: Union[Sequence[int], Set[int], int] = None,
                     exclude_elements: Union[Sequence[str], Set[str], str] = None,
                     charge: Union[Sequence[Union[str, int]], Set[Union[str, int]], str, int] = 'all',
                     multiplicity: Union[Sequence[int], Set[int], int, str] = 'all') -> BACDataset:
@@ -350,6 +352,8 @@ def extract_dataset(ref_database: ReferenceDatabase,
     Args:
          ref_database: Reference database.
          level_of_theory: Level of theory.
+         idxs: Only include reference species with these indices in the returned data.
+         exclude_idxs: Exclude reference species with these indices from the returned data.
          exclude_elements: Sequence of element symbols to exclude.
          charge: Allowable charges. Possible values are 'all'; a combination of 'neutral, 'positive', and 'negative';
                  or a sequence of integers.
@@ -360,6 +364,12 @@ def extract_dataset(ref_database: ReferenceDatabase,
     """
     species = ref_database.extract_level_of_theory(level_of_theory, as_error_canceling_species=False)
 
+    if idxs is not None:
+        idxs = {idxs} if isinstance(idxs, int) else set(idxs)
+        species = [spc for spc in species if spc.index in idxs]
+    if exclude_idxs is not None:
+        exclude_idxs = {exclude_idxs} if isinstance(exclude_idxs, int) else set(exclude_idxs)
+        species = [spc for spc in species if spc.index not in exclude_idxs]
     if exclude_elements is not None:
         elements = {exclude_elements} if isinstance(exclude_elements, str) else set(exclude_elements)
         species = [spc for spc in species if not any(e in spc.formula for e in elements)]

--- a/arkane/encorr/dataTest.py
+++ b/arkane/encorr/dataTest.py
@@ -381,6 +381,27 @@ class TestFuncs(unittest.TestCase):
         dataset = extract_dataset(DATABASE, LEVEL_OF_THEORY)
         self.assertIsInstance(dataset, BACDataset)
 
+        # Test only retrieving specific indices
+        idxs = 211
+        dataset = extract_dataset(DATABASE, LEVEL_OF_THEORY, idxs=idxs)
+        self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset[0].spc.index, idxs)
+        idxs = [211, 362]
+        dataset = extract_dataset(DATABASE, LEVEL_OF_THEORY, idxs=idxs)
+        self.assertEqual(len(dataset), 2)
+        for d in dataset:
+            self.assertTrue(d.spc.index in {211, 362})
+
+        # Test excluding indices
+        idxs = 211
+        dataset = extract_dataset(DATABASE, LEVEL_OF_THEORY, exclude_idxs=idxs)
+        for d in dataset:
+            self.assertNotEqual(d.spc.index, idxs)
+        idxs = [211, 362]
+        dataset = extract_dataset(DATABASE, LEVEL_OF_THEORY, exclude_idxs=idxs)
+        for d in dataset:
+            self.assertTrue(d.spc.index not in {211, 362})
+
         # Test excluding elements
         elements = 'N'
         dataset = extract_dataset(DATABASE, LEVEL_OF_THEORY, exclude_elements=elements)

--- a/arkane/input.py
+++ b/arkane/input.py
@@ -523,7 +523,8 @@ def ae(species_energies, level_of_theory=None, write_to_database=False, overwrit
     job_list.append(job)
 
 
-def bac(level_of_theory, bac_type='p', train_names='main',
+def bac(level_of_theory, bac_type='p', train_names='main', crossval=False,
+        idxs=None, exclude_idxs=None,
         exclude_elements=None, charge='all', multiplicity='all',
         weighted=False, write_to_database=False, overwrite=False,
         fit_mol_corr=True, global_opt=True, global_opt_iter=10):
@@ -533,6 +534,9 @@ def bac(level_of_theory, bac_type='p', train_names='main',
         level_of_theory,
         bac_type=bac_type,
         db_names=train_names,
+        crossval=crossval,
+        idxs=idxs,
+        exclude_idxs=exclude_idxs,
         exclude_elements=exclude_elements,
         charge=charge,
         multiplicity=multiplicity,

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -1111,11 +1111,14 @@ Parameter              Required?    Description
 ``level_of_theory``    Yes          Calculated data will be extracted from the reference database using this level of theory
 ``bac_type``           No           BAC type: 'p' for Petersson (default), 'm' for Melius
 ``train_names``        No           Names of training data folders in the RMG database (default: 'main')
+``crossval``           No           Perform leave-one-out cross-validation (default: False)
+``idxs``               No           Only include reference species with these indices in the training data (default: None)
+``exclude_idxs``       No           Exclude reference species with these indices from the training data (default: None)
 ``exclude_elements``   No           Exclude molecules with the elements in this list from the training data (default: None)
 ``charge``             No           Set the allowed charges ('neutral', 'positive', 'negative', or integers) for molecules in the training data (default: 'all')
 ``multiplicity``       No           Set the allowed multiplicities for molecules in the training data (default: 'all')
 ``weighted``           No           Weight the data to diversify substructures (default: False)
-``write_to_database``  No           Write the BACs to the database (default: False)
+``write_to_database``  No           Write the BACs to the database; has no effect if crossval is True (default: False)
 ``overwrite``          No           If BACs already exist, overwrite them (default: False)
 ``fit_mol_corr``       No           Fit the optional molecular correction term (Melius only, default: True)
 ``global_opt``         No           Perform a global optimization (Melius only, default: True)


### PR DESCRIPTION
### Motivation or Problem
Evaluate BAC fits with leave-one-out cross-validation.

### Description of Changes
Adds a new `CrossVal` class to perform cross-validation for BACs. Currently, only implements leave-one-out cross-validation, but can be simply extended to other types of cross-validation by adding other classes from `sklearn.model_selection`. Also adds new functionality for specifying/excluding indices of reference species when fitting BACs.

### Testing
Added unit tests for `CrossVal` class and ran some cross-validation jobs.