### PR TITLE
Save metal attributes in adsorption thermo groups file.

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -133,6 +133,12 @@ def save_entry(f, entry):
     f.write(f'    longDesc = \n"""\n{entry.long_desc.strip()}\n""",\n')
     if entry.rank:
         f.write("    rank = {0},\n".format(entry.rank))
+    if entry.metal:
+        f.write("    metal = {0},\n".format(entry.metal))
+    if entry.facet:
+        f.write("    facet = {0},\n".format(entry.facet))
+    if entry.site:
+        f.write("    site = {0},\n".format(entry.site))
 
     f.write(')\n\n')
 


### PR DESCRIPTION
Small change. The new attributes were not saved when saving thermo groups.
The fact that we didn't know it was missing shows that database i/o is not 100% tested.