### PR TITLE
Save labeled adjacency lists of all reactions

### DIFF
--- a/examples/rmg/catalysis/ch4_o2/input.py
+++ b/examples/rmg/catalysis/ch4_o2/input.py
@@ -80,6 +80,7 @@ options(
     units='si',
     generateOutputHTML=True,
     generatePlots=False, # Enable to make plots of core and edge size etc. But takes a lot of the total runtime!
+    generateLabeledReactions=True,
     saveEdgeSpecies=True,
     saveSimulationProfiles=True,
 )

--- a/examples/rmg/catalysis/ch4_o2/input.py
+++ b/examples/rmg/catalysis/ch4_o2/input.py
@@ -80,7 +80,7 @@ options(
     units='si',
     generateOutputHTML=True,
     generatePlots=False, # Enable to make plots of core and edge size etc. But takes a lot of the total runtime!
-    generateLabeledReactions=False,
+    generateLabeledReactions=True,
     saveEdgeSpecies=True,
     saveSimulationProfiles=True,
 )

--- a/examples/rmg/catalysis/ch4_o2/input.py
+++ b/examples/rmg/catalysis/ch4_o2/input.py
@@ -80,7 +80,7 @@ options(
     units='si',
     generateOutputHTML=True,
     generatePlots=False, # Enable to make plots of core and edge size etc. But takes a lot of the total runtime!
-    generateLabeledReactions=True,
+    generateLabeledReactions=False,
     saveEdgeSpecies=True,
     saveSimulationProfiles=True,
 )

