### PR TITLE
Bidentate CO treatment improved

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1219,9 +1219,14 @@ class ThermoDatabase(object):
             return thermo0
 
         if species.contains_surface_site():
-            thermo0 = self.get_thermo_data_for_surface_species(species)
-            thermo0 = self.correct_binding_energy(thermo0, species)
-            return thermo0
+            try:
+                thermo0 = self.get_thermo_data_for_surface_species(species)
+                thermo0 = self.correct_binding_energy(thermo0, species)
+                return thermo0
+            except:
+                logging.error("Error attempting to get thermo for species %s with structure \n%s", 
+                    species, species.molecule[0].to_adjacency_list())
+                raise
 
         try:
             quantum_mechanics = get_input('quantum_mechanics')

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1458,9 +1458,10 @@ class ThermoDatabase(object):
         if species.is_surface_site():
             raise DatabaseError("Can't estimate thermo of vacant site. Should be in library (and should be 0).")
 
-        logging.debug("Trying to generate thermo for surface species with these %d resonance isomer(s):",
+        logging.debug("Trying to generate thermo for surface species using first of %d resonance isomer(s):",
                       len(species.molecule))
         molecule = species.molecule[0]
+        logging.debug("Before removing from surface:\n" + molecule.to_adjacency_list())
         # only want/need to do one resonance structure,
         # because will need to regenerate others in gas phase
         dummy_molecule = molecule.copy(deep=True)
@@ -1529,7 +1530,6 @@ class ThermoDatabase(object):
         dummy_molecule.update_connectivity_values()
         dummy_molecule.update()
 
-        logging.debug("Before removing from surface:\n" + molecule.to_adjacency_list())
         logging.debug("After removing from surface:\n" + dummy_molecule.to_adjacency_list())
 
         dummy_species = Species()

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1531,6 +1531,16 @@ class ThermoDatabase(object):
                         adsorbed_atoms[0].increment_radical()
                         adsorbed_atoms[1].decrement_lone_pairs()
                         adsorbed_atoms[1].increment_radical()
+                #For bidentate CO because we want C[-1]#O[+1] but not .C#O.
+                if (bond.order == 3 and adsorbed_atoms[0].radical_electrons and 
+                    adsorbed_atoms[1].radical_electrons and 
+                    (adsorbed_atoms[0].lone_pairs or adsorbed_atoms[1].lone_pairs)):
+                    adsorbed_atoms[0].decrement_radical()
+                    adsorbed_atoms[1].decrement_radical()
+                    if adsorbed_atoms[0].lone_pairs:
+                        adsorbed_atoms[1].increment_lone_pairs()
+                    else:
+                        adsorbed_atoms[0].increment_lone_pairs()
 
         dummy_molecule.update_connectivity_values()
         dummy_molecule.update()

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -787,6 +787,27 @@ multiplicity 2
         self.assertTrue('Adsorption correction' in thermo.comment,
                         'Adsorption correction not added to thermo.')
 
+
+    def test_adsorbate_thermo_generation_bidentate_weird_CO(self):
+        """Test thermo generation for a bidentate adsorbate weird resonance of CO
+           
+        C-:O:
+        #  |
+        X  X
+        """
+        spec = Species(molecule=[Molecule().from_adjacency_list("""
+1 O u0 p2 c0 {2,S} {4,S}
+2 C u0 p0 c0 {1,S} {3,T}
+3 X u0 p0 c0 {2,T}
+4 X u0 p0 c0 {1,S}""")])
+        spec.generate_resonance_structures()
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.get_thermo_data(spec)
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue('Adsorption correction' in thermo.comment,
+                        'Adsorption correction not added to thermo.')
+
     def test_adsorbate_thermo_generation_bidentate_nonadjacent(self):
         """Test thermo generation for a bidentate adsorbate, CH2X-CH2-CH2X
 


### PR DESCRIPTION
### Problem
Before the changes, when running with bidentate surface families the mechanism generation would in some cases crash due to the following resonance structure of gas-phase CO when obtaining the gas-phase counterpart of bidentate CO:
```
Error: Could not update atomtypes for this molecule:
multiplicity 1
1 O u1 p1 c0 {2,T}
2 C u1 p0 c0 {1,T}
```

The surface species in question is:
```
Before removing from surface:
1 O u0 p2 c0 {2,S} {4,S}
2 C u0 p0 c0 {1,S} {3,T}
3 X u0 p0 c0 {2,T}
4 X u0 p0 c0 {1,S}
```

### Description of Changes
1. This adds a unit test for the treatment of the bidentate CO adsorbate that previously had the strange gas-phase counterpart.
2. More descriptive messages that help to debug this kind of error when obtaining surface thermo.
3. Adds an if statement to correct the resonance structure of gas-phase CO (should be specific to CO) after removing bidentate CO from the surface.

### Testing
I tried running the same input file again with these changes and the mechanism generation completed successfully without the crash. I saw in the RMG.log file that the correct gas-phase counterpart for CO was formed:
```
1 C u0 p1 c-1 {2,T}
2 O u0 p1 c+1 {1,T}
```