### PR TITLE
Reverse kinetics for sticking coefficient

### DIFF
--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -31,7 +31,7 @@ from rmgpy.molecule.molecule cimport Atom, Molecule
 from rmgpy.molecule.element cimport Element
 from rmgpy.kinetics.model cimport KineticsModel
 from rmgpy.kinetics.arrhenius cimport Arrhenius
-from rmgpy.kinetics.surface cimport SurfaceArrhenius
+from rmgpy.kinetics.surface cimport SurfaceArrhenius, StickingCoefficient
 
 cimport numpy as np
 
@@ -105,7 +105,9 @@ cdef class Reaction:
 
     cpdef reverse_surface_arrhenius_rate(self, SurfaceArrhenius k_forward, str reverse_units, Tmin=?, Tmax=?)
 
-    cpdef generate_reverse_rate_coefficient(self, bint network_kinetics=?, Tmin=?, Tmax=?)
+    cpdef reverse_sticking_coeff_rate(self, StickingCoefficient k_forward, str reverse_units, double surface_site_density, Tmin=?, Tmax=?)
+
+    cpdef generate_reverse_rate_coefficient(self, bint network_kinetics=?, Tmin=?, Tmax=?, double surface_site_density=?)
 
     cpdef np.ndarray calculate_tst_rate_coefficients(self, np.ndarray Tlist)
 

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -95,7 +95,7 @@ cdef class Reaction:
 
     cpdef int get_stoichiometric_coefficient(self, Species spec)
 
-    cpdef double get_rate_coefficient(self, double T, double P=?)
+    cpdef double get_rate_coefficient(self, double T, double P=?, double surface_site_density=?)
 
     cpdef double get_surface_rate_coefficient(self, double T, double surface_site_density) except -2
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -53,9 +53,9 @@ import rmgpy.constants as constants
 from rmgpy.exceptions import ReactionError, KineticsError
 from rmgpy.kinetics import KineticsData, ArrheniusBM, ArrheniusEP, ThirdBody, Lindemann, Troe, Chebyshev, \
     PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, get_rate_coefficient_units_from_reaction_order, \
-    StickingCoefficient, SurfaceArrheniusBEP, StickingCoefficientBEP
+    SurfaceArrheniusBEP, StickingCoefficientBEP
 from rmgpy.kinetics.arrhenius import Arrhenius  # Separate because we cimport from rmgpy.kinetics.arrhenius
-from rmgpy.kinetics.surface import SurfaceArrhenius  # Separate because we cimport from rmgpy.kinetics.surface
+from rmgpy.kinetics.surface import SurfaceArrhenius, StickingCoefficient  # Separate because we cimport from rmgpy.kinetics.surface
 from rmgpy.kinetics.diffusionLimited import diffusion_limiter
 from rmgpy.molecule.element import Element, element_list
 from rmgpy.molecule.molecule import Molecule, Atom
@@ -854,11 +854,40 @@ class Reaction:
         kr.fit_to_data(Tlist, klist, reverse_units, kf.T0.value_si)
         return kr
 
-    def generate_reverse_rate_coefficient(self, network_kinetics=False, Tmin=None, Tmax=None):
+    def reverse_sticking_coeff_rate(self, k_forward, reverse_units, surface_site_density, Tmin=None, Tmax=None):
+        """
+        Reverses the given k_forward, which must be a StickingCoefficient type.
+        You must supply the correct units for the reverse rate.
+        The equilibrium constant is evaluated from the current reaction instance (self).
+        The surface_site_density in `mol/m^2` is used to evalaute the forward rate constant.
+        """
+        cython.declare(kf=StickingCoefficient, kr=SurfaceArrhenius)
+        cython.declare(Tlist=np.ndarray, klist=np.ndarray, i=cython.int)
+        if not isinstance(k_forward, StickingCoefficient): # Only reverse StickingCoefficient rates
+            raise TypeError(f'Expected a StickingCoefficient object for k_forward but received {k_forward}')
+        kf = k_forward
+        if Tmin is not None and Tmax is not None:
+            Tlist = 1.0 / np.linspace(1.0 / Tmax.value, 1.0 / Tmin.value, 50)
+        else:
+            Tlist = 1.0 / np.arange(0.0005, 0.0034, 0.0001)
+        # Determine the values of the reverse rate coefficient k_r(T) at each temperature
+        klist = np.zeros_like(Tlist)
+        for i in range(len(Tlist)):
+            klist[i] = \
+                self.get_surface_rate_coefficient(Tlist[i], surface_site_density=surface_site_density) / \
+                self.get_equilibrium_constant(Tlist[i], surface_site_density=surface_site_density)
+        kr = SurfaceArrhenius()
+        kr.fit_to_data(Tlist, klist, reverse_units, kf.T0.value_si)
+        return kr
+
+    def generate_reverse_rate_coefficient(self, network_kinetics=False, Tmin=None, Tmax=None, surface_site_density=0):
         """
         Generate and return a rate coefficient model for the reverse reaction. 
         Currently this only works if the `kinetics` attribute is one of several
         (but not necessarily all) kinetics types.
+
+        If the reaction kinetics model is Sticking Coefficient, please provide a nonzero
+        surface site density in `mol/m^2` which is required to evaluate the rate coefficient.
         """
         cython.declare(Tlist=np.ndarray, Plist=np.ndarray, K=np.ndarray,
                        rxn=Reaction, klist=np.ndarray, i=cython.size_t,
@@ -875,6 +904,7 @@ class Reaction:
             ThirdBody.__name__,
             Lindemann.__name__,
             Troe.__name__,
+            StickingCoefficient.__name__,
         )
 
         # Get the units for the reverse rate coefficient
@@ -906,6 +936,13 @@ class Reaction:
                 return self.reverse_surface_arrhenius_rate(kf, kunits, Tmin, Tmax)
             else:
                 return self.reverse_arrhenius_rate(kf, kunits, Tmin, Tmax)
+
+        elif isinstance(kf, StickingCoefficient):
+            if surface_site_density <= 0:
+                raise ValueError("Please provide a postive surface site density in mol/m^2 " 
+                                f"for calculating the rate coefficient of {StickingCoefficient.__name__} kinetics")
+            else:
+                return self.reverse_sticking_coeff_rate(kf, kunits, surface_site_density, Tmin, Tmax)
 
         elif network_kinetics and self.network_kinetics is not None:
             kf = self.network_kinetics


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG had no method to reverse Sticking Coefficient kinetics.  I believe this is related to this website issue https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2079.  Adding a method to reverse Sticking Coeffs could be useful to compare Sticking Coeff kinetics with literature rates that are expressed as Arrhenius in the reverse direction.  This method could also be useful if we need to reverse sticking coefficient kinetics in training reactions.


### Description of Changes
Added StickingCoefficient kinetics handling to reaction `get_rate_coefficient` method so that we can use this method for all types of kinetics.
Added a method to reverse StickingCoefficient kinetics with default surface site density.


### Testing
Added a unit test for reversing StickingCoefficient kinetics

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
