### PR TITLE
halogen additions (simultaneous update with DB)

### DIFF
--- a/documentation/source/reference/molecule/atomtype.rst
+++ b/documentation/source/reference/molecule/atomtype.rst
@@ -23,6 +23,7 @@ Atom type       Description
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ``R``           any atom with any local bond structure
 ``R!H``         any non-hydrogen atom with any local bond structure
+``R!H!Val7``    any non-hydrogen and non-halogen atom (a non-terminal atom)
 *Hydrogen atom types*
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ``H``           hydrogen atom with up to one single bond

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -350,7 +350,7 @@ class Database(object):
                 f.write(species_dict[label].molecule[0].to_adjacency_list(label=label, remove_h=False))
                 f.write('\n')
 
-    def save(self, path):
+    def save(self, path, reindex=True):
         """
         Save the current database to the file at location `path` on disk. 
         """
@@ -358,7 +358,11 @@ class Database(object):
             os.makedirs(os.path.dirname(path))
         except OSError:
             pass
-        entries = self.get_entries_to_save()
+        
+        if reindex:
+            entries = self.get_entries_to_save()
+        else: 
+            entries = self.entries.values()
 
         f = codecs.open(path, 'w', 'utf-8')
         f.write('#!/usr/bin/env python\n')

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -2138,8 +2138,8 @@ class ThermoDatabase(object):
         cyclic = molecule.is_cyclic()
         # Generate estimates of the thermodynamics parameters
         for atom in molecule.atoms:
