### PR TITLE
vdW families change_bond action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
     - stage: test
       install:
         # Clone RMG-database
-        - git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
+        - git clone -b vdw_actions https://github.com/ReactionMechanismGenerator/RMG-database.git
         - cd RMG-Py
         # Create and activate environment
         - conda env create -q -f environment.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -34,14 +34,15 @@ cd $TARGET_DIR
 
 # create a new branch in RMG-tests with the name equal to
 # the branch name of the tested RMG-Py branch:
-RMGTESTSBRANCH=rmgpy-$DEPLOY_BRANCH
+RMGTESTSBRANCH=rmgpydb-$DEPLOY_BRANCH
 
 git checkout -b $RMGTESTSBRANCH || true 
 git checkout $RMGTESTSBRANCH
 
 # create an empty commit with the SHA-ID of the 
 # tested commit of the RMG-Py branch:
-git commit --allow-empty -m rmgpy-$REV
+DB_DEPLOY_BRANCH="vdw_actions"
+git commit --allow-empty -m rmgpydb-$REV-${DB_DEPLOY_BRANCH}
 
 # push to the branch to the RMG/RMG-tests repo:
 git push -f $REPO $RMGTESTSBRANCH > /dev/null

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -298,6 +298,30 @@ class ReactionRecipe(object):
                 # Apply the action
                 if action[0] == 'CHANGE_BOND':
                     info = int(info)
+                    # Check first to see if we have a bond
+                    if not struct.has_bond(atom1, atom2):
+                        if info < 1:
+                            raise InvalidActionError('Attempted to change a nonexistent bond.')
+                        # If we do not have a bond, it might be because we are trying to change a vdW bond
+                        # Lets see if one of that atoms is a surface site, 
+                        # If we have a surface site, we will make a single bond, then change it by info - 1
+                        is_vdW_bond = False
+                        for atom in (atom1, atom2):
+                            if atom.is_surface_site():
+                                is_vdW_bond = True
+                                break
+                        if not is_vdW_bond: # no surface site, so no vdW bond
+                            raise InvalidActionError('Attempted to change a nonexistent bond.')
+                        else: # we found a surface site, so we will make a single bond
+                            bond = GroupBond(atom1, atom2, order=[1]) if pattern else Bond(atom1, atom2, order=1)
+                            struct.add_bond(bond)
+                            atom1.apply_action(['FORM_BOND', label1, 1, label2])
+                            atom2.apply_action(['FORM_BOND', label1, 1, label2])
+                            # Now subtract 1 from info
+                            info -= 1
+                            # If info is 0, then we can continue since we don't have to change the bond
+                            if info == 0:
+                                continue
                     bond = struct.get_bond(atom1, atom2)
                     if bond.is_benzene():
                         struct.props['validAromatic'] = False

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -329,10 +329,22 @@ class ReactionRecipe(object):
                         atom1.apply_action(['CHANGE_BOND', label1, info, label2])
                         atom2.apply_action(['CHANGE_BOND', label1, info, label2])
                         bond.apply_action(['CHANGE_BOND', label1, info, label2])
+                        if pattern:
+                            if bond.is_van_der_waals():
+                                if atom1.is_surface_site():
+                                    atom1.atomtype = [ATOMTYPES['Xv']]
+                                else:
+                                    atom2.atomtype = [ATOMTYPES['Xv']]
                     else:
                         atom1.apply_action(['CHANGE_BOND', label1, -info, label2])
                         atom2.apply_action(['CHANGE_BOND', label1, -info, label2])
                         bond.apply_action(['CHANGE_BOND', label1, -info, label2])
+                        if pattern:
+                            if bond.is_van_der_waals():
+                                if atom1.is_surface_site():
+                                    atom1.atomtype = [ATOMTYPES['Xv']]
+                                else:
+                                    atom2.atomtype = [ATOMTYPES['Xv']]
                 elif (action[0] == 'FORM_BOND' and forward) or (action[0] == 'BREAK_BOND' and not forward):
                     if struct.has_bond(atom1, atom2):
                         raise InvalidActionError('Attempted to create an existing bond.')

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -356,6 +356,13 @@ class ReactionRecipe(object):
                     atom2.apply_action(['FORM_BOND', label1, info, label2])
                 elif (action[0] == 'BREAK_BOND' and forward) or (action[0] == 'FORM_BOND' and not forward):
                     if not struct.has_bond(atom1, atom2):
+                        if info == 0:
+                            if atom1.is_surface_site() or atom2.is_surface_site():
+                                # We are trying to break a vdW bond, but the atoms are not connected in
+                                # the graph. The bond will break when we split the merged products
+                                # in the `apply_recipe()` functions. Thus, there is nothing to do here,
+                                # so we continue to the next action.
+                                continue
                         raise InvalidActionError('Attempted to remove a nonexistent bond.')
                     bond = struct.get_bond(atom1, atom2)
                     struct.remove_bond(bond)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1967,6 +1967,10 @@ class KineticsFamily(Database):
             return []
 
         if len(reactants) > len(template.reactants):
+            # If the template contains a surface site, we do not want to split it because it will break vdw bonds
+            if isinstance(template.reactants[0].item, Group):
+                if template.reactants[0].item.contains_surface_site():
+                    return []
             # if the family has one template and is bimolecular split template into multiple reactants
             try:
                 grps = template.reactants[0].item.split()

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2256,16 +2256,20 @@ class KineticsFamily(Database):
             # Desorption should have desorbed something (else it was probably bidentate)
             # so delete reactions that don't make a gas-phase desorbed product
             # Eley-Rideal reactions should have one gas-phase product in the reverse direction 
+
+            # Determine how many surf reactants we expect based on the template
+            n_surf_expected = len([r for r in self.forward_template.reactants if r.item.contains_surface_site()])
+
+            # Now iterate through the reactions and toss them out if they number of surface reactants does not match
+            # does not match the expected number
             pruned_list = []
             for reaction in rxn_list:
-                for reactant in reaction.reactants:
-                    if not reactant.contains_surface_site():
-                        # found a desorbed species, we're ok
-                        pruned_list.append(reaction)
-                        break
-                else:  # didn't break, so all species still adsorbed
+                n_surf_reaction = len([r for r in reaction.reactants if r.contains_surface_site()])
+                if n_surf_expected != n_surf_reaction:
                     logging.debug("Removing {0} reaction {1!s} with no desorbed species".format(self.label, reaction))
-                    continue  # to next reaction immediately
+                    continue
+                else:
+                    pruned_list.append(reaction)
             rxn_list = pruned_list
 
         # If products is given, remove reactions from the reaction list that

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Dissociation_vdW/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Dissociation_vdW/groups.py
@@ -21,7 +21,7 @@ template(reactants=["Combined", "VacantSite"], products=["Adsorbate1", "Adsorbat
 reverse = "Surface_Association_vdW"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 1, '*3'],
+    ['CHANGE_BOND', '*1', 1, '*3'],
     ['FORM_BOND', '*2', 1, '*4'],
     ['BREAK_BOND', '*1', 1, '*2'],
 ])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Some vdW reaction families can not generate reactions in reverse direction.
### Description of Changes
Use `CHANGE_BOND` action instead of `FORM_BOND`/`BREAK_BOND` action for vdW families.  Changed the procedure for `CHANGE_BOND` action when applying the reaction recipe so that we form a vdw bond then change it.
### Testing
Tested the `Surface_Dissociation_Double_vdW` family with `O=X + O=X <--> X + O2~X` reaction. The family can generate reactions in both directions with this branch, but only in the forward direction on master


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
