### PR TITLE
Switch to OpenBabel 3

### DIFF
--- a/arkane/encorr/bacTest.py
+++ b/arkane/encorr/bacTest.py
@@ -38,7 +38,7 @@ import unittest
 from collections import Counter
 
 import numpy as np
-import pybel
+from openbabel import pybel
 
 from rmgpy import settings
 from rmgpy.molecule import Molecule

--- a/arkane/encorr/data.py
+++ b/arkane/encorr/data.py
@@ -42,7 +42,7 @@ from dataclasses import dataclass
 from typing import Callable, Iterable, List, Sequence, Set, Union
 
 import numpy as np
-import pybel
+from openbabel import pybel
 
 from rmgpy import settings
 from rmgpy.molecule import Atom, Bond, get_element

--- a/arkane/encorr/dataTest.py
+++ b/arkane/encorr/dataTest.py
@@ -35,7 +35,7 @@ import unittest
 from collections import Counter
 
 import numpy as np
-import pybel
+from openbabel import pybel
 
 from rmgpy.molecule import Molecule as RMGMolecule
 

--- a/documentation/source/users/rmg/species.rst
+++ b/documentation/source/users/rmg/species.rst
@@ -42,7 +42,9 @@ the same species: ::
    
     structure=InChI("InChI=1S/CH4/h1H4"),
 
-
+Be careful using the SMILES shorthand with lowercase letters for aromatics,
+radicals, or double bonds, because these can be ambiguous and the resulting
+molecule may depend on the version of OpenBabel, RDKit, and RMG in use.
 To quickly generate any adjacency list, or to generate an adjacency list from
 other types of molecular representations such as SMILES, InChI, or even common
 species names, use the Molecule Search tool found here: http://rmg.mit.edu/molecule_search

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - nose
   - rmg::numdifftools
   - numpy >=1.10.0
-  - openbabel
+  - conda-forge::openbabel >= 3
   - pandas
   - psutil
   - rmg::pydas >=1.0.2

--- a/rmgpy/molecule/converter.pxd
+++ b/rmgpy/molecule/converter.pxd
@@ -26,6 +26,7 @@
 ###############################################################################
 
 cimport rmgpy.molecule.molecule as mm
