### PR TITLE
Adding surface coverage dependent kinetics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
     - stage: test
       install:
         # Clone RMG-database
-        - git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
+        - git clone -b coverage_dependence https://github.com/ReactionMechanismGenerator/RMG-database.git
         - cd RMG-Py
         # Create and activate environment
         - conda env create -q -f environment.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,8 +40,9 @@ git checkout -b $RMGTESTSBRANCH || true
 git checkout $RMGTESTSBRANCH
 
 # create an empty commit with the SHA-ID of the 
-# tested commit of the RMG-Py branch:
-git commit --allow-empty -m rmgpy-$REV
+# tested commit of the RMG-Py branch:\
+DB_DEPLOY_BRANCH="coverage_dependence"
+git commit --allow-empty -m rmgpydb-$REV-${DB_DEPLOY_BRANCH}
 
 # push to the branch to the RMG/RMG-tests repo:
 git push -f $REPO $RMGTESTSBRANCH > /dev/null

--- a/rmgpy/kinetics/surface.pxd
+++ b/rmgpy/kinetics/surface.pxd
@@ -39,8 +39,12 @@ cdef class StickingCoefficient(KineticsModel):
     cdef public ScalarQuantity _n
     cdef public ScalarQuantity _Ea
     cdef public ScalarQuantity _T0
+    cdef public ScalarQuantity _eps_ki
+    cdef public ScalarQuantity _mu_ki
+    cdef public ScalarQuantity _nu_ki
+    cdef public # _species
     
-    cpdef double get_sticking_coefficient(self, double T) except -1
+    cpdef double get_sticking_coefficient(self, double T, double species=?) except -1
 
     cpdef change_t0(self, double T0)
 
@@ -56,8 +60,12 @@ cdef class StickingCoefficientBEP(KineticsModel):
     cdef public ScalarQuantity _n
     cdef public ScalarQuantity _alpha
     cdef public ScalarQuantity _E0
+    cdef public ScalarQuantity _eps_ki
+    cdef public ScalarQuantity _mu_ki
+    cdef public ScalarQuantity _nu_ki
+    cdef public # _species
     
-    cpdef double get_sticking_coefficient(self, double T, double dHrxn=?) except -1
+    cpdef double get_sticking_coefficient(self, double T, double dHrxn=?) except -1 # todo: update this with coverage params
     cpdef double get_activation_energy(self, double dHrxn) except -1
     cpdef StickingCoefficient to_arrhenius(self, double dHrxn)
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -234,7 +234,7 @@ cdef class StickingCoefficient(KineticsModel):
             exp(sqrt(cov[0, 0])),
             sqrt(cov[1, 1]),
             sqrt(cov[2, 2]) * 0.001,
-        )  # todo: add in coverage params here
+        )  # todo: add in coverage params here?
 
         return self
 
@@ -436,8 +436,12 @@ cdef class StickingCoefficientBEP(KineticsModel):
             T0=(1, "K"),
             Tmin=self.Tmin,
             Tmax=self.Tmax,
+            eps_ki=self.eps_ki,
+            mu_ki=self.mu_ki,
+            nu_ki=self.nu_ki,
+            species=self.species,
             comment=self.comment,
-        )  # todo: update this with coverage dependent params
+        )
 
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2:
         """
@@ -617,6 +621,10 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
             T0=(1, "K"),
             Tmin=self.Tmin,
             Tmax=self.Tmax,
+            eps_ki=self.eps_ki,
+            mu_ki=self.mu_ki,
+            nu_ki=self.nu_ki,
+            species=self.species,
             uncertainty = self.uncertainty,
             comment=self.comment,
-        )  # todo: add in coverage params here
+        )

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -176,7 +176,7 @@ cdef class StickingCoefficient(KineticsModel):
         nu_ki = self._nu_ki
         species = self._species  # todo: need to get the concentration/surface site fraction/surface coverage of said species
         if species:
-            stickingCoefficient = A * (T / T0) ** n * exp(-Ea / (constants.R * T)) *
+            stickingCoefficient = A * (T / T0) ** n * exp(-Ea / (constants.R * T)) # * # todo: fix this
         else:
             stickingCoefficient = A * (T / T0) ** n * exp(-Ea / (constants.R * T))
 
@@ -234,7 +234,11 @@ cdef class StickingCoefficient(KineticsModel):
             exp(sqrt(cov[0, 0])),
             sqrt(cov[1, 1]),
             sqrt(cov[2, 2]) * 0.001,
-        )  # todo: add in coverage params here?
+        )
+        self.eps_ki  # todo: figure out what these should be
+        self.mu_ki
+        self.nu_ki
+        self.sepcies
 
         return self
 


### PR DESCRIPTION
### Motivation or Problem
Some published surface models, such as deutschmann's model [here](https://www.detchem.com/public/files/mechanisms/11_CH4_O2_ReducedGas_Quiceno2006/sm_CH4_O2_Ptwire_2006_chemkin.txt) from [this paper](https://www.sciencedirect.com/science/article/pii/S0926860X06000810), have coverage dependent kinetics.  RMG does not currently have surface coverage dependence.

### Description of Changes
- adding in coverage dependent attributes to `SurfaceArrhenius`, `SurfaceArrheniusBEP`, `StickingCoefficient`, and `StickingCoefficientBEP`
- importing and saving training reactions/kinetics libraries with coverage dependence 
- use coverage parameters during model generation by getting current concentration of an adsorbed species
- saving proper chemkin and cantera files with coverage dependence
- show coverage parameters in `output.html`

### Testing
To be edited in later as more work is done on this PR.

### Reviewer Tips

in chemkin docs, coverage dependence is
```
k_prime = k * 10^(Z_k*nu_ki) * Z_k^mu_ki * exp[ - eps_ki*Z_k / RT ]
where
Z_k     = Site Fraction of species k           
Species = CH(S)           
nu_ki   =  0.1000               
mu_ki   =   0.000               
eps_ki  =   0.00      kcal/mol
```

and in cantera is:

```
a   Coefficient for exponential dependence on the coverage
m   Power-law exponent of coverage dependence
E   Activation energy dependence on coverage

Example:

equation: 2 H(s) => H2 + 2 Pt(s)
rate-constant: {A: 3.7e21 cm^2/mol/s, b: 0, Ea: 67400 J/mol}
coverage-dependencies: {H(s): {a: 0, m: 0, E: -6000 J/mol}}
```
![Screen Shot 2020-10-26 at 12 46 21 PM](https://user-images.githubusercontent.com/32168291/97346067-54e32a00-1861-11eb-9338-1e0db2b8d07e.jpg)

and in the deutschmann paper is:

![Screen Shot 2020-10-26 at 12 43 01 PM](https://user-images.githubusercontent.com/32168291/97346131-6d534480-1861-11eb-970d-91fcd837cde5.jpg)
