### PR TITLE
Modify Pmin/Pmax code in main.py & Feed in species_list for ThirdBody type kinetics to allow collision limit violation check

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -63,6 +63,7 @@ from rmgpy.data.kinetics.library import KineticsLibrary, LibraryReaction
 from rmgpy.data.rmg import RMGDatabase
 from rmgpy.exceptions import ForbiddenStructureException, DatabaseError, CoreError
 from rmgpy.kinetics.diffusionLimited import diffusion_limiter
+from rmgpy.kinetics import ThirdBody
 from rmgpy.molecule import Molecule
 from rmgpy.qm.main import QMDatabaseWriter
 from rmgpy.reaction import Reaction
@@ -1244,7 +1245,10 @@ class RMG(util.Subject):
                                   '"Violation factor" is the ratio of the rate coefficient to the collision limit'
                                   ' rate at the relevant conditions\n\n')
                 for violator in violators:
-                    rxn_string = violator[0].to_chemkin()
+                    if isinstance(violator[0].kinetics, ThirdBody):
+                        rxn_string = violator[0].to_chemkin(self.reaction_model.core.species)
+                    else:
+                        rxn_string = violator[0].to_chemkin()
                     direction = violator[1]
                     ratio = violator[2]
                     condition = violator[3]

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -674,12 +674,8 @@ class RMG(util.Subject):
         # determine min and max values for T and P (don't determine P values for liquid reactors)
         self.Tmin = min([x.Trange[0].value_si if x.Trange else x.T.value_si for x in self.reaction_systems])
         self.Tmax = max([x.Trange[1].value_si if x.Trange else x.T.value_si for x in self.reaction_systems])
-        try:
-            self.Pmin = min([x.Prange[0].value_si if x.Prange else x.P.value_si for x in self.reaction_systems])
-            self.Pmax = max([x.Prange[1].value_si if x.Prange else x.P.value_si for x in self.reaction_systems])
-        except AttributeError:
-            # For LiquidReactor, Pmin and Pmax remain with the default value of `None`
-            pass
+        self.Pmin = min([x.Prange[0].value_si if hasattr(x, 'Prange') and x.Prange else x.P.value_si for x in self.reaction_systems])
+        self.Pmax = max([x.Prange[1].value_si if hasattr(x, 'Prange') and x.Prange else x.P.value_si for x in self.reaction_systems])
 
         self.rmg_memories = []
 


### PR DESCRIPTION
### Motivation or Problem
See #1872.

Essentially the original code intended to get reactions to high pressure limit by setting P=1e8 Pa in LiquidReactor, but it couldn't perform the collision limit violation check for PDep type reactions because LiquidReactor doesn't have Prange attribute. (main.py line 677)

```
        try:
            self.Pmin = min([x.Prange[0].value_si if x.Prange else x.P.value_si for x in self.reaction_systems])
            self.Pmax = max([x.Prange[1].value_si if x.Prange else x.P.value_si for x in self.reaction_systems])
        except AttributeError:
            # For LiquidReactor, Pmin and Pmax remain with the default value of `None`
            pass
```

### Description of Changes
Added dummy variable `Prange` in LiquidReactor. With this, Pmin = Pmax = P = 1e8 Pa to get reactions to high pressure limit for LiquidReactor.

### Testing

This is my testing script. The original code gave an AttributeError when trying to access x.Prange. This PR's code can perform the collision limit violation check.

```
from rmgpy.rmg.main import RMG, RMGDatabase
from rmgpy.solver.liquid import LiquidReactor
from rmgpy.kinetics import PDepArrhenius
from rmgpy import settings

rmg = RMG()
rmg.reaction_systems = [LiquidReactor(298,{})]

rmg.Tmin = min([x.Trange[0].value_si if x.Trange else x.T.value_si for x in rmg.reaction_systems])
rmg.Tmax = max([x.Trange[1].value_si if x.Trange else x.T.value_si for x in rmg.reaction_systems])
rmg.Pmin = min([x.Prange[0].value_si if x.Prange else x.P.value_si for x in rmg.reaction_systems])
rmg.Pmax = max([x.Prange[1].value_si if x.Prange else x.P.value_si for x in rmg.reaction_systems])

db = RMGDatabase()
db.load(
    path=settings['database.directory'],
    thermo_libraries=['primaryThermoLibrary'],
    transport_libraries=[],
    reaction_libraries=['NOx2018'],
    seed_mechanisms=[],
    kinetics_families='default',
    kinetics_depositories=['training'],
    depository=False,
)

for rxn in db.kinetics.libraries["NOx2018"].get_library_reactions():
    if isinstance(rxn.kinetics,PDepArrhenius):
        for i, spc in enumerate(rxn.reactants):
            rxn.reactants[i].thermo = db.thermo.get_thermo_data(spc)
        for i, spc in enumerate(rxn.products):
            rxn.products[i].thermo = db.thermo.get_thermo_data(spc)
        PDeprxn = rxn
        break

PDeprxn.check_collision_limit_violation(t_min=rmg.Tmin, t_max=rmg.Tmax,p_min=rmg.Pmin, p_max=rmg.Pmax)
```