### PR TITLE
Using metal attributes

### DIFF
--- a/examples/rmg/catalysis/methane_steam/input.py
+++ b/examples/rmg/catalysis/methane_steam/input.py
@@ -1,6 +1,6 @@
 # Data sources
 database(
-    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC'], 
+    thermoLibraries=['surfaceThermoNi111', 'surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC'], 
     reactionLibraries = [('Surface/Deutschmann_Ni', True)], # when Pt is used change the library to Surface/CPOX_Pt/Deutschmann2006
     seedMechanisms = [],
     kineticsDepositories = ['training'],

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -75,6 +75,8 @@ class Entry(object):
     `metal`             Which metal the thermo calculation was done on (``None`` if not used)
     `facet`             Which facet the thermo calculation was done on (``None`` if not used)
     `site`              Which surface site the molecule prefers (``None`` if not used)
+    `binding_energies'  The surface binding energies for C,H,O, and N
+    `surface_site_density`  The surface site density
     =================== ========================================================
 
     """
@@ -95,6 +97,8 @@ class Entry(object):
                  metal=None,
                  facet=None,
                  site=None,
+                 binding_energies=None,
+                 surface_site_density=None,
                  ):
         self.index = index
         self.label = label
@@ -111,6 +115,8 @@ class Entry(object):
         self.metal = metal
         self.facet = facet
         self.site = site
+        self.binding_energies = binding_energies
+        self.surface_site_density = surface_site_density
 
     def __str__(self):
         return self.label

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -134,6 +134,14 @@ def save_entry(f, entry):
     if entry.long_desc.strip() != '':
         f.write(f'    longDesc = \n"""\n{entry.long_desc.strip()}\n""",\n')
 
+    # write metal attributes
+    if entry.metal:
+        f.write('    metal = "{0}",\n'.format(entry.metal))
+    if entry.facet:
+        f.write('    facet = "{0}",\n'.format(entry.facet))
+    if entry.site:
+        f.write('    site = "{0}",\n'.format(entry.site))
+
     f.write(')\n\n')
 
 

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -670,6 +670,7 @@ class TestTreeGeneration(unittest.TestCase):
             kinetics_families=[],
             depository=False,
             solvation=False,
+            surface=False,
             testing=True,
         )
         cls.database.load_forbidden_structures()
@@ -833,6 +834,7 @@ class TestGenerateReactions(unittest.TestCase):
                               'Surface_Dissociation_vdW'],
             depository=False,
             solvation=False,
+            surface=False,
             testing=True,
         )
         cls.database.load_forbidden_structures()

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -64,6 +64,7 @@ def setUpModule():
         testing=True,
         depository=False,
         solvation=False,
+        surface=False,
     )
     # load empty forbidden structures to avoid any dependence on forbidden structures
     # for these tests

--- a/rmgpy/data/kinetics/libraryTest.py
+++ b/rmgpy/data/kinetics/libraryTest.py
@@ -79,6 +79,9 @@ class TestLibrary(unittest.TestCase):
         for library_name in ['ethane-oxidation', 'surface-example']:
             copy_path = os.path.join(settings['test_data.directory'], 'testing_database',
                                     'kinetics', 'libraries', library_name+'-copy')
+            if os.path.exists(copy_path):
+                logging.warning(f"Removing existing directory {copy_path}.")
+                shutil.rmtree(copy_path)
             os.makedirs(copy_path)
             try:
                 self.libraries[library_name].save(os.path.join(copy_path, 'reactions.py'))

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -40,6 +40,7 @@ from rmgpy.data.kinetics.database import KineticsDatabase
 from rmgpy.data.solvation import SolvationDatabase
 from rmgpy.data.statmech import StatmechDatabase
 from rmgpy.data.thermo import ThermoDatabase
+from rmgpy.data.surface import MetalDatabase
 from rmgpy.data.transport import TransportDatabase
 from rmgpy.exceptions import DatabaseError
 
@@ -62,6 +63,7 @@ class RMGDatabase(object):
         self.kinetics = None
         self.statmech = None
         self.solvation = None
+        self.surface = None
 
         # Store the newly created database in the module.
         global database
@@ -80,6 +82,7 @@ class RMGDatabase(object):
              statmech_libraries=None,
              depository=True,
              solvation=True,
+             surface=True,
              testing=False):
         """
         Load the RMG database from the given `path` on disk, where `path`
@@ -105,6 +108,9 @@ class RMGDatabase(object):
 
         if solvation:
             self.load_solvation(os.path.join(path, 'solvation'))
+
+        if surface:
+            self.load_surface(os.path.join(path, 'surface'))
 
     def load_thermo(self, path, thermo_libraries=None, depository=True):
         """
@@ -173,6 +179,14 @@ class RMGDatabase(object):
         self.solvation = SolvationDatabase()
         self.solvation.load(path)
 
+    def load_surface(self, path):
+        """
+        Load the RMG metal database from the given `path` on disk, where
+        `path` points to the top-level folder of the RMG surface database.
+        """
+        self.surface = MetalDatabase()
+        self.surface.load(path)
+
     def load_statmech(self, path, statmech_libraries=None, depository=True):
         """
         Load the RMG statmech database from the given `path` on disk, where
@@ -213,6 +227,7 @@ class RMGDatabase(object):
         self.statmech.save(os.path.join(path, 'statmech'))
         self.solvation.save(os.path.join(path, 'solvation'))
         self.transport.save(os.path.join(path, 'transport'))
+        self.surface.save(os.path.join(path, 'surface'))
 
     def save_old(self, path):
         """
@@ -248,6 +263,8 @@ def get_db(name=''):
             return database.transport
         elif name == 'solvation':
             return database.solvation
+        elif name == 'surface':
+            return database.surface
         elif name == 'statmech':
             return database.statmech
         elif name == 'forbidden':

--- a/rmgpy/data/rmg.py
+++ b/rmgpy/data/rmg.py
@@ -82,7 +82,7 @@ class RMGDatabase(object):
              statmech_libraries=None,
              depository=True,
              solvation=True,
-             surface=True,
+             surface=True,  # on by default, because solvation is also on by default
              testing=False):
         """
         Load the RMG database from the given `path` on disk, where `path`
@@ -93,7 +93,6 @@ class RMGDatabase(object):
 
         Argument testing will load a lighter version of the database used for unit-tests
         """
-        self.load_thermo(os.path.join(path, 'thermo'), thermo_libraries, depository)
         if not testing:
             self.load_transport(os.path.join(path, 'transport'), transport_libraries)
             self.load_forbidden_structures(os.path.join(path, 'forbiddenStructures.py'))
@@ -110,15 +109,17 @@ class RMGDatabase(object):
             self.load_solvation(os.path.join(path, 'solvation'))
 
         if surface:
-            self.load_surface(os.path.join(path, 'surface'))
+            self.load_thermo(os.path.join(path, 'thermo'), thermo_libraries, depository, surface)
 
-    def load_thermo(self, path, thermo_libraries=None, depository=True):
+
+
+    def load_thermo(self, path, thermo_libraries=None, depository=True, surface=False):
         """
         Load the RMG thermo database from the given `path` on disk, where
         `path` points to the top-level folder of the RMG thermo database.
         """
         self.thermo = ThermoDatabase()
-        self.thermo.load(path, thermo_libraries, depository)
+        self.thermo.load(path, thermo_libraries, depository, surface)
 
     def load_transport(self, path, transport_libraries=None):
         """
@@ -227,7 +228,6 @@ class RMGDatabase(object):
         self.statmech.save(os.path.join(path, 'statmech'))
         self.solvation.save(os.path.join(path, 'solvation'))
         self.transport.save(os.path.join(path, 'transport'))
-        self.surface.save(os.path.join(path, 'surface'))
 
     def save_old(self, path):
         """
@@ -263,8 +263,6 @@ def get_db(name=''):
             return database.transport
         elif name == 'solvation':
             return database.solvation
-        elif name == 'surface':
-            return database.surface
         elif name == 'statmech':
             return database.statmech
         elif name == 'forbidden':

--- a/rmgpy/data/surface.py
+++ b/rmgpy/data/surface.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+
+"""
+import os.path
+import re
+import logging
+
+from rmgpy.data.base import Database, Entry, DatabaseError
+import rmgpy.quantity
+
+
+################################################################################
+
+def save_entry(f, entry):
+    """
+    Write a Pythonic string representation of the given `entry` in the metal
+    database to the file object `f`.
+    """
+    f.write('entry(\n')
+    f.write('    index = {0:d},\n'.format(entry.index))
+    f.write('    label = "{0}",\n'.format(entry.label))
+    if entry.bindingEnergies:
+        f.write('    bindingEnergies = {\n')
+        for key, value in entry.bindingEnergies.items():
+            f.write(f"        {key!r}: {value!r},\n")
+        f.write("    }\n")
+    if entry.surfaceSiteDesnity:
+        f.write('    surfaceSiteDensity = {0},\n'.format(entry.surfaceSiteDesnity))
+    if entry.facet:
+        f.write('    facet = "{0}",\n'.format(entry.facet))
+    if entry.metal:
+        f.write('    metal = "{0}",\n'.format(entry.metal))
+    f.write(f'    shortDesc = """{entry.short_desc.strip()}""",\n')
+    f.write(f'    longDesc = \n"""\n{entry.long_desc.strip()}\n""",\n')
+    f.write(')\n\n')
+
+
+################################################################################
+
+
+################################################################################
+
+class MetalLibrary(Database):
+    """
+    A class for working with a RMG metal library.
+    """
+
+    def __init__(self, label='', name='', short_desc='', long_desc=''):
+        Database.__init__(self, label=label, name=name, short_desc=short_desc, long_desc=long_desc)
+
+    def load_entry(self,
+                   index,
+                   label,
+                   metal='',
+                   facet='',
+                   surfaceSiteDensity=None,
+                   bindingEnergies=None,
+                   shortDesc='',
+                   longDesc='',
+                   ):
+        """
+        Method for parsing entries in database files.
+        Note that these argument names are retained for backward compatibility.
+        """
+        if bindingEnergies:
+            binding_energies = dict()
+            for element, energy in bindingEnergies.items():
+                binding_energies[element] = rmgpy.quantity.Energy(energy)
+        else:
+            binding_energies = None
+        
+        if surfaceSiteDensity:
+            surface_site_density = rmgpy.quantity.SurfaceConcentration(*surfaceSiteDensity)
+        else:
+            surface_site_density = None
+
+        self.entries[label] = Entry(
+            index=index,
+            label=label,
+            metal=metal,
+            facet=facet,
+            surface_site_density=surface_site_density,
+            binding_energies=binding_energies,
+            short_desc=shortDesc,
+            long_desc=longDesc.strip(),
+        )
+
+    def load(self, path):
+        """
+        Load the metal library from the given path
+        """
+        Database.load(self, path, local_context={}, global_context={})
+
+    def save_entry(self, f, entry):
+        """
+        Write the given `entry` in the metal database to the file object `f`.
+        """
+        return save_entry(f, entry)
+
+    def get_binding_energies(self, label):
+        """
+        Get a metal's binding energies from its label.
+
+        Raises DatabaseError (rather than returning None) if it can't be found.
+        """
+        try:
+            binding_energies = self.entries[label].binding_energies
+        except KeyError:
+            raise DatabaseError(f'Metal {label!r} not found in metal library database.')
+        if binding_energies is None:
+            raise DatabaseError(f'Metal {label!r} has no binding energies in metal library database.')
+        return binding_energies
+
+    def get_surface_site_density(self, label):
+        """
+        Get a metal's surface site desnity from its label.
+
+        Raises DatabaseError (rather than returning None) if it can't be found.
+        """
+        try:
+            surface_site_density = self.entries[label].surface_site_density
+        except KeyError:
+            raise DatabaseError(f'Metal {label!r} not found in metal library database.')
+        if surface_site_density is None:
+            raise DatabaseError(f'Metal {label!r} has no surface site density in metal library database.')
+        return surface_site_density
+
+    def get_all_entries_on_metal(self, metal_name):
+        """
+        Get all entries from the database that are on a certain metal, for any facet,
+        returning the labels.
+
+        Raises DatabaseError (rather than an empty list) if none can be found.
+        """
+        matches = []
+        for label, entry in self.entries.items():
+            if entry.metal == metal_name:
+                matches.append(label)
+
+        if len(matches) == 0:
+            raise DatabaseError(f'Metal {metal_name!r} not found in database.')
+
+        return matches
+
+
+################################################################################
+
+class MetalDatabase(object):
+    """
+    A class for working with the RMG metal database.
+    """
+
+    def __init__(self):
+        self.libraries = {}
+        self.libraries['surface'] = MetalLibrary()
+        self.groups = {}
+        self.local_context = {}
+        self.global_context = {}
+
+    def __reduce__(self):
+        """
+        A helper function used when pickling a MetalDatabase object.
+        """
+        d = {
+            'libraries': self.libraries,
+        }
+        return (MetalDatabase, (), d)
+
+    def __setstate__(self, d):
+        """
+        A helper function used when unpickling a MetalDatabase object.
+        """
+        self.libraries = d['libraries']
+
+    def load(self, path, libraries=None, depository=True):
+        """
+        Load the metal database from the given `path` on disk, where `path`
+        points to the top-level folder of the surface database.
+        
+        Load the metal library
+        """
+        self.libraries['surface'].load(os.path.join(path, 'libraries', 'metal.py'))
+
+    def get_binding_energies(self, metal_label):
+        """
+        Get a metal's binding energies from its label
+        """
+        return self.libraries['surface'].get_binding_energies(metal_label)
+
+    def get_surface_site_density(self, metal_label):
+        """
+        Get a metal's surface site desnity from its label
+        """
+        return self.libraries['surface'].get_surface_site_density(metal_label)
+
+    def get_all_entries_on_metal(self, metal):
+        """
+        Get all entries from the database that are on a certain metal, on any facet,
+        returning the labels.
+        """
+        return self.libraries['surface'].get_all_entries_on_metal(metal)
+
+    def find_binding_energies(self, metal):
+        """
+        Tries to find a match in the database when given a metal and/or facet and returns the binding energies or a
+        best guess of binding energies.
+        """
+        if metal is None:
+            raise DatabaseError("Cannot search for nothing.")
+        assert isinstance(metal, str)
+
+        facet = re.search('\d+', metal)
+
+        if facet is not None:
+            try:
+                metal_binding_energies = self.libraries['surface'].get_binding_energies(metal)
+            except DatabaseError:
+                # no exact match was found, so continue on as if no facet was given
+                logging.warning("Requested metal %r not found in database.", metal)
+                metal = metal[:facet.span()[0]]
+                logging.warning("Searching for generic %r.", metal)
+                facet = None
+
+        if facet is None:
+            # no facet was specified, so use the first
+            metal_entry_matches = self.libraries['surface'].get_all_entries_on_metal(metal)
+
+            if len(metal_entry_matches) == 1:
+                metal_binding_energies = self.libraries['surface'].get_binding_energies(metal_entry_matches[0])
+            elif metal_entry_matches is None:  # no matches
+                raise DatabaseError(f"No metal {metal} found in metal database.")
+            else:  # multiple matches
+                # average the binding energies together? just pick the first one?
+                # just picking the first one for now...
+                logging.warning(f"Found multiple binding energies for {metal!r}. Using {metal_entry_matches[0]!r}.")
+                metal_binding_energies = self.libraries['surface'].get_binding_energies(metal_entry_matches[0])
+
+        return metal_binding_energies
+
+    def save(self, path):
+        """
+        Save the metal database to the given `path` on disk, where `path`
+        points to the top-level folder of the metal database.
+        """
+        path = os.path.abspath(path)
+        if not os.path.exists(path):
+            os.mkdir(path)
+        self.save_libraries(os.path.join(path, 'libraries'))
+
+    def save_libraries(self, path):
+        """
+        Save the metal libraries to the given `path` on disk, where `path`
+        points to the top-level folder of the metal libraries.
+        """
+        if not os.path.exists(path):
+            os.mkdir(path)
+        for library in self.libraries.keys():
+            self.libraries[library].save(os.path.join(path, library + '.py'))

--- a/rmgpy/data/surface.py
+++ b/rmgpy/data/surface.py
@@ -35,6 +35,7 @@ import re
 import logging
 
 from rmgpy.data.base import Database, Entry, DatabaseError
+# from rmgpy.data.thermo import ThermoDatabase, Entry, DatabaseError
 import rmgpy.quantity
 
 

--- a/rmgpy/data/surface.py
+++ b/rmgpy/data/surface.py
@@ -136,14 +136,15 @@ class MetalLibrary(Database):
         try:
             binding_energies = self.entries[label].binding_energies
         except KeyError:
-            raise DatabaseError(f'Metal {label!r} not found in metal library database.')
+            raise DatabaseError(f'Metal {label!r} not found in metal library database. \
+            Labels should be formatted MetalFacet (ex. Pt111).')
         if binding_energies is None:
             raise DatabaseError(f'Metal {label!r} has no binding energies in metal library database.')
         return binding_energies
 
     def get_surface_site_density(self, label):
         """
-        Get a metal's surface site desnity from its label.
+        Get a metal's surface site density from its label.
 
         Raises DatabaseError (rather than returning None) if it can't be found.
         """

--- a/rmgpy/data/surfaceTest.py
+++ b/rmgpy/data/surfaceTest.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import os
+from unittest import TestCase, TestLoader, TextTestRunner
+
+from rmgpy import settings
+from rmgpy.data.surface import MetalDatabase
+from rmgpy.data.base import Entry #DatabaseError
+from rmgpy.exceptions import DatabaseError
+from rmgpy.quantity import Energy, SurfaceConcentration
+
+###################################################
+
+class TestMetalDatabase(TestCase):
+
+    def setUp(self):
+        self.database = MetalDatabase()
+        self.database.load(os.path.join(settings['database.directory'], 'surface'))
+
+    def tearDown(self):
+        """
+        Reset the database & parameters
+        """
+        import rmgpy.data.rmg
+        rmgpy.data.rmg.database = None
+
+    def test_load_metal_library(self):
+        """Test we can obtain metal parameters from a library"""
+
+        test_entry = Entry(
+            index=1,
+            label="Pt111",
+            binding_energies={
+                'H': Energy(-2.75367887E+00, 'eV/molecule'),
+                'C': Energy(-7.02515507E+00, 'eV/molecule'),
+                'N': Energy(-4.63224568E+00, 'eV/molecule'),
+                'O': Energy(-3.81153179E+00, 'eV/molecule'),
+            },
+            surface_site_density=SurfaceConcentration(2.483E-09, 'mol/cm^2'),
+            facet="111",
+            metal="Pt",
+            short_desc=u"fcc",
+            long_desc=u"""
+        Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+            """,
+        )
+
+        self.assertEqual(repr(self.database.get_binding_energies(test_entry.label)), repr(test_entry.binding_energies))
+        self.assertEqual(repr(self.database.get_surface_site_density(test_entry.label)), repr(test_entry.surface_site_density))
+
+    def test_load_from_label(self):
+        """Test we can obtain metal parameters from a string"""
+
+        test_pt111 = "Pt111"
+        self.assertIsNotNone(self.database.get_binding_energies(test_pt111))
+
+        test_notexistent = "Pt000"
+        with self.assertRaises(DatabaseError):
+            self.database.get_binding_energies(test_notexistent)
+
+    def test_load_all_entries_on_one_metal(self):
+        """Test we can load all entries from the database on one metal"""
+
+        self.assertGreaterEqual(len(self.database.get_all_entries_on_metal("Pt")), 2)
+        self.assertGreaterEqual(len(self.database.get_all_entries_on_metal("Ni")), 2)
+        self.assertGreaterEqual(len(self.database.get_all_entries_on_metal("Co")), 2)
+
+#####################################################
+
+
+if __name__ == '__main__':
+    suite = TestLoader().loadTestsFromTestCase(TestMetalDatabase)
+    TextTestRunner(verbosity=2).run(suite)

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1375,7 +1375,7 @@ class ThermoDatabase(object):
         Returns:
             None, stores result in self.binding_energies
         """
-    
+        
         if isinstance(binding_energies, str):
             # Want to load the binding energies from the database
             metal_db = rmgpy.data.rmg.database.surface

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -846,9 +846,6 @@ class ThermoDatabase(object):
         }
         self.global_context = {}
 
-        # Catalyst properties
-        self.set_binding_energies()
-
     def __reduce__(self):
         """
         A helper function used when pickling a ThermoDatabase object.
@@ -1385,7 +1382,7 @@ class ThermoDatabase(object):
             binding_energies = metal_db.find_binding_energies(binding_energies)
 
         for element, energy in binding_energies.items():
-            binding_energies[element] = rmgpy.quantity.Energy(binding_energies[element])
+            binding_energies[element] = rmgpy.quantity.Energy(energy)
 
         self.binding_energies = binding_energies
 
@@ -1400,10 +1397,10 @@ class ThermoDatabase(object):
         :param metal_to_scale_to: the metal you want to scale to (string e.g 'Pt111' or None)
         :return: corrected thermo
         """
+        metal_db = rmgpy.data.rmg.database.surface
+        
         if metal_to_scale_from == metal_to_scale_to:
             return thermo
-
-        metal_db = rmgpy.data.rmg.database.surface
 
         if metal_to_scale_to is None:
             metal_to_scale_to_binding_energies = self.binding_energies

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1254,7 +1254,12 @@ class ThermoDatabase(object):
 
             if species.contains_surface_site():
                 if entry.metal is not None:
-                    thermo0 = self.correct_binding_energy(thermo0, species, metal_to_scale_from=entry.metal, metal_to_scale_to=metal_to_scale_to)
+                    if entry.facet is not None:
+                        db_label = entry.metal + entry.facet
+                        thermo0 = self.correct_binding_energy(thermo0, species, metal_to_scale_from=db_label,
+                                                              metal_to_scale_to=metal_to_scale_to)
+                    else:  # no facet was given
+                        thermo0 = self.correct_binding_energy(thermo0, species, metal_to_scale_from=entry.metal, metal_to_scale_to=metal_to_scale_to)
                 else:  # assume the thermo came from pt 111
                     thermo0 = self.correct_binding_energy(thermo0, species, metal_to_scale_from=None, metal_to_scale_to=metal_to_scale_to)
             return thermo0

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -136,6 +136,13 @@ def save_entry(f, entry):
     if entry.rank:
         f.write("    rank = {0},\n".format(entry.rank))
 
+    if entry.metal:
+        f.write('    metal = "{0}",\n'.format(entry.metal))
+    if entry.facet:
+        f.write('    facet = "{0}",\n'.format(entry.facet))
+    if entry.site:
+        f.write('    site = "{0}",\n'.format(entry.site))
+
     f.write(')\n\n')
 
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1226,7 +1226,7 @@ class ThermoDatabase(object):
         if species.contains_surface_site():
             try:
                 thermo0 = self.get_thermo_data_for_surface_species(species)
-                thermo0 = self.correct_binding_energy(thermo0, species, metal_to_scale_to=metal_to_scale_to)
+                thermo0 = self.correct_binding_energy(thermo0, species, metal_to_scale_from="Pt111", metal_to_scale_to=metal_to_scale_to)  # group adsorption values come from Pt111
                 return thermo0
             except:
                 logging.error("Error attempting to get thermo for species %s with structure \n%s", 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1505,7 +1505,7 @@ class ThermoDatabase(object):
                 change_in_binding_energy = delta_atomic_adsorption_energy[element].value_si * normalized_bonds[element]
                 thermo.H298.value_si += change_in_binding_energy
                 comments.append(f'{normalized_bonds[element]:.2f}{element}')
-        thermo.comment += " Binding energy corrected by LSR ({})".format('+'.join(comments))
+        thermo.comment += " Binding energy corrected by LSR ({}) from {}".format('+'.join(comments), metal_to_scale_from)
         return thermo
 
     def get_thermo_data_for_surface_species(self, species):

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -55,8 +55,10 @@ def setUpModule():
     database = RMGDatabase()
     database.load_thermo(
         os.path.join(settings['database.directory'], 'thermo'),
-        thermo_libraries=['DFT_QCI_thermo', 'SABIC_aromatics', 'primaryThermoLibrary']
+        thermo_libraries=['DFT_QCI_thermo', 'SABIC_aromatics', 'primaryThermoLibrary'],
+        surface=True,
     )
+    database.load_surface(os.path.join(settings['database.directory'], 'surface'))
 
 
 def tearDownModule():
@@ -89,7 +91,7 @@ class TestThermoDatabase(unittest.TestCase):
         cls.database.set_binding_energies('Pt111')
 
         cls.databaseWithoutLibraries = ThermoDatabase()
-        cls.databaseWithoutLibraries.load(os.path.join(settings['database.directory'], 'thermo'), libraries=[])
+        cls.databaseWithoutLibraries.load(os.path.join(settings['database.directory'], 'thermo'), libraries=[], surface=True)
         cls.databaseWithoutLibraries.set_binding_energies('Pt111')
 
         # Set up ML estimator

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -86,9 +86,11 @@ class TestThermoDatabase(unittest.TestCase):
         """A function that is run ONCE before all unit tests in this class."""
         global database
         cls.database = database.thermo
+        cls.database.set_binding_energies('Pt111')
 
         cls.databaseWithoutLibraries = ThermoDatabase()
         cls.databaseWithoutLibraries.load(os.path.join(settings['database.directory'], 'thermo'), libraries=[])
+        cls.databaseWithoutLibraries.set_binding_energies('Pt111')
 
         # Set up ML estimator
         models_path = os.path.join(settings['database.directory'], 'thermo', 'ml', 'main')

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -106,6 +106,8 @@ def catalyst_properties(bindingEnergies=None,
     Metal is the label of a metal in the surface metal library.
     Defaults to Pt(111) if not specified.
     """
+    # Normally we wouldn't load the database until after reading the input file,
+    # but we need to load the metal surfaces library to validate the input.
     metal_db = MetalDatabase()
     metal_db.load(os.path.join(settings['database.directory'], 'surface'))
 
@@ -119,7 +121,7 @@ def catalyst_properties(bindingEnergies=None,
             rmg.binding_energies = metal_db.get_binding_energies(metal)
             rmg.surface_site_density = metal_db.get_surface_site_density(metal)
         except DatabaseError:
-            logging.error('Metal %r missing from surface library', metal)
+            logging.error('Metal %r missing from surface library. Please specify both metal and facet.', metal)
             raise
     else: # metal not specified
         if bindingEnergies is None:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -400,8 +400,9 @@ class RMG(util.Subject):
         # check libraries
         self.check_libraries()
 
+        # set global binding energies variable
         if self.binding_energies:
-            self.database.thermo.set_delta_atomic_adsorption_energies(self.binding_energies)
+            self.database.thermo.set_binding_energies(self.binding_energies)
 
         # set global variable solvent
         if self.solvent:

--- a/rmgpy/test_data/testing_database/kinetics/libraries/surface-example/dictionary.txt
+++ b/rmgpy/test_data/testing_database/kinetics/libraries/surface-example/dictionary.txt
@@ -1,0 +1,101 @@
+
+Ni
+1 X u0 p0 c0
+
+O2
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+
+CH4
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+
+H2
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+
+
+H2O
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+
+
+CO
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+
+
+CO2
+1 C u0 p0 c0 {2,D} {3,D}
+2 O u0 p2 c0 {1,D}
+3 O u0 p2 c0 {1,D}
+
+
+CH2O
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+
+
+CH3OH
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+
+
+
+OX
+1 X u0 p0 c0 {2,D}
+2 O u0 p2 c0 {1,D}
+
+
+CH3X
+1 C u0 p0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 {1,S}
+3 H u0 p0 {1,S}
+4 H u0 p0 {1,S}
+5 X u0 p0 {1,S}
+
+
+HX
+1 H u0 p0 {2,S}
+2 X u0 p0 {1,S}
+
+
+O2X
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u1 p2 c0 {1,S}
+3 X u0 p0 c0 {1,S}
+
+HOX
+1 O u0 p2 {2,S} {3,S}
+2 H u0 p0 {1,S}
+3 X u0 p0 {1,S}
+
+
+OCX
+1 C u0 p0 {2,D} {3,D}
+2 O u0 p2 {1,D} 
+3 X u0 p0 {1,D} 
+
+
+
+
+
+
+

--- a/rmgpy/test_data/testing_database/kinetics/libraries/surface-example/reactions.py
+++ b/rmgpy/test_data/testing_database/kinetics/libraries/surface-example/reactions.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface"
+shortDesc = u""
+longDesc = u"""
+test surface mechanism: based upon Olaf Deutschmann's work:
+"Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+Delgado et al
+Catalysts, 2015, 5, 871-904
+"""
+
+entry(
+    index = 1,
+    label = "O2 + Ni + Ni <=> OX + OX",
+    kinetics = StickingCoefficient(
+        A = 4.36E-2,
+        n = -0.206,
+        Ea=(1.5E3, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)
+
+
+entry(
+    index = 2,
+    label = "O2 + Ni <=> O2X",
+    kinetics = StickingCoefficient(
+        A = 0.0,
+        n = 0,
+        Ea=(0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)
+
+entry(
+    index = 3,
+    label = "CH4 + Ni + Ni <=> CH3X + HX",
+    kinetics = StickingCoefficient(
+        A = 8.0E-3,
+        n = 0,
+        Ea=(0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)
+
+entry(
+    index = 4,
+    label = "H2 + Ni + Ni <=> HX + HX",
+    kinetics = StickingCoefficient(
+        A = 3.2E-2,
+        n = 0,
+        Ea=(0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)
+
+
+entry(
+    index = 5,
+    label = "HX + HOX <=> H2O + Ni + Ni",
+    kinetics = SurfaceArrhenius(
+        A=(1.85E16, 'm^2/(mol*s)'),
+        n = 0.086,
+        Ea=(41500.0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)
+
+
+entry(
+    index = 6,
+    label = "CO + Ni <=> OCX",
+    kinetics = StickingCoefficient(
+        A = 5.0E-1,
+        n = 0,
+        Ea=(0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)
+
+
+
+entry(
+    index = 7,
+    label = "OCX + OX <=> CO2 + Ni + Ni",
+    kinetics = SurfaceArrhenius(
+        A=(2.00E15, 'm^2/(mol*s)'),
+        n = 0.0,
+        Ea=(123600.0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up""",
+	metal = "Ni",
+)

--- a/rmgpy/test_data/testing_database/thermo/groups/adsorptionPt111.py
+++ b/rmgpy/test_data/testing_database/thermo/groups/adsorptionPt111.py
@@ -25,6 +25,8 @@ entry(
 ***********
 This node should be empty, ensuring that one of the nodes below is used.
 """,
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -47,7 +49,9 @@ entry(
    R
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -71,7 +75,9 @@ entry(
   R-R
    :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -96,7 +102,9 @@ entry(
  RO-R
    :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -122,7 +130,9 @@ entry(
    O
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -148,7 +158,9 @@ entry(
  RO-OR
    :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -173,7 +185,9 @@ entry(
    O--O
    |  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -200,7 +214,9 @@ entry(
    O
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -223,7 +239,9 @@ entry(
    O
    ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -251,7 +269,9 @@ entry(
    O
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -280,7 +300,9 @@ entry(
    O
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -306,7 +328,9 @@ entry(
  R2N-R
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -331,7 +355,9 @@ entry(
    NR2
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -352,7 +378,9 @@ entry(
     shortDesc="""Came from NH double-bonded on Pt(111)""",
     longDesc="""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -375,7 +403,9 @@ entry(
     N
    |||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -402,7 +432,9 @@ entry(
  R2N-OR
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -427,7 +459,9 @@ entry(
   RN=O
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -453,7 +487,9 @@ entry(
  R-N-OR
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -479,7 +515,9 @@ entry(
    N
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -504,7 +542,9 @@ entry(
    N--O
   ||  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -531,7 +571,9 @@ entry(
    N
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -559,7 +601,9 @@ entry(
  R2N-NR2
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -585,7 +629,9 @@ entry(
  RN=NR
    :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -610,7 +656,9 @@ entry(
   N==N
   |  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -637,7 +685,9 @@ entry(
  R-N-NR2
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -664,7 +714,9 @@ entry(
    N
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -692,7 +744,9 @@ entry(
    N
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -719,7 +773,9 @@ entry(
  RN--NR
   |  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -747,7 +803,9 @@ entry(
  R-N-CR3
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -775,7 +833,9 @@ entry(
    N
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -804,7 +864,9 @@ entry(
    N
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -829,7 +891,9 @@ entry(
  O-N=O
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -852,7 +916,9 @@ entry(
    C
  ||||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -877,7 +943,9 @@ entry(
   C--C
   |  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -905,7 +973,9 @@ entry(
    C
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -934,7 +1004,9 @@ entry(
    C
   |||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -960,7 +1032,9 @@ entry(
    C
   |||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -987,7 +1061,9 @@ entry(
  R-C--C-R
   ||  ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1012,7 +1088,9 @@ entry(
  R-C-R
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1041,7 +1119,9 @@ entry(
  R2C--CR2
    |  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1067,7 +1147,9 @@ entry(
    CR3
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1097,7 +1179,9 @@ entry(
  R3C-CR3
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1124,7 +1208,9 @@ entry(
   R3C-R
      :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1149,7 +1235,9 @@ entry(
   C==N
  ||  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1176,7 +1264,9 @@ entry(
     C
    ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1204,7 +1294,9 @@ entry(
    C
   |||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1230,7 +1322,9 @@ entry(
    C
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1257,7 +1351,9 @@ entry(
    C
   |||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1285,7 +1381,9 @@ entry(
  R2C--CR
    |  ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1316,7 +1414,9 @@ entry(
  R-C-CR3
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1343,7 +1443,9 @@ entry(
  R2C=NR
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1373,7 +1475,9 @@ entry(
  R-C-NR2
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1399,7 +1503,9 @@ entry(
  R2C=O
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1428,7 +1534,9 @@ entry(
   R-C-OR
     |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1457,7 +1565,9 @@ entry(
  R3C-NR2
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1485,7 +1595,9 @@ entry(
  R3C-OR
     :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1511,7 +1623,9 @@ entry(
  RC--C
   |  ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1540,7 +1654,9 @@ entry(
    C-R
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1570,7 +1686,9 @@ entry(
    C-R
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1595,7 +1713,9 @@ entry(
  RC#N
    :
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1623,7 +1743,9 @@ entry(
   C--N
  ||  ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1651,7 +1773,9 @@ entry(
    C-R
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1678,7 +1802,9 @@ entry(
  RC--NR
  ||  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1707,7 +1833,9 @@ entry(
    C-R
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1734,7 +1862,9 @@ entry(
    C=O
    |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1762,7 +1892,9 @@ entry(
   C--O
  ||  |
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1790,7 +1922,9 @@ entry(
    C-R
   ||
 ***********
-"""
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1802,6 +1936,8 @@ entry(
 2 C  u0 {1,[S,D,T,Q]}
 """,
     thermo='C-*R3',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1813,6 +1949,8 @@ entry(
 2 N  u0 {1,[S,D,T,Q]}
 """,
     thermo='N-*R2',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1824,6 +1962,8 @@ entry(
 2 O  u0 {1,[S,D,T,Q]}
 """,
     thermo='O-*R',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1840,7 +1980,9 @@ entry(
         H298=(-45.38, 'kcal/mol'),
         S298=(-38.17, 'cal/(mol*K)'),
     ),
-    shortDesc="""Average of C-*R3, N-*R2 and O-*R thermo. """
+    shortDesc="""Average of C-*R3, N-*R2 and O-*R thermo. """,
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1854,6 +1996,8 @@ entry(
 4 C  u0
 """,
     thermo='C-*R2C-*R2',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1867,6 +2011,8 @@ entry(
 4 N  u0
 """,
     thermo='C=*RN-*R',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1880,6 +2026,8 @@ entry(
 4 O  u0
 """,
     thermo='C=*RO-*R',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1893,6 +2041,8 @@ entry(
 4 N  u0
 """,
     thermo='N-*RN-*R',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1911,7 +2061,9 @@ entry(
         H298=(-37.29, 'kcal/mol'),
         S298=(-44.37, 'cal/(mol*K)'),
     ),
-    shortDesc="""Average of C-*R2C-*R2, C=*RN-*R, C=*RO-* and N-*RN-*R thermo. """
+    shortDesc="""Average of C-*R2C-*R2, C=*RN-*R, C=*RO-* and N-*RN-*R thermo. """,
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1928,7 +2080,9 @@ entry(
         H298=(-7.79, 'kcal/mol'),
         S298=(-20.48, 'cal/(mol*K)'),
     ),
-    shortDesc="""Average of (CR4)*, (NR3)* and (OR2)* thermo. """
+    shortDesc="""Average of (CR4)*, (NR3)* and (OR2)* thermo. """,
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1942,7 +2096,9 @@ entry(
 4 O  u0 p2 c0 {2,[S,D]} {3,[S,D]}
 """,
     thermo='N=*O-*',
-    longDesc="""Is there really any way to do N*O* besides N=*O-* ?"""
+    longDesc="""Is there really any way to do N*O* besides N=*O-* ?""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1956,7 +2112,9 @@ entry(
 4 O  u0 p2 c0 {2,S} {3,S}
 """,
     thermo='O-*O-*',
-    longDesc="""Is there really any way to do O*O* besides O-*O-* ?"""
+    longDesc="""Is there really any way to do O*O* besides O-*O-* ?""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1968,7 +2126,9 @@ entry(
 2 N  u0 {1,T} {3,[S,D]}
 3 R  u0 {2,[S,D]}
 """,
-    thermo='N*'
+    thermo='N*',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -1983,7 +2143,9 @@ entry(
 5 R  u0 {2,S}
 """,
     thermo='(CR2NR)*',
-    longDesc="""Perhaps should be an average?"""
+    longDesc="""Perhaps should be an average?""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -1996,7 +2158,9 @@ entry(
 3 R  u0 {2,[S,D,T]}
 4 R  u0 {2,[S,D,T]}
 """,
-    thermo='(CRN)*'
+    thermo='(CRN)*',
+    metal="Pt",
+    facet="111",
 )
 
 entry(
@@ -2011,7 +2175,9 @@ entry(
 5 R  u0 p0 c0 {2,S}
 """,
     thermo='(NR3)*',
-    longDesc="""Do we have data for this?"""
+    longDesc="""Do we have data for this?""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -2025,7 +2191,9 @@ entry(
 4 R  u0 {2,S}
 """,
     thermo='(NRO)*',
-    longDesc="""Parent of (RN=O)* and (RN=NR)*. Should it be an average?"""
+    longDesc="""Parent of (RN=O)* and (RN=NR)*. Should it be an average?""",
+    metal = "Pt",
+    facet = "111",
 )
 
 tree(

--- a/rmgpy/tools/isotopesTest.py
+++ b/rmgpy/tools/isotopesTest.py
@@ -59,6 +59,7 @@ def setUpModule():
         testing=True,
         depository=False,
         solvation=False,
+        surface=False,
     )
     database.load_forbidden_structures()
 

--- a/rmgpy/tools/uncertaintyTest.py
+++ b/rmgpy/tools/uncertaintyTest.py
@@ -62,6 +62,7 @@ class TestUncertainty(unittest.TestCase):
             kinetics_depositories=['training'],
             thermo_libraries=['primaryThermoLibrary'],
             reaction_libraries=['GRI-Mech3.0'],
+            surface=False,
         )
 
         # Prepare the database by loading training reactions and averaging the rate rules verbosely

--- a/rmgpy/tools/uncertaintyTest.py
+++ b/rmgpy/tools/uncertaintyTest.py
@@ -62,7 +62,6 @@ class TestUncertainty(unittest.TestCase):
             kinetics_depositories=['training'],
             thermo_libraries=['primaryThermoLibrary'],
             reaction_libraries=['GRI-Mech3.0'],
-            surface=False,
         )
 
         # Prepare the database by loading training reactions and averaging the rate rules verbosely

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -357,11 +357,62 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
             self.compat_func_name = test_name
             yield test, group_name
 
+    def test_metal_libraries(self):
+        for library_name, library in self.database.surface.libraries.items():
+            test = lambda x: self.general_check_metal_database_has_catalyst_properties(library)
+            test_name = "Metal library {0}: Entries have catalyst properties?".format(library_name)
+            test.description = test_name
+            self.compat_func_name = test_name
+            yield test, library_name
+
+            test = lambda x: self.general_check_metal_database_has_reasonable_labels(library)
+            test_name = "Metal library {0}: Entries have reasonable labels?".format(library_name)
+            test.description = test_name
+            self.compat_func_name = test_name
+            yield test, library_name
+
     # These are the actual tests, that don't start with a "test_" name:
     def kinetics_check_surface_training_reactions_can_be_used(self, family_name):
         """Test that surface training reactions can be averaged and used for generating rate rules"""
         family = self.database.kinetics.families[family_name]
         family.add_rules_from_training(thermo_database=self.database.thermo)
+
+    def general_check_metal_database_has_catalyst_properties(self, library):
+        """Test that each entry has catalyst properties"""
+        for entry in library.entries.values():
+            if not entry.binding_energies:
+                raise AttributeError('Entry {} has no binding energies'.format(entry.label))
+            assert isinstance(entry.binding_energies, dict)
+            for element in 'CHON':
+                if not entry.binding_energies[element]:
+                    raise KeyError('Entry {} has no {} binding energy'.format(entry.label, element))
+                if not isinstance(entry.binding_energies[element], tuple):
+                    raise TypeError('Entry {} binding energy value for {} should be a tuple, but is type {}'.format(
+                        entry.label, element, type(entry.binding_energies[element])))
+                if not isinstance(entry.binding_energies[element][0], float):
+                    raise TypeError('Entry {} binding energy for {} should be a float, but is type {}'.format(
+                        entry.label, element, type(entry.binding_energies[element][0])))
+                assert entry.binding_energies[element][0] < 0.  # binding energies should all be negative... probably
+                assert entry.binding_energies[element][1] == 'eV/molecule'
+
+            if not entry.surface_site_density:
+                raise AttributeError('Entry {} has no surface site density'.format(entry.label))
+            assert isinstance(entry.surface_site_density, tuple)
+            if not isinstance(entry.surface_site_density[0], float):
+                raise TypeError('Entry {} should be a float, but is type {}'.format(entry.label, type(entry.surface_site_density[0])))
+            assert 1e-8 > entry.surface_site_density[0] > 1e-10  # values should be reasonable
+            if not isinstance(entry.surface_site_density[1], str):
+                raise TypeError('Entry {} should be a str, but is type {}'.format(entry.label, type(entry.surface_site_density[1])))
+
+    def general_check_metal_database_has_reasonable_labels(self, library):
+        """Test that each entry has a reasonable label corresponding to its metal and facet"""
+        for entry in library.entries.values():
+            if entry.metal not in entry.label:
+                raise NameError('Entry {} with metal attribute {} does not have metal in its label'.format(entry.label, entry.metal))
+            if entry.facet not in entry.label:
+                raise NameError('Entry {} with facet attribute {} does not have facet in its label'.format(entry.label, entry.facet))
+            if not entry.label[0].isupper():
+                raise NameError('Entry {} should start with a capital letter'.format(entry.label))
 
     def kinetics_check_training_reactions_have_surface_attributes(self, family_name):
         """Test that each surface training reaction has surface attributes"""

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -48,6 +48,7 @@ from rmgpy.exceptions import ImplicitBenzeneError, UnexpectedChargeError
 from rmgpy.molecule import Group
 from rmgpy.molecule.atomtype import ATOMTYPES
 from rmgpy.molecule.pathfinder import find_shortest_path
+from rmgpy.quantity import ScalarQuantity
 
 
 class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want to use nose test generators
@@ -386,23 +387,23 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
             for element in 'CHON':
                 if not entry.binding_energies[element]:
                     raise KeyError('Entry {} has no {} binding energy'.format(entry.label, element))
-                if not isinstance(entry.binding_energies[element], tuple):
-                    raise TypeError('Entry {} binding energy value for {} should be a tuple, but is type {}'.format(
+                if not isinstance(entry.binding_energies[element], ScalarQuantity):
+                    raise TypeError('Entry {} binding energy value for {} should be a ScalarQuantity, but is type {}'.format(
                         entry.label, element, type(entry.binding_energies[element])))
-                if not isinstance(entry.binding_energies[element][0], float):
+                if not isinstance(entry.binding_energies[element].value, float):
                     raise TypeError('Entry {} binding energy for {} should be a float, but is type {}'.format(
-                        entry.label, element, type(entry.binding_energies[element][0])))
-                assert entry.binding_energies[element][0] < 0.  # binding energies should all be negative... probably
-                assert entry.binding_energies[element][1] == 'eV/molecule'
+                        entry.label, element, type(entry.binding_energies[element].value)))
+                assert entry.binding_energies[element].value < 0.  # binding energies should all be negative... probably
+                assert entry.binding_energies[element].units == 'eV/molecule'
 
             if not entry.surface_site_density:
                 raise AttributeError('Entry {} has no surface site density'.format(entry.label))
-            assert isinstance(entry.surface_site_density, tuple)
-            if not isinstance(entry.surface_site_density[0], float):
-                raise TypeError('Entry {} should be a float, but is type {}'.format(entry.label, type(entry.surface_site_density[0])))
-            assert 1e-8 > entry.surface_site_density[0] > 1e-10  # values should be reasonable
-            if not isinstance(entry.surface_site_density[1], str):
-                raise TypeError('Entry {} should be a str, but is type {}'.format(entry.label, type(entry.surface_site_density[1])))
+            assert isinstance(entry.surface_site_density, ScalarQuantity)
+            if not isinstance(entry.surface_site_density.value, float):
+                raise TypeError('Entry {} should be a float, but is type {}'.format(entry.label, type(entry.surface_site_density.value)))
+            if not isinstance(entry.surface_site_density.units, str):
+                raise TypeError('Entry {} should be a str, but is type {}'.format(entry.label, type(entry.surface_site_density.units)))
+            assert 1e-4 > entry.surface_site_density.value_si > 1e-6  # values should be reasonable
 
     def general_check_metal_database_has_reasonable_labels(self, library):
         """Test that each entry has a reasonable label corresponding to its metal and facet"""

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -405,6 +405,12 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
                 raise TypeError('Entry {} should be a str, but is type {}'.format(entry.label, type(entry.surface_site_density.units)))
             assert 1e-4 > entry.surface_site_density.value_si > 1e-6  # values should be reasonable
 
+            assert isinstance(entry.metal, str)  # all entries should have a metal attribute, at minimum
+            if entry.facet:
+                assert isinstance(entry.facet, str)
+            if entry.site:
+                assert isinstance(entry.site, str)
+
     def general_check_metal_database_has_reasonable_labels(self, library):
         """Test that each entry has a reasonable label corresponding to its metal and facet"""
         for entry in library.entries.values():
@@ -424,6 +430,14 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
             if not entry.metal:
                 logging.error(f'Expected a metal attribute for {entry} in {family} family but found {entry.metal!r}')
                 failed = True
+            else:
+                assert isinstance(entry.metal, str)
+
+            if entry.facet:
+                assert isinstance(entry.facet, str)
+            if entry.site:
+                assert isinstance(entry.site, str)
+
         if failed:
             raise ValueError("Error occured in databaseTest. Please check log warnings for all error messages.")
 

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -457,7 +457,7 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
                     failed = True
         for entry in entries:
             if isinstance(entry.metal, type(None)):
-                logginge.error(f'Expected a metal attribute in {library} library for {entry} but found None')
+                logging.error(f'Expected a metal attribute in {library} library for {entry} but found None')
                 failed = True
         if failed:
             raise ValueError("Error occured in databaseTest. Please check log warnings for all error messages.")
@@ -1324,7 +1324,7 @@ Origin Group AdjList:
             if '111' in library_name:
                 if entry.facet is not '111':
                     logging.error(f'Expected {entry} facet attribute in {library_name} library to match 111, but was {entry.facet}')
-                    failed = true
+                    failed = True
             if not entry.metal:
                 logging.error(f'Expected a metal attribute for {entry} in {library} library but found {entry.metal!r}')
                 failed = True

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -359,7 +359,7 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
             yield test, group_name
 
     def test_metal_libraries(self):
-        for library_name, library in self.database.surface.libraries.items():
+        for library_name, library in self.database.thermo.surface['metal'].libraries.items():
             test = lambda x: self.general_check_metal_database_has_catalyst_properties(library)
             test_name = "Metal library {0}: Entries have catalyst properties?".format(library_name)
             test.description = test_name


### PR DESCRIPTION
### Motivation or Problem
Currently, RMG can only use surfaceThermoPt111 as it assumes the reference point is Pt111. We want to be able to:

- use thermo from all sorts of different metals and use LSRs to scale to wherever
- properly use kinetics training reactions that were on different metals (reverse reactions in particular)

This also adds a new metal database so users don't have to look up binding energies for specific metals of interest

### Reviewer Tips
I just created this PR so we would have a place for discussion.
Sister database PR is #[387](https://github.com/ReactionMechanismGenerator/RMG-database/pull/387)