### PR TITLE
Short-circuit Species.is_isomorphic when strict=False

### DIFF
--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -291,12 +291,16 @@ class Species(object):
                 if molecule.is_isomorphic(other, generate_initial_map=generate_initial_map,
                                           save_order=save_order, strict=strict):
                     return True
+                elif not strict:
+                    return False
         elif isinstance(other, Species):
             for molecule1 in self.molecule:
                 for molecule2 in other.molecule:
                     if molecule1.is_isomorphic(molecule2, generate_initial_map=generate_initial_map,
                                                save_order=save_order, strict=strict):
                         return True
+                    elif not strict:
+                        return False
         else:
             raise ValueError('Unexpected value "{0!r}" for other parameter;'
                              ' should be a Molecule or Species object.'.format(other))

--- a/rmgpy/speciesTest.py
+++ b/rmgpy/speciesTest.py
@@ -437,6 +437,26 @@ Thermo library: primaryThermoLibrary
         test = Species(smiles='C1=CC=CC=C1')
 
         self.assertTrue(test.is_isomorphic(self.species2))
+        
+    def test_is_isomorphic_strict(self):
+        """Test that the strict argument to Species.is_isomorphic works"""
+        spc1 = Species(smiles='[CH2]C1=CC=CC2=C1C=CC1=C2C=CC=C1')
+        spc2 = Species(smiles='C=C1C=CC=C2C1=C[CH]C1=C2C=CC=C1')
+        spc3 = Species(smiles='[CH2]C1=CC2=C(C=C1)C1=C(C=CC=C1)C=C2')
+
+        self.assertFalse(spc1.is_isomorphic(spc2, strict=True))
+        self.assertTrue(spc1.is_isomorphic(spc2, strict=False))
+        self.assertFalse(spc1.is_isomorphic(spc3, strict=True))
+        self.assertFalse(spc1.is_isomorphic(spc3, strict=False))
+
+        spc1.generate_resonance_structures()
+        spc2.generate_resonance_structures()
+        spc3.generate_resonance_structures()
+
+        self.assertTrue(spc1.is_isomorphic(spc2, strict=True))
+        self.assertTrue(spc1.is_isomorphic(spc2, strict=False))
+        self.assertFalse(spc1.is_isomorphic(spc3, strict=True))
+        self.assertFalse(spc1.is_isomorphic(spc3, strict=False))
 
 
 ################################################################################


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
For non-strict isomorphism, a single negative comparison is sufficient to conclude that two species are different. Therefore, `Species.is_isomorphic` should return early instead of doing comparing all resonance structure combinations.

Thanks to @alongd for pointing out the bug.

### Description of Changes
Fix `Species.is_isomorphic` to return early when `strict=False`.

### Testing
A unit test was added to confirm that the `strict` argument works properly. I also tested to confirm that it correctly returns early now, but it's not straightforward to write a unit test for that.
