### PR TITLE
Updated the Pt binding energy values based on recent DFT calculations

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1350,10 +1350,10 @@ class ThermoDatabase(object):
             None, stores result in self.delta_atomic_adsorption_energy
         """
         reference_binding_energies = {
-            'C': rmgpy.quantity.Energy(-6.750, 'eV/molecule'),
-            'H': rmgpy.quantity.Energy(-2.479, 'eV/molecule'),
-            'O': rmgpy.quantity.Energy(-3.586, 'eV/molecule'),
-            'N': rmgpy.quantity.Energy(-4.352, 'eV/molecule'),
+            'C': rmgpy.quantity.Energy(-7.025, 'eV/molecule'),
+            'H': rmgpy.quantity.Energy(-2.754, 'eV/molecule'),
+            'O': rmgpy.quantity.Energy(-3.811, 'eV/molecule'),
+            'N': rmgpy.quantity.Energy(-4.632, 'eV/molecule'),
         }
 
         # Use Pt(111) reference if no binding energies are provided


### PR DESCRIPTION
The updated values are consistent with how the atomic binding energies on the other 9 metals are calculated (to be included in the database). [PR#387](https://github.com/ReactionMechanismGenerator/RMG-database/pull/387)
The DFT calculations were conducted by Katrin Blondal and Bjarne Kreitz at Brown University in the fall 2019.