### PR TITLE
Decay Framework

### DIFF
--- a/rmgpy/rmg/decay.py
+++ b/rmgpy/rmg/decay.py
@@ -34,6 +34,34 @@ from rmgpy.molecule.group import Group
 from rmgpy.species import Species
 from rmgpy.data.kinetics.family import ReactionRecipe
 
+def decay_species(spc, check_deterministic=True):
+    """
+    recursively decays a species object as long as there are valid decay recipes
+    raises a warning if the decays could've been done in a different order
+    """
+    decay = None
+    for mol in spc.molecule:
+        d = decay_molecule(mol,check_deterministic=check_deterministic)
+        if d != mol and decay is None:
+            decay = d
+            if not check_deterministic:
+                break
+        elif d != mol:
+            sm = spc.molecule[0].to_smiles()
+            logging.warning(f"found more than one possible decay for {sm}, may not be able to deterministically determine decay")
+            break
+    
+    if type(decay) == list:
+        dlist = []
+        for dmol in decay:
+            dspc = Species(molecule=[dmol])
+            dspc.generate_resonance_structures()
+            decay_spc = decay_species(dspc)
+            dlist.extend(decay_spc)
+        return dlist
+    else:
+        return [spc]
+
 def decay_molecule(mol, check_deterministic=True):
     """
     breaks down a molecule object down one step using the first valid recipe and atom mappings

--- a/rmgpy/rmg/decay.py
+++ b/rmgpy/rmg/decay.py
@@ -34,6 +34,20 @@ from rmgpy.molecule.group import Group
 from rmgpy.species import Species
 from rmgpy.data.kinetics.family import ReactionRecipe
 
+decay_group_recipe_pairs = [(Group().from_adjacency_list("""
+    1  *3 O u0 p2 c0 {2,S} {4,S}
+    2  *2 O u0 p2 c0 {1,S} {3,S}
+    3  *1 R!H u1 px c0 {2,S}
+    4  H u0 p0  c0 {1,S}
+    """),
+    ReactionRecipe(actions=[
+    ['BREAK_BOND', '*3', 1, '*2'],
+    ['CHANGE_BOND', '*2', 1, '*1'],
+    ['LOSE_RADICAL', '*1','1'],
+    ['GAIN_RADICAL','*3','1']
+    ])),
+                            ]
+
 def decay_species(spc, check_deterministic=True):
     """
     recursively decays a species object as long as there are valid decay recipes

--- a/rmgpy/rmg/decay.py
+++ b/rmgpy/rmg/decay.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2019 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+"""
+Contains classes for automatically breaking down unstable or non-existent species
+"""
+import logging
+from rmgpy.molecule.group import Group
+from rmgpy.species import Species
+from rmgpy.data.kinetics.family import ReactionRecipe
+
+def decay_molecule(mol, check_deterministic=True):
+    """
+    breaks down a molecule object down one step using the first valid recipe and atom mappings
+    raises a warning if there were multiple valid recipes/atom mappings
+    """
+    ind = None
+    for i,(grp,_) in enumerate(decay_group_recipe_pairs):
+        if mol.is_subgraph_isomorphic(grp):  #check is True at most twice
+            if ind is None:
+                ind = i
+                if not check_deterministic:
+                    break
+            else:
+                sm = mol.to_smiles()
+                logging.warning(f"found more than one possible decay for {sm}, may not be able to deterministically determine decay")
+                break
+    
+    if ind is None:
+        return mol
+    else:
+        grp,recipe = decay_group_recipe_pairs[ind]
+        mol2 = mol.copy(deep=True)
+        subs = mol2.find_subgraph_isomorphisms(grp)
+        
+        if len(subs)>1:
+            sm = mol.to_smiles()
+            logging.warning(f"found more than one possible decay for {sm}, may not be able to deterministically determine decay")
+        sub = subs[0]
+        for key,item in sub.items():
+            if item.label:
+                key.label = item.label
+        recipe.apply_forward(mol2)
+        mol2.clear_labeled_atoms()
+        mol2.update()
+        return mol2.split()
+        

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -908,7 +908,7 @@ class CoreEdgeReactionModel:
         G298 = reaction.get_free_energy_of_reaction(298)
         gibbs_is_positive = G298 > -1e-8
 
