### PR TITLE
surface bidentate thermo fix

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1632,7 +1632,7 @@ class ThermoDatabase(object):
         # define the comparison function to find the lowest energy
         def lowest_energy(species):
             if hasattr(species.thermo, 'H298'):
-                return species.thermo.H298.value
+                return species.thermo.H298.value_si
             else:
                 return species.thermo.get_enthalpy(298.0)
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1638,7 +1638,7 @@ class ThermoDatabase(object):
         add_thermo_data(thermo, adsorption_thermo, group_additivity=True)
 
         if thermo.label:
-            thermo.label += 'X'
+            thermo.label += 'X' * len(adsorbed_atoms)
 
         find_cp0_and_cpinf(species, thermo)
         return thermo

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1561,6 +1561,7 @@ class ThermoDatabase(object):
                     raise NotImplementedError("Can't remove surface bond of type {}".format(bond.order))
             dummy_molecule.remove_atom(site)
 
+        dummy_molecules = [dummy_molecule.copy(deep=True)]
         if len(adsorbed_atoms) == 2:
             # Bidentate adsorption.
             # Try to turn adjacent biradical into a bond.
@@ -1573,6 +1574,7 @@ class ThermoDatabase(object):
                     bond.increment_order()
                     adsorbed_atoms[0].decrement_radical()
                     adsorbed_atoms[1].decrement_radical()
+                    dummy_molecules.append(dummy_molecule.copy(deep=True))
                     if (adsorbed_atoms[0].radical_electrons and
                             adsorbed_atoms[1].radical_electrons and
                             bond.order < 3):
@@ -1580,6 +1582,7 @@ class ThermoDatabase(object):
                         bond.increment_order()
                         adsorbed_atoms[0].decrement_radical()
                         adsorbed_atoms[1].decrement_radical()
+                        dummy_molecules.append(dummy_molecule.copy(deep=True))
                     if (adsorbed_atoms[0].lone_pairs and
                             adsorbed_atoms[1].lone_pairs and 
                             bond.order < 3):
@@ -1590,6 +1593,7 @@ class ThermoDatabase(object):
                         adsorbed_atoms[0].increment_radical()
                         adsorbed_atoms[1].decrement_lone_pairs()
                         adsorbed_atoms[1].increment_radical()
