### PR TITLE
Remove temporary seed mechanisms if they exist

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -1342,6 +1342,10 @@ class RMG(util.Subject):
         temp_seed_dir = os.path.join(self.output_directory, 'seed_tmp')
 
         # Move the seed from the previous iteration to a temporary directory in case we run into errors
+
+        # First, remove the temporary seed mechanism if it exists from a previous run
+        if os.path.exists(temp_seed_dir):
+            shutil.rmtree(temp_seed_dir)
         try:
             os.rename(seed_dir, temp_seed_dir)
         except PermissionError:  # The Windows Subsystem for Linux (WSL) can have problems with renaming


### PR DESCRIPTION
### Motivation or Problem
We had a user run into an issue where running an RMG job the second time crashes because there was an existing temporary seed mechanism. This PR checks for this possibility before trying to overwrite the temporary seed.