-        if family.own_reverse and hasattr(reaction, 'reverse'):
+        if family.own_reverse and len(reaction.products)==len(reaction.reactants) and hasattr(reaction, 'reverse'):
             if reaction.reverse:
                 # The kinetics family is its own reverse, so we could estimate kinetics in either direction
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -58,6 +58,7 @@ from rmgpy.rmg.pdep import PDepReaction, PDepNetwork
 from rmgpy.rmg.react import react_all
 from rmgpy.species import Species
 from rmgpy.thermo.thermoengine import submit
+from rmgpy.rmg.decay import decay_species
 
 
 ################################################################################
@@ -267,7 +268,7 @@ class CoreEdgeReactionModel:
         # At this point we can conclude that the species is new
         return None
 
-    def make_new_species(self, object, label='', reactive=True, check_existing=True, generate_thermo=True):
+    def make_new_species(self, object, label='', reactive=True, check_existing=True, generate_thermo=True, check_decay=False):
         """
         Formally create a new species from the specified `object`, which can be
         either a :class:`Molecule` object or an :class:`rmgpy.species.Species`
@@ -292,19 +293,27 @@ class CoreEdgeReactionModel:
                 return spec, False
 
         # If we're here then we're ready to make the new species
+        try:
+            spec = Species(label=label,molecule=[molecule],reactive=reactive,thermo=object.thermo, transport_data=object.transport_data)
+        except AttributeError:
+            spec = Species(label=label, molecule=[molecule], reactive=reactive)
+        
+        spec.generate_resonance_structures()
+        
+        if check_decay:
+            spcs = decay_species(spec)
+            if len(spcs) == 1:
+                spec = spcs[0]
+            else:
+                return [self.make_new_species(spc) for spc in spcs]
+        
         if reactive:
             self.species_counter += 1  # count only reactive species
-            species_index = self.species_counter
+            spec.index = self.species_counter
         else:
-            species_index = -1
-        try:
-            spec = Species(index=species_index, label=label, molecule=[molecule], reactive=reactive,
-                           thermo=object.thermo, transport_data=object.transport_data)
-        except AttributeError:
-            spec = Species(index=species_index, label=label, molecule=[molecule], reactive=reactive)
+            spec.index = -1
 
         spec.creation_iteration = self.iteration_num
-        spec.generate_resonance_structures()
         spec.molecular_weight = Quantity(spec.molecule[0].get_molecular_weight() * 1000., "amu")
 
         if generate_thermo:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -437,12 +437,23 @@ class CoreEdgeReactionModel:
         """
 
         # Determine the proper species objects for all reactants and products
-        try:
+        if forward.family and forward.is_forward:
             reactants = [self.make_new_species(reactant, generate_thermo=generate_thermo)[0] for reactant in forward.reactants]
-            products = [self.make_new_species(product, generate_thermo=generate_thermo)[0] for product in forward.products]
-        except:
-            logging.error(f"Error when making species in reaction {forward:s} from {forward.family:s}")
-            raise
+            products = []
+            for product in forward.products:
+                spcs = self.make_new_species(product, generate_thermo=generate_thermo,check_decay=True)
+                if type(spcs) == tuple:
+                    products.append(spcs[0])
+                elif type(spcs) == list:
+                    products.extend([spc[0] for spc in spcs])
+        else:
+            try:
+                reactants = [self.make_new_species(reactant, generate_thermo=generate_thermo)[0] for reactant in forward.reactants]
+                products = [self.make_new_species(product, generate_thermo=generate_thermo)[0] for product in forward.products]
+            except:
+                logging.error(f"Error when making species in reaction {forward:s} from {forward.family:s}")
+                raise
+        
         if forward.specific_collider is not None:
             forward.specific_collider = self.make_new_species(forward.specific_collider)[0]
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -474,7 +474,7 @@ class CoreEdgeReactionModel:
                 return rxn, False
 
         # Generate the reaction pairs if not yet defined
-        if forward.pairs is None:
+        if forward.pairs is None or len(forward.pairs) != max(len(forward.reactants), len(forward.products)):
             forward.generate_pairs()
             if hasattr(forward, 'reverse'):
                 if forward.reverse:


### PR DESCRIPTION
This improves RMG's handling of Q.OOH species that usually don't really exist. There are a couple fixes particular to Q.OOH, but most importantly this lays out a larger framework for handling species RMG templates think exist, but really aren't wells. Within this framework a set of recipes for decays are defined and automatically applied to species involved in new reactions. If the reaction can be estimated in a direction where any decaying species are in the products RMG will estimate in that direction and break apart the decaying species giving a more physical reaction sequence and improving rate estimation. 