### PR TITLE
Remove Eley-Rideal reactions that involve no gas-phase species 

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2211,9 +2211,10 @@ class KineticsFamily(Database):
                                     generate_products_and_reactions((1, 2, 0))
 
         # ToDo: try to remove this hard-coding of reaction family name..
-        if not forward and 'adsorption' in self.label.lower():
+        if not forward and ('adsorption' in self.label.lower() or 'eleyrideal' in self.label.lower()):
             # Desorption should have desorbed something (else it was probably bidentate)
             # so delete reactions that don't make a gas-phase desorbed product
+            # Eley-Rideal reactions should have one gas-phase product in the reverse direction 
             pruned_list = []
             for reaction in rxn_list:
                 for reactant in reaction.reactants:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Addresses [database issue #448](https://github.com/ReactionMechanismGenerator/RMG-database/issues/448) caused by the reverse Surface_EleyRideal_Addition_Multiple_Bond reaction of a bidentate.

### Description of Changes
Involves hard-coding 'eleyrideal' in family.py and is treated the same way as avoiding desorption of half of a bidentate in reverse adsorption.

### Testing
I tested this on the latest RMG master (database and RMG-Py) for methane catalytic combustion. Before these changes I got the error reported in [issue #448](https://github.com/ReactionMechanismGenerator/RMG-database/issues/448). With these changes, the mechanism generation completed without errors.

