### PR TITLE
Debug library to training script

### DIFF
--- a/ipython/kinetics_library_to_training.ipynb
+++ b/ipython/kinetics_library_to_training.ipynb
@@ -20,7 +20,7 @@
     "# Set libraries to load reactions from; set to None to load all libraries\n",
     "libraries = ['vinylCPD_H']\n",
     "\n",
-    "# Set families to add training reactions to; either 'all' or a list, e.g. ['R_Addition_MultipleBond']\n",
+    "# Set families to add training reactions to; either 'default' or a list, e.g. ['R_Addition_MultipleBond']\n",
     "families = ['Intra_R_Add_Endocyclic']\n",
     "\n",
     "# Specify whether to plot kinetics comparisons\n",
@@ -73,8 +73,9 @@
     "# If we want accurate kinetics comparison, add existing training reactions and fill tree by averaging\n",
     "if compare_kinetics:\n",
     "    for family in database.kinetics.families.values():\n",
-    "        family.add_rules_from_training(thermo_database=database.thermo)\n",
-    "        family.fill_rules_by_averaging_up(verbose=verbose_comments)"
+    "        if not family.auto_generated:\n",
+    "            family.add_rules_from_training(thermo_database=database.thermo)\n",
+    "            family.fill_rules_by_averaging_up(verbose=verbose_comments)"
    ]
   },
   {
@@ -94,7 +95,7 @@
    "source": [
     "master_dict, multiple_dict = process_reactions(database,\n",
     "                                               libraries,\n",
-    "                                               families,\n",
+    "                                               list(database.kinetics.families.keys()),\n",
     "                                               compare_kinetics=compare_kinetics,\n",
     "                                               show_all=show_all,\n",
     "                                               filter_aromatic=filter_aromatic)"
@@ -213,9 +214,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:rmg_env]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-rmg_env-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -227,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/ipython/kinetics_library_to_training_tools.py
+++ b/ipython/kinetics_library_to_training_tools.py
@@ -33,6 +33,7 @@ from io import BytesIO
 import numpy as np
 import matplotlib.pyplot as plt
 from IPython.display import display, HTML
+from rmgpy.quantity import ScalarQuantity
 
 
 # HTML formatting for output
@@ -177,6 +178,15 @@ def process_reactions(database, libraries, families, compare_kinetics=True, show
                 else:
                     lib_rxn.reactants = fam_rxn.products
                     lib_rxn.products = fam_rxn.reactants
+
+                if len(lib_rxn.reactants) == 1:
+                    units = 's^-1'
+                elif len(lib_rxn.reactants) == 2:
+                    units = 'cm^3/(mol*s)'
+                elif len(lib_rxn.reactants) == 3:
+                    units = 'cm^6/(mol^2*s)'
+                A = lib_rxn.kinetics.A
+                lib_rxn.kinetics.A = ScalarQuantity(value=A.value_si*A.get_conversion_factor_from_si_to_cm_mol_s(),units=units,uncertainty_type=A.uncertainty_type,uncertainty=A.uncertainty_si*A.get_conversion_factor_from_si_to_cm_mol_s())
 
                 if fam_rxn.family in reaction_dict:
                     reaction_dict[fam_rxn.family].append(lib_rxn)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2770,6 +2770,7 @@ class KineticsFamily(Database):
                 if species.is_isomorphic(labeled_molecule, save_order=self.save_order):
                     species.molecule = [labeled_molecule]
                     reaction.products[index] = species
+                    labeled_products.remove(labeled_molecule)
                     break
             else:
                 raise ActionError('Could not find isomorphic molecule to fit the original product {} from '
@@ -2779,6 +2780,7 @@ class KineticsFamily(Database):
                 if species.is_isomorphic(labeled_molecule, save_order=self.save_order):
                     species.molecule = [labeled_molecule]
                     reaction.reactants[index] = species
+                    labeled_reactants.remove(labeled_molecule)
                     break
             else:
                 raise ActionError('Could not find isomorphic molecule to fit the original reactant {} from '


### PR DESCRIPTION
### Motivation or Problem
I encountered two errors while converting a library containing this Diels-Alder reaction to training reaction. 

(1) Two reactants were wrongly added with the same atom label by `add_atom_labels_for_reaction` because the two reactants are isomorphic.

(2) The A unit caused problem in `add_rules_from_training` because only cm mol s units were expected.

```
Reaction(reactants=[Species(label="ISP", molecule=[Molecule(smiles="C=CC(=C)C")], molecular_weight=(68.117,'amu')), Species(label="ISP", molecule=[Molecule(smiles="C=CC(=C)C")], molecular_weight=(68.117,'amu'))], products=[Species(label="DISP_2", molecule=[Molecule(smiles="C=CC1(C)CCC=C(C)C1")], molecular_weight=(136.234,'amu'))])
```


### Description of Changes
(1) In `add_atom_labels_for_reaction`, I modified such that the labeled_molecule is removed after it is matched to one of the reactant. This way, two reactants won't be matched to the same atom label.

(2) In `kinetics_library_to_training_tools` I added an unit conversion for A from arbitrary unit to cm mol s unit.

### Testing
After the change, the `kinetics_library_to_training.ipynb` can process the library without error.
