### PR TITLE
Ignore RMG_Py.egg-info files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ ipython/*
 
 # Q2DTor
 external/Q2DTor
+
+# egg files (pip install -e)
+RMG_Py.egg-info/*


### PR DESCRIPTION
### Motivation or Problem
A better way to add RMG-Py to the PYTHONPATH variable is to run `pip install -e` from within the rmg_env. This has the benefit that the repo is isolated to the conda environment, so multiple installs of RMG-Py can be managed by making/managing multiple conda environments.

Doing this creates egg-info files, which should be ignored by git