### PR TITLE
Readded try-except for Pmin and Pmax determination

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -675,8 +675,11 @@ class RMG(util.Subject):
         # determine min and max values for T and P (don't determine P values for liquid reactors)
         self.Tmin = min([x.Trange[0].value_si if x.Trange else x.T.value_si for x in self.reaction_systems])
         self.Tmax = max([x.Trange[1].value_si if x.Trange else x.T.value_si for x in self.reaction_systems])
-        self.Pmin = min([x.Prange[0].value_si if hasattr(x, 'Prange') and x.Prange else x.P.value_si for x in self.reaction_systems])
-        self.Pmax = max([x.Prange[1].value_si if hasattr(x, 'Prange') and x.Prange else x.P.value_si for x in self.reaction_systems])
+        try:
+            self.Pmin = min([x.Prange[0].value_si if hasattr(x, 'Prange') and x.Prange else x.P.value_si for x in self.reaction_systems])
+            self.Pmax = max([x.Prange[1].value_si if hasattr(x, 'Prange') and x.Prange else x.P.value_si for x in self.reaction_systems])
+        except AttributeError:
+            pass
 
         self.rmg_memories = []
 


### PR DESCRIPTION
This commit prevents error message when running with surfaceReactor
For now, Pmin and Pmax of surfaceReactor remain with the default value of `None`

See comments on https://github.com/ReactionMechanismGenerator/RMG-Py/commit/219590135056ceb98571a6bd04a47b6955456eeb 
