### PR TITLE
Default binding energies for ThermoDB

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1426,6 +1426,8 @@ class ThermoDatabase(object):
         """
         
         if isinstance(binding_energies, str):
+            if not self.surface:
+                self.load_surface()
             binding_energies = self.surface['metal'].find_binding_energies(binding_energies)
 
         for element, energy in binding_energies.items():

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -854,6 +854,14 @@ class ThermoDatabase(object):
         }
         self.global_context = {}
 
+        # Use Pt111 binding energies as default
+        self.binding_energies = {
+            'H': (-2.75368,'eV/molecule'),
+            'C': (-7.02516,'eV/molecule'),
+            'N': (-4.63225,'eV/molecule'),
+            'O': (-3.81153,'eV/molecule'),
+        }
+
     def __reduce__(self):
         """
         A helper function used when pickling a ThermoDatabase object.

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -856,10 +856,10 @@ class ThermoDatabase(object):
 
         # Use Pt111 binding energies as default
         self.binding_energies = {
-            'H': (-2.75368,'eV/molecule'),
-            'C': (-7.02516,'eV/molecule'),
-            'N': (-4.63225,'eV/molecule'),
-            'O': (-3.81153,'eV/molecule'),
+            'H': rmgpy.quantity.Energy(-2.75368,'eV/molecule'),
+            'C': rmgpy.quantity.Energy(-7.02516,'eV/molecule'),
+            'N': rmgpy.quantity.Energy(-4.63225,'eV/molecule'),
+            'O': rmgpy.quantity.Energy(-3.81153,'eV/molecule'),
         }
 
     def __reduce__(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
AttributeError: 'ThermoDatabase' object has no attribute 'binding_energies'
https://github.com/ReactionMechanismGenerator/RMG-website/issues/208

### Description of Changes
Use Pt111 binding energies as default.
