### PR TITLE
Minor: Update group attribute name to py3

### DIFF
--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -192,6 +192,8 @@ cdef class Group(Graph):
 
     cpdef bint is_aromatic_ring(self)
 
+    cpdef bint has_wildcards(self)
+
     cpdef bint standardize_atomtype(self)
 
     cpdef bint add_explicit_ligands(self)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -2074,7 +2074,7 @@ class Group(Graph):
         for index, atom in enumerate(self.atoms):
             claimed_atom_type = atom.atomtype[0]
             # Do not perform is this atom has wildCards
-            if atom.hasWildCards:
+            if atom.has_wildcards():
                 continue
             elif claimed_atom_type is ATOMTYPES['CO'] or claimed_atom_type is ATOMTYPES['CS']:
                 for bond12 in atom.bonds.values():

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1952,6 +1952,19 @@ class Group(Graph):
                         return False
         return True
 
+    def has_wildcards(self):
+        """
+        This function is a Group level wildcards checker.
+
+        Returns a 'True' if any of the atoms in this group has wildcards.
+        """
+
+        for atom1 in self.atoms:
+            if atom1.has_wildcards():
+                return True
+
+        return False
+
     def standardize_atomtype(self):
         """
         This function changes the atomtypes in a group if the atom must

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1985,9 +1985,7 @@ class Group(Graph):
         modified = False
 
         # If this atom or any of its ligands has wild cards, then don't try to standardize
-        if self.hasWildCards: return modified
-        for bond12, atom2 in self.bonds.items():
-            if atom2.hasWildCards: return modified
+        if self.has_wildcards(): return modified
 
         # list of :class:AtomType which are elements with more sub-divided atomtypes beneath them
         specifics = [elementLabel for elementLabel in allElements if elementLabel not in nonSpecifics]

--- a/rmgpy/molecule/groupTest.py
+++ b/rmgpy/molecule/groupTest.py
@@ -397,6 +397,7 @@ class TestGroupAtom(unittest.TestCase):
         for index, atom in enumerate(group.atoms):
             self.assertTrue(atom.has_wildcards(),
                             'GroupAtom with index {0} should have wildcards, but does not'.format(index))
+        self.assertTrue(group.has_wildcards(), 'Group should have wildcards, but does not')
 
     def test_make_sample_atom(self):
         """


### PR DESCRIPTION
### Motivation or Problem
1. hasWildCards should be has_wildcards
2. standardize_atomtype() function throws attribute error because Group() doesn't have has_wildcards attribute. It really should be a checking done on the atoms.

### Description of Changes
1. Changed from hasWildCards to has_wildcards
2. Add a for loop to loop through self.atoms and changed self.has_wildcards to atom.has_wildcards.