-            # Iterate over heavy (non-hydrogen) atoms
-            if atom.is_non_hydrogen():
+            # Iterate over atoms and skip hydogens and halogens (since there are no groups centered on these atomtypes)
+            if atom.is_non_hydrogen() and not atom.is_halogen():
                 # Get initial thermo estimate from main group database
                 data_added = False
                 try:

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -256,7 +256,8 @@ ATOMTYPES['Xo']   = AtomType('Xo', generic=['X'], specific=[],
 ATOMTYPES['R']    = AtomType(label='R', generic=[], specific=[
     'H',
     'R!H',
-    'Val4','Val5','Val6','Val7',    
+    'R!H!Val7',
+    'Val4','Val5','Val6','Val7',
     'He','Ne','Ar',
     'C','Ca','Cs','Csc','Cd','CO','CS','Cdd','Cdc','Ct','Cb','Cbf','Cq','C2s','C2sc','C2d','C2dc','C2tc',
     'N','N0sc','N1s','N1sc','N1dc','N3s','N3sc','N3d','N3t','N3b','N5sc','N5dc','N5ddc','N5dddc','N5tc','N5b','N5bd',
@@ -283,15 +284,26 @@ ATOMTYPES['R!H']  = AtomType(label='R!H', generic=['R'], specific=[
     'I','I1s',
     'F','F1s'])
 
-ATOMTYPES['Val4'] = AtomType(label='Val4', generic=['R', 'R!H'], specific=[
+ATOMTYPES['R!H!Val7']  = AtomType(label='R!H!Val7', generic=['R'], specific=[
+    'Val4','Val5','Val6',
+    'He','Ne','Ar',
+    'C','Ca','Cs','Csc','Cd','CO','CS','Cdd','Cdc','Ct','Cb','Cbf','Cq','C2s','C2sc','C2d','C2dc','C2tc',
+    'N','N0sc','N1s','N1sc','N1dc','N3s','N3sc','N3d','N3t','N3b','N5sc','N5dc','N5ddc','N5dddc','N5tc','N5b','N5bd',
+    'O','Oa','O0sc','O2s','O2sc','O2d','O4sc','O4dc','O4tc','O4b',
+    'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf','Siq',
+    'P','P0sc','P1s','P1sc','P1dc','P3s','P3d','P3t','P3b','P5s','P5sc','P5d','P5dd','P5dc','P5ddc','P5t','P5td','P5tc','P5b','P5bd',
+    'S','Sa','S0sc','S2s','S2sc','S2d','S2dc','S2tc','S4s','S4sc','S4d','S4dd','S4dc','S4b','S4t','S4tdc','S6s','S6sc','S6d','S6dd','S6ddd','S6dc','S6t','S6td','S6tt','S6tdc',
+    ])
+
+ATOMTYPES['Val4'] = AtomType(label='Val4', generic=['R', 'R!H', 'R!H!Val7'], specific=[
     'C','Ca','Cs','Csc','Cd','CO','CS','Cq','Cdd','Cdc','Ct','Cb','Cbf','C2s','C2sc','C2d','C2dc','C2tc',
     'Si','Sis','Sid','Sidd','Sit','SiO','Sib','Sibf','Siq'])
 
-ATOMTYPES['Val5'] = AtomType(label='Val5', generic=['R', 'R!H'], specific=[
+ATOMTYPES['Val5'] = AtomType(label='Val5', generic=['R', 'R!H', 'R!H!Val7'], specific=[
     'N','N0sc','N1s','N1sc','N1dc','N3s','N3sc','N3d','N3t','N3b','N5sc','N5dc','N5ddc','N5dddc','N5tc','N5b','N5bd',
     'P','P0sc','P1s','P1sc','P1dc','P3s','P3d','P3t','P3b','P5s','P5sc','P5d','P5dd','P5dc','P5ddc','P5t','P5td','P5tc','P5b','P5bd'])
 
-ATOMTYPES['Val6'] = AtomType(label='Val6', generic=['R', 'R!H'], specific=[
+ATOMTYPES['Val6'] = AtomType(label='Val6', generic=['R', 'R!H', 'R!H!Val7'], specific=[
     'O','Oa','O0sc','O2s','O2sc','O2d','O4sc','O4dc','O4tc','O4b',
     'S','Sa','S0sc','S2s','S2sc','S2d','S2dc','S2tc','S4s','S4sc','S4d','S4dd','S4dc','S4b','S4t','S4tdc','S6s','S6sc','S6d','S6dd','S6ddd','S6dc','S6t','S6td','S6tt','S6tdc'])
 
@@ -303,300 +315,300 @@ ATOMTYPES['Val7'] = AtomType(label='Val7', generic=['R', 'R!H'], specific=[
 
 ATOMTYPES['H'] = AtomType('H', generic=['R'], specific=[])
 
-ATOMTYPES['He'] = AtomType('He', generic=['R', 'R!H'], specific=[])
-ATOMTYPES['Ne'] = AtomType('Ne', generic=['R', 'R!H'], specific=[])
-ATOMTYPES['Ar'] = AtomType('Ar', generic=['R', 'R!H'], specific=[])
+ATOMTYPES['He'] = AtomType('He', generic=['R', 'R!H', 'R!H!Val7'], specific=[])
+ATOMTYPES['Ne'] = AtomType('Ne', generic=['R', 'R!H', 'R!H!Val7'], specific=[])
+ATOMTYPES['Ar'] = AtomType('Ar', generic=['R', 'R!H', 'R!H!Val7'], specific=[])
 
-ATOMTYPES['C'] = AtomType('C', generic=['R', 'R!H', 'Val4'], specific=['Ca', 'Cs', 'Csc', 'Cd', 'CO', 'Cq', 'CS', 'Cdd', 'Cdc', 'Ct', 'Cb', 'Cbf', 'C2s', 'C2sc', 'C2d', 'C2dc', 'C2tc'],
+ATOMTYPES['C'] = AtomType('C', generic=['R', 'R!H', 'R!H!Val7', 'Val4'], specific=['Ca', 'Cs', 'Csc', 'Cd', 'CO', 'Cq', 'CS', 'Cdd', 'Cdc', 'Ct', 'Cb', 'Cbf', 'C2s', 'C2sc', 'C2d', 'C2dc', 'C2tc'],
                           single=[], all_double=[], r_double=[], o_double=[], s_double=[], triple=[], quadruple=[], benzene=[], lone_pairs=[], charge=[])  # todo: double check to see if quadruple should be blank or 0 for all of these as well as being 1 for quadruple
-ATOMTYPES['Ca'] = AtomType('Ca', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 4)
+ATOMTYPES['Ca'] = AtomType('Ca', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 4)
                            single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for Ca: atomic carbon (closed shell)
-ATOMTYPES['Cs'] = AtomType('Cs', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 4-8)
+ATOMTYPES['Cs'] = AtomType('Cs', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 4-8)
                            single=[0,1,2,3,4], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for Cs: C, CC,
-ATOMTYPES['Csc'] = AtomType('Csc', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 3-6)
+ATOMTYPES['Csc'] = AtomType('Csc', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 3-6)
                             single=[0,1,2,3], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for Csc: C1=CCC([O-])[CH+]1, O[O+]=C[C+]C([O-])[O-]
-ATOMTYPES['Cd'] = AtomType('Cd', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 6-8)
+ATOMTYPES['Cd'] = AtomType('Cd', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 6-8)
                            single=[0,1,2], all_double=[1], r_double=[1], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for Cd: C=C, C=N
-ATOMTYPES['Cdc'] = AtomType('Cdc', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 6)
+ATOMTYPES['Cdc'] = AtomType('Cdc', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 6)
                             single=[0,1], all_double=[1], r_double=[0, 1], o_double=[0, 1], s_double=[0, 1], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for Cdc: [CH+]=C=[CH-], [CH+]=N[O-] (one of the res structures of Fulminic acid)
-ATOMTYPES['CO'] = AtomType('CO', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 6-8)
+ATOMTYPES['CO'] = AtomType('CO', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 6-8)
                            single=[0,1,2], all_double=[1], r_double=[0], o_double=[1], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for CO: C=O
-ATOMTYPES['CS'] = AtomType('CS', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 6-8)
+ATOMTYPES['CS'] = AtomType('CS', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 6-8)
                            single=[0,1,2], all_double=[1], r_double=[0], o_double=[0], s_double=[1], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for CS: C=S
-ATOMTYPES['Cdd'] = AtomType('Cdd', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['Cdd'] = AtomType('Cdd', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 8)
                             single=[0], all_double=[2], r_double=[0, 1, 2], o_double=[0, 1, 2], s_double=[0, 1, 2], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for Cdd: O=C=O, C=C=C
-ATOMTYPES['Ct'] = AtomType('Ct', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['Ct'] = AtomType('Ct', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 7-8)
                            single=[0,1], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for Ct: C#C, C#N
-ATOMTYPES['Cb'] = AtomType('Cb', generic=['R', 'R!H', 'C', 'Val4'], specific=[],
+ATOMTYPES['Cb'] = AtomType('Cb', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],
                            single=[0,1], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[1, 2], lone_pairs=[], charge=[])
 # examples for Cb: benzene (C6H6)
-ATOMTYPES['Cbf'] = AtomType('Cbf', generic=['R', 'R!H', 'C', 'Val4'], specific=[],
+ATOMTYPES['Cbf'] = AtomType('Cbf', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],
                             single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[3], lone_pairs=[], charge=[])
 # examples for Cbf: Naphthalene
-ATOMTYPES['Cq'] = AtomType('Cq', generic=['R', 'R!H', 'C', 'Val4'], specific=[],
+ATOMTYPES['Cq'] = AtomType('Cq', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],
                            single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[1], benzene=[0], lone_pairs=[], charge=[])
 # examples for Cq: C2
-ATOMTYPES['C2s'] = AtomType('C2s', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 4-6)
+ATOMTYPES['C2s'] = AtomType('C2s', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 4-6)
                             single=[0,1,2], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for C2s: singlet[CH2]
-ATOMTYPES['C2sc'] = AtomType('C2sc', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 5-8)
+ATOMTYPES['C2sc'] = AtomType('C2sc', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 5-8)
                              single=[0,1,2,3], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[-1])
 # examples for C2sc: [CH2-][N+]#N
-ATOMTYPES['C2d'] = AtomType('C2d', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 6)
+ATOMTYPES['C2d'] = AtomType('C2d', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 6)
                             single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for C2d: singlet[C]=C
-ATOMTYPES['C2dc'] = AtomType('C2dc', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['C2dc'] = AtomType('C2dc', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 7-8)
                              single=[0,1], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[-1])
 # examples for C2dc: C=[C-][N+]#N, [CH-]=[N+]=O, [CH+]=C=[CH-]
-ATOMTYPES['C2tc'] = AtomType('C2tc', generic=['R', 'R!H', 'C', 'Val4'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['C2tc'] = AtomType('C2tc', generic=['R', 'R!H', 'R!H!Val7', 'C', 'Val4'], specific=[],  # (shared electrons = 8)
                              single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[1], charge=[-1])
 # examples for C2tc: [C-]#[O+], H[N+]#[C-]
 
-ATOMTYPES['N'] = AtomType('N', generic=['R', 'R!H', 'Val5'], specific=['N0sc', 'N1s', 'N1sc', 'N1dc', 'N3s', 'N3sc', 'N3d', 'N3t', 'N3b', 'N5sc', 'N5dc', 'N5ddc', 'N5dddc', 'N5tc', 'N5b', 'N5bd'],
+ATOMTYPES['N'] = AtomType('N', generic=['R', 'R!H', 'R!H!Val7', 'Val5'], specific=['N0sc', 'N1s', 'N1sc', 'N1dc', 'N3s', 'N3sc', 'N3d', 'N3t', 'N3b', 'N5sc', 'N5dc', 'N5ddc', 'N5dddc', 'N5tc', 'N5b', 'N5bd'],
                           single=[], all_double=[], r_double=[], o_double=[], s_double=[], triple=[], quadruple=[], benzene=[], lone_pairs=[], charge=[])
-ATOMTYPES['N0sc'] = AtomType('N0sc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['N0sc'] = AtomType('N0sc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 7-8)
                              single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[3], charge=[-2])
 # examples for N0sc: [NH+]#[N+][N-2] with adjList 1 N u0 p0 c+1 {2,S} {3,T}; 2 H u0 p0 c0 {1,S}; 3 N u0 p0 c+1 {1,T} {4,S}; 4 N u0 p3 c-2 {3,S}
-ATOMTYPES['N1s'] = AtomType('N1s', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 5-6)
+ATOMTYPES['N1s'] = AtomType('N1s', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 5-6)
                             single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for N1s: closed shell N-N, closed shell NH
-ATOMTYPES['N1sc'] = AtomType('N1sc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 6-8)
+ATOMTYPES['N1sc'] = AtomType('N1sc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 6-8)
                              single=[0,1,2], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1])
 # examples for N1sc: [NH-][S+]=C, [NH-][N+]#C
-ATOMTYPES['N1dc'] = AtomType('N1dc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['N1dc'] = AtomType('N1dc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 8)
                              single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1])
 # examples for N1dc: [N-]=[N+]=N terminal nitrogen on azide (two lone pairs), [N-]=[NH+], [N-]=[SH+]
-ATOMTYPES['N3s'] = AtomType('N3s', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 5-8)
+ATOMTYPES['N3s'] = AtomType('N3s', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 5-8)
                             single=[0,1,2,3], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for N3s: NH3, NH2, NH, N, C[NH]...
-ATOMTYPES['N3sc'] = AtomType('N3sc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 4-6)
+ATOMTYPES['N3sc'] = AtomType('N3sc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 4-6)
                              single=[0,1,2], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[+1])
 # examples for N3sc: !! N3sc should eventually be deleted, see #1206
-ATOMTYPES['N3d'] = AtomType('N3d', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['N3d'] = AtomType('N3d', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 7-8)
                             single=[0,1], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for N3d: N=O, N=N, C=N, [O]N=O, [N]=O, [N]=C
-ATOMTYPES['N3t'] = AtomType('N3t', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['N3t'] = AtomType('N3t', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 8)
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[1], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for N3t: N2, N#C, N#[C], N#CC
-ATOMTYPES['N3b'] = AtomType('N3b', generic=['R', 'R!H', 'N', 'Val5'], specific=[],
+ATOMTYPES['N3b'] = AtomType('N3b', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[1], charge=[0])
 # examples for N3b: Oxazole, Pyradine, Pyrazine, 1,3,5-Triazine, Benzimidazole, Purine
-ATOMTYPES['N5sc'] = AtomType('N5sc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 4-8)
+ATOMTYPES['N5sc'] = AtomType('N5sc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 4-8)
                              single=[0,1,2,3,4], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], benzene=[0], lone_pairs=[0], charge=[+1, +2])
 # examples for N5sc: [NH3+][O-]
-ATOMTYPES['N5dc'] = AtomType('N5dc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 6-8)
+ATOMTYPES['N5dc'] = AtomType('N5dc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 6-8)
                              single=[0,1,2], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for N5dc: O[N+](=O)(O-) nitrate group, [N+](=O)(O)[O-], O=[N+][O-], [N+](=O)(O[N+](=O)[O-])[O-], C=[N+]=[SH-], [NH2+]=[SH-]
-ATOMTYPES['N5ddc'] = AtomType('N5ddc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['N5ddc'] = AtomType('N5ddc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 8)
                               single=[0], all_double=[2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for N5ddc: N=[N+]=[N-] center nitrogen on azide, [N-]=[N+]=O, C=[N+]=[SH-]
-ATOMTYPES['N5dddc'] = AtomType('N5dddc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 6)
+ATOMTYPES['N5dddc'] = AtomType('N5dddc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 6)
                                single=[0], all_double=[3], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[-1])
 # examples for N5dddc: C=[N-](=C)=[NH2+]
-ATOMTYPES['N5tc'] = AtomType('N5tc', generic=['R', 'R!H', 'N', 'Val5'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['N5tc'] = AtomType('N5tc', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],  # (shared electrons = 7-8)
                              single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for N5tc: C[N+]#[C-] isocyano group, N#[N+][O-], [NH+]#[C-] (note that C- has p1 here), [N+]#[C-] (note that C- has p1 here), [O-][N+]#C (one of the res structures of Fulminic acid), C[N+]#[C-] (note that C- has p1 here)
-ATOMTYPES['N5b'] = AtomType('N5b', generic=['R', 'R!H', 'N', 'Val5'], specific=[],
+ATOMTYPES['N5b'] = AtomType('N5b', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],
                             single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[0], charge=[0, +1])
 # examples for N5b: Pyrrole, Indole, Benzimidazole, Purine; Note that this is the only N atomtype with valence 5 which isn't necessarily charged.
-ATOMTYPES['N5bd'] = AtomType('N5bd', generic=['R', 'R!H', 'N', 'Val5'], specific=[],
+ATOMTYPES['N5bd'] = AtomType('N5bd', generic=['R', 'R!H', 'R!H!Val7', 'N', 'Val5'], specific=[],
                              single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[2], lone_pairs=[0], charge=[0])
 # examples for N5bd: AdjList """1 N u0 p0 c0 {2,B} {6,B} {7,D} 2 C u0 p0 {1,B} {3,B} {8,S} 3 C u0 p0 {2,B} {4,B} {9,S} 4 C u0 p0 {3,B} {5,B} {10,S} 5 C u0 p0 {4,B} {6,B} {11,S} 6 N u0 p1 {1,B} {5,B} 7 O u0 p2 c0 {1,D} 8 H u0 p0 {2,S} 9 H u0 p0 {3,S} 10 H u0 p0 {4,S} 11 H u0 p0 {5,S}"""
 
-ATOMTYPES['O'] = AtomType('O', generic=['R', 'R!H', 'Val6'], specific=['Oa', 'O0sc', 'O2s', 'O2sc', 'O2d', 'O4sc', 'O4dc', 'O4tc', 'O4b'],
+ATOMTYPES['O'] = AtomType('O', generic=['R', 'R!H', 'R!H!Val7', 'Val6'], specific=['Oa', 'O0sc', 'O2s', 'O2sc', 'O2d', 'O4sc', 'O4dc', 'O4tc', 'O4b'],
                           single=[], all_double=[], r_double=[], o_double=[], s_double=[], triple=[], quadruple=[], benzene=[], lone_pairs=[], charge=[])
-ATOMTYPES['Oa'] = AtomType('Oa', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 6)
+ATOMTYPES['Oa'] = AtomType('Oa', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 6)
                            single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[3], charge=[0])
 # examples for Oa: atomic oxygen (closed shell)
-ATOMTYPES['O0sc'] = AtomType('O0sc', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['O0sc'] = AtomType('O0sc', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
                              single=[0,1], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[3], charge=[-1])
 # examples for O0sc: Nitric acid O[N+](=O)([O-])
-ATOMTYPES['O2s'] = AtomType('O2s', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['O2s'] = AtomType('O2s', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
                             single=[0,1,2], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for O2s: H2O, OH, CH3OH
-ATOMTYPES['O2sc'] = AtomType('O2sc', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 6)
+ATOMTYPES['O2sc'] = AtomType('O2sc', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 6)
                              single=[0,1], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[+1])
 # examples for O2sc: C=[S-][O+]
-ATOMTYPES['O2d'] = AtomType('O2d', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['O2d'] = AtomType('O2d', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
                             single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for O2d: CO2, CH2O
-ATOMTYPES['O4sc'] = AtomType('O4sc', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 5-8)
+ATOMTYPES['O4sc'] = AtomType('O4sc', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 5-8)
                              single=[0,1,2,3], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[+1])
 # examples for O4sc: [O-][OH+]C
-ATOMTYPES['O4dc'] = AtomType('O4dc', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['O4dc'] = AtomType('O4dc', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 7-8)
                              single=[0,1], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[+1])
 # examples for O4dc: the positively charged O in ozone [O-][O+]=O
-ATOMTYPES['O4tc'] = AtomType('O4tc', generic=['R', 'R!H', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['O4tc'] = AtomType('O4tc', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],  # (shared electrons = 8)
                              single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[1], charge=[+1])
 # examples for O4tc: [C-]#[O+]
-ATOMTYPES['O4b'] = AtomType('O4b', generic=['R', 'R!H', 'O', 'Val6'], specific=[],
+ATOMTYPES['O4b'] = AtomType('O4b', generic=['R', 'R!H', 'R!H!Val7', 'O', 'Val6'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[1], charge=[0])
 # examples for O4b: Furane, Benzofurane, Oxazole...
 
-ATOMTYPES['Ne'] = AtomType('Ne', generic=['R', 'R!H'], specific=[])
-ATOMTYPES['Si'] = AtomType('Si', generic=['R', 'R!H', 'Val4'], specific=['Sis', 'Sid', 'Sidd', 'Sit', 'SiO', 'Sib', 'Sibf', 'Siq'],
+ATOMTYPES['Ne'] = AtomType('Ne', generic=['R', 'R!H', 'R!H!Val7'], specific=[])
+ATOMTYPES['Si'] = AtomType('Si', generic=['R', 'R!H', 'R!H!Val7', 'Val4'], specific=['Sis', 'Sid', 'Sidd', 'Sit', 'SiO', 'Sib', 'Sibf', 'Siq'],
                            single=[], all_double=[], r_double=[], o_double=[], s_double=[], triple=[], quadruple=[], benzene=[], lone_pairs=[], charge=[])
-ATOMTYPES['Sis'] = AtomType('Sis', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Sis'] = AtomType('Sis', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                             single=[], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[], charge=[])
-ATOMTYPES['SiO'] = AtomType('SiO', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['SiO'] = AtomType('SiO', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                             single=[], all_double=[1], r_double=[], o_double=[1], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[], charge=[])
-ATOMTYPES['Sid'] = AtomType('Sid', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Sid'] = AtomType('Sid', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                             single=[], all_double=[1], r_double=[], o_double=[0], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[], charge=[])
-ATOMTYPES['Sidd'] = AtomType('Sidd', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Sidd'] = AtomType('Sidd', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                              single=[], all_double=[2], r_double=[0, 1, 2], o_double=[0, 1, 2], s_double=[0, 1, 2], triple=[0], quadruple=[], benzene=[0], lone_pairs=[], charge=[])
-ATOMTYPES['Sit'] = AtomType('Sit', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Sit'] = AtomType('Sit', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                             single=[], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[], charge=[])
-ATOMTYPES['Sib'] = AtomType('Sib', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Sib'] = AtomType('Sib', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                             single=[], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[2], lone_pairs=[], charge=[])
-ATOMTYPES['Sibf'] = AtomType('Sibf', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Sibf'] = AtomType('Sibf', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                              single=[], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[3], lone_pairs=[], charge=[])
-ATOMTYPES['Siq'] = AtomType('Siq', generic=['R', 'R!H', 'Si', 'Val4'], specific=[],
+ATOMTYPES['Siq'] = AtomType('Siq', generic=['R', 'R!H', 'R!H!Val7', 'Si', 'Val4'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[1], benzene=[0], lone_pairs=[], charge=[])
 
-ATOMTYPES['P'] = AtomType('P', generic=['R', 'R!H', 'Val5'], specific=['P0sc', 'P1s', 'P1sc', 'P1dc', 'P3s', 'P3d', 'P3t', 'P3b', 'P5s', 'P5sc', 'P5d', 'P5dd', 'P5dc', 'P5ddc', 'P5t', 'P5td', 'P5tc', 'P5b', 'P5bd'],
+ATOMTYPES['P'] = AtomType('P', generic=['R', 'R!H', 'R!H!Val7', 'Val5'], specific=['P0sc', 'P1s', 'P1sc', 'P1dc', 'P3s', 'P3d', 'P3t', 'P3b', 'P5s', 'P5sc', 'P5d', 'P5dd', 'P5dc', 'P5ddc', 'P5t', 'P5td', 'P5tc', 'P5b', 'P5bd'],
                           single=[], all_double=[], r_double=[], o_double=[], s_double=[], triple=[], quadruple=[], benzene=[], lone_pairs=[], charge=[])
-ATOMTYPES['P0sc'] = AtomType('P0sc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P0sc'] = AtomType('P0sc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[3], charge=[-2])
 # examples for P0sc: [PH-2] (Phosphanediide), [P-2][P+]#[PH+] with adjList '''1 P u0 p3 c-2 {2,S}  2 P u0 p0 c+1 {1,S} {3,T} 3 P u0 p0 c+1 {2,T} {4,S}  4 H u0 p0 c0 {3,S}'''
-ATOMTYPES['P1s'] = AtomType('P1s', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P1s'] = AtomType('P1s', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for P1s: closed shell [PH] (Phosphinidene)
-ATOMTYPES['P1sc'] = AtomType('P1sc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P1sc'] = AtomType('P1sc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0,1,2], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1])
 # examples for P1sc: C[PH-] (methylphosphanide)
-ATOMTYPES['P1dc'] = AtomType('P1dc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P1dc'] = AtomType('P1dc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1])
 # examples for P1dc: C=[P-] (methylidenephosphanide)
-ATOMTYPES['P3s'] = AtomType('P3s', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P3s'] = AtomType('P3s', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1,2,3], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for P3s: PH3, PCl3
-ATOMTYPES['P3d'] = AtomType('P3d', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P3d'] = AtomType('P3d', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for P3d: O=[PH] with adjList '''1 O u0 p2 c0 {2,D} 2 P u0 p1 c0 {1,D} {3,S} 3 H u0 p0 c0 {2,S}'''
-ATOMTYPES['P3t'] = AtomType('P3t', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P3t'] = AtomType('P3t', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[1], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for P3t: P#P (diphosphorus)
-ATOMTYPES['P3b'] = AtomType('P3b', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P3b'] = AtomType('P3b', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[1], charge=[0])
 # examples for P3b: c1ccpcc1 (phosphorine) with InChI 'InChI=1S/C5H5P/c1-2-4-6-5-3-1/h1-5H'
-ATOMTYPES['P5s'] = AtomType('P5s', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5s'] = AtomType('P5s', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1,2,3,4,5], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for P5s: P(Cl)(Cl)(Cl)(Cl)Cl (phosphorus pentachloride)
-ATOMTYPES['P5sc'] = AtomType('P5sc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5sc'] = AtomType('P5sc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0,1,2,3,4,5,6], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], benzene=[0], lone_pairs=[0], charge=[-1, +1, +2])
 # examples for P5sc: [O-][PH3+] (oxidophosphanium), F[P-](F)(F)(F)(F)F (Hexafluorophosphate)
-ATOMTYPES['P5d'] = AtomType('P5d', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5d'] = AtomType('P5d', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1,2,3], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for P5d: OP(=O)(O)O (phosphoric acid)
-ATOMTYPES['P5dd'] = AtomType('P5dd', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5dd'] = AtomType('P5dd', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1], all_double=[2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for P5dd: CP(=O)=O (methylphosphinate)
-ATOMTYPES['P5dc'] = AtomType('P5dc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5dc'] = AtomType('P5dc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0,1,2], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for P5dc: C=C[P+](=N)[O-] (ethenyl-imino-oxidophosphanium), C[P+](=C)C (methylenedimethylphosphorane)
-ATOMTYPES['P5ddc'] = AtomType('P5ddc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5ddc'] = AtomType('P5ddc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                               single=[0], all_double=[2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for P5ddc: C=[P+]=N (imino(methylidene)phosphanium)
-ATOMTYPES['P5t'] = AtomType('P5t', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5t'] = AtomType('P5t', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0,1,2], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for P5t: N#P(Cl)Cl (phosphonitrile chloride)
-ATOMTYPES['P5td'] = AtomType('P5td', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5td'] = AtomType('P5td', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for P5td: COC(=O)C#P=O (methyl phosphorylacetate)
-ATOMTYPES['P5tc'] = AtomType('P5tc', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5tc'] = AtomType('P5tc', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[+1])
 # examples for P5tc: C[P+]#C (methyl(methylidyne)phosphanium), C#[P+]O (hydroxy(methylidyne)phosphanium)
-ATOMTYPES['P5b'] = AtomType('P5b', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5b'] = AtomType('P5b', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                             single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[0], charge=[0, +1])
 # examples for P5b: C1=CC=[PH+]C=C1 (Phosphoniabenzene)
-ATOMTYPES['P5bd'] = AtomType('P5bd', generic=['R', 'R!H', 'P', 'Val5'], specific=[],
+ATOMTYPES['P5bd'] = AtomType('P5bd', generic=['R', 'R!H', 'R!H!Val7', 'P', 'Val5'], specific=[],
                              single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[2], lone_pairs=[0], charge=[0])
 # examples for P5bd: C1=CC=P(=S)C=C1 (Phosphorin 1-sulfide), C1=CC=P(=O)C=C1 (Phosphorin 1-oxide)
 
-ATOMTYPES['S'] = AtomType('S', generic=['R', 'R!H', 'Val6'], specific=['Sa', 'S0sc', 'S2s', 'S2sc', 'S2d', 'S2dc', 'S2tc', 'S4s', 'S4sc', 'S4d', 'S4dd', 'S4dc', 'S4b', 'S4t', 'S4tdc', 'S6s', 'S6sc', 'S6d', 'S6dd', 'S6ddd', 'S6dc', 'S6t', 'S6td', 'S6tt', 'S6tdc'],
+ATOMTYPES['S'] = AtomType('S', generic=['R', 'R!H', 'R!H!Val7', 'Val6'], specific=['Sa', 'S0sc', 'S2s', 'S2sc', 'S2d', 'S2dc', 'S2tc', 'S4s', 'S4sc', 'S4d', 'S4dd', 'S4dc', 'S4b', 'S4t', 'S4tdc', 'S6s', 'S6sc', 'S6d', 'S6dd', 'S6ddd', 'S6dc', 'S6t', 'S6td', 'S6tt', 'S6tdc'],
                           single=[], all_double=[], r_double=[], o_double=[], s_double=[], triple=[], quadruple=[], benzene=[], lone_pairs=[], charge=[])
-ATOMTYPES['Sa'] = AtomType('Sa', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 6)
+ATOMTYPES['Sa'] = AtomType('Sa', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 6)
                            single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[3], charge=[0])
 # examples for Sa: atomic sulfur (closed shell)
-ATOMTYPES['S0sc'] = AtomType('S0sc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 7-8)
+ATOMTYPES['S0sc'] = AtomType('S0sc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 7-8)
                              single=[0,1], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[3], charge=[-1])
 # examples for S0sc: [S-][S+]=S
-ATOMTYPES['S2s'] = AtomType('S2s', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 6-8)
+ATOMTYPES['S2s'] = AtomType('S2s', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 6-8)
                             single=[0,1,2], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for S2s: [S], [SH], S {H2S}, [S][S], SS {H2S2}, SSC, CSSC, SO {HSOH}...
-ATOMTYPES['S2sc'] = AtomType('S2sc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 7-10)
+ATOMTYPES['S2sc'] = AtomType('S2sc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 7-10)
                              single=[0,1,2,3], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1, +1])
 # examples for S2sc: N#[N+][S-](O)O
-ATOMTYPES['S2d'] = AtomType('S2d', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 8)
+ATOMTYPES['S2d'] = AtomType('S2d', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 8)
                             single=[0], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[0])
 # examples for S2d: S=S, C=S, S=O, S=N, S=C=S, S=C=O, S=C=S...
-ATOMTYPES['S2dc'] = AtomType('S2dc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],
+ATOMTYPES['S2dc'] = AtomType('S2dc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],
                              single=[0,1], all_double=[1, 2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1])
 # *Composite atomtype; examples for S2dc: [SH-]=[N+]
-ATOMTYPES['S2tc'] = AtomType('S2tc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 10)
+ATOMTYPES['S2tc'] = AtomType('S2tc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 10)
                              single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[2], charge=[-1])
 # examples for S2tc: [S-]#[NH+]
-ATOMTYPES['S4s'] = AtomType('S4s', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 6-10)
+ATOMTYPES['S4s'] = AtomType('S4s', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 6-10)
                             single=[0,1,2,3,4], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for S4s: H4S, SH3CH3...
-ATOMTYPES['S4sc'] = AtomType('S4sc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 5-8)
+ATOMTYPES['S4sc'] = AtomType('S4sc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 5-8)
                              single=[0,1,2,3,4,5], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[-1, +1])
 # examples for S4sc: CS[S+]([O-])C, O[SH..-][N+]#N
-ATOMTYPES['S4d'] = AtomType('S4d', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 8-10)
+ATOMTYPES['S4d'] = AtomType('S4d', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 8-10)
                             single=[0,1,2], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for S4d: O=S(O)O {Sulfurous acid}
-ATOMTYPES['S4dd'] = AtomType('S4dd', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 10)
+ATOMTYPES['S4dd'] = AtomType('S4dd', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 10)
                              single=[0], all_double=[2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for S4dd: O=S=O
-ATOMTYPES['S4dc'] = AtomType('S4dc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],
+ATOMTYPES['S4dc'] = AtomType('S4dc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],
                              single=[0,1,2,3,4,5], all_double=[1, 2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[1], charge=[-1, +1])
 # *Composite atomtype; examples for S4dc: [CH2-][S+]=C {where the [CH2-] has a lone pair}, [O+][S-](=O)=O, [O-][S+]=C, [NH-][S+]=C {where the [NH-] has two lone pairs}, [O-][S+]=O
-ATOMTYPES['S4b'] = AtomType('S4b', generic=['R', 'R!H', 'S', 'Val6'], specific=[],
+ATOMTYPES['S4b'] = AtomType('S4b', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],
                             single=[0], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[], benzene=[2], lone_pairs=[1], charge=[0])
 # examples for S4b: Thiophene, Benzothiophene, Benzo[c]thiophene, Thiazole, Benzothiazole...
-ATOMTYPES['S4t'] = AtomType('S4t', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 10)
+ATOMTYPES['S4t'] = AtomType('S4t', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 10)
                             single=[0,1], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[1], quadruple=[], benzene=[0], lone_pairs=[1], charge=[0])
 # examples for S4t: C#S, C#SO, C#[S]
-ATOMTYPES['S4tdc'] = AtomType('S4tdc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],
+ATOMTYPES['S4tdc'] = AtomType('S4tdc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],
                               single=[0,1,2], all_double=[0, 1, 2], r_double=[], o_double=[], s_double=[], triple=[1, 2], quadruple=[], benzene=[0], lone_pairs=[1], charge=[-1, +1])
 # *Composite atomtype; examples for S4tdc: [C-]#[S+]
-ATOMTYPES['S6s'] = AtomType('S6s', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 6-12)
+ATOMTYPES['S6s'] = AtomType('S6s', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 6-12)
                             single=[0,1,2,3,4,5,6], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6s: H6S, F6S
-ATOMTYPES['S6sc'] = AtomType('S6sc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 7-14)
+ATOMTYPES['S6sc'] = AtomType('S6sc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 7-14)
                              single=[0,1,2,3,4,5,6,7], all_double=[0], r_double=[0], o_double=[0], s_double=[0], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[0], charge=[-1, +1, +2])
 # examples for S6sc: [O-][S+2](O)(O)[O-]CS(=O)
-ATOMTYPES['S6d'] = AtomType('S6d', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 8-12)
+ATOMTYPES['S6d'] = AtomType('S6d', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 8-12)
                             single=[0,1,2,3,4], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6d: [SH4]=O, SF4=O, [SH4]=C, C[SH3]=C...
-ATOMTYPES['S6dd'] = AtomType('S6dd', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 10-12)
+ATOMTYPES['S6dd'] = AtomType('S6dd', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 10-12)
                              single=[0,1,2], all_double=[2], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6dd: S(=O)(=O)(O)O {H2SO4, Sulfuric acid}, Perfluorooctanesulfonic acid, Pyrosulfuric acid, Thiosulfuric acid {middle S}, OS(=O)(=O)OOS(=O)(=O)O
-ATOMTYPES['S6ddd'] = AtomType('S6ddd', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 12)
+ATOMTYPES['S6ddd'] = AtomType('S6ddd', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 12)
                               single=[0], all_double=[3], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6ddd: O=S(=O)(=O)
-ATOMTYPES['S6dc'] = AtomType('S6dc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],
+ATOMTYPES['S6dc'] = AtomType('S6dc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],
                              single=[0,1,2,3,4,5], all_double=[1, 2, 3], r_double=[], o_double=[], s_double=[], triple=[0], quadruple=[0], benzene=[0], lone_pairs=[0], charge=[-1, +1, +2])
 # *Composite atomtype; examples for S6dc: O=[S+2]([O-])[O-], [CH-]=[SH3+], [CH-]=[SH2+]O, [CH-][SH2+], O=[S+](=O)[O-], [OH+]=[S-](=O)=O
-ATOMTYPES['S6t'] = AtomType('S6t', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 9-12)
+ATOMTYPES['S6t'] = AtomType('S6t', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 9-12)
                             single=[0,1,2,3], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6t: H3S#N
-ATOMTYPES['S6td'] = AtomType('S6td', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 11-12)
+ATOMTYPES['S6td'] = AtomType('S6td', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 11-12)
                              single=[0,1], all_double=[1], r_double=[], o_double=[], s_double=[], triple=[1], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6td: HS(=O)#N
-ATOMTYPES['S6tt'] = AtomType('S6tt', generic=['R', 'R!H', 'S', 'Val6'], specific=[],  # (shared electrons = 12)
+ATOMTYPES['S6tt'] = AtomType('S6tt', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],  # (shared electrons = 12)
                              single=[0], all_double=[0], r_double=[], o_double=[], s_double=[], triple=[2], quadruple=[], benzene=[0], lone_pairs=[0], charge=[0])
 # examples for S6tt: N#S#N
-ATOMTYPES['S6tdc'] = AtomType('S6tdc', generic=['R', 'R!H', 'S', 'Val6'], specific=[],
+ATOMTYPES['S6tdc'] = AtomType('S6tdc', generic=['R', 'R!H', 'R!H!Val7', 'S', 'Val6'], specific=[],
                               single=[0,1,2,3,4], all_double=[0, 1, 2], r_double=[], o_double=[], s_double=[], triple=[1, 2], quadruple=[], benzene=[0], lone_pairs=[0], charge=[-1, +1])
 # *Composite atomtype; examples for S6tdc: [SH2+]#[C-], [N-]=[S+]#N
 
@@ -625,6 +637,7 @@ ATOMTYPES['Xo'].set_actions(increment_bond=['Xo'], decrement_bond=['Xo'], form_b
 
 ATOMTYPES['R'].set_actions(increment_bond=['R'], decrement_bond=['R'], form_bond=['R'], break_bond=['R'], increment_radical=['R'], decrement_radical=['R'], increment_lone_pair=['R'], decrement_lone_pair=['R'])
 ATOMTYPES['R!H'].set_actions(increment_bond=['R!H'], decrement_bond=['R!H'], form_bond=['R!H'], break_bond=['R!H'], increment_radical=['R!H'], decrement_radical=['R!H'], increment_lone_pair=['R!H'], decrement_lone_pair=['R!H'])
+ATOMTYPES['R!H!Val7'].set_actions(increment_bond=['R!H!Val7'], decrement_bond=['R!H!Val7'], form_bond=['R!H!Val7'], break_bond=['R!H!Val7'], increment_radical=['R!H!Val7'], decrement_radical=['R!H!Val7'], increment_lone_pair=['R!H!Val7'], decrement_lone_pair=['R!H!Val7'])
 ATOMTYPES['Val4'].set_actions(increment_bond=['Val4'], decrement_bond=['Val4'], form_bond=['Val4'], break_bond=['Val4'], increment_radical=['Val4'], decrement_radical=['Val4'], increment_lone_pair=['Val4'], decrement_lone_pair=['Val4'])
 ATOMTYPES['Val5'].set_actions(increment_bond=['Val5'], decrement_bond=['Val5'], form_bond=['Val5'], break_bond=['Val5'], increment_radical=['Val5'], decrement_radical=['Val5'], increment_lone_pair=['Val5'], decrement_lone_pair=['Val5'])
 ATOMTYPES['Val6'].set_actions(increment_bond=['Val6'], decrement_bond=['Val6'], form_bond=['Val6'], break_bond=['Val6'], increment_radical=['Val6'], decrement_radical=['Val6'], increment_lone_pair=['Val6'], decrement_lone_pair=['Val6'])

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -499,7 +499,7 @@ class GroupAtom(Vertex):
 
     def is_nitrogen(self):
         """
-        Return ``True`` if the atom represents an sulfur atom or ``False`` if not.
+        Return ``True`` if the atom represents a nitrogen atom or ``False`` if not.
         """
         all_nitrogen = [ATOMTYPES['N']] + ATOMTYPES['N'].specific
         check_list = [x in all_nitrogen for x in self.atomtype]
@@ -507,10 +507,34 @@ class GroupAtom(Vertex):
 
     def is_carbon(self):
         """
-        Return ``True`` if the atom represents an sulfur atom or ``False`` if not.
+        Return ``True`` if the atom represents a carbon atom or ``False`` if not.
         """
         all_carbon = [ATOMTYPES['C']] + ATOMTYPES['C'].specific
         check_list = [x in all_carbon for x in self.atomtype]
+        return all(check_list)
+
+    def is_fluorine(self):
+        """
+        Return ``True`` if the atom represents a fluorine atom or ``False`` if not.
+        """
+        all_fluorine = [ATOMTYPES['F']] + ATOMTYPES['F'].specific
+        check_list = [x in all_fluorine for x in self.atomtype]
+        return all(check_list)
+
+    def is_chlorine(self):
+        """
+        Return ``True`` if the atom represents a chlorine atom or ``False`` if not.
+        """
+        all_chlorine = [ATOMTYPES['Cl']] + ATOMTYPES['Cl'].specific
+        check_list = [x in all_chlorine for x in self.atomtype]
+        return all(check_list)
+
+    def is_bromine(self):
+        """
+        Return ``True`` if the atom represents a bromine atom or ``False`` if not.
+        """
+        all_bromine = [ATOMTYPES['Br']] + ATOMTYPES['Br'].specific
+        check_list = [x in all_bromine for x in self.atomtype]
         return all(check_list)
 
     def has_wildcards(self):

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -58,6 +58,8 @@ cdef class Atom(Vertex):
 
     cpdef bint is_non_hydrogen(self)
 
+    cpdef bint is_halogen(self)
+
     cpdef bint is_carbon(self)
 
     cpdef bint is_oxygen(self)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -335,6 +335,13 @@ class Atom(Vertex):
         """
         return self.element.number != 1
 
+    def is_halogen(self):
+        """
+        Return ``True`` if the atom represents a halogen atom (F, Cl, Br, I)
+        ``False`` if it does.
+        """
+        return self.element.number in [9, 17, 35, 53]
+
     def is_carbon(self):
         """
         Return ``True`` if the atom represents a carbon atom or ``False`` if

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -397,6 +397,13 @@ class Atom(Vertex):
         """
         return self.element.number == 17
 
+    def is_bromine(self):
+        """
+        Return ``True`` if the atom represents a bromine atom or ``False`` if
+        not.
+        """
+        return self.element.number == 35
+
     def is_iodine(self):
         """
         Return ``True`` if the atom represents an iodine atom or ``False`` if

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -208,6 +208,17 @@ class TestAtom(unittest.TestCase):
             else:
                 self.assertFalse(atom.is_chlorine())
 
+    def test_is_bromine(self):
+        """
+        Test the Atom.is_bromine() method.
+        """
+        for element in element_list:
+            atom = Atom(element=element, radical_electrons=1, charge=0, label='*1', lone_pairs=3)
+            if element.symbol == 'Br':
+                self.assertTrue(atom.is_bromine())
+            else:
+                self.assertFalse(atom.is_bromine())
+
     def test_is_iodine(self):
         """
         Test the Atom.is_iodine() method.

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -120,6 +120,17 @@ class TestAtom(unittest.TestCase):
             else:
                 self.assertTrue(atom.is_non_hydrogen(), "Atom {0!r} isn't reporting is_non_hydrogen()".format(atom))
 
+    def test_is_halogen(self):
+        """
+        Test the Atom.is_halogen() method.
+        """
+        for element in element_list:
+            atom = Atom(element=element, radical_electrons=1, charge=0, label='*1', lone_pairs=3)
+            if element.symbol in ['F', 'Cl', 'Br', 'I']:
+                self.assertTrue(atom.is_halogen())
+            else:
+                self.assertFalse(atom.is_halogen(), "Atom {0!r} is reporting is_halogen(), but it shouldn't be".format(atom))
+
     def test_is_carbon(self):
         """
         Test the Atom.is_carbon() method.

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -81,6 +81,24 @@ SMILES_LOOKUPS = {
         1 C u1 p1 c0 {2,S}
         2 H u0 p0 c0 {1,S}
         """,
+    '[C]F':  # We'd return the quartet without this
+        """
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
+        2 F u0 p3 c0 {1,S}
+        """,
+    '[C]Cl':  # We'd return the quartet without this
+        """
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
+        2 Cl u0 p3 c0 {1,S}
+        """,
+    '[C]Br':  # We'd return the quartet without this
+        """
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
+        2 Br u0 p3 c0 {1,S}
+        """,
     '[X]':  # Surface site
         """
         multiplicity 1
@@ -131,8 +149,13 @@ RADICAL_LOOKUPS = {
     'H2N': '[NH2]',
     'HN': '[NH]',
     'NO': '[N]=O',
+    'F' : '[F]',
     'Cl': '[Cl]',
+    'Br': '[Br]',
     'I': '[I]',
+    'CF': '[C]F',
+    'CCl': '[C]Cl',
+    'CBr': '[C]Br'
 }
 
 

--- a/rmgpy/molecule/translatorTest.py
+++ b/rmgpy/molecule/translatorTest.py
@@ -715,6 +715,33 @@ class SMILESGenerationTest(unittest.TestCase):
         smiles = '[O][O]'
         self.compare(adjlist, smiles)
 
+        # Test CF
+        adjlist = '''
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
+        2 F u0 p3 c0 {1,S}
+        '''
+        smiles = '[C]F'
+        self.compare(adjlist, smiles)
+
+        # Test CCl
+        adjlist = '''
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
+        2 Cl u0 p3 c0 {1,S}
+        '''
+        smiles = '[C]Cl'
+        self.compare(adjlist, smiles)
+
+        # Test CBr
+        adjlist = '''
+        multiplicity 2
+        1 C u1 p1 c0 {2,S}
+        2 Br u0 p3 c0 {1,S}
+        '''
+        smiles = '[C]Br'
+        self.compare(adjlist, smiles)
+
     def test_aromatics(self):
         """Test that different aromatics representations returns different SMILES."""
         mol1 = Molecule().from_adjacency_list("""

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -1268,7 +1268,7 @@ Origin Group AdjList:
 
         # print out entries skipped from exception we can't currently handle
         if skipped:
-            print("These entries were skipped because too big benzene rings or has nitrogen sample atom:")
+            print("These entries were skipped because too big benzene rings:")
             for entryName in skipped:
                 print(entryName)
 
@@ -1744,14 +1744,6 @@ The following adjList may have atoms in a different ordering than the input file
                         logging.error("Problem making sample molecule for group {}\n{}".format(
                             entryName, entry.item.to_adjacency_list()))
                         raise
-                    # for now ignore sample atoms that use nitrogen types
-                    nitrogen = False
-                    for atom in sample_molecule.atoms:
-                        if atom.is_nitrogen():
-                            nitrogen = True
-                    if nitrogen:
-                        skipped.append(entryName)
-                        continue
 
                     atoms = sample_molecule.get_all_labeled_atoms()
                     match = group.descend_tree(sample_molecule, atoms, strict=True)
@@ -1787,7 +1779,7 @@ Origin Group AdjList:
 
         # print out entries skipped from exception we can't currently handle
         if skipped:
-            print("These entries were skipped because too big benzene rings or has nitrogen sample atom:")
+            print("These entries were skipped because too big benzene rings:")
             for entryName in skipped:
                 print(entryName)
 


### PR DESCRIPTION
This PR goes with https://github.com/ReactionMechanismGenerator/RMG-database/pull/434.  Importantly, this PR adds the lone pairs to make a sample bromine atom, which was previously causing the DB Travis build to fail.  I also added a new atom type `R!H!Val7!`, which will be used in kinetics trees, and halogen identification functions (i.e `is_bromine`) to the molecule and group Atom classes.