### PR TITLE
Correct surfaceThermoPt111 library name in examples and documentation.

### DIFF
--- a/documentation/source/users/rmg/surfaces.rst
+++ b/documentation/source/users/rmg/surfaces.rst
@@ -25,13 +25,13 @@ This block should also contain the reference adatom binding energies
 Here is an example catalyst properties block for Pt(111)::
 
     catalystProperties(
-        bindingEnergies = { 
-                            'H': (-2.479, 'eV/molecule'),
-                            'O': (-3.586, 'eV/molecule'),
-                            'C': (-6.750, 'eV/molecule'),
-                            'N': (-4.352, 'eV/molecule'),
+        bindingEnergies = {
+                            'H': (-2.754, 'eV/molecule'),
+                            'O': (-3.811, 'eV/molecule'),
+                            'C': (-7.025, 'eV/molecule'),
+                            'N': (-4.632, 'eV/molecule'),
                         },
-        surfaceSiteDensity=(2.72e-9, 'mol/cm^2'),
+        surfaceSiteDensity=(2.483e-9, 'mol/cm^2'),
     )
 
 
@@ -257,10 +257,10 @@ Deviating from these values will result in adsorption energies being modified,
 even for species taken from the thermochemistry libraries::
 
     bindingEnergies = { # default values for Pt(111)
-                       'H':(-2.479, 'eV/molecule'),
-                       'O':(-3.586, 'eV/molecule'),
-                       'C':(-6.750, 'eV/molecule'),
-                       'N':(-4.352, 'eV/molecule'),
+                        'H': (-2.754, 'eV/molecule'),
+                        'O': (-3.811, 'eV/molecule'),
+                        'C': (-7.025, 'eV/molecule'),
+                        'N': (-4.632, 'eV/molecule'),
                        }
 
 

--- a/documentation/source/users/rmg/surfaces.rst
+++ b/documentation/source/users/rmg/surfaces.rst
@@ -140,7 +140,7 @@ of the gas-phase precursor ([Goldsmith2017]_).
 Following is an example for how a thermo library for species adsorbed on platinum 
 is provided in the input file database module::
 
-    thermoLibraries=['surfaceThermoPt']
+    thermoLibraries=['surfaceThermoPt111']
     
 This can be added along with other gas-phase reaction libraries for coupling 
 of gas-phase and surface reactions.  

--- a/examples/rmg/catalysis/ch4_o2/input.py
+++ b/examples/rmg/catalysis/ch4_o2/input.py
@@ -1,6 +1,6 @@
 # Data sources
 database(
-    thermoLibraries=['surfaceThermoPt', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC','DFT_QCI_thermo'], # 'surfaceThermoPt' is the default. Thermo data is derived using bindingEnergies for other metals 
+    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC','DFT_QCI_thermo'], # 'surfaceThermoPt' is the default. Thermo data is derived using bindingEnergies for other metals 
     reactionLibraries = [('Surface/CPOX_Pt/Deutschmann2006', False)], # when Ni is used change the library to Surface/Deutschmann_Ni 
     seedMechanisms = [],
     kineticsDepositories = ['training'],

--- a/examples/rmg/catalysis/methane_steam/input.py
+++ b/examples/rmg/catalysis/methane_steam/input.py
@@ -1,6 +1,6 @@
 # Data sources
 database(
-    thermoLibraries=['surfaceThermoPt', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC'], 
+    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC'], 
     reactionLibraries = [('Surface/Deutschmann_Ni', True)], # when Pt is used change the library to Surface/CPOX_Pt/Deutschmann2006
     seedMechanisms = [],
     kineticsDepositories = ['training'],

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1374,6 +1374,7 @@ class ThermoDatabase(object):
         Returns:
             None, stores result in self.delta_atomic_adsorption_energy
         """
+        # If changing these, remember to update the example input files and documentation.
         reference_binding_energies = {
             'C': rmgpy.quantity.Energy(-7.025, 'eV/molecule'),
             'H': rmgpy.quantity.Energy(-2.754, 'eV/molecule'),


### PR DESCRIPTION
The recently merged https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1907 and https://github.com/ReactionMechanismGenerator/RMG-database/pull/391 renamed the surface thermo libraries to include the facet, i.e `surfaceThermoPt` became `surfaceThermoPt111`.

This small pull request updates the example rmg input files and documentation to match.

Also fixes the reference adsorption energies in the documentation, which had been overlooked.

