### PR TITLE
Updated catalystProperties in catalysis example input files

### DIFF
--- a/examples/rmg/catalysis/ch4_o2/input.py
+++ b/examples/rmg/catalysis/ch4_o2/input.py
@@ -11,12 +11,12 @@ database(
 
 catalystProperties(
     bindingEnergies = {  # default values for Pt(111)    
-                          'H': (-2.479, 'eV/molecule'),
-                          'O': (-3.586, 'eV/molecule'),
-                          'C': (-6.750, 'eV/molecule'),
-                          'N': (-4.352, 'eV/molecule'),
+                          'H': (-2.754, 'eV/molecule'),
+                          'O': (-3.811, 'eV/molecule'),
+                          'C': (-7.025, 'eV/molecule'),
+                          'N': (-4.632, 'eV/molecule'),
                       },
-    surfaceSiteDensity=(2.72e-9, 'mol/cm^2'), # Default for Pt(111)
+    surfaceSiteDensity=(2.483e-9, 'mol/cm^2'), # Default for Pt(111)
 )
 
 species(

--- a/examples/rmg/catalysis/methane_steam/input.py
+++ b/examples/rmg/catalysis/methane_steam/input.py
@@ -10,12 +10,12 @@ database(
 
 catalystProperties(
     bindingEnergies = {  # values for Ni(111)
-                        'H': (-2.778, 'eV/molecule'),
-                        'O': (-4.485, 'eV/molecule'),
-                        'C': (-5.997, 'eV/molecule'),
-                        'N': (-4.352, 'eV/molecule'), # Unknown! don't use with Nitrogen adsorbates!
+                        'H': (-2.892, 'eV/molecule'),
+                        'O': (-4.989, 'eV/molecule'),
+                        'C': (-6.798, 'eV/molecule'),
+                        'N': (-5.164, 'eV/molecule'), 
                       },
-    surfaceSiteDensity=(2.9e-9, 'mol/cm^2'), # values for Ni(111)
+    surfaceSiteDensity=(3.148e-9, 'mol/cm^2'), # values for Ni(111)
 )
 
 # List of species


### PR DESCRIPTION
To be consistent with the hard-coded Pt111 reference binding energy values and with the metal attributes database. https://github.com/ReactionMechanismGenerator/RMG-database/commit/05ee78b278b54f40713d2f58c5b30cd692f5319
(Updated both the bindingEnergies and surfaceSiteDensity).

Addresses issue #1995 

The updated values were calculated by Katrin Blondal and Bjarne Kreitz at Brown University, using the PBE-D3(ABC) functional.
