### PR TITLE
Minor change rotor

### DIFF
--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -398,9 +398,9 @@ class GaussianLog(ESSAdapter):
             vlist = vlist[:-1]
 
         # Determine the set of dihedral angles corresponding to the loaded energies
-        # This assumes that you start at 0.0, finish at 360.0, and take
-        # constant step sizes in between
-        angle = np.arange(0.0, 2 * math.pi + 0.00001, 2 * math.pi / (len(vlist) - 1), np.float64)
+        # This assumes that all of the angles are evenly spaced with a constant step size
+        scan_res = math.pi / 180 * self._load_scan_angle()
+        angle = np.arange(0.0, scan_res * (len(vlist) - 1) + 0.00001, scan_res, np.float64)
 
         return vlist, angle
 

--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -526,32 +526,30 @@ cdef class HinderedRotor(Torsion):
         numterms = 6
         cdef bint negative_barrier
         negative_barrier = True
-        # numterms is actually half the number of terms. It is called numterms 
+        # numterms is actually half the number of terms. It is called numterms
         # because it is the number of terms of either the cosine or sine fit
 
         maxterms = np.floor(len(angle) / 3.0)
         while negative_barrier and numterms < maxterms:
             # Fit Fourier series potential
             N = V.shape[0]
-            A = np.zeros((N + 1, 2 * numterms), np.float64)
-            b = np.zeros(N + 1, np.float64)
-            for i in range(N):
-                phi = angle[i]
-                for m in range(numterms):
-                    A[i, m] = cos(m * phi)
-                    A[i, numterms + m] = sin(m * phi)
-                    b[i] = V[i]
+            # A: [1, cos(phi), ..., cos(M * phi), sin(phi), ..., sin(M * phi)]
+            A = np.zeros((N + 1, 2 * numterms - 1), np.float64)
+            A[:-1, 0] = 1
+            for m in range(1, numterms):
+                A[:-1, m] = np.cos(m * angle)
+                A[:-1, numterms + m - 1] = np.sin(m * angle)
             # This row forces dV/dangle = 0 at angle = 0
-            for m in range(numterms):
-                A[N, m + numterms] = 1
+            A[N, numterms:] = 1
+            b = np.concatenate((V, np.array([0.])))
+
             x, residues, rank, s = np.linalg.lstsq(A, b, rcond=RCOND)
             fit = np.dot(A, x)
             x *= 0.001
-            # This checks if there are any negative values in the forier fit.
-            # This part of the algorithm is replicated from the fucntion HinderedRotor(Torsion)
+            # This checks if there are any negative values in the Fourier fit.
             negative_barrier = False
             V0 = 0.0
-            self.fourier = ([x[1:numterms], x[numterms + 1:2 * numterms]], "kJ/mol")
+            self.fourier = ([x[1:numterms], x[numterms:2 * numterms - 1]], "kJ/mol")
             fourier = self._fourier.value_si
             for k in range(fourier.shape[1]):
                 V0 -= fourier[0, k] * (k + 1) * (k + 1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Minor changes to Arkane's rotor related functions.

For commit 1, ARC is currently using load_scan_enerigies(). However, load_scan_enerigies() is always assuming the scan is 0 - 360, which may not be true.
For commit 2, When fitting scanned PES to a Fourier series, we are now fitting:
`k_0 * cos(0 * phi) + ... + k_n * cos(n * phi) + k_n+1  * sin(0 * phi) + .... + k_2n * sin(n * phi) = E`
and 
`k_n+1 + k_n+2 ... + k_2n = 0`
However, I don't think we should include `k_n+1`, we are fitting a coefficient before a variable that always equal to zero. This will not helpful to the fitting, but also weaken the constraint we put `k_n+1 + k_n+2 ... + k_2n = 0`, since `k_n+1` literally can be any number. 

### Description of Changes
For commit 1, the script uses the actual scan step size to build up the `angle` array.
For commit 2, I remove the sin(0*phi)s from A matrix and vectorize some of the calculations.

### Testing
The unit tests are passed. I also did some tests on rotor related calculations. `load_scan_energies` works as designed, and the fitted curves has very tiny differences compared to previous ones, but dV/dangle(0) is closed to zero (makes the result better in some cases).

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
