### PR TITLE
Update anacondaDeveloper.rst

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -23,12 +23,13 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    For Linux users, you can check whether these are already installed by simply calling them via the command line, which
    will let you know if they are missing. To install any missing packages, you should use the appropriate package manager
    for your system. For example, on Ubuntu you would use the ``apt`` package manager. For Ubuntu 16 and newer, the
-   necessary commands would be ::
+   necessary command would be ::
 
-    sudo apt install git
-    sudo apt install gcc
-    sudo apt install g++
-    sudo apt install make
+    sudo apt install git gcc g++ make
+    
+   On Fedora the package manager is ``dnf`` ::
+   
+    sudo dnf install git gcc gcc-c++ make
 
    For MacOS users, these packages will not come preinstalled, but can be easily obtained by installing the XCode Command Line Tools.
    These are a set of packages relevant for software development which have been bundled together by Apple. The easiest way


### PR DESCRIPTION
Replaces pull request #1983

Combine Ubuntu installation commands for gcc, g++, git and make to one line;
add equivalent for installation instruction for Fedora since this is a major distro on the Red Hat side (vs. Debian side of the Linux world with Ubuntu).
This should add clarity for newer users.
Motivation or Problem

The documentation for the developer install on Linux would benefit from providing instructions specific to Fedora and not just Ubuntu since this is another widely-used distro and serves as a template for most Red Hat derivatives.
Description of Changes

The necessary command to install gcc, g++, make, and git was added.
Also the four Ubuntu commands were compressed to one line.
Both changes should make installation slightly easier either for those copying and pasting or novice users.
Testing

The suggested command was executed successfully on a Fedora 32 system.
Installation of multiple packages in one line with apt was confirmed on a current Ubuntu 20.04 system.
These steps have been followed to set up RMG developer environments on Ubuntu 20.04 and Fedora 32.
Reviewer Tips

Suggestions for verifying that this PR works or other notes for the reviewer.