+cimport rmgpy.molecule.element as elements
 
 
 cpdef to_rdkit_mol(mm.Molecule mol, bint remove_h=*, bint return_mapping=*, bint sanitize=*)

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -262,9 +262,16 @@ def from_ob_mol(mol, obmol, raise_atomtype_exception=True):
     and assumes overall spin multiplicity is radical count + 1
     """
     # Below are the declared variables for cythonizing the module
-    # cython.declare(i=cython.int)
-    # cython.declare(radical_electrons=cython.int, charge=cython.int, lone_pairs=cython.int)
-    # cython.declare(atom=mm.Atom, atom1=mm.Atom, atom2=mm.Atom, bond=mm.Bond)
+    cython.declare(
+        number=cython.int,
+        isotope=cython.int,
+        element=elements.Element,
+        charge=cython.int,
+        valence=cython.int,
+        radical_electrons=cython.int,
+        atom=mm.Atom,
+        )
+
     if openbabel is None:
         raise DependencyError('OpenBabel is not installed. Please install or use RDKit.')
 

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -233,6 +233,7 @@ def to_ob_mol(mol, return_mapping=False):
         if atom.element.isotope != -1:
             a.SetIsotope(atom.element.isotope)
         a.SetFormalCharge(atom.charge)
+        # a.SetImplicitHCount(0) # the default is 0
         ob_atom_ids[atom] = a.GetId()
     orders = {1: 1, 2: 2, 3: 3, 4: 4, 1.5: 5}
     for atom1 in mol.vertices:

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -39,7 +39,7 @@ import cython
 from rdkit import Chem
 # Test if openbabel is installed
 try:
-    import openbabel
+    from openbabel import openbabel
 except ImportError:
     openbabel = None
 

--- a/rmgpy/molecule/pathfinderTest.py
+++ b/rmgpy/molecule/pathfinderTest.py
@@ -399,9 +399,9 @@ class FindAllylDelocalizationPathsTest(unittest.TestCase):
         self.assertTrue(paths)
 
     def test_nitrogenated_birad(self):
-        smiles = '[CH]=C[N]'
+        smiles = '[N]C=[CH]'
         mol = Molecule().from_smiles(smiles)
-        paths = find_allyl_delocalization_paths(mol.atoms[3])
+        paths = find_allyl_delocalization_paths(mol.atoms[0])
         self.assertTrue(paths)
 
 

--- a/rmgpy/molecule/pathfinderTest.py
+++ b/rmgpy/molecule/pathfinderTest.py
@@ -311,15 +311,14 @@ class FindButadieneEndWithChargeTest(unittest.TestCase):
         expected_idx_path = [3, 2, 4, 6]
         self.assertEquals(idx_path, expected_idx_path)
 
-    def test_c6h6o4(self):
-        inchi = "InChI=1S/C6H6O4/c1-2-4-9-6(7)3-5-10-8/h2-3H,1,5H2"
+    def test_c8h14o4(self):
+        inchi = "InChI=1S/C8H14O4S/c1-3-6-13(2,11)7-8(9)4-5-12-10/h3,6H,1,4-5,7H2,2H3,(H-,10,11)"
         mol = Molecule().from_inchi(inchi)
         start = mol.atoms[0]
         path = find_butadiene_end_with_charge(start)
         idx_path = [mol.atoms.index(atom) + 1 for atom in path[0::2]]
-
-        expected_idx_path = [1, 2, 4, 9]
-        self.assertEquals(idx_path, expected_idx_path)
+        expected_idx_path = [1, 3, 6, 13]
+        self.assertEqual(idx_path, expected_idx_path)
 
     def test_c6h6o6(self):
         inchi = "InChI=1S/C6H6O6/c7-6(2-5-12-9)10-3-1-4-11-8/h1,7H,4-5H2"

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -394,7 +394,10 @@ def _openbabel_translator(input_object, identifier_type, mol=None):
         obmol = openbabel.OBMol()
         ob_conversion.ReadString(obmol, input_object)
         obmol.AddHydrogens()
-        obmol.AssignSpinMultiplicity(True)
+        # In OpenBabel 3+ the function obmol.AssignSpinMultiplicity(True) does nothing.
+        # We could write our own method here and call obatom.SetSpinMultiplicity on
+        # each atom, but instead we will leave them blank for now and fix them 
+        # in the from_ob_mol() method.
         if mol is None:
             mol = mm.Molecule()
         output = from_ob_mol(mol, obmol)

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -39,7 +39,7 @@ import cython
 from rdkit import Chem
 # Test if openbabel is installed
 try:
-    import openbabel
+    from openbabel import openbabel
 except ImportError:
     BACKENDS = ['rdkit']
 else:

--- a/rmgpy/molecule/translatorTest.py
+++ b/rmgpy/molecule/translatorTest.py
@@ -1338,7 +1338,17 @@ class InChIParsingTest(unittest.TestCase):
         u_indices = [4, 5]
         self.compare(inchi, u_indices)
 
+    @work_in_progress
     def test_c6h6o4(self):
+        """
+        This test used to pass with OpenBabel < 3.0, but I think the inchi is invalid?
+        or at least not standard.
+        OpenBabel reports:
+            Problems/mismatches: Mobile-H( Hydrogens: Locations or number, Number; Charge(s): Do not match)
+        and cactus.nci.nih.gov converts it to InChI=1S/C6H7O4/c1-2-4-9-6(7)3-5-10-8/h2-3,8H,1,5H2/q+1
+        which at least doesn't make OpenBabel complain. However, both have a net charge
+        and cause RMG to crash. I'm not sure what the molecule was ever supposed to represent.
+        """
         inchi = 'InChI=1S/C6H6O4/c1-2-4-9-6(7)3-5-10-8/h2-3H,1,5H2'
         u_indices = [1, 3, 4, 8]
         self.compare(inchi, u_indices)

--- a/utilities.py
+++ b/utilities.py
@@ -102,7 +102,7 @@ def _check_openbabel():
     missing = False
 
     try:
-        import openbabel
+        from openbabel import openbabel
     except ImportError:
         print('{0:<30}{1}'.format('OpenBabel',
                                   'Not found. Necessary for SMILES/InChI functionality for nitrogen compounds.'))


### PR DESCRIPTION
### Motivation or Problem
The release notes say OpenBabel 3 a major improvement
https://github.com/openbabel/openbabel/releases/tag/openbabel-3-0-0
but it does break some things in the API
https://open-babel.readthedocs.io/en/latest/UseTheLibrary/migration.html#migrating-to-3-0
so subsequent commits on this pull request should fix RMG to be compatible.

This pull request is currently a stub. Please feel free to contribute commits!

### Description of Changes
- update the environment.yaml to use the official updated cclib and openbabel conda packages.
- change import statements
- when reading radicals from OpenBabel molecules, calculate spin multiplicity based on undervalence of atoms, because OpenBabel no longer does this for you
- Mark a couple of broken unit tests as work_in_progress, because they seem to have malformed InChIs that we can no longer read, and I'm not sure what the correct molecule is supposed to be.

### Testing
- Tests run locally on my Mac.
- Continuous Integration tests will be run.

### Reviewer Tips
- if someone can figure out the broken InChIs in the unit tests, that'd be great.

Further detailed commentary is in the individual commit messages.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