--- a/examples/rmg/catalysis/meoh_synthesis/input.py
+++ b/examples/rmg/catalysis/meoh_synthesis/input.py
@@ -1,0 +1,445 @@
+# Data sources
+database(
+    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC','DFT_QCI_thermo'],
+    reactionLibraries = ['BurkeH2O2inArHe','BurkeH2O2inN2'],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies =['surface','default'],
+    kineticsEstimator = 'rate rules',
+)
+
+catalystProperties( # default values for Cu(111) calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+    bindingEnergies = {
+                       'C':(-4.96033553, 'eV/molecule'),
+                       'O':(-4.20763879, 'eV/molecule'),
+                       'N':(-3.58446699, 'eV/molecule'),
+                       'H':(-2.58383235, 'eV/molecule'),
+                       },
+    surfaceSiteDensity=(2.943e-9, 'mol/cm^2'),  # from Katrin
+)
+
+# List of species
+species(
+    label='X',
+    reactive=True,
+    structure=adjacencyList("1 X u0"),
+)
+
+species(
+    label='N2',
+    reactive=False,
+    structure=SMILES("N#N"),
+)
+
+species(
+    label='H2',
+    reactive=True,
+    structure=SMILES("[H][H]"),
+)
+
+species(
+    label='CO',
+    reactive=True,
+    structure=SMILES("[C-]#[O+]"),
+)
+
+species(
+    label='CO2',
+    reactive=True,
+    structure=SMILES("O=C=O"),
+)
+
+species(
+    label='H2O',
+    reactive=True,
+    structure=SMILES("O"),
+)
+
+species(
+    label='CH2O',
+    reactive=True,
+    structure=SMILES("C=O"),
+)
+
+species(
+    label='HCOOH',
+    reactive=True,
+    structure=SMILES("O=CO"),
+)
+
+species(
+    label='CH3OH',
+    reactive=True,
+    structure=SMILES("CO"),
+)
+
+species(
+    label='HCOOCH3',
+    reactive=True,
+    structure=SMILES("O=COC"),
+)
+
+species(
+   label='H*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 H u0 p0 c0 {2,S}
+2 X u0 p0 c0 {1,S}
+"""),
+)
+
+species(
+   label='O*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,D}
+2 X u0 p0 c0 {1,D}
+"""),
+)
+
+species(
+   label='OH*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 X u0 p0 c0 {1,S}
+"""),
+)
+
+species(
+   label='H2O*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 X u0 p0 c0
+"""),
+)
+
+species(
+   label='CO*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 X u0 p0 c0 {2,D}
+"""),
+)
+
+species(
+   label='CO2*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,D} {2,D}
+4 X u0 p0 c0
+"""),
+)
+
+# species(
+#    label='CO3*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+#
+# """),
+# )
+
+# species(
+#    label='HCO3*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+#
+# """),
+# )
+
+species(
+   label='HCO*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 X u0 p0 c0 {2,S}
+"""),
+)
+
+# species(
+#    label='COH*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+#
+# """),
+# )
+
+# species(
+#    label='HCOH*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+# 1 O u0 p2 c0 {2,S} {4,S}
+# 2 C u0 p0 c0 {1,S} {3,S} {5,D}
+# 3 H u0 p0 c0 {2,S}
+# 4 H u0 p0 c0 {1,S}
+# 5 X u0 p0 c0 {2,D}
+# """),
+# )
+
+species(
+   label='HCOO*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 X u0 p0 c0 {1,S}
+"""),
+)
+
+# species(
+#    label='H2CO2*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+#
+# """),
+# )
+
+species(
+   label='COOH*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {5,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {3,S}
+"""),
+)
+
+# species(
+#    label='HCOOH*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+#
+# """),
+# )
+
+species(
+   label='CH2O*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 X u0 p0 c0
+"""),
+)
+
+species(
+   label='CH3O*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 X u0 p0 c0 {1,S}
+"""),
+)
+
+# species(
+#    label='CH2OH*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+# 1 O u0 p2 c0 {2,S} {5,S}
+# 2 C u0 p0 c0 {1,S} {3,S} {4,S} {6,S}
+# 3 H u0 p0 c0 {2,S}
+# 4 H u0 p0 c0 {2,S}
+# 5 H u0 p0 c0 {1,S}
+# 6 X u0 p0 c0 {2,S}
+# """),
+# )
+
+species(
+   label='CH3O2*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u0 p2 c0 {3,S} {6,S}
+2 O u0 p2 c0 {3,S} {7,S}
+3 C u0 p0 c0 {1,S} {2,S} {4,S} {5,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {1,S}
+7 X u0 p0 c0 {2,S}
+"""),
+)
+
+species(
+   label='CH3OH*',
+   reactive=True,
+   structure=adjacencyList(
+       """
+ 1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
+7 X u0 p0 c0
+"""),
+)
+
+# species(
+#    label='HCOOCH3*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+# """),
+# )
+
+# species(
+#    label='H2COOCH3*',
+#    reactive=True,
+#    structure=adjacencyList(
+#        """
+#
+# """),
+# )
+
+#----------
+# Reaction systems
+surfaceReactor(
+    temperature=[(483,'K'),(547, 'K')],
+    initialPressure=(15.0, 'bar'),
+    nSims = 4,
+    initialGasMoleFractions={
+        "CO": 0.0,
+        "CO2": 0.776,
+        "H2": 0.7669,
+        "N2": 0.1555,
+    },
+    initialSurfaceCoverages={
+        "X": 1.0,
+    },
+    surfaceVolumeRatio=(1.e5, 'm^-1'),
+    # terminationConversion = { "CO2":0.95,},
+    terminationTime=(500., 's'),
+    terminationRateRatio=0.001
+)
+
+surfaceReactor(
+    temperature=[(483,'K'),(547, 'K')],
+    initialPressure=(60.0, 'bar'),
+    nSims = 4,
+    initialGasMoleFractions={
+        "CO": 0.0,
+        "CO2": 0.776,
+        "H2": 0.7669,
+        "N2": 0.1555,
+    },
+    initialSurfaceCoverages={
+        "X": 1.0,
+    },
+    surfaceVolumeRatio=(1.e5, 'm^-1'),
+    # terminationConversion = { "CO2":0.95,},
+    terminationTime=(500., 's'),
+    terminationRateRatio=0.001
+)
+
+surfaceReactor(
+    temperature=[(483,'K'),(547, 'K')],
+    initialPressure=(15.0, 'bar'),
+    nSims = 4,
+    initialGasMoleFractions={
+        "CO": 0.2019,
+        "CO2": 0.0,
+        "H2": 0.6424,
+        "N2": 0.1557,
+    },
+    initialSurfaceCoverages={
+        "X": 1.0,
+    },
+    surfaceVolumeRatio=(1.e5, 'm^-1'),
+    # terminationConversion = { "CO":0.95,},
+    terminationTime=(500., 's'),
+    terminationRateRatio=0.001
+)
+
+surfaceReactor(
+    temperature=[(483,'K'),(547, 'K')],
+    initialPressure=(60.0, 'bar'),
+    nSims = 4,
+    initialGasMoleFractions={
+        "CO": 0.2019,
+        "CO2": 0.0,
+        "H2": 0.6424,
+        "N2": 0.1557,
+    },
+    initialSurfaceCoverages={
+        "X": 1.0,
+    },
+    surfaceVolumeRatio=(1.e5, 'm^-1'),
+    # terminationConversion = { "CO":0.95,},
+    terminationTime=(500., 's'),
+    terminationRateRatio=0.001
+)
+
+simulator(
+    atol=1e-18,
+    rtol=1e-12,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=1e-5,
+# inturrupt tolerance was 0.1 wout pruning, 1e8 w pruning on
+    toleranceInterruptSimulation=1e-5,
+    maximumEdgeSpecies=500000,
+# PRUNING: uncomment to prune
+#    minCoreSizeForPrune=50,
+# prune before simulation based on thermo
+#    toleranceThermoKeepSpeciesInEdge=0.5,
+# prune rxns from edge that dont move into core
+#    minSpeciesExistIterationsForPrune=2,
+# FILTERING: set so threshold is slightly larger than max rate constants
+#    filterReactions=True,
+#    filterThreshold=5e8, # default value
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=True,
+)
+
+generatedSpeciesConstraints(
+    allowed=['input species','reaction libraries'],
+    maximumRadicalElectrons=2,
+    maximumCarbonAtoms=12,
+)

--- a/examples/rmg/catalysis/meoh_synthesis/input.py
+++ b/examples/rmg/catalysis/meoh_synthesis/input.py
@@ -433,6 +433,7 @@ options(
     units='si',
     saveRestartPeriod=None,
     generateOutputHTML=True,
+    generateLabeledReactions=True,
     generatePlots=False,
     saveEdgeSpecies=True,
     saveSimulationProfiles=True,

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1534,7 +1534,7 @@ class KineticsFamily(Database):
                     struct.update_charge()
             else:
                 raise TypeError('Expecting Molecule or Group object, not {0}'.format(struct.__class__.__name__))
-            product_net_charge += struct.get_net_charge()
+            product_net_charge += struc.get_net_charge()
         if reactant_net_charge != product_net_charge:
             logging.debug(
                 'The net charge of the reactants {0} differs from the net charge of the products {1} in reaction '

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1534,7 +1534,7 @@ class KineticsFamily(Database):
                     struct.update_charge()
             else:
                 raise TypeError('Expecting Molecule or Group object, not {0}'.format(struct.__class__.__name__))
-            product_net_charge += struc.get_net_charge()
+            product_net_charge += struct.get_net_charge()
         if reactant_net_charge != product_net_charge:
             logging.debug(
                 'The net charge of the reactants {0} differs from the net charge of the products {1} in reaction '

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1398,7 +1398,7 @@ class KineticsFamily(Database):
                 # For groups, we ignore the product template for a purely aromatic group
                 # If there is an analagous aliphatic group in the family, then the product template will be identical
                 # There should NOT be any families that consist solely of aromatic reactant templates
-                return []
+                return ([], []) if return_adjacency_lists else [] # (though I doubt this is ever called with return_adjacency_lists=True for a Group not a Molecule)
 
         if not forward:
             # Hardcoding of reaction family for reverse of peroxyl disproportionation
@@ -1602,7 +1602,10 @@ class KineticsFamily(Database):
 
         # Generate the product structures by applying the forward reaction recipe
         try:
-            product_structures, reaction_adjacency_lists = self.apply_recipe(reactant_structures, forward=forward, return_adjacency_lists=True)
+            if return_adjacency_lists:
+                product_structures, reaction_adjacency_lists = self.apply_recipe(reactant_structures, forward=forward, return_adjacency_lists=True)
+            else:
+                product_structures = self.apply_recipe(reactant_structures, forward=forward, return_adjacency_lists=False)
             if not product_structures:
                 return (None, None) if return_adjacency_lists else None
         except (InvalidActionError, KekulizationError):
@@ -1921,6 +1924,8 @@ class KineticsFamily(Database):
                 specified reactants and products within this family.
             Degenerate reactions are returned as separate reactions.
         """
+        from rmgpy.rmg.input import get_input
+        save_adjacency_lists = get_input('generate_labeled_reactions')
 
         rxn_list = []
 
@@ -1965,15 +1970,20 @@ class KineticsFamily(Database):
                     for mapping in mappings:
                         reactant_structures = [molecule]
                         try:
-                            product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
+                            if save_adjacency_lists:
+                                product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
                                                                                    [mapping], forward, return_adjacency_lists=True)
+                            else:
+                                product_structures = self._generate_product_structures(reactant_structures,
+                                                                                   [mapping], forward, return_adjacency_lists=False)
                         except ForbiddenStructureException:
                             pass
                         else:
                             if product_structures is not None:
                                 rxn = self._create_reaction(reactant_structures, product_structures, forward)
                                 if rxn:
-                                    rxn.adjacency_list = reaction_adjacency_list
+                                    if save_adjacency_lists:
+                                        rxn.adjacency_list = reaction_adjacency_list
                                     rxn_list.append(rxn)
 
         # Bimolecular reactants: A + B --> products
@@ -2008,15 +2018,20 @@ class KineticsFamily(Database):
                                 # that can produce different products depending on the order of reactants
                                 reactant_structures = [molecule_b, molecule_a]
                                 try:
-                                    product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
+                                    if save_adjacency_lists:
+                                        product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
                                                                                            [map_b, map_a], forward, return_adjacency_lists=True)
+                                    else:
+                                        product_structures = self._generate_product_structures(reactant_structures,
+                                                                                           [map_b, map_a], forward, return_adjacency_lists=False)
                                 except ForbiddenStructureException:
                                     pass
                                 else:
                                     if product_structures is not None:
                                         rxn = self._create_reaction(reactant_structures, product_structures, forward)
                                         if rxn:
-                                            rxn.adjacency_list = reaction_adjacency_list
+                                            if save_adjacency_lists:
+                                                rxn.adjacency_list = reaction_adjacency_list
                                             rxn_list.append(rxn)
 
                         # Only check for swapped reactants if they are different
@@ -2031,8 +2046,12 @@ class KineticsFamily(Database):
                                 for map_b in mappings_b:
                                     reactant_structures = [molecule_a, molecule_b]
                                     try:
-                                        product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
+                                        if save_adjacency_lists:
+                                            product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
                                                                                                [map_a, map_b], forward, return_adjacency_lists=True)
+                                        else:
+                                            product_structures = self._generate_product_structures(reactant_structures,
+                                                                                               [map_a, map_b], forward, return_adjacency_lists=False)
                                     except ForbiddenStructureException:
                                         pass
                                     else:
@@ -2040,7 +2059,8 @@ class KineticsFamily(Database):
                                             rxn = self._create_reaction(reactant_structures, product_structures,
                                                                         forward)
                                             if rxn:
-                                                rxn.adjacency_list = reaction_adjacency_list
+                                                if save_adjacency_lists:
+                                                    rxn.adjacency_list = reaction_adjacency_list
                                                 rxn_list.append(rxn)
 
         # Termolecular reactants: A + B + C --> products
@@ -2088,17 +2108,24 @@ class KineticsFamily(Database):
                         reactant_structures = [site1, site2, adsorbateMolecule]
                         # should be in same order as reaction template recipe?
                         try:
-                            product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
+                            if save_adjacency_lists:
+                                product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
                                                                                    [map_a, map_b, map_c],
                                                                                    forward,
                                                                                    return_adjacency_lists=True)
+                            else:
+                                product_structures = self._generate_product_structures(reactant_structures,
+                                                            [map_a, map_b, map_c],
+                                                            forward,
+                                                            return_adjacency_lists=False)
                         except ForbiddenStructureException:
                             pass
                         else:
                             if product_structures is not None:
                                 rxn = self._create_reaction(reactant_structures, product_structures, forward)
                                 if rxn:
-                                    rxn.adjacency_list = reaction_adjacency_list
+                                    if save_adjacency_lists:
+                                        rxn.adjacency_list = reaction_adjacency_list
                                     rxn_list.append(rxn)
             else:
                 # _generate_reactions was called with mismatched number of reactants and templates
@@ -2157,19 +2184,25 @@ class KineticsFamily(Database):
                     for map_a, map_b, map_c in itertools.product(mappings_a, mappings_b, mappings_c):
                         reactant_structures = [site1, site2, adsorbateMolecule]
                         try:
-                            product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
+                            if save_adjacency_lists:
+                                product_structures, reaction_adjacency_list = self._generate_product_structures(reactant_structures,
                                                                                    [map_a, map_b, map_c],
                                                                                    forward,
                                                                                    return_adjacency_lists=True)
+                            else:
+                                product_structures = self._generate_product_structures(reactant_structures,
+                                                                                   [map_a, map_b, map_c],
+                                                                                   forward,
+                                                                                   return_adjacency_lists=False)
                         except ForbiddenStructureException:
                             pass
                         else:
                             if product_structures is not None:
                                 rxn = self._create_reaction(reactant_structures, product_structures, forward)
                                 if rxn:
-                                    rxn.adjacency_list = reaction_adjacency_list
+                                    if save_adjacency_lists:
+                                        rxn.adjacency_list = reaction_adjacency_list
                                     rxn_list.append(rxn)
-
             else:
                 """
                 Not a bidentate surface reaction, just a gas-phase
@@ -2203,11 +2236,18 @@ class KineticsFamily(Database):
                                             _reactantStructures = [_reactantStructures[_i] for _i in order]
                                             _maps = [_maps[_i] for _i in order]
                                             try:
-                                                _productStructures, _reaction_adjacency_list = self._generate_product_structures(
-                                                    _reactantStructures,
-                                                    _maps,
-                                                    forward,
-                                                    return_adjacency_lists=True)
+                                                if save_adjacency_lists:
+                                                    _productStructures, _reaction_adjacency_list = self._generate_product_structures(
+                                                        _reactantStructures,
+                                                        _maps,
+                                                        forward,
+                                                        return_adjacency_lists=True)
+                                                else:
+                                                    _productStructures = self._generate_product_structures(
+                                                        _reactantStructures,
+                                                        _maps,
+                                                        forward,
+                                                        return_adjacency_lists=False)
                                             except ForbiddenStructureException:
                                                 pass
                                             else:
@@ -2216,7 +2256,8 @@ class KineticsFamily(Database):
                                                                                  _productStructures,
                                                                                  forward)
                                                     if _rxn:
-                                                        _rxn.adjacency_list = _reaction_adjacency_list
+                                                        if save_adjacency_lists:
+                                                            _rxn.adjacency_list = _reaction_adjacency_list
                                                         rxn_list.append(_rxn)
 
                             # Reactants stored as A + B + C

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -755,7 +755,7 @@ def pressure_dependence(
 def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None,
             generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False,
             saveEdgeSpecies=False, keepIrreversible=False, trimolecularProductReversible=True, wallTime='00:00:00:00',
-            saveSeedModulus=-1):
+            saveSeedModulus=-1, generateLabeledReactions=False):
     if saveRestartPeriod:
         logging.warning("`saveRestartPeriod` flag was set in the input file, but this feature has been removed. Please "
                         "remove this line from the input file. This will throw an error after RMG-Py 3.1. For "
@@ -772,6 +772,9 @@ def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=Fals
     rmg.generate_plots = generatePlots
     rmg.save_simulation_profiles = saveSimulationProfiles
     rmg.verbose_comments = verboseComments
+    if generateLabeledReactions:
+        logging.warning('Generate Labeled Adjacency List for reactions option was turned on.')
+    rmg.generate_labeled_reactions = generateLabeledReactions
     if saveEdgeSpecies:
         logging.warning(
             'Edge species saving was turned on. This will slow down model generation for large simulations.')
@@ -1197,6 +1200,7 @@ def save_input_file(path, rmg):
     f.write('options(\n')
     f.write('    units = "{0}",\n'.format(rmg.units))
     f.write('    generateOutputHTML = {0},\n'.format(rmg.generate_output_html))
+    f.write('    generateLabeledReactions = {0},\n'.format(rmg.generate_labeled_reactions))
     f.write('    generatePlots = {0},\n'.format(rmg.generate_plots))
     f.write('    saveSimulationProfiles = {0},\n'.format(rmg.save_simulation_profiles))
     f.write('    saveEdgeSpecies = {0},\n'.format(rmg.save_edge_species))
@@ -1228,6 +1232,8 @@ def get_input(name):
             return rmg.ml_estimator, rmg.ml_settings
         elif name == 'thermo_central_database':
             return rmg.thermo_central_database
+        elif name == 'generate_labeled_reactions':
+            return rmg.generate_labeled_reactions
         else:
             raise Exception('Unrecognized keyword: {}'.format(name))
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -68,7 +68,7 @@ from rmgpy.molecule import Molecule
 from rmgpy.qm.main import QMDatabaseWriter
 from rmgpy.reaction import Reaction
 from rmgpy.rmg.listener import SimulationProfileWriter, SimulationProfilePlotter
-from rmgpy.rmg.output import OutputHTMLWriter
+from rmgpy.rmg.output import OutputHTMLWriter, OutputLabeledReactionsWriter
 from rmgpy.rmg.pdep import PDepReaction
 from rmgpy.rmg.settings import ModelSettings
 from rmgpy.solver.base import TerminationTime, TerminationConversion
@@ -134,6 +134,7 @@ class RMG(util.Subject):
     `verbosity`                         The level of logging verbosity for console output
     `units`                             The unit system to use to save output files (currently must be 'si')
     `generate_output_html`              ``True`` to draw pictures of the species and reactions, saving a visualized model in an output HTML file.  ``False`` otherwise
+    `generate_labeled_reactions`        ``True`` to export labeled adjacency lists for reactions in a text file
     `generate_plots`                    ``True`` to generate plots of the job execution statistics after each iteration, ``False`` otherwise
     `verbose_comments`                  ``True`` to keep the verbose comments for database estimates, ``False`` otherwise
     `save_edge_species`                 ``True`` to save chemkin and HTML files of the edge species, ``False`` otherwise
@@ -210,6 +211,7 @@ class RMG(util.Subject):
         self.verbosity = logging.INFO
         self.units = 'si'
         self.generate_output_html = None
+        self.generate_labeled_reactions = None
         self.generate_plots = None
         self.save_simulation_profiles = None
         self.verbose_comments = None
@@ -647,6 +649,9 @@ class RMG(util.Subject):
 
         if self.generate_output_html:
             self.attach(OutputHTMLWriter(self.output_directory))
+
+        if self.generate_labeled_reactions:
+            self.attach(OutputLabeledReactionsWriter(self.output_directory))
 
         if self.quantum_mechanics:
             self.attach(QMDatabaseWriter())

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -1357,3 +1357,51 @@ class OutputHTMLWriter(object):
 
     def update(self, rmg):
         save_output(rmg)
+
+def save_labeled_reactions_file(path, reaction_model, part_core_edge='core'):
+    """
+    Save the labeled reaction adjacency lists from the provided reaction_model
+    into a yaml file at the given path
+    :param path: path to save the file
+    :param reaction_model: reaction model
+    :param part_core_edge: 'core' or 'edge'
+    :return: None
+    """
+    if part_core_edge == 'core':
+        reactions = [rxn for rxn in reaction_model.core.reactions] + reaction_model.output_reaction_list
+    elif part_core_edge == 'edge':
+        reactions = [rxn for rxn in reaction_model.edge.reactions] + reaction_model.output_reaction_list
+
+    with open(path, "w") as f:
+        for i, rxn in enumerate(reactions):
+            f.write("{0:d}\n{1!s}\n{2!s}\n".format(i, rxn, rxn.family))
+            try:
+                f.write(rxn.adjacency_list)
+                f.write("\n")
+            except:
+                pass
+            f.write("============================================================================\n")
+
+def save_labeled_reactions(rmg):
+    """
+    Save the current reaction model's labeled reaction adjacency lists to files.
+    """
+    logging.info('Saving current reaction adjacency lists to file...')
+    save_labeled_reactions_file(os.path.join(rmg.output_directory,'chemkin','reaction_adjacency_lists.txt'), rmg.reaction_model, 'core')
+    if rmg.save_edge_species:
+        logging.info('Saving current model edge reaction adjacency lists to file...')
+        save_labeled_reactions_file(os.path.join(rmg.output_directory,'chemkin','edge_reaction_adjacency_lists.txt' ), rmg.reaction_model, 'edge')
+
+class OutputLabeledReactionsWriter(object):
+    """
+    This class exports labeled adjacency lists for reactions.
+
+    This is to interface with other software tools that wish to
+    automate transition state searches.
+    """
+    def __init__(self, output_directory=''):
+        super(OutputLabeledReactionsWriter, self).__init__()
+
+    def update(self, rmg):
+        save_labeled_reactions(rmg)
+

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -1373,14 +1373,16 @@ def save_labeled_reactions_file(path, reaction_model, part_core_edge='core'):
         reactions = [rxn for rxn in reaction_model.edge.reactions] + reaction_model.output_reaction_list
 
     with open(path, "w") as f:
+        f.write('---\nreactions:\n')
         for i, rxn in enumerate(reactions):
-            f.write("{0:d}\n{1!s}\n{2!s}\n".format(i, rxn, rxn.family))
-            try:
-                f.write(rxn.adjacency_list)
-                f.write("\n")
-            except:
-                pass
-            f.write("============================================================================\n")
+            f.write(f"  - index: {i:d}\n    reaction: {rxn!s}\n    reaction_family: {rxn.family!s}\n")
+            if hasattr(rxn, 'adjacency_list'):
+                for line in rxn.adjacency_list.splitlines(True):
+                    if line in ('reactant\n', 'product\n'):
+                        f.write('    {0}: |\n'.format(line.strip()))
+                    elif line.strip():
+                        f.write('        '+line)
+            f.write("\n")
 
 def save_labeled_reactions(rmg):
     """

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -1375,11 +1375,13 @@ def save_labeled_reactions_file(path, reaction_model, part_core_edge='core'):
     with open(path, "w") as f:
         f.write('---\nreactions:\n')
         for i, rxn in enumerate(reactions):
-            f.write(f"  - index: {i:d}\n    reaction: {rxn!s}\n    reaction_family: {rxn.family!s}\n")
+            f.write(f"  - index: {i+1:d}\n    reaction: {rxn!s}\n    reaction_family: {rxn.family!s}\n")
             if hasattr(rxn, 'adjacency_list'):
                 for line in rxn.adjacency_list.splitlines(True):
                     if line in ('reactant\n', 'product\n'):
                         f.write('    {0}: |\n'.format(line.strip()))
+                    elif line == 'multiplicity -187\n':
+                        pass
                     elif line.strip():
                         f.write('        '+line)
             f.write("\n")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
For third-party tools wishing to calculate reactions, eg. via automated TST calculations, it's helpful to have adjacency lists of reactant and product structures, with the atom order invariant, and with reaction recipe labels on the atoms. 

### Description of Changes
With this PR, if you put `generateLabeledReactions=True` in the options section of the input file, then it will save a YAML file with the adjacency list for every reaction. If you also have `saveEdgeSpecies=True` then it'll save edge reactions too.


### Testing
Added the `generateLabeledReactions=True` option to the `examples/rmg/catalysis/ch4_o2/input.py` example input file and ran it. 

### Work in Progress
- [ ] Add unit tests?
- [ ] Add documentation

please add to this list as appropriate


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
