### PR TITLE
Use adjlist as the species structure instead of SMILES in an Arkane PDep network file

### DIFF
--- a/arkane/pdep.py
+++ b/arkane/pdep.py
@@ -665,7 +665,7 @@ class PressureDependenceJob(object):
                 f.write('species(\n')
                 f.write('    label = {0!r},\n'.format(str(spec)))
                 if len(spec.molecule) > 0:
-                    f.write('    structure = SMILES({0!r}),\n'.format(spec.molecule[0].to_smiles()))
+                    f.write(f'    structure = adjacencyList("""{spec.molecule[0].to_adjacency_list()}"""),\n')
                 if spec.conformer is not None:
                     if spec.conformer.E0 is not None:
                         f.write('    E0 = {0!r},\n'.format(spec.conformer.E0))


### PR DESCRIPTION
### Motivation or Problem
Species structures saved in Arkane network files is given in SMILES, which sometimes can be ambiguous. The case I came across was CH2(S) which has the same SMILES as CH2(T), and reading it automatically by T3 failed. Of course in this particular case the multiplicity, which is also given, could be used to differentiate between these states, but we could think of other cases where adjacency list is superior to SMILES in terms of ambiguity (e.g., smiles for hyper-valence species is at times interpreted wrong, whereas adjlists are usually/always better.).

### Description of Changes
Added an attribute to RMG passed to `CoreEdgeReactionModel` and then to `PDepNetwork` for requesting an adjlist structure form in Arkane network files instead of SMILES.

<!---### Testing
A clear and concise description of testing that you've done or plan to do.-->

