### PR TITLE
Test reaction family recipes when testing database

### DIFF
--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -1383,7 +1383,12 @@ Origin Group AdjList:
         if len(sample_reactants) == 1 == len(family.forward_template.reactants):
             reactants = list(sample_reactants.values())[0]
             for reactant in reactants:
-                products = family.apply_recipe([reactant])
+                try:
+                    products = family.apply_recipe([reactant])
+                except Exception as e:
+                    test1.append(make_error_message([reactant],
+                          message=f"During apply_recipe had an {type(e)!s}: {e!s}"))
+                    continue
                 if products is None:
                     test1.append(make_error_message([reactant],
                         message="apply_recipe returned None, indicating wrong number of products or a charged product."))
@@ -1398,7 +1403,12 @@ Origin Group AdjList:
             reactant_lists = [sample_reactants[k] for k in family.forward_template.reactants ]
             pairs = zip(*reactant_lists)
             for reactant1, reactant2 in pairs:
-                products = family.apply_recipe([reactant1, reactant2])
+                try:
+                    products = family.apply_recipe([reactant1, reactant2])
+                except Exception as e:
+                    test1.append(make_error_message([reactant1, reactant2],
+                          message=f"During apply_recipe had an {type(e)!s}: {e!s}"))
+                    continue
                 if products is None:
                     test1.append(make_error_message([reactant1, reactant2],
                         message="apply_recipe returned None, indicating wrong number of products or a charged product."))
@@ -1416,7 +1426,12 @@ Origin Group AdjList:
             else:
                 pairs = zip(itertools.cycle(sr[0]), sr[1])
             for reactant1, reactant2 in pairs:
-                products = family.apply_recipe([reactant1, reactant2])
+                try:
+                    products = family.apply_recipe([reactant1, reactant2])
+                except Exception as e:
+                    test1.append(make_error_message([reactant1, reactant2],
+                          message=f"During apply_recipe had an {type(e)!s}: {e!s}"))
+                    continue
                 if products is None:
                     test1.append(make_error_message([reactant1, reactant2],
                         message="apply_recipe returned None, indicating wrong number of products or a charged product."))
@@ -1438,7 +1453,12 @@ Origin Group AdjList:
                 assert longest == 2
                 triplets = zip(itertools.cycle(sr[0]), itertools.cycle(sr[1]), sr[2])
             for reactant1, reactant2, reactant3 in triplets:
-                products = family.apply_recipe([reactant1, reactant2, reactant3])
+                try:
+                    products = family.apply_recipe([reactant1, reactant2, reactant3])
+                except Exception as e:
+                    test1.append(make_error_message([reactant1, reactant2, reactant3],
+                          message=f"During apply_recipe had an {type(e)!s}: {e!s}"))
+                    continue
                 if products is None:
                     test1.append(make_error_message([reactant1, reactant2, reactant3],
                         message="apply_recipe returned None, indicating wrong number of products or a charged product."))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
There were recently some problems detected in reaction family recipes and templates (eg. #2038, #2039), and I wanted to see if these could have been found earlier with better testing of the database.

### Description of Changes
The new test, which runs on every reaction family, uses the machinery of the existing test for descending the tree, to create a sample molecule from the group definition of every node. It then takes these sample molecules, and tries reacting them according to the reaction recipe. It doesn't do every combination (I thought that might be too many) but reacts each molecule at least once. It reports any errors, from things like charged species, atoms that fail atom-type generation, etc. 

### Testing
The new test fails (correctly) on the master database at commit 2aae843, because it detects the problem causing #2039 in Surface_Bidentate_Dissociation, which was fixed by RMG-database PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/445.
With that PR (now merged) it passes.

Unfortunately it was not able to detect the problem causing #2038 in Surface_Adsorption_Abstraction_vdW, which will be fixed by RMG-database PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/446 because the test always uses the simplest possible sample molecule, and that bug only shows up with a more complex reactant.  I can't think of a way to test every possible reactant in less than infinite time.

So this new test doesn't guarantee to catch all recipe bugs, but it catches some, and is not too horribly slow.


### Note
~Don't merge until after https://github.com/ReactionMechanismGenerator/RMG-database/pull/445~ (it's now merged)
