### PR TITLE
Used fsolve for BM if only 1 training reaction

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -3400,7 +3400,7 @@ class KineticsFamily(Database):
             if kinetics is not None:
                 entry = entries[i]
                 std = kinetics.uncertainty.get_expected_log_uncertainty() / 0.398  # expected uncertainty is std * 0.398
-                st = "BM rule fitted to {0} training reactions at node {1}".format(len(rxnlists[i]), entry.label)
+                st = "BM rule fitted to {0} training reactions at node {1}".format(len(rxnlists[i][0]), entry.label)
                 st += "\nTotal Standard Deviation in ln(k): {0}".format(std)
                 new_entry = Entry(
                     index=index,


### PR DESCRIPTION
### Motivation or Problem
1. If there's only one training reaction in the node, we should be able to solve E0 for ArrheniusBM with A and n from the training reaction.
2. The `"BM rule fitted to {0} training reactions at node {1}".format(len(rxnlists[i]), entry.label)` always show BM rule fitted to 2 training reactions right now

### Description of Changes
1. If `len(rxns) == 1` in `fit_to_reactions`, E0 will be solved numerically with Ea from the one training reaction. Otherwise it will perform the original fitting.
2. Changed to `"BM rule fitted to {0} training reactions at node {1}".format(len(rxnlists[i][0]), entry.label)` because `rxnlists[i]` is a tuple containing a list of training reactions and the entry label `([rxns], entry.label)`.

### Testing
One-training-reaction node is very sensitive for the initial guess of E0 fed to curve_fit. For a one-training-reaction node that I'm working on, using fit_curve with the current initial guess of E0 gives this plot: 
![image](https://user-images.githubusercontent.com/45482070/84522156-24309880-aca4-11ea-9c2c-8d4fa6955fff.png)

Using a better initial guess for E0 gives this:
![image](https://user-images.githubusercontent.com/45482070/84521935-c13f0180-aca3-11ea-85ae-bf4ba0f8009a.png)

Using this PR, it gives this plot with both initial guess:
![image](https://user-images.githubusercontent.com/45482070/84522097-0400d980-aca4-11ea-9b7b-223ed1e9575e.png)




