### PR TITLE
Add label swaps for own-reverse family Surface_Abstraction_single_vdW

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1528,6 +1528,9 @@ class KineticsFamily(Database):
                 atom_labels['*5'].label = '*1'
                 atom_labels['*2'].label = '*4'
                 atom_labels['*4'].label = '*2'
+            else:
+                raise KineticsError(f"Unsure how to reverse labels of {label} reaction.")
+
         if not forward:
             template = self.reverse_template
             product_num = self.reactant_num or len(template.products)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1529,7 +1529,7 @@ class KineticsFamily(Database):
                 atom_labels['*2'].label = '*4'
                 atom_labels['*4'].label = '*2'
             else:
-                raise KineticsError(f"Unsure how to reverse labels of {label} reaction.")
+                logging.warning(f"Unsure how to reverse labels of {label} reaction.")
 
         if not forward:
             template = self.reverse_template

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1521,6 +1521,13 @@ class KineticsFamily(Database):
                 atom_labels['*2'].label = '*3'
                 atom_labels['*3'].label = '*2'
 
+            elif label == 'surface_abstraction_single_vdw':
+                # *3 migrates from *2-*1 to *4-*5
+                # so swap *1 with *5, swap *2 with *4
+                atom_labels['*1'].label = '*5'
+                atom_labels['*5'].label = '*1'
+                atom_labels['*2'].label = '*4'
+                atom_labels['*4'].label = '*2'
         if not forward:
             template = self.reverse_template
             product_num = self.reactant_num or len(template.products)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The new reaction family Surface_Abstraction_single_vdW in https://github.com/ReactionMechanismGenerator/RMG-database/pull/456
is its own reverse, so needs some hard-coding in RMG-Py to swap the atom labels.

Other families are also missing these label swaps.


### Description of Changes
I added label swaps for the new family.

I also added a check to see if other families are their own reverse and don't have this done, and quite a lot show up.
I turned the exception into a warning, but there are quite a few.
**_Should we fix these? Or should this be done as a database test?  Or do they really not matter and we should silence the warning?_**

### Testing
Database tests pass locally.

### Reviewer Tips
Some discussion is needed about the other families missing label swaps.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
