### PR TITLE
Update model chemistry documentation

### DIFF
--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -144,6 +144,7 @@ Model Chemistry                                  AEC   BC   SOC  Freq Scale Supp
 ``'MRCI+Davidson/aug-cc-pV(T+d)Z'``               v         v               H, C, N, O, S
 ``'wb97x-d/aug-cc-pvtz'``                         v         v               H, C, N, O
 ``'wb97x-d3/def2-tzvp'``                          v    v    v    v (0.984)  H, C, N, O, F, S, Cl, Br
+``'wb97m-v/def2-tzvpd'``                          v         v    v (1.002)  H, C, N, O, F, S, Cl, Br
 ``'b97d-3/def2-msvp'``                            v    v    v    v (1.014)  H, C, N, O, F, S, Cl, Br
 ================================================ ===== ==== ==== ========== =========================
 

--- a/documentation/source/users/arkane/input.rst
+++ b/documentation/source/users/arkane/input.rst
@@ -110,9 +110,9 @@ The table below shows which model chemistries have atomization energy correction
 corrections (BC), and spin orbit corrections (SOC). It also lists which elements are available
 for a given model chemistry.
 
-================================================ ===== ==== ==== ========== ====================
+================================================ ===== ==== ==== ========== =========================
 Model Chemistry                                  AEC   BC   SOC  Freq Scale Supported Elements
-================================================ ===== ==== ==== ========== ====================
+================================================ ===== ==== ==== ========== =========================
 ``'CBS-QB3'``                                     v    v    v    v (0.990)  H, C, N, O, P, S
 ``'CBS-QB3-Paraskevas'``                          v    v    v    v (0.990)  H, C, N, O, P, S
 ``'G3'``                                          v         v               H, C, N, O, P, S
@@ -143,7 +143,9 @@ Model Chemistry                                  AEC   BC   SOC  Freq Scale Supp
 ``'B3LYP/6-31G(d,p)'``                            v    v         v (0.961)  H, C, O, S
 ``'MRCI+Davidson/aug-cc-pV(T+d)Z'``               v         v               H, C, N, O, S
 ``'wb97x-d/aug-cc-pvtz'``                         v         v               H, C, N, O
-================================================ ===== ==== ==== ========== ====================
+``'wb97x-d3/def2-tzvp'``                          v    v    v    v (0.984)  H, C, N, O, F, S, Cl, Br
+``'b97d-3/def2-msvp'``                            v    v    v    v (1.014)  H, C, N, O, F, S, Cl, Br
+================================================ ===== ==== ==== ========== =========================
 
 Notes:
 


### PR DESCRIPTION
This PR updates the documentation tabulating which levels of theory are supported by Arkane. It adds `ωB97X-D3/def2-TZVP` and `B97-D3/def2-mSVP`, which were added in [RMG-database PR #459](https://github.com/ReactionMechanismGenerator/RMG-database/pull/459). It also adds `ωB97M-V/def2-TZVPD` to the Arkane documentation since this LoT was already in [RMG-database](https://github.com/ReactionMechanismGenerator/RMG-database/blob/aec_bac_wb97xd3_b97d3/input/quantum_corrections/data.py#L77).

Let's merge this PR once [RMG-database PR #459](https://github.com/ReactionMechanismGenerator/RMG-database/pull/459) is merged.
