### PR TITLE
Reset connectivity values when manipulating the graph

### DIFF
--- a/rmgpy/molecule/graph.pyx
+++ b/rmgpy/molecule/graph.pyx
@@ -232,6 +232,7 @@ cdef class Graph(object):
         """
         self.vertices.append(vertex)
         vertex.edges = dict()
+        vertex.reset_connectivity_values()
         return vertex
 
     cpdef Edge add_edge(self, Edge edge):
@@ -243,6 +244,7 @@ cdef class Graph(object):
             raise ValueError('Attempted to add edge between vertices not in the graph.')
         edge.vertex1.edges[edge.vertex2] = edge
         edge.vertex2.edges[edge.vertex1] = edge
+        self.reset_connectivity_values()
         return edge
 
     cpdef list get_all_edges(self):
@@ -300,6 +302,7 @@ cdef class Graph(object):
             del vertex2.edges[vertex]
         vertex.edges = dict()
         self.vertices.remove(vertex)
+        self.reset_connectivity_values()
 
     cpdef remove_edge(self, Edge edge):
         """
@@ -309,6 +312,7 @@ cdef class Graph(object):
         """
         del edge.vertex1.edges[edge.vertex2]
         del edge.vertex2.edges[edge.vertex1]
+        self.reset_connectivity_values()
 
     cpdef Graph copy(self, bint deep=False):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1118,9 +1118,10 @@ class Molecule(Graph):
 
     def update(self, log_species=True, raise_atomtype_exception=True, sort_atoms=True):
         """
-        Update connectivity values, atom types of atoms.
+        Update the charge and atom types of atoms.
         Update multiplicity, and sort atoms (if ``sort_atoms`` is ``True``)
-        using the new connectivity values.
+        Does not necessarily update the connectivity values (which are used in isomorphism checks)
+        If you need that, call update_connectivity_values()
         """
 
         for atom in self.atoms:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->
This is more of an issue than a pull request. Or at least, a Work In Progress.

### Motivation or Problem

There was a bug in #2006 caused by stale connectivity values on atoms, which had not been recalculated after a bond was removed from a graph. The isomorphism checks use the connectivity values, assumed they were correct, noticed they were different, and erroneously declared two molecules as being different. I fixed that issue by explicitly calling `Molecule.update_connecitvity_values()`, but thought it would be a good insurance, more defensive coding, and a good idea to make sure what whenever you add or remove a vertex or edge to a graph, you reset or invalidate the connectivity values, by calling `reset_connectivity_values()`. This `reset` rather than `update` merely marks them all as `-1`, so that next time some code calls the `sort_atoms` method, it'll detect they're invalid and update them.  

I thought this would likely prevent future errors, and perhaps (worst case) reveal some existing ones. 

But it seems to be messing up a symmetry number unit test.  
That begs the question, is this change introducing an error, or revealing an error?
Something must have been relying on those connectivity values not being -1, but does it matter that they were likely incorrect?  I expect it's somewhere in the ring detection (I think all those algorithms for detecting small sets of small rings involve deleting bonds). Apparently they need non-zero connectivity values, but should they have updated connectivity values?


### Description of Changes

When you add or remove a vertex or edge to a graph, it resets the connectivity values, because they will no longer be valid.


### Testing

The test  "Test the Species.get_symmetry_number() (total symmetry) from issue #332" fails.
The symmetry number is different each time and rarely the expected 12:
AssertionError: 96.0 != 12
AssertionError: 384.0 != 12
AssertionError: 24.0 != 12
AssertionError: 48.0 != 12

### Reviewer Tips

Don't forget to `make` after checking out this branch - you'll need to recompile graph.o.

You can run just the failing test much quicker than the full suite by doing:
`nosetests rmgpy/molecule/symmetryTest.py`


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
