### PR TITLE
Surface site constraint

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -909,6 +909,7 @@ all of RMG's reaction families. ::
         maximumSiliconAtoms=2,
         maximumSulfurAtoms=2,
         maximumHeavyAtoms=10,
+        maximumSurfaceSites=2,
         maximumRadicalElectrons=2,
         maximumSingletCarbenes=1,
         maximumCarbeneRadicals=0,

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -82,6 +82,11 @@ def fails_species_constraints(species):
         if struct.get_num_atoms('S') > max_sulfur_atoms:
             return True
 
+    max_surface_sites = species_constraints.get('maximumSurfaceSites', -1)
+    if max_surface_sites != -1:
+        if struct.get_num_atoms('X') > max_surface_sites:
+            return True
+
     max_heavy_atoms = species_constraints.get('maximumHeavyAtoms', -1)
     if max_heavy_atoms != -1:
         if struct.get_num_atoms() - struct.get_num_atoms('H') > max_heavy_atoms:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -813,6 +813,7 @@ def generated_species_constraints(**kwargs):
         'maximumNitrogenAtoms',
         'maximumSiliconAtoms',
         'maximumSulfurAtoms',
+        'maximumSurfaceSites',
         'maximumHeavyAtoms',
         'maximumRadicalElectrons',
         'maximumSingletCarbenes',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The bidentate families can make molecules with a bunch of surface sites.  I was getting a bunch of edge species with 3 or 4 sites.  This PR adds a `maximumSurfaceSites` constraint if you want to limit the number of surface sites that can be in a species in your model.  

### Description of Changes
Added a `maximumSurfaceSites` constraint with default value `-1` (no constraint)

### Testing
Added a unit test and successfully used `maximumSurfaceSites = 2` when running RMG.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
