### PR TITLE
Avoid accessibility test for Retroene family

### DIFF
--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -125,7 +125,7 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
                 yield test, family_name
 
             # these families have some sort of difficulty which prevents us from testing accessibility right now
-            difficult_families = ['Diels_alder_addition', 'Intra_R_Add_Exocyclic', 'Intra_R_Add_Endocyclic']
+            difficult_families = ['Diels_alder_addition', 'Intra_R_Add_Exocyclic', 'Intra_R_Add_Endocyclic', 'Retroene']
             generated_trees = ["R_Recombination"]
 
             if len(family.forward_template.reactants) < len(family.groups.top) and family_name not in difficult_families:


### PR DESCRIPTION
### Motivation or Problem
I am adding a new family Retroene. The accessibility test of Retroene family does not pass, which is due to that RMG-Py database test cannot correctly generate sample molecules for groups with `inRing` attributes. 

### Solution
Accessibility would not be a problem for ATG generated trees. I simply added  `Retroene` into the `difficult_families` so that it won't run the accessibility test for Retroene. This should be merged before merging the database PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/438 to allow the database PR passing the Travis tests. 