### PR TITLE
Updated the amu values of common elements in gas phase chemistry

### DIFF
--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -179,32 +179,32 @@ X = Element(0,    'X', 'surface_site'   , 0.0)
 
 # Period 1
 # Hydrogen
-H  = Element(1,   'H' , 'hydrogen'      , 0.00100794)
-D  = Element(1,   'H' , 'deuterium'     , 0.002014101, 2, 'D')
+H  = Element(1,   'H' , 'hydrogen'      , 0.001007971)  # assuming 99.9855% 1_H, 0.0145% 2_H; see https://applets.kcvs.ca/IPTEI/pdf-elements/hydrogen.pdf
+D  = Element(1,   'H' , 'deuterium'     , 0.0020141017781, 2, 'D')  # see https://applets.kcvs.ca/IPTEI/pdf-elements/hydrogen.pdf
 T  = Element(1,   'H' , 'tritium'       , 0.003016049, 3, 'T')
-He = Element(2,   'He', 'helium'        , 0.004002602)
+He = Element(2,   'He', 'helium'        , 0.004002601)  # see  https://applets.kcvs.ca/IPTEI/pdf-elements/helium.pdf
 
 # Period 2
 Li = Element(3,   'Li', 'lithium'       , 0.006941)
 Be = Element(4,   'Be', 'beryllium'     , 0.009012182)
 B  = Element(5,   'B',  'boron'         , 0.010811)
-C  = Element(6,   'C' , 'carbon'        , 0.0120107)
-C13= Element(6,   'C' , 'carbon-13'     , 0.0130033, 13, 'CI')
-N  = Element(7,   'N' , 'nitrogen'      , 0.01400674)
-O  = Element(8,   'O' , 'oxygen'        , 0.0159994)
-O18= Element(8,   'O' , 'oxygen-18'     , 0.0179999, 18, 'OI')
-F  = Element(9,   'F' , 'fluorine'      , 0.018998403)
-Ne = Element(10,  'Ne', 'neon'          , 0.0201797)
+C  = Element(6,   'C' , 'carbon'        , 0.01201064)  # assuming 1.06% 13_C, 98.94% 12_C; see https://applets.kcvs.ca/IPTEI/pdf-elements/carbon.pdf
+C13= Element(6,   'C' , 'carbon-13'     , 0.013003354, 13, 'CI')  # see https://applets.kcvs.ca/IPTEI/pdf-elements/carbon.pdf
+N  = Element(7,   'N' , 'nitrogen'      , 0.01400686)  # assuming 0.3795% 15_N, 99.9855% 14_N; see https://applets.kcvs.ca/IPTEI/pdf-elements/nitrogen.pdf
+O  = Element(8,   'O' , 'oxygen'        , 0.0159994)  # assuming 99.7572% 16_O2, 0.2045% 18_O2, 0.0384% 17_O2; see https://applets.kcvs.ca/IPTEI/pdf-elements/oxygen.pdf
+O18= Element(8,   'O' , 'oxygen-18'     , 0.017999159613, 18, 'OI')  # see https://applets.kcvs.ca/IPTEI/pdf-elements/oxygen.pdf
+F  = Element(9,   'F' , 'fluorine'      , 0.018998403163)  # see https://applets.kcvs.ca/IPTEI/pdf-elements/fluorine.pdf
+Ne = Element(10,  'Ne', 'neon'          , 0.02018005)   # see https://applets.kcvs.ca/IPTEI/pdf-elements/neon.pdf
 
 # Period 3
 Na = Element(11,  'Na', 'sodium'        , 0.022989770)
 Mg = Element(12,  'Mg', 'magnesium'     , 0.0243050)
 Al = Element(13,  'Al', 'aluminium'     , 0.026981538)
 Si = Element(14,  'Si', 'silicon'       , 0.0280855)
-P  = Element(15,  'P' , 'phosphorus'    , 0.030973761)
-S  = Element(16,  'S' , 'sulfur'        , 0.032065)
-Cl = Element(17,  'Cl', 'chlorine'      , 0.035453)
-Ar = Element(18,  'Ar', 'argon'         , 0.039348)
+P  = Element(15,  'P' , 'phosphorus'    , 0.030973761998)  # see https://applets.kcvs.ca/IPTEI/pdf-elements/phosphorus.pdf
+S  = Element(16,  'S' , 'sulfur'        , 0.0320725)  # assuming 0.7630% 33_S, 4.3650% 34_S, 0.0158% 36_S, 94.8562% 32_S; see https://applets.kcvs.ca/IPTEI/pdf-elements/sulfur.pdf
+Cl = Element(17,  'Cl', 'chlorine'      , 0.03545214)  # assuming 24.2% 37_Cl, 75.8% 35_Cl; see https://applets.kcvs.ca/IPTEI/pdf-elements/chlorine.pdf
+Ar = Element(18,  'Ar', 'argon'         , 0.0398775)  # assuming 1.04% 36_Ar, 2.165% 38_Ar, 96.795% 40_Ar; see https://applets.kcvs.ca/IPTEI/pdf-elements/argon.pdf
 
 # Period 4
 K  = Element(19,  'K' , 'potassium'     , 0.0390983)


### PR DESCRIPTION
### Motivation or Problem
Our element mass value for Ar is outdated.
The element mass is used in Arkane to compute the molar mass of a species, affecting calculated pressure-dependent rates.

### Description of Changes
The element mass for Ar as well as other common elements was updated.
Data taken from IUPAC (https://applets.kcvs.ca/IPTEI/IPTEI.html)
Element isotope composition was averaged when needed, comments were added.
For most other elements (not Ar), the change was not significant. I used the significant digits from the IUPAC source.