+                        dummy_molecules.append(dummy_molecule.copy(deep=True))
                 #For bidentate CO because we want C[-1]#O[+1] but not .C#O.
                 if (bond.order == 3 and adsorbed_atoms[0].radical_electrons and 
                     adsorbed_atoms[1].radical_electrons and 
@@ -1600,18 +1604,42 @@ class ThermoDatabase(object):
                         adsorbed_atoms[1].increment_lone_pairs()
                     else:
                         adsorbed_atoms[0].increment_lone_pairs()
+                    dummy_molecules.append(dummy_molecule.copy(deep=True))
 
-        dummy_molecule.update_connectivity_values()
-        dummy_molecule.update()
+        for dummy_molecule in dummy_molecules[:]:
+            try:
+                dummy_molecule.update_connectivity_values()
+                dummy_molecule.update()
+            except:
+                dummy_molecules.remove(dummy_molecule)
+                logging.debug(f"Removing {dummy_molecule} from possible structure list:\n{dummy_molecule.to_adjacency_list()}")
+            else:
+                logging.debug("After removing from surface:\n" + dummy_molecule.to_adjacency_list())
 
-        logging.debug("After removing from surface:\n" + dummy_molecule.to_adjacency_list())
+        if len(dummy_molecules) == 0:
+            raise RuntimeError(f"Cannot get thermo for gas-phase molecule. No valid dummy molecules from original molecule:\n{molecule.to_adjacency_list()}")
 
-        dummy_species = Species()
-        dummy_species.molecule.append(dummy_molecule)
-        dummy_species.generate_resonance_structures()
-        thermo = self.get_thermo_data(dummy_species)
+        
+        # if len(molecule) > 1, it will assume all resonance structures have already been generated when it tries to generate them, so evaluate each configuration separately and pick the lowest energy one by H298 value
+        gas_phase_species = []
+        for dummy_molecule in dummy_molecules:
+            dummy_species = Species()
+            dummy_species.molecule = [dummy_molecule]
+            dummy_species.generate_resonance_structures()
+            dummy_species.thermo = self.get_thermo_data(dummy_species)
+            gas_phase_species.append(dummy_species)
+            
+        # define the comparison function to find the lowest energy
+        def lowest_energy(species):
+            if hasattr(species.thermo, 'H298'):
+                return species.thermo.H298.value
+            else:
+                return species.thermo.get_enthalpy(298.0)
 
-        thermo.comment = "Gas phase thermo from {0}. Adsorption correction:".format(thermo.comment)
+        species = min(gas_phase_species, key=lowest_energy)
+
+        thermo = species.thermo
+        thermo.comment = f"Gas phase thermo for {thermo.label or species.molecule[0].to_smiles()} from {thermo.comment}. Adsorption correction:"
         logging.debug("Using thermo from gas phase for species {}\n".format(species.label) + repr(thermo))
 
         if not isinstance(thermo, ThermoData):

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -730,7 +730,7 @@ multiplicity 2
         self.assertEqual(set(initial), set(spec.molecule))
         self.assertFalse('radical' in thermo.comment,
                          "Applied radical correction instead of finding C2(T) directly in library")
-        self.assertEqual(thermo.label, 'C2(T)X', 'Should have found triplet C2 in the gas phase library')
+        self.assertEqual(thermo.label, 'C2(T)XX', 'Should have found triplet C2 in the gas phase library')
         self.assertTrue('Adsorption correction' in thermo.comment,
                         'Adsorption correction not added to thermo.')
         # Now see what happens for X=C=C=X
@@ -746,7 +746,7 @@ multiplicity 2
         self.assertEqual(set(initial), set(spec.molecule))
         self.assertFalse('radical' in thermo.comment,
                          "Applied radical correction instead of finding C2(T) directly in library")
-        self.assertEqual(thermo.label, 'C2(T)X', 'Should have found triplet C2 in the gas phase library')
+        self.assertEqual(thermo.label, 'C2(T)XX', 'Should have found triplet C2 in the gas phase library')
         self.assertTrue('Adsorption correction' in thermo.comment,
                         'Adsorption correction not added to thermo.')
          # Now see what happens for X#C-C#X
@@ -762,7 +762,7 @@ multiplicity 2
         self.assertEqual(set(initial), set(spec.molecule))
         self.assertFalse('radical' in thermo.comment,
                          "Applied radical correction instead of finding C2(T) directly in library")
-        self.assertEqual(thermo.label, 'C2(T)X', 'Should have found triplet C2 in the gas phase library')
+        self.assertEqual(thermo.label, 'C2(T)XX', 'Should have found triplet C2 in the gas phase library')
         self.assertTrue('Adsorption correction' in thermo.comment,
                         'Adsorption correction not added to thermo.')
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -791,6 +791,78 @@ multiplicity 2
         self.assertTrue('Adsorption correction' in thermo.comment,
                         'Adsorption correction not added to thermo.')
 
+
+    def test_adsorbate_thermo_generation_bidentate_asymmetric_NNOH(self):
+        """Test thermo generation for a bidentate adsorbate, N(=X)N(X)OH
+
+        N--N--O-H
+        ‖  |
+        X  X
+        """
+        spec = Species(molecule=[Molecule().from_adjacency_list("""
+1 O u0 p2 c0 {2,S} {4,S}
+2 N u0 p1 c0 {1,S} {3,S} {5,S}
+3 N u0 p1 c0 {2,S} {6,D}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {2,S}
+6 X u0 p0 c0 {3,D}""")])
+        spec.generate_resonance_structures()
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.get_thermo_data(spec)
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue('Adsorption correction' in thermo.comment,
+                        'Adsorption correction not added to thermo.')
+        match_str = 'Gas phase thermo for ON=[N]'
+        self.assertEqual(thermo.comment[0:len(match_str)], match_str,
+                         'Gas phase species in thermo.comment should be ON=[N]')
+
+
+    def test_adsorbate_thermo_generation_bidentate_OO(self):
+        """Test thermo generation for a bidentate adsorbate, [X]OO[X]
+
+        O--O
+        |  |
+        X  X
+        """
+        spec = Species(molecule=[Molecule().from_adjacency_list("""
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 X u0 p0 c0 {1,S}
+4 X u0 p0 c0 {2,S}""")])
+        spec.generate_resonance_structures()
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.get_thermo_data(spec)
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue('Adsorption correction' in thermo.comment,
+                        'Adsorption correction not added to thermo.')
+        self.assertEqual(thermo.label, 'O2XX', 'thermo.label should be O2XX')
+
+
+    def test_adsorbate_thermo_generation_bidentate_CO(self):
+        """Test thermo generation for a bidentate adsorbate, [X][C-]=[O+][X]
+
+        C- = O+
+        |    |
+        X    X
+        """
+        spec = Species(molecule=[Molecule().from_adjacency_list("""
+[Pt][C-]=[O+][Pt]
+1 O u0 p1 c+1 {2,D} {4,S}
+2 C u0 p1 c-1 {1,D} {3,S}
+3 X u0 p0 c0 {2,S}
+4 X u0 p0 c0 {1,S}""")])
+        spec.generate_resonance_structures()
+        initial = list(spec.molecule)  # Make a copy of the list
+        thermo = self.database.get_thermo_data(spec)
+        self.assertEqual(len(initial), len(spec.molecule))
+        self.assertEqual(set(initial), set(spec.molecule))
+        self.assertTrue('Adsorption correction' in thermo.comment,
+                        'Adsorption correction not added to thermo.')
+        self.assertEqual(thermo.label, 'COXX', 'thermo.label should be COXX')
+
+
     def test_adsorbate_thermo_raises_error(self):
         """Test thermo generation group tree error handling.
         """


### PR DESCRIPTION
### Motivation or Problem
Surface bidentate reaction crashed (#2039) trying to get the thermo model for some species. It looks like it sometimes tried the wrong configuration of the gas-phase molecule.

### Description of Changes
Added code to try multiple configurations and pick the one that works.
If multiple configurations are valid it uses the lowest energy one.

### Testing
Currently has thermo test for `N(=X)N(X)OH`
and tests for the molecules mentioned in the issue 2039 thread:
`C*O*` becomes `C[-1]#O[+1]`
`O*O*` becomes `[O][O]`
`C*C*` becomes `[C]#[C]`
`N*N*O` becomes `N#N=O` (the middle Nitrogen has valence 5)

### Reviewer Tips


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
