### PR TITLE
Adding in coverage dependent effects to surface kinetics

### DIFF
--- a/documentation/source/users/rmg/surfaces.rst
+++ b/documentation/source/users/rmg/surfaces.rst
@@ -325,6 +325,61 @@ The following is a list of the current pre-packaged surface reaction libraries i
 
 
 
+Coverage Dependence
+===================
+
+An Arrhenius-like expression can be used to describe the effect of the coverage (:math:`\theta_{k}`) of species k on the forward rate constant for a given surface reaction. RMG has the capability to account for such coverage dependent kinetics, as specified in the following equation:
+
+.. math:: k_f = A T^b \exp \left( - \frac{E_a}{RT} \right)\prod_k 10^{a_k \theta_k} \theta_k^{m_k}\exp \left( \frac{- E_k \theta_k}{RT} \right)
+    :label: covdepeqn
+
+where the parameters :math:`a_k`, :math:`m_k`, and :math:`E_k` are the modifiers for the pre-exponential, temperature exponent, and activation energy from species k. 
+
+input file specifications
+-------------------------
+Coverage dependent parameters are applied if the "coverage_dependence" attribute is set to "True" in the catalyst properties block::
+
+    catalystProperties(
+        metal = Pt111
+        coverageDependence=True,
+    )
+
+By default, this field is false. 
+
+
+Coverage block in families and libraries
+----------------------------------------
+Coverage dependent parameters can be added to a family or library reaction by specifying a dictionary in the "coverage_dependence" field, with the names of the species serving as the keys. Nested within that dictionary is a dictionary of the coverage dependent parameters for each species. For example::
+
+    entry(
+        index = 5,
+        label = "NH_X + X <=> N_X + H_X",
+        kinetics = SurfaceArrhenius(
+            A = (7.22E20, 'cm^2/(mol*s)'), 
+            n = 0.0,
+            Ea = (5.3, 'kcal/mol'),
+            Tmin = (200, 'K'),
+            Tmax = (3000, 'K'),
+            coverage_dependence = {'N_X': {'a':0.0, 'm':0.0, 'E':(15.5, 'kcal/mol')},
+                                   'H_X': {'a':0.0, 'm':0.0, 'E':(1.0, 'kcal/mol')}},
+        ),
+        shortDesc = u"""Surface_Dissociation""",
+        longDesc = u"""
+    "The role of adsorbate–adsorbate interactions in the rate controlling step 
+    and the most abundant reaction intermediate of NH3 decomposition on Ru"
+    D.G. Vlachos et al. (2004). Catalysis Letters 96, 13–22. 
+    https://doi.org/10.1023/B:CATL.0000029523.22277.e1
+    This reaction used RMG's surface site density of Ru0001 = 2.630E-9(mol/cm^2) to calculate the A factor.
+    A = 1.9E12(1/s)/2.630E-9(mol/cm^2) = 7.22E20 cm^2/(mol*s)
+    This is R5 in Table 2 (set A)
+    """,
+        metal = "Ru",
+        facet = "0001",
+    )
+
+The species "N_X" and "H_X" are the coverage dependent species in this example, and they also happen to be species partaking in this reaction. However, any species that are listed in the species dictionary can also be used. 
+
+
 Examples
 =========
 

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -462,7 +462,7 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
         )
         del kinetics['arrhenius high']
 
-        tokens = tokens[1].split()
+        tokens = case_preserved_tokens[1].split()
         kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E':(float(tokens[3]), Eunits)}
         try:
             # is a sticking coefficient

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -463,13 +463,13 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
         del kinetics['arrhenius high']
 
         tokens = tokens[1].split()
-        kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'E': (tokens[3].strip(), Eunits), 'm': tokens[2].strip(), 'a':tokens[1].strip()}
+        kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'a':tokens[1].strip(), 'm': tokens[2].strip(), 'E': (tokens[3].strip(), Eunits)}
         try:
             # is a sticking coefficient
-            kinetics['sticking coefficient'][species_dict[tokens[0].strip()]] = {'E': (tokens[3].strip(), Eunits), 'm': tokens[2].strip(), 'a':tokens[1].strip()}
+            kinetics['sticking coefficient'][species_dict[tokens[0].strip()]] = {'a':tokens[1].strip(), 'm': tokens[2].strip(), 'E': (tokens[3].strip(), Eunits)}
         except KeyError:
             # is a not a sticking coefficient
-            kinetics['surface arrhenius'].coverage_dependence[species_dict[tokens[0].strip()]] = {'E': (tokens[3].strip(), 'J/mol'), 'm': tokens[2].strip(), 'a':tokens[1].strip()}
+            kinetics['surface arrhenius'].coverage_dependence[species_dict[tokens[0].strip()]] = {'a':tokens[1].strip(), 'm': tokens[2].strip(), 'E': (tokens[3].strip(), Eunits)}
 
     elif 'LOW' in line:
         # Low-pressure-limit Arrhenius parameters

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -463,13 +463,13 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
         del kinetics['arrhenius high']
 
         tokens = tokens[1].split()
-        kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'a':tokens[1].strip(), 'm': tokens[2].strip(), 'E': (tokens[3].strip(), Eunits)}
+        kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E':(float(tokens[3]), Eunits)}
         try:
             # is a sticking coefficient
-            kinetics['sticking coefficient'][species_dict[tokens[0].strip()]] = {'a':tokens[1].strip(), 'm': tokens[2].strip(), 'E': (tokens[3].strip(), Eunits)}
+            kinetics['sticking coefficient'][species_dict[tokens[0].strip()]] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E':(float(tokens[3]), Eunits)}
         except KeyError:
             # is a not a sticking coefficient
-            kinetics['surface arrhenius'].coverage_dependence[species_dict[tokens[0].strip()]] = {'a':tokens[1].strip(), 'm': tokens[2].strip(), 'E': (tokens[3].strip(), Eunits)}
+            kinetics['surface arrhenius'].coverage_dependence[species_dict[tokens[0].strip()]] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E': (float(tokens[3]), Eunits)}
 
     elif 'LOW' in line:
         # Low-pressure-limit Arrhenius parameters

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1789,6 +1789,10 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         string += '\n    STICK'
+        if kinetics.coverage_dependence is not None:
+            for species, cov_params in kinetics.coverage_dependence.items():
+                string += f'\n    COV / {species.label:<41}'
+                string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
     elif isinstance(kinetics, _kinetics.Arrhenius):
         conversion_factor = kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
         if not isinstance(kinetics, _kinetics.SurfaceArrhenius):
@@ -1805,6 +1809,10 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.n.value_si,
             kinetics.Ea.value_si / 4184.
         )
+        if isinstance(kinetics, _kinetics.SurfaceArrhenius) and kinetics.coverage_dependence:
+            for species, cov_params in kinetics.coverage_dependence.items():
+                string += f'\n    COV / {species.label:<41}'
+                string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1711,8 +1711,7 @@ def write_reaction_string(reaction, java_library=False):
 ################################################################################
 
 
-def write_kinetics_entry(reaction, species_list, verbose=True, java_library=False, commented=False,
-                         coverage_dependence=False):
+def write_kinetics_entry(reaction, species_list, verbose=True, java_library=False, commented=False):
     """
     Return a string representation of the reaction as used in a Chemkin
     file. Use `verbose = True` to turn on kinetics comments.
@@ -1744,8 +1743,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
                                         specific_collider=reaction.specific_collider,
                                         reversible=reaction.reversible,
                                         kinetics=kinetics)
-            string += write_kinetics_entry(new_reaction, species_list, verbose, java_library, commented,
-                                           coverage_dependence=coverage_dependence)
+            string += write_kinetics_entry(new_reaction, species_list, verbose, java_library, commented)
             string += "DUPLICATE\n"
 
         if commented:
@@ -1814,12 +1812,11 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         string += '\n    STICK'
-        if coverage_dependence:
-            if kinetics.coverage_dependence is not None:
-                for species, cov_params in kinetics.coverage_dependence.items():
-                    label = get_species_identifier(species)
-                    string += f'\n    COV / {label:<41}'
-                    string += f"{cov_params['a'].value:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si:<6.3f} /"
+        if kinetics.coverage_dependence is not None:
+            for species, cov_params in kinetics.coverage_dependence.items():
+                label = get_species_identifier(species)
+                string += f'\n    COV / {label:<41}'
+                string += f"{cov_params['a'].value:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si:<6.3f} /"
     elif isinstance(kinetics, _kinetics.Arrhenius):
         conversion_factor = kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
         if not isinstance(kinetics, _kinetics.SurfaceArrhenius):
@@ -1837,11 +1834,10 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         if isinstance(kinetics, _kinetics.SurfaceArrhenius) and kinetics.coverage_dependence:
-            if coverage_dependence is True:
-                for species, cov_params in kinetics.coverage_dependence.items():
-                    label = get_species_identifier(species)
-                    string += f'\n    COV / {label:<41}'
-                    string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si/4184.:<6.3f} /"
+            for species, cov_params in kinetics.coverage_dependence.items():
+                label = get_species_identifier(species)
+                string += f'\n    COV / {label:<41}'
+                string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si/4184.:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()
@@ -2108,7 +2104,7 @@ def save_transport_file(path, species):
                 ))
 
 
-def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicates=True, coverage_dependence=False):
+def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicates=True):
     """
     Save a Chemkin input file to `path` on disk containing the provided lists
     of `species` and `reactions`.
@@ -2156,7 +2152,7 @@ def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicat
     global _chemkin_reaction_count
     _chemkin_reaction_count = 0
     for rxn in reactions:
-        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose, coverage_dependence=coverage_dependence))
+        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose))
         # Don't forget to mark duplicates!
         f.write('\n')
     f.write('END\n\n')
@@ -2166,7 +2162,7 @@ def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicat
 
 
 def save_chemkin_surface_file(path, species, reactions, verbose=True, check_for_duplicates=True,
-                              surface_site_density=None, coverage_dependence=False):
+                              surface_site_density=None):
     """
     Save a Chemkin *surface* input file to `path` on disk containing the provided lists
     of `species` and `reactions`.
@@ -2216,8 +2212,7 @@ def save_chemkin_surface_file(path, species, reactions, verbose=True, check_for_
     global _chemkin_reaction_count
     _chemkin_reaction_count = 0
     for rxn in reactions:
-        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose,
-                                     coverage_dependence=coverage_dependence))
+        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose))
         f.write('\n')
     f.write('END\n\n')
     f.close()
@@ -2310,13 +2305,11 @@ def save_chemkin(reaction_model, path, verbose_path, dictionary_path=None, trans
         # We should already have marked everything as duplicates by now so use check_for_duplicates=False
         save_chemkin_file(gas_path, gas_species_list, gas_rxn_list, verbose=False, check_for_duplicates=False)
         save_chemkin_surface_file(surface_path, surface_species_list, surface_rxn_list, verbose=False,
-                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density,
-                                  coverage_dependence=reaction_model.coverage_dependence)
+                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density)
         logging.info('Saving annotated version of Chemkin files...')
         save_chemkin_file(gas_verbose_path, gas_species_list, gas_rxn_list, verbose=True, check_for_duplicates=False)
         save_chemkin_surface_file(surface_verbose_path, surface_species_list, surface_rxn_list, verbose=True,
-                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density,
-                                  coverage_dependence=reaction_model.coverage_dependence)
+                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density)
 
     else:
         # Gas phase only

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1812,11 +1812,11 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         string += '\n    STICK'
-        if kinetics.coverage_dependence is not None:
+        if kinetics.coverage_dependence:
             for species, cov_params in kinetics.coverage_dependence.items():
                 label = get_species_identifier(species)
                 string += f'\n    COV / {label:<41}'
-                string += f"{cov_params['a'].value:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si:<6.3f} /"
+                string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3g} {cov_params['E'].value_si/4184:<6.3f} /"
     elif isinstance(kinetics, _kinetics.Arrhenius):
         conversion_factor = kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
         if not isinstance(kinetics, _kinetics.SurfaceArrhenius):
@@ -1837,7 +1837,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             for species, cov_params in kinetics.coverage_dependence.items():
                 label = get_species_identifier(species)
                 string += f'\n    COV / {label:<41}'
-                string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si/4184.:<6.3f} /"
+                string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3g} {cov_params['E'].value_si/4184.:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1812,11 +1812,6 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         string += '\n    STICK'
-        if kinetics.coverage_dependence:
-            for species, cov_params in kinetics.coverage_dependence.items():
-                label = get_species_identifier(species)
-                string += f'\n    COV / {label:<41}'
-                string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3g} {cov_params['E'].value_si/4184:<6.3f} /"
     elif isinstance(kinetics, _kinetics.Arrhenius):
         conversion_factor = kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
         if not isinstance(kinetics, _kinetics.SurfaceArrhenius):
@@ -1833,11 +1828,6 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.n.value_si,
             kinetics.Ea.value_si / 4184.
         )
-        if isinstance(kinetics, _kinetics.SurfaceArrhenius) and kinetics.coverage_dependence:
-            for species, cov_params in kinetics.coverage_dependence.items():
-                label = get_species_identifier(species)
-                string += f'\n    COV / {label:<41}'
-                string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3g} {cov_params['E'].value_si/4184.:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()
@@ -1876,6 +1866,13 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
         string += '{0:<9.1f} {1:<9.1f} {2:<9.1f}'.format(0, 0, 0)
 
     string += '\n'
+
+    if getattr(kinetics, 'coverage_dependence', None):
+        # Write coverage dependence parameters for surface reactions
+        for species, cov_params in kinetics.coverage_dependence.items():
+            label = get_species_identifier(species)
+            string += f'    COV / {label:<41} '
+            string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<9.3g} {cov_params['E'].value_si/4184.:<9.3f} /\n"
 
     if isinstance(kinetics, (_kinetics.ThirdBody, _kinetics.Lindemann, _kinetics.Troe)):
         # Write collider efficiencies

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -463,13 +463,13 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
         del kinetics['arrhenius high']
 
         tokens = tokens[1].split()
-        kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'E': (tokens[1].strip(), Eunits), 'm': tokens[2].strip(), 'a':tokens[3].strip()}
+        kinetics['coverage dependence'][species_dict[tokens[0].strip()]] = {'E': (tokens[3].strip(), Eunits), 'm': tokens[2].strip(), 'a':tokens[1].strip()}
         try:
             # is a sticking coefficient
-            kinetics['sticking coefficient'][species_dict[tokens[0].strip()]] = {'E': (tokens[1].strip(), Eunits), 'm': tokens[2].strip(), 'a':tokens[3].strip()}
+            kinetics['sticking coefficient'][species_dict[tokens[0].strip()]] = {'E': (tokens[3].strip(), Eunits), 'm': tokens[2].strip(), 'a':tokens[1].strip()}
         except KeyError:
             # is a not a sticking coefficient
-            kinetics['surface arrhenius'].coverage_dependence[species_dict[tokens[0].strip()]] = {'E': (tokens[1].strip(), 'J/mol'), 'm': tokens[2].strip(), 'a':tokens[3].strip()}
+            kinetics['surface arrhenius'].coverage_dependence[species_dict[tokens[0].strip()]] = {'E': (tokens[3].strip(), 'J/mol'), 'm': tokens[2].strip(), 'a':tokens[1].strip()}
 
     elif 'LOW' in line:
         # Low-pressure-limit Arrhenius parameters
@@ -1818,7 +1818,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
                 for species, cov_params in kinetics.coverage_dependence.items():
                     label = get_species_identifier(species)
                     string += f'\n    COV / {label:<41}'
-                    string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
+                    string += f"{cov_params['a'].value:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si:<6.3f} /"
     elif isinstance(kinetics, _kinetics.Arrhenius):
         conversion_factor = kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
         if not isinstance(kinetics, _kinetics.SurfaceArrhenius):
@@ -1840,7 +1840,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
                 for species, cov_params in kinetics.coverage_dependence.items():
                     label = get_species_identifier(species)
                     string += f'\n    COV / {label:<41}'
-                    string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
+                    string += f"{cov_params['a'].value:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1841,7 +1841,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
                 for species, cov_params in kinetics.coverage_dependence.items():
                     label = get_species_identifier(species)
                     string += f'\n    COV / {label:<41}'
-                    string += f"{cov_params['a'].value:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si:<6.3f} /"
+                    string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<6.3f} {cov_params['E'].value_si/4184.:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1710,7 +1710,8 @@ def write_reaction_string(reaction, java_library=False):
 ################################################################################
 
 
-def write_kinetics_entry(reaction, species_list, verbose=True, java_library=False, commented=False):
+def write_kinetics_entry(reaction, species_list, verbose=True, java_library=False, commented=False,
+                         coverage_dependence=False):
     """
     Return a string representation of the reaction as used in a Chemkin
     file. Use `verbose = True` to turn on kinetics comments.
@@ -1742,7 +1743,8 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
                                         specific_collider=reaction.specific_collider,
                                         reversible=reaction.reversible,
                                         kinetics=kinetics)
-            string += write_kinetics_entry(new_reaction, species_list, verbose, java_library, commented)
+            string += write_kinetics_entry(new_reaction, species_list, verbose, java_library, commented,
+                                           coverage_dependence=coverage_dependence)
             string += "DUPLICATE\n"
 
         if commented:
@@ -1811,10 +1813,12 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         string += '\n    STICK'
-        if kinetics.coverage_dependence is not None:
-            for species, cov_params in kinetics.coverage_dependence.items():
-                string += f'\n    COV / {species.label:<41}'
-                string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
+        if coverage_dependence:
+            if kinetics.coverage_dependence is not None:
+                for species, cov_params in kinetics.coverage_dependence.items():
+                    label = get_species_identifier(species)
+                    string += f'\n    COV / {label:<41}'
+                    string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
     elif isinstance(kinetics, _kinetics.Arrhenius):
         conversion_factor = kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
         if not isinstance(kinetics, _kinetics.SurfaceArrhenius):
@@ -1832,9 +1836,11 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
             kinetics.Ea.value_si / 4184.
         )
         if isinstance(kinetics, _kinetics.SurfaceArrhenius) and kinetics.coverage_dependence:
-            for species, cov_params in kinetics.coverage_dependence.items():
-                string += f'\n    COV / {species.label:<41}'
-                string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
+            if coverage_dependence is True:
+                for species, cov_params in kinetics.coverage_dependence.items():
+                    label = get_species_identifier(species)
+                    string += f'\n    COV / {label:<41}'
+                    string += f"{cov_params['E'].value_si:<9.3e} {cov_params['m'].value:<6.3f} {cov_params['a'].value:<6.3f} /"
     elif isinstance(kinetics, (_kinetics.Lindemann, _kinetics.Troe)):
         arrhenius = kinetics.arrheniusHigh
         conversion_factor = arrhenius.A.get_conversion_factor_from_si_to_cm_mol_s()
@@ -2101,7 +2107,7 @@ def save_transport_file(path, species):
                 ))
 
 
-def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicates=True):
+def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicates=True, coverage_dependence=False):
     """
     Save a Chemkin input file to `path` on disk containing the provided lists
     of `species` and `reactions`.
@@ -2149,7 +2155,7 @@ def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicat
     global _chemkin_reaction_count
     _chemkin_reaction_count = 0
     for rxn in reactions:
-        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose))
+        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose, coverage_dependence=coverage_dependence))
         # Don't forget to mark duplicates!
         f.write('\n')
     f.write('END\n\n')
@@ -2159,7 +2165,7 @@ def save_chemkin_file(path, species, reactions, verbose=True, check_for_duplicat
 
 
 def save_chemkin_surface_file(path, species, reactions, verbose=True, check_for_duplicates=True,
-                              surface_site_density=None):
+                              surface_site_density=None, coverage_dependence=False):
     """
     Save a Chemkin *surface* input file to `path` on disk containing the provided lists
     of `species` and `reactions`.
@@ -2209,7 +2215,8 @@ def save_chemkin_surface_file(path, species, reactions, verbose=True, check_for_
     global _chemkin_reaction_count
     _chemkin_reaction_count = 0
     for rxn in reactions:
-        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose))
+        f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose,
+                                     coverage_dependence=coverage_dependence))
         f.write('\n')
     f.write('END\n\n')
     f.close()
@@ -2302,11 +2309,13 @@ def save_chemkin(reaction_model, path, verbose_path, dictionary_path=None, trans
         # We should already have marked everything as duplicates by now so use check_for_duplicates=False
         save_chemkin_file(gas_path, gas_species_list, gas_rxn_list, verbose=False, check_for_duplicates=False)
         save_chemkin_surface_file(surface_path, surface_species_list, surface_rxn_list, verbose=False,
-                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density)
+                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density,
+                                  coverage_dependence=reaction_model.coverage_dependence)
         logging.info('Saving annotated version of Chemkin files...')
         save_chemkin_file(gas_verbose_path, gas_species_list, gas_rxn_list, verbose=True, check_for_duplicates=False)
         save_chemkin_surface_file(surface_verbose_path, surface_species_list, surface_rxn_list, verbose=True,
-                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density)
+                                  check_for_duplicates=False, surface_site_density=reaction_model.surface_site_density,
+                                  coverage_dependence=reaction_model.coverage_dependence)
 
     else:
         # Gas phase only

--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -470,7 +470,7 @@ class ChemkinTest(unittest.TestCase):
                                       Ea=(5.0, 'kJ/mol'),
                                       T0=(1.0, 'K'),
                                       coverage_dependence={
-                                          s_x: {'E': (0.1, 'J/mol'), 'm': -1.0, 'a': 1.0},}))
+                                          s_x: {'a': 1.0, 'm': -1.0, 'E': (0.1, 'J/mol')},}))
 
         reactions = [self.rxn_covdep]
 

--- a/rmgpy/chemkinTest.py
+++ b/rmgpy/chemkinTest.py
@@ -477,8 +477,7 @@ class ChemkinTest(unittest.TestCase):
         # save_chemkin_file
         chemkin_save_path = os.path.join(folder, 'surface', 'chem-surface_new.inp')
         dictionary_save_path = os.path.join(folder, 'surface', 'species_dictionary_new.txt')
-        save_chemkin_file(chemkin_save_path, species, reactions, verbose=True, check_for_duplicates=True,
-                          coverage_dependence=True)
+        save_chemkin_file(chemkin_save_path, species, reactions, verbose=True, check_for_duplicates=True)
         save_species_dictionary(dictionary_save_path, species, old_style=False)
 
         # load chemkin file

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1211,7 +1211,8 @@ class KineticsFamily(Database):
                     alpha=0,
                     E0=deepcopy(data.Ea),
                     Tmin=deepcopy(data.Tmin),
-                    Tmax=deepcopy(data.Tmax)
+                    Tmax=deepcopy(data.Tmax),
+                    coverage_dependence=deepcopy(data.coverage_dependence),
                 )
             elif isinstance(data, SurfaceArrhenius):
                 data = SurfaceArrheniusBEP(
@@ -1222,7 +1223,8 @@ class KineticsFamily(Database):
                     alpha=0,
                     E0=deepcopy(data.Ea),
                     Tmin=deepcopy(data.Tmin),
-                    Tmax=deepcopy(data.Tmax)
+                    Tmax=deepcopy(data.Tmax),
+                    coverage_dependence=deepcopy(data.coverage_dependence),
                 )
             else:
                 raise NotImplementedError("Unexpected training kinetics type {} for {}".format(type(data), entry))
@@ -1303,7 +1305,8 @@ class KineticsFamily(Database):
                     alpha=0,
                     E0=deepcopy(data.Ea),
                     Tmin=deepcopy(data.Tmin),
-                    Tmax=deepcopy(data.Tmax)
+                    Tmax=deepcopy(data.Tmax),
+                    coverage_dependence=deepcopy(data.coverage_dependence),
                 )
             else:
                 data = data.to_arrhenius_ep()

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -434,6 +434,15 @@ class KineticsLibrary(Database):
             # Create a new reaction per entry
             rxn = entry.item
             rxn_string = entry.label
+
+            # Convert coverage dependence label to species label
+            if hasattr(entry.data, 'coverage_dependence'):
+                if entry.data.coverage_dependence:
+                    coverage_dependence_update = {}
+                    for key, value in entry.data.coverage_dependence.items():
+                        coverage_dependence_update[species_dict[key]] = value
+                    entry.data.coverage_dependence = coverage_dependence_update
+
             # Convert the reactants and products to Species objects using the species_dict
             reactants, products = rxn_string.split('=>')
             reversible = True

--- a/rmgpy/kinetics/surface.pxd
+++ b/rmgpy/kinetics/surface.pxd
@@ -39,6 +39,7 @@ cdef class StickingCoefficient(KineticsModel):
     cdef public ScalarQuantity _n
     cdef public ScalarQuantity _Ea
     cdef public ScalarQuantity _T0
+    cdef public dict _coverage_dependence
     
     cpdef double get_sticking_coefficient(self, double T) except -1
 
@@ -56,7 +57,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
     cdef public ScalarQuantity _n
     cdef public ScalarQuantity _alpha
     cdef public ScalarQuantity _E0
-    
+    cdef public dict _coverage_dependence
     cpdef double get_sticking_coefficient(self, double T, double dHrxn=?) except -1
     cpdef double get_activation_energy(self, double dHrxn) except -1
     cpdef StickingCoefficient to_arrhenius(self, double dHrxn)
@@ -65,8 +66,10 @@ cdef class StickingCoefficientBEP(KineticsModel):
 
 ################################################################################
 cdef class SurfaceArrhenius(Arrhenius):
+    cdef public dict _coverage_dependence
     pass
 ################################################################################
 cdef class SurfaceArrheniusBEP(ArrheniusEP):
+    cdef public dict _coverage_dependence
     pass
 

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -87,7 +87,7 @@ cdef class StickingCoefficient(KineticsModel):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -293,7 +293,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -495,7 +495,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -589,7 +589,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -84,7 +84,7 @@ cdef class StickingCoefficient(KineticsModel):
         string = 'StickingCoefficient(A={0!r}, n={1!r}, Ea={2!r}, T0={3!r}'.format(self.A, self.n, self.Ea, self.T0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
-        if self.coverage_dependence is not None:
+        if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
                 string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
@@ -290,7 +290,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
                                                                                          self.E0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
-        if self.coverage_dependence is not None:
+        if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
                 string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
@@ -492,7 +492,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         string = 'SurfaceArrhenius(A={0!r}, n={1!r}, Ea={2!r}, T0={3!r}'.format(self.A, self.n, self.Ea, self.T0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
-        if self.coverage_dependence is not None:
+        if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
                 string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
@@ -586,7 +586,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
                                                                                       self.E0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
-        if self.coverage_dependence is not None:
+        if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
                 string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -129,8 +129,14 @@ cdef class StickingCoefficient(KineticsModel):
         """The coverage dependence parameters."""
         def __get__(self):
             return self._coverage_dependence
-        def __set__(self, dict):
-            self._coverage_dependence = dict
+        def __set__(self, value):
+             self._coverage_dependence = {}
+             if value:
+                 for species, parameters in value.items():
+                     processed_parameters = {'E': quantity.Energy(parameters['E']),
+                                             'm': quantity.Dimensionless(parameters['m']),
+                                             'a': quantity.Dimensionless(parameters['a'])}
+                     self._coverage_dependence[species] = processed_parameters
 
     cpdef double get_sticking_coefficient(self, double T) except -1:
         """
@@ -324,8 +330,14 @@ cdef class StickingCoefficientBEP(KineticsModel):
         """The coverage dependence parameters."""
         def __get__(self):
             return self._coverage_dependence
-        def __set__(self, dict):
-            self._coverage_dependence = dict
+        def __set__(self, value):
+             self._coverage_dependence = {}
+             if value:
+                 for species, parameters in value.items():
+                     processed_parameters = {'E': quantity.Energy(parameters['E']),
+                                             'm': quantity.Dimensionless(parameters['m']),
+                                             'a': quantity.Dimensionless(parameters['a'])}
+                     self._coverage_dependence[species] = processed_parameters
 
     cpdef double get_sticking_coefficient(self, double T, double dHrxn=0.0) except -1:
         """
@@ -453,8 +465,14 @@ cdef class SurfaceArrhenius(Arrhenius):
         """The coverage dependence parameters."""
         def __get__(self):
             return self._coverage_dependence
-        def __set__(self, dict):
-            self._coverage_dependence = dict
+        def __set__(self, value):
+             self._coverage_dependence = {}
+             if value:
+                 for species, parameters in value.items():
+                     processed_parameters = {'E': quantity.Energy(parameters['E']),
+                                             'm': quantity.Dimensionless(parameters['m']),
+                                             'a': quantity.Dimensionless(parameters['a'])}
+                     self._coverage_dependence[species] = processed_parameters
 
     def __repr__(self):
         """
@@ -535,8 +553,14 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         """The coverage dependence parameters."""
         def __get__(self):
             return self._coverage_dependence
-        def __set__(self, dict):
-            self._coverage_dependence = dict
+        def __set__(self, value):
+             self._coverage_dependence = {}
+             if value:
+                 for species, parameters in value.items():
+                     processed_parameters = {'E': quantity.Energy(parameters['E']),
+                                             'm': quantity.Dimensionless(parameters['m']),
+                                             'a': quantity.Dimensionless(parameters['a'])}
+                     self._coverage_dependence[species] = processed_parameters
 
     def __repr__(self):
         """

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -47,28 +47,34 @@ cdef class StickingCoefficient(KineticsModel):
     Similar to :class:`Arrhenius` but with different units for `A`.
     The attributes are:
 
-    =============== =============================================================
-    Attribute       Description
-    =============== =============================================================
-    `A`             The preexponential factor
-    `T0`            The reference temperature
-    `n`             The temperature exponent
-    `Ea`            The activation energy
-    `Tmin`          The minimum temperature at which the model is valid, or zero if unknown or undefined
-    `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
-    `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
-    `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
-    `comment`       Information about the model (e.g. its source)
-    =============== =============================================================
+    ======================= =============================================================
+    Attribute               Description
+    ======================= =============================================================
+    `A`                     The preexponential factor
+    `T0`                    The reference temperature
+    `n`                     The temperature exponent
+    `Ea`                    The activation energy
+    `Tmin`                  The minimum temperature at which the model is valid, or zero if unknown or undefined
+    `Tmax`                  The maximum temperature at which the model is valid, or zero if unknown or undefined
+    `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
+    `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
+                             `E`, the activation energy dependence on coverage,
+                             `m`, the power-law exponent of coverage dependence, and
+                             `a`, the coefficient for exponential dependence on the coverage
+    `comment`               Information about the model (e.g. its source)
+    ======================= =============================================================
     
     """
 
-    def __init__(self, A=None, n=0.0, Ea=None, T0=(1.0, "K"), Tmin=None, Tmax=None, Pmin=None, Pmax=None, comment=''):
+    def __init__(self, A=None, n=0.0, Ea=None, T0=(1.0, "K"), Tmin=None, Tmax=None, Pmin=None, Pmax=None,
+                 coverage_dependence=None, comment=''):
         KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, comment=comment)
         self.A = A
         self.n = n
         self.Ea = Ea
         self.T0 = T0
+        self.coverage_dependence = coverage_dependence
 
     def __repr__(self):
         """
@@ -89,7 +95,7 @@ cdef class StickingCoefficient(KineticsModel):
         A helper function used when pickling a StickingCoefficient object.
         """
         return (StickingCoefficient, (self.A, self.n, self.Ea, self.T0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
-                                      self.comment))
+                                      self.coverage_dependence, self.comment))
 
     property A:
         """The preexponential factor."""
@@ -119,6 +125,13 @@ cdef class StickingCoefficient(KineticsModel):
         def __set__(self, value):
             self._T0 = quantity.Temperature(value)
 
+    property coverage_dependence:
+        """The coverage dependence parameters."""
+        def __get__(self):
+            return self._coverage_dependence
+        def __set__(self, dict):
+            self._coverage_dependence = dict
+
     cpdef double get_sticking_coefficient(self, double T) except -1:
         """
         Return the sticking coefficient (dimensionless) at temperature `T` in K. 
@@ -128,6 +141,7 @@ cdef class StickingCoefficient(KineticsModel):
         n = self._n.value_si
         Ea = self._Ea.value_si
         T0 = self._T0.value_si
+
         stickingCoefficient = A * (T / T0) ** n * exp(-Ea / (constants.R * T))
         if stickingCoefficient < 0:
             raise ValueError("Sticking coefficients cannot be negative, check your preexponential factor.")
@@ -227,28 +241,34 @@ cdef class StickingCoefficientBEP(KineticsModel):
     Sticking Coefficients are between 0 and 1.
     The attributes are:
 
-    =============== =============================================================
-    Attribute       Description
-    =============== =============================================================
-    `A`             The preexponential factor
-    `n`             The temperature exponent
-    `alpha`         The Evans-Polanyi slope
-    `E0`            The activation energy for a thermoneutral reaction
-    `Tmin`          The minimum temperature at which the model is valid, or zero if unknown or undefined
-    `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
-    `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
-    `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
-    `comment`       Information about the model (e.g. its source)
-    =============== =============================================================
+    ======================= =============================================================
+    Attribute               Description
+    ======================= =============================================================
+    `A`                     The preexponential factor
+    `n`                     The temperature exponent
+    `alpha`                 The Evans-Polanyi slope
+    `E0`                    The activation energy for a thermoneutral reaction
+    `Tmin`                  The minimum temperature at which the model is valid, or zero if unknown or undefined
+    `Tmax`                  The maximum temperature at which the model is valid, or zero if unknown or undefined
+    `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
+    `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
+                             `E`, the activation energy dependence on coverage,
+                             `m`, the power-law exponent of coverage dependence, and
+                             `a`, the coefficient for exponential dependence on the coverage
+    `comment`               Information about the model (e.g. its source)
+    ======================= =============================================================
     
     """
 
-    def __init__(self, A=None, n=0.0, alpha=0.0, E0=None, Tmin=None, Tmax=None, Pmin=None, Pmax=None, comment=''):
+    def __init__(self, A=None, n=0.0, alpha=0.0, E0=None, Tmin=None, Tmax=None, Pmin=None, Pmax=None,
+                 coverage_dependence=None, comment=''):
         KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, comment=comment)
         self.A = A
         self.n = n
         self.alpha = alpha
         self.E0 = E0
+        self.coverage_dependence = coverage_dependence
 
     def __repr__(self):
         """
@@ -270,7 +290,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
         A helper function used when pickling an StickingCoefficientBEP object.
         """
         return (StickingCoefficientBEP, (self.A, self.n, self.alpha, self.E0, self.Tmin, self.Tmax,
-                                         self.Pmin, self.Pmax, self.comment))
+                                         self.Pmin, self.Pmax, self.coverage_dependence, self.comment))
 
     property A:
         """The preexponential factor."""
@@ -300,6 +320,13 @@ cdef class StickingCoefficientBEP(KineticsModel):
         def __set__(self, value):
             self._E0 = quantity.Energy(value)
 
+    property coverage_dependence:
+        """The coverage dependence parameters."""
+        def __get__(self):
+            return self._coverage_dependence
+        def __set__(self, dict):
+            self._coverage_dependence = dict
+
     cpdef double get_sticking_coefficient(self, double T, double dHrxn=0.0) except -1:
         """
         Return the sticking coefficient (dimensionless) at
@@ -309,6 +336,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
         Ea = self.get_activation_energy(dHrxn)
         A = self._A.value_si
         n = self._n.value_si
+
         stickingCoefficient = A * T ** n * exp(-Ea / (constants.R * T))
         assert 0 <= stickingCoefficient
         return min(stickingCoefficient, 1.0)
@@ -341,6 +369,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
             T0=(1, "K"),
             Tmin=self.Tmin,
             Tmax=self.Tmax,
+            coverage_dependence=self.coverage_dependence,
             comment=self.comment,
         )
 
@@ -382,21 +411,35 @@ cdef class SurfaceArrhenius(Arrhenius):
     
     The attributes are:
 
-    =============== =============================================================
-    Attribute       Description
-    =============== =============================================================
-    `A`             The preexponential factor
-    `T0`            The reference temperature
-    `n`             The temperature exponent
-    `Ea`            The activation energy
-    `Tmin`          The minimum temperature at which the model is valid, or zero if unknown or undefined
-    `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
-    `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
-    `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
-    `uncertainty`   Uncertainty information
-    `comment`       Information about the model (e.g. its source)
-    =============== =============================================================
+    ======================= =============================================================
+    Attribute               Description
+    ======================= =============================================================
+    `A`                     The preexponential factor
+    `T0`                    The reference temperature
+    `n`                     The temperature exponent
+    `Ea`                    The activation energy
+    `Tmin`                  The minimum temperature at which the model is valid, or zero if unknown or undefined
+    `Tmax`                  The maximum temperature at which the model is valid, or zero if unknown or undefined
+    `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
+    `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
+                             `E`, the activation energy dependence on coverage,
+                             `m`, the power-law exponent of coverage dependence, and
+                             `a`, the coefficient for exponential dependence on the coverage
+    `uncertainty`           Uncertainty information
+    `comment`               Information about the model (e.g. its source)
+    ======================= =============================================================
     """
+    def __init__(self, A=None, n=0.0, Ea=None, T0=(1.0, "K"), Tmin=None, Tmax=None, Pmin=None, Pmax=None,
+                 coverage_dependence=None, uncertainty=None, comment=''):
+        KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, uncertainty=uncertainty,
+                               comment=comment)
+        self.A = A
+        self.n = n
+        self.Ea = Ea
+        self.T0 = T0
+        self.coverage_dependence = coverage_dependence
+
     property A:
         """The preexponential factor. 
     
@@ -405,6 +448,13 @@ cdef class SurfaceArrhenius(Arrhenius):
             return self._A
         def __set__(self, value):
             self._A = quantity.SurfaceRateCoefficient(value)
+
+    property coverage_dependence:
+        """The coverage dependence parameters."""
+        def __get__(self):
+            return self._coverage_dependence
+        def __set__(self, dict):
+            self._coverage_dependence = dict
 
     def __repr__(self):
         """
@@ -426,8 +476,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         A helper function used when pickling a SurfaceArrhenius object.
         """
         return (SurfaceArrhenius, (self.A, self.n, self.Ea, self.T0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
-                                   self.uncertainty, self.comment))
-
+                                   self.coverage_dependence, self.uncertainty, self.comment))
 
 ################################################################################
 
@@ -439,25 +488,40 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
     It is very similar to the gas-phase :class:`ArrheniusEP`.
     The only differences being the A factor has different units,
     (and the catalysis community prefers to call it BEP rather than EP!)
+    and has a coverage_dependence parameter for coverage dependence
     
     The attributes are:
 
-    =============== =============================================================
-    Attribute       Description
-    =============== =============================================================
-    `A`             The preexponential factor
-    `n`             The temperature exponent
-    `alpha`         The Evans-Polanyi slope
-    `E0`            The activation energy for a thermoneutral reaction
-    `Tmin`          The minimum temperature at which the model is valid, or zero if unknown or undefined
-    `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
-    `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
-    `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
-    `uncertainty`   Uncertainty information
-    `comment`       Information about the model (e.g. its source)
-    =============== =============================================================
+    ======================= =============================================================
+    Attribute               Description
+    ======================= =============================================================
+    `A`                     The preexponential factor
+    `n`                     The temperature exponent
+    `alpha`                 The Evans-Polanyi slope
+    `E0`                    The activation energy for a thermoneutral reaction
+    `Tmin`                  The minimum temperature at which the model is valid, or zero if unknown or undefined
+    `Tmax`                  The maximum temperature at which the model is valid, or zero if unknown or undefined
+    `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
+    `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
+                             `E`, the activation energy dependence on coverage,
+                             `m`, the power-law exponent of coverage dependence, and
+                             `a`, the coefficient for exponential dependence on the coverage
+    `uncertainty`           Uncertainty information
+    `comment`               Information about the model (e.g. its source)
+    ======================= =============================================================
     
     """
+    def __init__(self, A=None, n=0.0, alpha=0.0, E0=None, Tmin=None, Tmax=None, Pmin=None, Pmax=None, uncertainty=None,
+                 coverage_dependence=None, comment=''):
+        KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, uncertainty=uncertainty,
+                               comment=comment,)
+        self.A = A
+        self.n = n
+        self.alpha = alpha
+        self.E0 = E0
+        self.coverage_dependence = coverage_dependence
+
     property A:
         """The preexponential factor. 
     
@@ -466,6 +530,13 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
             return self._A
         def __set__(self, value):
             self._A = quantity.SurfaceRateCoefficient(value)
+
+    property coverage_dependence:
+        """The coverage dependence parameters."""
+        def __get__(self):
+            return self._coverage_dependence
+        def __set__(self, dict):
+            self._coverage_dependence = dict
 
     def __repr__(self):
         """
@@ -488,7 +559,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         A helper function used when pickling an SurfaceArrheniusBEP object.
         """
         return (SurfaceArrheniusBEP, (self.A, self.n, self.alpha, self.E0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
-                                      self.uncertainty, self.comment))
+                                      self.uncertainty, self.coverage_dependence, self.comment))
 
     cpdef SurfaceArrhenius to_arrhenius(self, double dHrxn):
         """
@@ -506,6 +577,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
             T0=(1, "K"),
             Tmin=self.Tmin,
             Tmax=self.Tmax,
-            uncertainty = self.uncertainty,
+            uncertainty=self.uncertainty,
+            coverage_dependence=self.coverage_dependence,
             comment=self.comment,
         )

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -59,9 +59,9 @@ cdef class StickingCoefficient(KineticsModel):
     `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
     `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
-                             `E`, the activation energy dependence on coverage,
+                             `a`, the coefficient for exponential dependence on the coverage,
                              `m`, the power-law exponent of coverage dependence, and
-                             `a`, the coefficient for exponential dependence on the coverage
+                             `E`, the activation energy dependence on coverage.
     `comment`               Information about the model (e.g. its source)
     ======================= =============================================================
     
@@ -87,7 +87,7 @@ cdef class StickingCoefficient(KineticsModel):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -264,9 +264,9 @@ cdef class StickingCoefficientBEP(KineticsModel):
     `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
     `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
-                             `E`, the activation energy dependence on coverage,
+                             `a`, the coefficient for exponential dependence on the coverage,
                              `m`, the power-law exponent of coverage dependence, and
-                             `a`, the coefficient for exponential dependence on the coverage
+                             `E`, the activation energy dependence on coverage.
     `comment`               Information about the model (e.g. its source)
     ======================= =============================================================
     
@@ -293,7 +293,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -445,9 +445,9 @@ cdef class SurfaceArrhenius(Arrhenius):
     `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
     `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
-                             `E`, the activation energy dependence on coverage,
+                             `a`, the coefficient for exponential dependence on the coverage,
                              `m`, the power-law exponent of coverage dependence, and
-                             `a`, the coefficient for exponential dependence on the coverage
+                             `E`, the activation energy dependence on coverage.
     `uncertainty`           Uncertainty information
     `comment`               Information about the model (e.g. its source)
     ======================= =============================================================
@@ -495,7 +495,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -537,9 +537,9 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
     `Pmin`                  The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`                  The maximum pressure at which the model is valid, or zero if unknown or undefined
     `coverage_dependence`   A dictionary of coverage dependent parameters to a certain surface species with:
-                             `E`, the activation energy dependence on coverage,
+                             `a`, the coefficient for exponential dependence on the coverage,
                              `m`, the power-law exponent of coverage dependence, and
-                             `a`, the coefficient for exponential dependence on the coverage
+                             `E`, the activation energy dependence on coverage.
     `uncertainty`           Uncertainty information
     `comment`               Information about the model (e.g. its source)
     ======================= =============================================================
@@ -589,7 +589,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -84,6 +84,11 @@ cdef class StickingCoefficient(KineticsModel):
         string = 'StickingCoefficient(A={0!r}, n={1!r}, Ea={2!r}, T0={3!r}'.format(self.A, self.n, self.Ea, self.T0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
+        if self.coverage_dependence is not None:
+            string += ", coverage_dependence={"
+            for species, parameters in self.coverage_dependence.items():
+                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+            string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
@@ -285,6 +290,11 @@ cdef class StickingCoefficientBEP(KineticsModel):
                                                                                          self.E0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
+        if self.coverage_dependence is not None:
+            string += ", coverage_dependence={"
+            for species, parameters in self.coverage_dependence.items():
+                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+            string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
@@ -482,6 +492,11 @@ cdef class SurfaceArrhenius(Arrhenius):
         string = 'SurfaceArrhenius(A={0!r}, n={1!r}, Ea={2!r}, T0={3!r}'.format(self.A, self.n, self.Ea, self.T0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
+        if self.coverage_dependence is not None:
+            string += ", coverage_dependence={"
+            for species, parameters in self.coverage_dependence.items():
+                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+            string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.uncertainty is not None: string += ', uncertainty={0!r}'.format(self.uncertainty)
@@ -571,6 +586,11 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
                                                                                       self.E0)
         if self.Tmin is not None: string += ', Tmin={0!r}'.format(self.Tmin)
         if self.Tmax is not None: string += ', Tmax={0!r}'.format(self.Tmax)
+        if self.coverage_dependence is not None:
+            string += ", coverage_dependence={"
+            for species, parameters in self.coverage_dependence.items():
+                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+            string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.uncertainty is not None: string += ', uncertainty={0!r}'.format(self.uncertainty)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -87,7 +87,7 @@ cdef class StickingCoefficient(KineticsModel):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -293,7 +293,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -495,7 +495,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -589,7 +589,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         if self.coverage_dependence is not None:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"'{species}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}}"
+                string += f"'{species!r}': {{'E':({parameters['E'].value}, '{parameters['E'].units}'), 'm':{parameters['m']}, 'a':{parameters['a']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)

--- a/rmgpy/kinetics/surfaceTest.py
+++ b/rmgpy/kinetics/surfaceTest.py
@@ -36,6 +36,7 @@ import unittest
 import numpy as np
 
 from rmgpy.kinetics.surface import StickingCoefficient, SurfaceArrhenius
+from rmgpy.species import Species
 
 ################################################################################
 
@@ -55,7 +56,7 @@ class TestStickingCoefficient(unittest.TestCase):
         self.T0 = 1.
         self.Tmin = 300.
         self.Tmax = 3000.
-        self.coverage_dependence = {'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
+        self.coverage_dependence = {Species().from_adjacency_list('1 X u0 p0 c0'): {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
         self.comment = 'O2 dissociative'
         self.stick = StickingCoefficient(
             A=self.A,
@@ -227,7 +228,7 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.T0 = 1.
         self.Tmin = 300.
         self.Tmax = 3000.
-        self.coverage_dependence = {'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
+        self.coverage_dependence = {Species().from_adjacency_list('1 X u0 p0 c0'): {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
         self.comment = 'CH3x + Hx <=> CH4 + x + x'
         self.surfarr = SurfaceArrhenius(
             A=(self.A, 'm^2/(mol*s)'),

--- a/rmgpy/kinetics/surfaceTest.py
+++ b/rmgpy/kinetics/surfaceTest.py
@@ -37,6 +37,7 @@ import numpy as np
 
 from rmgpy.kinetics.surface import StickingCoefficient, SurfaceArrhenius
 from rmgpy.species import Species
+from rmgpy.molecule import Molecule
 
 ################################################################################
 
@@ -146,10 +147,20 @@ class TestStickingCoefficient(unittest.TestCase):
         self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
         self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
         self.assertEqual(self.stick.comment, stick.comment)
-        self.assertEqual(self.stick.coverage_dependence.keys(), stick.coverage_dependence.keys())
+        for key in self.stick.coverage_dependence.keys():
+            match = False
+            for key2 in stick.coverage_dependence.keys():
+                if key.is_identical(key2):
+                    match = True
+            self.assertTrue(match)
         for species, parameters in self.stick.coverage_dependence.items():
-            for key, value in parameters.items():
-                self.assertEqual(value.value_si, stick.coverage_dependence[species][key].value_si)
+            match = False
+            for species2 in stick.coverage_dependence.keys():
+                if species.is_identical(species2):
+                    match = True
+                    for key, value in parameters.items():
+                        self.assertEqual(value.value_si, stick.coverage_dependence[species2][key].value_si)
+            self.assertTrue(match)
         self.assertEqual(dir(self.stick), dir(stick))
 
     def test_repr(self):
@@ -158,7 +169,7 @@ class TestStickingCoefficient(unittest.TestCase):
         output with no loss of information.
         """
         namespace = {}
-        exec('stick = {0!r}'.format(self.stick), globals(), namespace)
+        exec(f'stick = {self.stick!r}', globals(), namespace)
         self.assertIn('stick', namespace)
         stick = namespace['stick']
         self.assertAlmostEqual(self.stick.A.value, stick.A.value, delta=1e0)
@@ -173,10 +184,10 @@ class TestStickingCoefficient(unittest.TestCase):
         self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
         self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
         self.assertEqual(self.stick.comment, stick.comment)
-        self.assertEqual(self.stick.coverage_dependence.keys(), stick.coverage_dependence.keys())
+        self.assertEqual([m.label for m in self.stick.coverage_dependence.keys()], list(stick.coverage_dependence.keys()))
         for species, parameters in self.stick.coverage_dependence.items():
             for key, value in parameters.items():
-                self.assertEqual(value.value_si, stick.coverage_dependence[species][key].value_si)
+                self.assertEqual(value.value_si, stick.coverage_dependence[species.label][key].value_si)
         self.assertEqual(dir(self.stick), dir(stick))
 
     def test_copy(self):
@@ -198,10 +209,20 @@ class TestStickingCoefficient(unittest.TestCase):
         self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
         self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
         self.assertEqual(self.stick.comment, stick.comment)
-        self.assertEqual(self.stick.coverage_dependence.keys(), stick.coverage_dependence.keys())
+        for key in self.stick.coverage_dependence.keys():
+            match = False
+            for key2 in stick.coverage_dependence.keys():
+                if key.is_identical(key2):
+                    match = True
+            self.assertTrue(match)
         for species, parameters in self.stick.coverage_dependence.items():
-            for key, value in parameters.items():
-                self.assertEqual(value.value_si, stick.coverage_dependence[species][key].value_si)
+            match = False
+            for species2 in stick.coverage_dependence.keys():
+                if species.is_identical(species2):
+                    match = True
+                    for key, value in parameters.items():
+                        self.assertEqual(value.value_si, stick.coverage_dependence[species2][key].value_si)
+            self.assertTrue(match)
         self.assertEqual(dir(self.stick), dir(stick))
 
     def test_is_identical_to(self):
@@ -318,9 +339,20 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
         self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
         self.assertEqual(self.surfarr.comment, surfarr.comment)
+        for key in self.surfarr.coverage_dependence.keys():
+            match = False
+            for key2 in surfarr.coverage_dependence.keys():
+                if key.is_identical(key2):
+                    match = True
+            self.assertTrue(match)
         for species, parameters in self.surfarr.coverage_dependence.items():
-            for key, value in parameters.items():
-                self.assertEqual(value.value_si, surfarr.coverage_dependence[species][key].value_si)
+            match = False
+            for species2 in surfarr.coverage_dependence.keys():
+                if species.is_identical(species2):
+                    match = True
+                    for key, value in parameters.items():
+                        self.assertEqual(value.value_si, surfarr.coverage_dependence[species2][key].value_si)
+            self.assertTrue(match)
         self.assertEqual(dir(self.surfarr), dir(surfarr))
 
     def test_repr(self):
@@ -344,10 +376,10 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
         self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
         self.assertEqual(self.surfarr.comment, surfarr.comment)
-        self.assertEqual(self.surfarr.coverage_dependence.keys(), surfarr.coverage_dependence.keys())
+        self.assertEqual([m.label for m in self.surfarr.coverage_dependence.keys()], list(surfarr.coverage_dependence.keys()))
         for species, parameters in self.surfarr.coverage_dependence.items():
             for key, value in parameters.items():
-                self.assertEqual(value.value_si, surfarr.coverage_dependence[species][key].value_si)
+                self.assertEqual(value.value_si, surfarr.coverage_dependence[species.label][key].value_si)
         self.assertEqual(dir(self.surfarr), dir(surfarr))
 
     def test_copy(self):
@@ -369,10 +401,20 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
         self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
         self.assertEqual(self.surfarr.comment, surfarr.comment)
-        self.assertEqual(self.surfarr.coverage_dependence.keys(), surfarr.coverage_dependence.keys())
+        for key in self.surfarr.coverage_dependence.keys():
+            match = False
+            for key2 in surfarr.coverage_dependence.keys():
+                if key.is_identical(key2):
+                    match = True
+            self.assertTrue(match)
         for species, parameters in self.surfarr.coverage_dependence.items():
-            for key, value in parameters.items():
-                self.assertEqual(value.value_si, surfarr.coverage_dependence[species][key].value_si)
+            match = False
+            for species2 in surfarr.coverage_dependence.keys():
+                if species.is_identical(species2):
+                    match = True
+                    for key, value in parameters.items():
+                        self.assertEqual(value.value_si, surfarr.coverage_dependence[species2][key].value_si)
+            self.assertTrue(match)
         self.assertEqual(dir(self.surfarr), dir(surfarr))
 
     def test_is_identical_to(self):

--- a/rmgpy/kinetics/surfaceTest.py
+++ b/rmgpy/kinetics/surfaceTest.py
@@ -55,6 +55,7 @@ class TestStickingCoefficient(unittest.TestCase):
         self.T0 = 1.
         self.Tmin = 300.
         self.Tmax = 3000.
+        self.coverage_dependence = {'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
         self.comment = 'O2 dissociative'
         self.stick = StickingCoefficient(
             A=self.A,
@@ -64,6 +65,7 @@ class TestStickingCoefficient(unittest.TestCase):
             Tmin=(self.Tmin, "K"),
             Tmax=(self.Tmax, "K"),
             comment=self.comment,
+            coverage_dependence=self.coverage_dependence,
         )
 
     def test_A(self):
@@ -108,6 +110,12 @@ class TestStickingCoefficient(unittest.TestCase):
         """
         self.assertEqual(self.stick.comment, self.comment)
 
+    def test_coverage_dependence(self):
+        """
+        Test that the coverage dependent parameters was properly set.
+        """
+        self.assertEqual(self.stick.coverage_dependence, self.coverage_dependence)
+
     def test_is_temperature_valid(self):
         """
         Test the StickingCoefficient.is_temperature_valid() method.
@@ -137,6 +145,10 @@ class TestStickingCoefficient(unittest.TestCase):
         self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
         self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
         self.assertEqual(self.stick.comment, stick.comment)
+        self.assertEqual(self.stick.coverage_dependence.keys(), stick.coverage_dependence.keys())
+        for species, parameters in self.stick.coverage_dependence.items():
+            for key, value in parameters.items():
+                self.assertEqual(value.value_si, stick.coverage_dependence[species][key].value_si)
         self.assertEqual(dir(self.stick), dir(stick))
 
     def test_repr(self):
@@ -160,6 +172,10 @@ class TestStickingCoefficient(unittest.TestCase):
         self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
         self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
         self.assertEqual(self.stick.comment, stick.comment)
+        self.assertEqual(self.stick.coverage_dependence.keys(), stick.coverage_dependence.keys())
+        for species, parameters in self.stick.coverage_dependence.items():
+            for key, value in parameters.items():
+                self.assertEqual(value.value_si, stick.coverage_dependence[species][key].value_si)
         self.assertEqual(dir(self.stick), dir(stick))
 
     def test_copy(self):
@@ -181,6 +197,10 @@ class TestStickingCoefficient(unittest.TestCase):
         self.assertAlmostEqual(self.stick.Tmax.value, stick.Tmax.value, 4)
         self.assertEqual(self.stick.Tmax.units, stick.Tmax.units)
         self.assertEqual(self.stick.comment, stick.comment)
+        self.assertEqual(self.stick.coverage_dependence.keys(), stick.coverage_dependence.keys())
+        for species, parameters in self.stick.coverage_dependence.items():
+            for key, value in parameters.items():
+                self.assertEqual(value.value_si, stick.coverage_dependence[species][key].value_si)
         self.assertEqual(dir(self.stick), dir(stick))
 
     def test_is_identical_to(self):
@@ -207,6 +227,7 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.T0 = 1.
         self.Tmin = 300.
         self.Tmax = 3000.
+        self.coverage_dependence = {'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
         self.comment = 'CH3x + Hx <=> CH4 + x + x'
         self.surfarr = SurfaceArrhenius(
             A=(self.A, 'm^2/(mol*s)'),
@@ -216,6 +237,7 @@ class TestSurfaceArrhenius(unittest.TestCase):
             Tmin=(self.Tmin, "K"),
             Tmax=(self.Tmax, "K"),
             comment=self.comment,
+            coverage_dependence=self.coverage_dependence,
         )
 
     def test_A(self):
@@ -260,6 +282,12 @@ class TestSurfaceArrhenius(unittest.TestCase):
         """
         self.assertEqual(self.surfarr.comment, self.comment)
 
+    def test_coverage_dependence(self):
+        """
+        Test that the coverage dependent parameters was properly set.
+        """
+        self.assertEqual(self.surfarr.coverage_dependence, self.coverage_dependence)
+
     def test_is_temperature_valid(self):
         """
         Test the SurfaceArrhenius.is_temperature_valid() method.
@@ -289,6 +317,9 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
         self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
         self.assertEqual(self.surfarr.comment, surfarr.comment)
+        for species, parameters in self.surfarr.coverage_dependence.items():
+            for key, value in parameters.items():
+                self.assertEqual(value.value_si, surfarr.coverage_dependence[species][key].value_si)
         self.assertEqual(dir(self.surfarr), dir(surfarr))
 
     def test_repr(self):
@@ -312,6 +343,10 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
         self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
         self.assertEqual(self.surfarr.comment, surfarr.comment)
+        self.assertEqual(self.surfarr.coverage_dependence.keys(), surfarr.coverage_dependence.keys())
+        for species, parameters in self.surfarr.coverage_dependence.items():
+            for key, value in parameters.items():
+                self.assertEqual(value.value_si, surfarr.coverage_dependence[species][key].value_si)
         self.assertEqual(dir(self.surfarr), dir(surfarr))
 
     def test_copy(self):
@@ -333,6 +368,10 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.assertAlmostEqual(self.surfarr.Tmax.value, surfarr.Tmax.value, 4)
         self.assertEqual(self.surfarr.Tmax.units, surfarr.Tmax.units)
         self.assertEqual(self.surfarr.comment, surfarr.comment)
+        self.assertEqual(self.surfarr.coverage_dependence.keys(), surfarr.coverage_dependence.keys())
+        for species, parameters in self.surfarr.coverage_dependence.items():
+            for key, value in parameters.items():
+                self.assertEqual(value.value_si, surfarr.coverage_dependence[species][key].value_si)
         self.assertEqual(dir(self.surfarr), dir(surfarr))
 
     def test_is_identical_to(self):

--- a/rmgpy/kinetics/surfaceTest.py
+++ b/rmgpy/kinetics/surfaceTest.py
@@ -38,6 +38,7 @@ import numpy as np
 from rmgpy.kinetics.surface import StickingCoefficient, SurfaceArrhenius
 from rmgpy.species import Species
 from rmgpy.molecule import Molecule
+import rmgpy.quantity as quantity
 
 ################################################################################
 
@@ -57,7 +58,10 @@ class TestStickingCoefficient(unittest.TestCase):
         self.T0 = 1.
         self.Tmin = 300.
         self.Tmax = 3000.
-        self.coverage_dependence = {Species().from_adjacency_list('1 X u0 p0 c0'): {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
+        s = Species().from_adjacency_list('1 X u0 p0 c0')
+        s.label = 'X'
+        self.coverage_dependence = {s: {'E': quantity.Energy(0.0, 'J/mol'), 'm': quantity.Dimensionless(-1.0),
+                                        'a': quantity.Dimensionless(0.0)}}
         self.comment = 'O2 dissociative'
         self.stick = StickingCoefficient(
             A=self.A,
@@ -116,7 +120,20 @@ class TestStickingCoefficient(unittest.TestCase):
         """
         Test that the coverage dependent parameters was properly set.
         """
-        self.assertEqual(self.stick.coverage_dependence, self.coverage_dependence)
+        for key in self.stick.coverage_dependence.keys():
+            match = False
+            for key2 in self.coverage_dependence.keys():
+                if key.is_identical(key2):
+                    match = True
+            self.assertTrue(match)
+        for species, parameters in self.stick.coverage_dependence.items():
+            match = False
+            for species2 in self.coverage_dependence.keys():
+                if species.is_identical(species2):
+                    match = True
+                    for key, value in parameters.items():
+                        self.assertEqual(value.value_si, self.coverage_dependence[species2][key].value_si)
+            self.assertTrue(match)
 
     def test_is_temperature_valid(self):
         """
@@ -249,7 +266,10 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.T0 = 1.
         self.Tmin = 300.
         self.Tmax = 3000.
-        self.coverage_dependence = {Species().from_adjacency_list('1 X u0 p0 c0'): {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}
+        s = Species().from_adjacency_list('1 X u0 p0 c0')
+        s.label = 'X'
+        self.coverage_dependence = {s: {'E': quantity.Energy(0.0, 'J/mol'), 'm': quantity.Dimensionless(-1.0),
+                                        'a': quantity.Dimensionless(0.0)}}
         self.comment = 'CH3x + Hx <=> CH4 + x + x'
         self.surfarr = SurfaceArrhenius(
             A=(self.A, 'm^2/(mol*s)'),
@@ -308,7 +328,20 @@ class TestSurfaceArrhenius(unittest.TestCase):
         """
         Test that the coverage dependent parameters was properly set.
         """
-        self.assertEqual(self.surfarr.coverage_dependence, self.coverage_dependence)
+        for key in self.surfarr.coverage_dependence.keys():
+            match = False
+            for key2 in self.coverage_dependence.keys():
+                if key.is_identical(key2):
+                    match = True
+            self.assertTrue(match)
+        for species, parameters in self.surfarr.coverage_dependence.items():
+            match = False
+            for species2 in self.coverage_dependence.keys():
+                if species.is_identical(species2):
+                    match = True
+                    for key, value in parameters.items():
+                        self.assertEqual(value.value_si, self.coverage_dependence[species2][key].value_si)
+            self.assertTrue(match)
 
     def test_is_temperature_valid(self):
         """

--- a/rmgpy/kinetics/surfaceTest.py
+++ b/rmgpy/kinetics/surfaceTest.py
@@ -60,8 +60,9 @@ class TestStickingCoefficient(unittest.TestCase):
         self.Tmax = 3000.
         s = Species().from_adjacency_list('1 X u0 p0 c0')
         s.label = 'X'
-        self.coverage_dependence = {s: {'E': quantity.Energy(0.0, 'J/mol'), 'm': quantity.Dimensionless(-1.0),
-                                        'a': quantity.Dimensionless(0.0)}}
+        self.coverage_dependence = {s: {'a': quantity.Dimensionless(0.0),
+                                        'm': quantity.Dimensionless(-1.0),
+                                        'E': quantity.Energy(0.0, 'J/mol')}}
         self.comment = 'O2 dissociative'
         self.stick = StickingCoefficient(
             A=self.A,
@@ -268,8 +269,9 @@ class TestSurfaceArrhenius(unittest.TestCase):
         self.Tmax = 3000.
         s = Species().from_adjacency_list('1 X u0 p0 c0')
         s.label = 'X'
-        self.coverage_dependence = {s: {'E': quantity.Energy(0.0, 'J/mol'), 'm': quantity.Dimensionless(-1.0),
-                                        'a': quantity.Dimensionless(0.0)}}
+        self.coverage_dependence = {s: {'a': quantity.Dimensionless(0.0),
+                                        'm': quantity.Dimensionless(-1.0),
+                                        'E': quantity.Energy(0.0, 'J/mol')}}
         self.comment = 'CH3x + Hx <=> CH4 + x + x'
         self.surfarr = SurfaceArrhenius(
             A=(self.A, 'm^2/(mol*s)'),

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -231,6 +231,17 @@ class TestSurfaceReaction(unittest.TestCase):
                                       comment="""Approximate rate""")
         )
 
+        # adding coverage dependent reaction
+        self.rxn_covdep = Reaction(
+            reactants=[s_h2, s_x, s_x],
+            products=[s_hx, s_hx],
+            kinetics=SurfaceArrhenius(A=(9.05e18, 'cm^5/(mol^2*s)'),
+                                      n=0.5,
+                                      Ea=(5.0, 'kJ/mol'),
+                                      T0=(1.0, 'K'),
+                                      coverage_dependence={Species().from_adjacency_list('1 X u0 p0 c0'): {'E': (0.1, 'J/mol'), 'm': -1.0, 'a': 1.0},
+                                                           Species().from_adjacency_list('1 X u0 p0 c0 {2,S}\n2 H u0 p0 c0 {1,S}'): {'E': (0.2, 'J/mol'), 'm': -2.0, 'a': 2.0}}))
+
     def test_is_surface_reaction_species(self):
         """Test is_surface_reaction for reaction based on Species """
         self.assertTrue(self.rxn1s.is_surface_reaction())

--- a/rmgpy/reactionTest.py
+++ b/rmgpy/reactionTest.py
@@ -139,7 +139,8 @@ class TestSurfaceReaction(unittest.TestCase):
     def setUp(self):
         m_h2 = Molecule().from_smiles("[H][H]")
         m_x = Molecule().from_adjacency_list("1 X u0 p0")
-        m_hx = Molecule().from_adjacency_list("1 H u0 p0 {2,S} \n 2 X u0 p0 {1,S}")
+        m_hx = Molecule().from_smiles("[H][*]")
+        # m_hx = Molecule().from_adjacency_list("1 H u0 p0 {2,S} \n 2 X u0 p0 {1,S}")
         m_ch3 = Molecule().from_smiles("[CH3]")
         m_ch3x = Molecule().from_adjacency_list("""1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
 2 H u0 p0 c0 {1,S}
@@ -148,6 +149,7 @@ class TestSurfaceReaction(unittest.TestCase):
 5 X u0 p0 c0 {1,S}""")
 
         s_h2 = Species(
+            label="H2(1)",
             molecule=[m_h2],
             thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000],
                                      "K"),
@@ -156,6 +158,7 @@ class TestSurfaceReaction(unittest.TestCase):
                               H298=(0, "kcal/mol"),
                               S298=(31.129, "cal/(mol*K)")))
         s_x = Species(
+            label="X(2)",
             molecule=[m_x],
             thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000],
                                      "K"),
@@ -163,6 +166,7 @@ class TestSurfaceReaction(unittest.TestCase):
                               H298=(0.0, "kcal/mol"),
                               S298=(0.0, "cal/(mol*K)")))
         s_hx = Species(
+            label="HX(3)",
             molecule=[m_hx],
             thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000],
                                      "K"),
@@ -171,6 +175,7 @@ class TestSurfaceReaction(unittest.TestCase):
                               S298=(0.44, "cal/(mol*K)")))
 
         s_ch3 = Species(
+            label="CH3(4)",
             molecule=[m_ch3],
             thermo=NASA(polynomials=[
                 NASAPolynomial(coeffs=[3.91547, 0.00184155, 3.48741e-06, -3.32746e-09, 8.49953e-13, 16285.6, 0.351743],
@@ -184,6 +189,7 @@ class TestSurfaceReaction(unittest.TestCase):
         )
 
         s_ch3x = Species(
+            label="CH3X(5)",
             molecule=[m_ch3x],
             thermo=NASA(polynomials=[
                 NASAPolynomial(coeffs=[-0.552219, 0.026442, -3.55617e-05, 2.60044e-08, -7.52707e-12, -4433.47, 0.692144],

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -99,12 +99,14 @@ def database(
 
 def catalyst_properties(bindingEnergies=None,
                         surfaceSiteDensity=None,
-                        metal=None):
+                        metal=None,
+                        coverageDependence=False):
     """
     Specify the properties of the catalyst.
     Binding energies of C,H,O,N atoms, and the surface site density.
     Metal is the label of a metal in the surface metal library.
     Defaults to Pt(111) if not specified.
+    coverageDependence defaults to False if not specified. If True then coverage dependent kinetics from libraries are used.
     """
     # Normally we wouldn't load the database until after reading the input file,
     # but we need to load the metal surfaces library to validate the input.
@@ -140,6 +142,11 @@ def catalyst_properties(bindingEnergies=None,
     logging.info("Using binding energies:\n%r", rmg.binding_energies)
     logging.info("Using surface site density: %r", rmg.surface_site_density)
 
+    if coverageDependence:
+        logging.info("Coverage dependence is turned ON")
+    else:
+        logging.info("Coverage dependence is turned OFF")
+    rmg.coverage_dependence = coverageDependence
 
 def convert_binding_energies(binding_energies):
     """
@@ -509,7 +516,8 @@ def surface_reactor(temperature,
                             termination=termination,
                             sensitive_species=sensitive_species,
                             sensitivity_threshold=sensitivityThreshold,
-                            sens_conditions=sens_conditions)
+                            sens_conditions=sens_conditions,
+                            coverage_dependence=rmg.coverage_dependence)
     rmg.reaction_systems.append(system)
     system.log_initial_conditions(number=len(rmg.reaction_systems))
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -185,6 +185,7 @@ class RMG(util.Subject):
         self.diffusion_limiter = None
         self.surface_site_density = None
         self.binding_energies = None
+        self.coverage_dependence = False
 
         self.reaction_model = None
         self.reaction_systems = None
@@ -264,6 +265,7 @@ class RMG(util.Subject):
         if self.surface_site_density:
             self.reaction_model.surface_site_density = self.surface_site_density
 
+        self.reaction_model.coverage_dependence = self.coverage_dependence
         self.reaction_model.verbose_comments = self.verbose_comments
         self.reaction_model.save_edge_species = self.save_edge_species
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -887,6 +887,12 @@ class CoreEdgeReactionModel:
                 reaction.reverse = None
         reaction.kinetics = kinetics
 
+        if hasattr(kinetics, 'coverage_dependence'):
+            if kinetics.coverage_dependence:
+                for species, values in kinetics.coverage_dependence.items():
+                    species_in_model = self.make_new_species(species)
+                    kinetics.coverage_dependence[species_in_model] = values
+
     def generate_kinetics(self, reaction):
         """
         Generate best possible kinetics for the given `reaction` using the kinetics database.

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -874,7 +874,13 @@ class CoreEdgeReactionModel:
         This ensures that species that are used in coverage-dependent kinetic
         expressions exist in the model. (Before this is called, they may have
         only existed in a reaction libary instance).
+
+        If <CoreEdgeReactionModel>self.coverage_dependence is False then
+        it instead removes any coverage_dependence from the kinetics.
         """
+        if not self.coverage_dependence:
+            kinetics.coverage_dependence = None
+            return
         cov_dep = {}
         for species, values in kinetics.coverage_dependence.items():
             species_in_model, is_new = self.make_new_species(species)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -649,12 +649,12 @@ class CoreEdgeReactionModel:
             logging.info('Generating kinetics for new reactions...')
         for reaction in self.new_reaction_list:
             # If the reaction already has kinetics (e.g. from a library),
-            # assume the kinetics are satisfactory
+            # assume the kinetics are satisfactory, else generate them
             if reaction.kinetics is None:
                 self.apply_kinetics_to_reaction(reaction)
-            elif hasattr(reaction.kinetics, 'coverage_dependence'):
-                if reaction.kinetics.coverage_dependence:
-                    self.apply_coverage_dependence_to_reaction(reaction.kinetics)
+
+            if getattr(reaction.kinetics, 'coverage_dependence', None):
+                self.process_coverage_dependence(reaction.kinetics)
 
         # For new reactions, convert ArrheniusEP to Arrhenius, and fix barrier heights.
         # self.new_reaction_list only contains *actually* new reactions, all in the forward direction.
@@ -868,8 +868,13 @@ class CoreEdgeReactionModel:
 
         spc.generate_energy_transfer_model()
 
-    def apply_coverage_dependence_to_reaction(self, kinetics):
-        """Apply the coverage dependence kinetics"""
+    def process_coverage_dependence(self, kinetics):
+        """Process the coverage dependence kinetics.
+
+        This ensures that species that are used in coverage-dependent kinetic
+        expressions exist in the model. (Before this is called, they may have
+        only existed in a reaction libary instance).
+        """
         cov_dep = {}
         for species, values in kinetics.coverage_dependence.items():
             species_in_model, is_new = self.make_new_species(species)
@@ -897,10 +902,6 @@ class CoreEdgeReactionModel:
                 # We're done with the "reverse" attribute, so delete it to save a bit of memory
                 reaction.reverse = None
         reaction.kinetics = kinetics
-
-        if hasattr(kinetics, 'coverage_dependence'):
-            if reaction.kinetics.coverage_dependence:
-                self.apply_coverage_dependence_to_reaction(kinetics)
 
     def generate_kinetics(self, reaction):
         """
@@ -1511,9 +1512,8 @@ class CoreEdgeReactionModel:
                                       reversible=rxn.reversible
                                       )
             r, isNew = self.make_new_reaction(rxn)  # updates self.new_species_list and self.newReactionlist
-            if hasattr(r.kinetics, 'coverage_dependence'):
-                if r.kinetics.coverage_dependence:
-                    self.apply_coverage_dependence_to_reaction(r.kinetics)
+            if getattr(r.kinetics, 'coverage_dependence', None):
+                self.process_coverage_dependence(r.kinetics)
             if not isNew:
                 logging.info("This library reaction was not new: {0}".format(rxn))
             elif self.pressure_dependence and rxn.elementary_high_p and rxn.is_unimolecular() \
@@ -1613,9 +1613,8 @@ class CoreEdgeReactionModel:
                                       reversible=rxn.reversible
                                       )
             r, isNew = self.make_new_reaction(rxn)  # updates self.new_species_list and self.newReactionlist
-            if hasattr(r.kinetics, 'coverage_dependence'):
-                if r.kinetics.coverage_dependence:
-                    self.apply_coverage_dependence_to_reaction(r.kinetics)
+            if getattr(r.kinetics, 'coverage_dependence', None):
+                self.process_coverage_dependence(r.kinetics)
             if not isNew:
                 logging.info("This library reaction was not new: {0}".format(rxn))
             elif self.pressure_dependence and rxn.elementary_high_p and rxn.is_unimolecular() \

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -85,9 +85,6 @@ cdef class SurfaceReactor(ReactionSystem):
                  sensitivity_threshold=1e-3,
                  sens_conditions=None,
                  coverage_dependence=False,
-                 cov_dep={},
-                 cov_dep_index_species={},
-                 current_surface_coverages={},
                  ):
         ReactionSystem.__init__(self,
                                 termination,
@@ -111,9 +108,10 @@ cdef class SurfaceReactor(ReactionSystem):
         self.constant_volume = True
         self.sens_conditions = sens_conditions
         self.n_sims = n_sims
-        self.cov_dep = cov_dep
-        self.cov_dep_index_species = cov_dep_index_species
-        self.current_surface_coverages = current_surface_coverages
+
+        self.cov_dep = {}
+        self.cov_dep_index_species = {}
+        self.current_surface_coverages = {}
 
     def convert_initial_keys_to_species_objects(self, species_dict):
         """

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -280,3 +280,237 @@ class SurfaceReactorCheck(unittest.TestCase):
 
         # Check that we've reached equilibrium by the end
         self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)
+
+    def test_solve_h2_coverage_dependence(self):
+        """
+        Test the surface batch reactor can properly apply coverage dependent parameters
+        with the dissociative adsorption of H2.
+
+        Here we choose a kinetic model consisting of the dissociative adsorption reaction
+        H2 + 2X <=> 2 HX
+        We use a SurfaceArrhenius for the rate expression.
+        """
+        h2 = Species(
+            molecule=[Molecule().from_smiles("[H][H]")],
+            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                              Cpdata=([6.955, 6.955, 6.956, 6.961, 7.003, 7.103, 7.502], "cal/(mol*K)"),
+                              H298=(0, "kcal/mol"),
+                              S298=(31.129, "cal/(mol*K)")))
+        x = Species(
+            molecule=[Molecule().from_adjacency_list("1 X u0 p0")],
+            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                              Cpdata=([0., 0., 0., 0., 0., 0., 0.], "cal/(mol*K)"),
+                              H298=(0.0, "kcal/mol"),
+                              S298=(0.0, "cal/(mol*K)")))
+        hx = Species(
+            molecule=[Molecule().from_adjacency_list("1 H u0 p0 {2,S} \n 2 X u0 p0 {1,S}")],
+            thermo=ThermoData(Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                              Cpdata=([1.50, 2.58, 3.40, 4.00, 4.73, 5.13, 5.57], "cal/(mol*K)"),
+                              H298=(-11.26, "kcal/mol"),
+                              S298=(0.44, "cal/(mol*K)")))
+
+        rxn1 = Reaction(reactants=[h2, x, x],
+                        products=[hx, hx],
+                        kinetics=SurfaceArrhenius(A=(9.05e18, 'cm^5/(mol^2*s)'),
+                                                  n=0.5,
+                                                  Ea=(5.0, 'kJ/mol'),
+                                                  T0=(1.0, 'K'),
+                                                  coverage_dependence={'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}))
+
+        core_species = [h2, x, hx]
+        edge_species = []
+        core_reactions = [rxn1]
+        edge_reactions = []
+
+        T = 1000
+        P_initial = 1.0e5
+        rxn_system = SurfaceReactor(
+            T, P_initial,
+            n_sims=1,
+            initial_gas_mole_fractions={h2: 1.0},
+            initial_surface_coverages={x: 1.0},
+            surface_volume_ratio=(1e1, 'm^-1'),
+            surface_site_density=(2.72e-9, 'mol/cm^2'),
+            termination=[])
+
+        rxn_system.initialize_model(core_species, core_reactions, edge_species, edge_reactions)
+
+        tlist = np.logspace(-13, -5, 81, dtype=np.float64)
+
+        self.assertIsInstance(rxn1.kinetics.coverage_dependence, dict)  # check to make sure coverage_dependence is still the correct type
+        for species, parameters in rxn1.kinetics.coverage_dependence.items():
+            self.assertIsInstance(species, str)  # species should be a string
+            self.assertIsInstance(parameters, dict)
+            self.assertIsNotNone(parameters['E'])
+            self.assertIsNotNone(parameters['m'])
+            self.assertIsNotNone(parameters['a'])
+
+        # Integrate to get the solution at each time point
+        t = []
+        y = []
+        reaction_rates = []
+        species_rates = []
+        for t1 in tlist:
+            rxn_system.advance(t1)
+            t.append(rxn_system.t)
+            # You must make a copy of y because it is overwritten by DASSL at
+            # each call to advance()
+            y.append(rxn_system.y.copy())
+            reaction_rates.append(rxn_system.core_reaction_rates.copy())
+            species_rates.append(rxn_system.core_species_rates.copy())
+
+        # Convert the solution vectors to np arrays
+        t = np.array(t, np.float64)
+        y = np.array(y, np.float64)
+        reaction_rates = np.array(reaction_rates, np.float64)
+        species_rates = np.array(species_rates, np.float64)
+        V = constants.R * rxn_system.T.value_si * np.sum(y) / rxn_system.P_initial.value_si
+
+        # Check that we're computing the species fluxes correctly
+        for i in range(t.shape[0]):
+            self.assertAlmostEqual(reaction_rates[i, 0], -1.0 * species_rates[i, 0],
+                                   delta=1e-6 * reaction_rates[i, 0])
+            self.assertAlmostEqual(reaction_rates[i, 0], -0.5 * species_rates[i, 1],
+                                   delta=1e-6 * reaction_rates[i, 0])
+            self.assertAlmostEqual(reaction_rates[i, 0], 0.5 * species_rates[i, 2],
+                                   delta=1e-6 * reaction_rates[i, 0])
+
+        # Check that we've reached equilibrium
+        self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)
+
+    def test_solve_ch3_coverage_dependence(self):
+        """
+        Test the surface batch reactor can properly apply coverage dependent parameters
+        with the nondissociative adsorption of CH3
+
+        Here we choose a kinetic model consisting of the  adsorption reaction
+        CH3 + X <=>  CH3X
+        We use a sticking coefficient for the rate expression.
+        """
+
+        ch3 = Species(
+            molecule=[Molecule().from_smiles("[CH3]")],
+            thermo=NASA(
+                polynomials=[
+                    NASAPolynomial(
+                        coeffs=[3.91547, 0.00184155, 3.48741e-06, -3.32746e-09, 8.49953e-13, 16285.6, 0.351743],
+                        Tmin=(100, 'K'), Tmax=(1337.63, 'K')),
+                    NASAPolynomial(
+                        coeffs=[3.54146, 0.00476786, -1.82148e-06, 3.28876e-10, -2.22545e-14, 16224, 1.66032],
+                        Tmin=(1337.63, 'K'), Tmax=(5000, 'K'))],
+                Tmin=(100, 'K'), Tmax=(5000, 'K'), E0=(135.382, 'kJ/mol'),
+                comment="""Thermo library: primaryThermoLibrary + radical(CH3)"""
+            ),
+            molecular_weight=(15.0345, 'amu'),
+        )
+
+        x = Species(
+            molecule=[Molecule().from_adjacency_list("1 X u0 p0")],
+            thermo=NASA(polynomials=[NASAPolynomial(coeffs=[0, 0, 0, 0, 0, 0, 0], Tmin=(298, 'K'), Tmax=(1000, 'K')),
+                                     NASAPolynomial(coeffs=[0, 0, 0, 0, 0, 0, 0], Tmin=(1000, 'K'), Tmax=(2000, 'K'))],
+                        Tmin=(298, 'K'), Tmax=(2000, 'K'), E0=(-6.19426, 'kJ/mol'),
+                        comment="""Thermo library: surfaceThermo""")
+        )
+
+        ch3x = Species(
+            molecule=[Molecule().from_adjacency_list("""1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {1,S}""")],
+            thermo=NASA(
+                polynomials=[
+                    NASAPolynomial(
+                        coeffs=[-0.552219, 0.026442, -3.55617e-05, 2.60044e-08, -7.52707e-12, -4433.47, 0.692144],
+                        Tmin=(298, 'K'), Tmax=(1000, 'K')),
+                    NASAPolynomial(
+                        coeffs=[3.62557, 0.00739512, -2.43797e-06, 1.86159e-10, 3.6485e-14, -5187.22, -18.9668],
+                        Tmin=(1000, 'K'), Tmax=(2000, 'K'))],
+                Tmin=(298, 'K'), Tmax=(2000, 'K'), E0=(-39.1285, 'kJ/mol'),
+                comment="""Thermo library: surfaceThermoNi111""")
+        )
+
+        rxn1 = Reaction(reactants=[ch3, x],
+                        products=[ch3x],
+                        kinetics=StickingCoefficient(
+                            A=0.1, n=0, Ea=(0, 'kcal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K'),
+                            coverage_dependence={'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}},
+                            comment="""Exact match found for rate rule (Adsorbate;VacantSite)"""
+                        )
+                        )
+        core_species = [ch3, x, ch3x]
+        edge_species = []
+        core_reactions = [rxn1]
+        edge_reactions = []
+
+        T = 800.
+        P_initial = 1.0e5
+        rxn_system = SurfaceReactor(
+            T, P_initial,
+            n_sims=1,
+            initial_gas_mole_fractions={ch3: 1.0},
+            initial_surface_coverages={x: 1.0},
+            surface_volume_ratio=(1., 'm^-1'),
+            surface_site_density=(2.72e-9, 'mol/cm^2'),
+            termination=[])
+        # in chemkin, the sites are mostly occupied in about 1e-8 seconds.
+
+        rxn_system.initialize_model(core_species, core_reactions, edge_species, edge_reactions)
+
+        tlist = np.logspace(-13, -5, 81, dtype=np.float64)
+
+        print("Surface site density:", rxn_system.surface_site_density.value_si)
+
+        print("rxn1 rate coefficient",
+              rxn1.get_surface_rate_coefficient(rxn_system.T.value_si, rxn_system.surface_site_density.value_si))
+
+        self.assertIsInstance(rxn1.kinetics.coverage_dependence, dict)  # check to make sure coverage_dependence is still the correct type
+        for species, parameters in rxn1.kinetics.coverage_dependence.items():
+            self.assertIsInstance(species, str)  # species should be a string
+            self.assertIsInstance(parameters, dict)
+            self.assertIsNotNone(parameters['E'])
+            self.assertIsNotNone(parameters['m'])
+            self.assertIsNotNone(parameters['a'])
+
+        # Integrate to get the solution at each time point
+        t = []
+        y = []
+        reaction_rates = []
+        species_rates = []
+        t.append(rxn_system.t)
+        # You must make a copy of y because it is overwritten by DASSL at
+        # each call to advance()
+        y.append(rxn_system.y.copy())
+        reaction_rates.append(rxn_system.core_reaction_rates.copy())
+        species_rates.append(rxn_system.core_species_rates.copy())
+        print("time: ", t)
+        print("moles:", y)
+        print("reaction rates:", reaction_rates)
+        print("species rates:", species_rates)
+        for t1 in tlist:
+            rxn_system.advance(t1)
+            t.append(rxn_system.t)
+            # You must make a copy of y because it is overwritten by DASSL at
+            # each call to advance()
+            y.append(rxn_system.y.copy())
+            reaction_rates.append(rxn_system.core_reaction_rates.copy())
+            species_rates.append(rxn_system.core_species_rates.copy())
+
+        # Convert the solution vectors to np arrays
+        t = np.array(t, np.float64)
+        y = np.array(y, np.float64)
+        reaction_rates = np.array(reaction_rates, np.float64)
+        species_rates = np.array(species_rates, np.float64)
+        V = constants.R * rxn_system.T.value_si * np.sum(y) / rxn_system.P_initial.value_si
+
+        # Check that we're computing the species fluxes correctly
+        for i in range(t.shape[0]):
+            self.assertAlmostEqual(reaction_rates[i, 0], -species_rates[i, 0],
+                                   delta=1e-6 * reaction_rates[i, 0])
+            self.assertAlmostEqual(reaction_rates[i, 0], -species_rates[i, 1],
+                                   delta=1e-6 * reaction_rates[i, 0])
+            self.assertAlmostEqual(reaction_rates[i, 0], species_rates[i, 2],
+                                   delta=1e-6 * reaction_rates[i, 0])
+
+        # Check that we've reached equilibrium by the end
+        self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -315,7 +315,7 @@ class SurfaceReactorCheck(unittest.TestCase):
                                                   n=0.5,
                                                   Ea=(5.0, 'kJ/mol'),
                                                   T0=(1.0, 'K'),
-                                                  coverage_dependence={'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}}))
+                                                  coverage_dependence={'*': {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}}))
 
         core_species = [h2, x, hx]
         edge_species = []
@@ -342,9 +342,9 @@ class SurfaceReactorCheck(unittest.TestCase):
         for species, parameters in rxn1.kinetics.coverage_dependence.items():
             self.assertIsInstance(species, str)  # species should be a string
             self.assertIsInstance(parameters, dict)
-            self.assertIsNotNone(parameters['E'])
-            self.assertIsNotNone(parameters['m'])
             self.assertIsNotNone(parameters['a'])
+            self.assertIsNotNone(parameters['m'])
+            self.assertIsNotNone(parameters['E'])
 
         # Integrate to get the solution at each time point
         t = []
@@ -435,7 +435,7 @@ class SurfaceReactorCheck(unittest.TestCase):
                         products=[ch3x],
                         kinetics=StickingCoefficient(
                             A=0.1, n=0, Ea=(0, 'kcal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K'),
-                            coverage_dependence={'*': {'E': (0.0, 'J/mol'), 'm': -1.0, 'a': 0.0}},
+                            coverage_dependence={'*': {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}},
                             comment="""Exact match found for rate rule (Adsorbate;VacantSite)"""
                         )
                         )
@@ -470,9 +470,9 @@ class SurfaceReactorCheck(unittest.TestCase):
         for species, parameters in rxn1.kinetics.coverage_dependence.items():
             self.assertIsInstance(species, str)  # species should be a string
             self.assertIsInstance(parameters, dict)
-            self.assertIsNotNone(parameters['E'])
-            self.assertIsNotNone(parameters['m'])
             self.assertIsNotNone(parameters['a'])
+            self.assertIsNotNone(parameters['m'])
+            self.assertIsNotNone(parameters['E'])
 
         # Integrate to get the solution at each time point
         t = []

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -331,6 +331,7 @@ class SurfaceReactorCheck(unittest.TestCase):
             initial_surface_coverages={x: 1.0},
             surface_volume_ratio=(1e1, 'm^-1'),
             surface_site_density=(2.72e-9, 'mol/cm^2'),
+            coverage_dependence=True,
             termination=[])
 
         rxn_system.initialize_model(core_species, core_reactions, edge_species, edge_reactions)
@@ -452,6 +453,7 @@ class SurfaceReactorCheck(unittest.TestCase):
             initial_surface_coverages={x: 1.0},
             surface_volume_ratio=(1., 'm^-1'),
             surface_site_density=(2.72e-9, 'mol/cm^2'),
+            coverage_dependence=True,
             termination=[])
         # in chemkin, the sites are mostly occupied in about 1e-8 seconds.
 

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -315,7 +315,7 @@ class SurfaceReactorCheck(unittest.TestCase):
                                                   n=0.5,
                                                   Ea=(5.0, 'kJ/mol'),
                                                   T0=(1.0, 'K'),
-                                                  coverage_dependence={'*': {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}}))
+                                                  coverage_dependence={x: {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}}))
 
         core_species = [h2, x, hx]
         edge_species = []
@@ -340,7 +340,7 @@ class SurfaceReactorCheck(unittest.TestCase):
 
         self.assertIsInstance(rxn1.kinetics.coverage_dependence, dict)  # check to make sure coverage_dependence is still the correct type
         for species, parameters in rxn1.kinetics.coverage_dependence.items():
-            self.assertIsInstance(species, str)  # species should be a string
+            self.assertIsInstance(species, Species)  # species should be a Species
             self.assertIsInstance(parameters, dict)
             self.assertIsNotNone(parameters['a'])
             self.assertIsNotNone(parameters['m'])
@@ -455,7 +455,7 @@ class SurfaceReactorCheck(unittest.TestCase):
                         products=[ch3x],
                         kinetics=StickingCoefficient(
                             A=0.1, n=0, Ea=(0, 'kcal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K'),
-                            coverage_dependence={'*': {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}},
+                            coverage_dependence={x: {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}},
                             comment="""Exact match found for rate rule (Adsorbate;VacantSite)"""
                         )
                         )
@@ -488,7 +488,7 @@ class SurfaceReactorCheck(unittest.TestCase):
 
         self.assertIsInstance(rxn1.kinetics.coverage_dependence, dict)  # check to make sure coverage_dependence is still the correct type
         for species, parameters in rxn1.kinetics.coverage_dependence.items():
-            self.assertIsInstance(species, str)  # species should be a string
+            self.assertIsInstance(species, Species)  # species should be a Species
             self.assertIsInstance(parameters, dict)
             self.assertIsNotNone(parameters['a'])
             self.assertIsNotNone(parameters['m'])

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -28,6 +28,7 @@
 ###############################################################################
 
 import unittest
+import time
 
 import numpy as np
 
@@ -351,6 +352,7 @@ class SurfaceReactorCheck(unittest.TestCase):
         y = []
         reaction_rates = []
         species_rates = []
+        start_time = time.time()
         for t1 in tlist:
             rxn_system.advance(t1)
             t.append(rxn_system.t)
@@ -359,6 +361,8 @@ class SurfaceReactorCheck(unittest.TestCase):
             y.append(rxn_system.y.copy())
             reaction_rates.append(rxn_system.core_reaction_rates.copy())
             species_rates.append(rxn_system.core_species_rates.copy())
+        run_time = time.time() - start_time
+        print(f"Simulation took {run_time:.3e} seconds in {self.id()}")
 
         # Convert the solution vectors to np arrays
         t = np.array(t, np.float64)
@@ -489,6 +493,7 @@ class SurfaceReactorCheck(unittest.TestCase):
         print("moles:", y)
         print("reaction rates:", reaction_rates)
         print("species rates:", species_rates)
+        start_time = time.time()
         for t1 in tlist:
             rxn_system.advance(t1)
             t.append(rxn_system.t)
@@ -497,6 +502,8 @@ class SurfaceReactorCheck(unittest.TestCase):
             y.append(rxn_system.y.copy())
             reaction_rates.append(rxn_system.core_reaction_rates.copy())
             species_rates.append(rxn_system.core_species_rates.copy())
+        run_time = time.time() - start_time
+        print(f"Simulation took {run_time:.3e} seconds in {self.id()}")
 
         # Convert the solution vectors to np arrays
         t = np.array(t, np.float64)

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -132,23 +132,22 @@ class SurfaceReactorCheck(unittest.TestCase):
         # Check that we've reached equilibrium
         self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)
 
-        # # Visualize the simulation results
-        # import pylab
-        # fig = pylab.figure(figsize=(6, 6))
-        # pylab.subplot(2, 1, 1)
-        # pylab.semilogx(t, y[:, 2])
-        # pylab.ylabel('Concentration (mol/m$^\\mathdefault{3 or 2}$)')
-        # pylab.legend(['HX'], loc=4)
-        # pylab.subplot(2, 1, 2)
-        # pylab.semilogx(t, species_rates)
-        # pylab.legend(['H2', 'X', 'HX'], loc=4)
-        # pylab.xlabel('Time (s)')
-        # pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
-        # # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
-        # pylab.tight_layout()
-        # # pylab.show()
-        # pylab.savefig('surfaceTestH2.pdf')
-
+        # Visualize the simulation results
+        import pylab
+        fig = pylab.figure(figsize=(6, 6))
+        pylab.subplot(2, 1, 1)
+        pylab.semilogx(t, y[:, 2])
+        pylab.ylabel('Concentration (mol/m$^\\mathdefault{3 or 2}$)')
+        pylab.legend(['HX'], loc=4)
+        pylab.subplot(2, 1, 2)
+        pylab.semilogx(t, species_rates)
+        pylab.legend(['H2', 'X', 'HX'], loc=4)
+        pylab.xlabel('Time (s)')
+        pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
+        # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
+        pylab.tight_layout()
+        # pylab.show()
+        pylab.savefig('surfaceTestH2.pdf')
         return
 
     def test_solve_ch3(self):
@@ -382,6 +381,23 @@ class SurfaceReactorCheck(unittest.TestCase):
 
         # Check that we've reached equilibrium
         self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)
+
+        # Visualize the simulation results
+        import pylab
+        fig = pylab.figure(figsize=(6, 6))
+        pylab.subplot(2, 1, 1)
+        pylab.semilogx(t, y[:, 2])
+        pylab.ylabel('Concentration (mol/m$^\\mathdefault{3 or 2}$)')
+        pylab.legend(['HX'], loc=4)
+        pylab.subplot(2, 1, 2)
+        pylab.semilogx(t, species_rates)
+        pylab.legend(['H2', 'X', 'HX'], loc=4)
+        pylab.xlabel('Time (s)')
+        pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
+        # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
+        pylab.tight_layout()
+        # pylab.show()
+        pylab.savefig('surfaceTestH2covdep.pdf')
 
     def test_solve_ch3_coverage_dependence(self):
         """

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -317,10 +317,25 @@ class SurfaceReactorCheck(unittest.TestCase):
                                                   T0=(1.0, 'K'),
                                                   coverage_dependence={x: {'a': 0.0, 'm': -1.0, 'E': (0.0, 'J/mol')}}))
 
+        rxn2 = Reaction(reactants=[h2, x, x],
+                        products=[hx, hx],
+                        kinetics=SurfaceArrhenius(A=(9.05e-18, 'cm^5/(mol^2*s)'), # 1e36 times slower
+                                                  n=0.5,
+                                                  Ea=(5.0, 'kJ/mol'),
+                                                  T0=(1.0, 'K'),
+                                                  coverage_dependence={x: {'a': 0.0, 'm': -1.0, 'E': (10.0, 'J/mol')}}
+                        ))
+
         core_species = [h2, x, hx]
         edge_species = []
         core_reactions = [rxn1]
         edge_reactions = []
+
+        # make it slower, for benchmarking
+        for j in range(200):
+            core_species.append(hx.copy())
+        for j in range(1000):
+            core_reactions.append(rxn2)
 
         T = 600
         P_initial = 1.0e5

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -84,7 +84,7 @@ class SurfaceReactorCheck(unittest.TestCase):
         core_reactions = [rxn1]
         edge_reactions = []
 
-        T = 1000
+        T = 600
         P_initial = 1.0e5
         rxn_system = SurfaceReactor(
             T, P_initial,
@@ -118,7 +118,7 @@ class SurfaceReactorCheck(unittest.TestCase):
         y = np.array(y, np.float64)
         reaction_rates = np.array(reaction_rates, np.float64)
         species_rates = np.array(species_rates, np.float64)
-        V = constants.R * rxn_system.T.value_si * np.sum(y) / rxn_system.P_initial.value_si
+        total_sites = y[0,1]
 
         # Check that we're computing the species fluxes correctly
         for i in range(t.shape[0]):
@@ -136,8 +136,8 @@ class SurfaceReactorCheck(unittest.TestCase):
         import pylab
         fig = pylab.figure(figsize=(6, 6))
         pylab.subplot(2, 1, 1)
-        pylab.semilogx(t, y[:, 2])
-        pylab.ylabel('Concentration (mol/m$^\\mathdefault{3 or 2}$)')
+        pylab.semilogx(t, y[:, 2] / total_sites)
+        pylab.ylabel('Surface coverage')
         pylab.legend(['HX'], loc=4)
         pylab.subplot(2, 1, 2)
         pylab.semilogx(t, species_rates)
@@ -322,7 +322,7 @@ class SurfaceReactorCheck(unittest.TestCase):
         core_reactions = [rxn1]
         edge_reactions = []
 
-        T = 1000
+        T = 600
         P_initial = 1.0e5
         rxn_system = SurfaceReactor(
             T, P_initial,
@@ -368,7 +368,7 @@ class SurfaceReactorCheck(unittest.TestCase):
         y = np.array(y, np.float64)
         reaction_rates = np.array(reaction_rates, np.float64)
         species_rates = np.array(species_rates, np.float64)
-        V = constants.R * rxn_system.T.value_si * np.sum(y) / rxn_system.P_initial.value_si
+        total_sites = y[0,1]
 
         # Check that we're computing the species fluxes correctly
         for i in range(t.shape[0]):
@@ -386,8 +386,8 @@ class SurfaceReactorCheck(unittest.TestCase):
         import pylab
         fig = pylab.figure(figsize=(6, 6))
         pylab.subplot(2, 1, 1)
-        pylab.semilogx(t, y[:, 2])
-        pylab.ylabel('Concentration (mol/m$^\\mathdefault{3 or 2}$)')
+        pylab.semilogx(t, y[:, 2] / total_sites)
+        pylab.ylabel('Surface coverage')
         pylab.legend(['HX'], loc=4)
         pylab.subplot(2, 1, 2)
         pylab.semilogx(t, species_rates)

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -132,23 +132,23 @@ class SurfaceReactorCheck(unittest.TestCase):
         # Check that we've reached equilibrium
         self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)
 
-        # Visualize the simulation results
-        import pylab
-        fig = pylab.figure(figsize=(6, 6))
-        pylab.subplot(2, 1, 1)
-        pylab.semilogx(t, y[:, 2] / total_sites)
-        pylab.ylabel('Surface coverage')
-        pylab.legend(['HX'], loc=4)
-        pylab.subplot(2, 1, 2)
-        pylab.semilogx(t, species_rates)
-        pylab.legend(['H2', 'X', 'HX'], loc=4)
-        pylab.xlabel('Time (s)')
-        pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
-        # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
-        pylab.tight_layout()
-        # pylab.show()
-        pylab.savefig('surfaceTestH2.pdf')
-        return
+        # # Visualize the simulation results
+        # import pylab
+        # fig = pylab.figure(figsize=(6, 6))
+        # pylab.subplot(2, 1, 1)
+        # pylab.semilogx(t, y[:, 2] / total_sites)
+        # pylab.ylabel('Surface coverage')
+        # pylab.legend(['HX'], loc=4)
+        # pylab.subplot(2, 1, 2)
+        # pylab.semilogx(t, species_rates)
+        # pylab.legend(['H2', 'X', 'HX'], loc=4)
+        # pylab.xlabel('Time (s)')
+        # pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
+        # # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
+        # pylab.tight_layout()
+        # # pylab.show()
+        # pylab.savefig('surfaceTestH2.pdf')
+        # return
 
     def test_solve_ch3(self):
         """
@@ -397,22 +397,22 @@ class SurfaceReactorCheck(unittest.TestCase):
         # Check that we've reached equilibrium
         self.assertAlmostEqual(reaction_rates[-1, 0], 0.0, delta=1e-2)
 
-        # Visualize the simulation results
-        import pylab
-        fig = pylab.figure(figsize=(6, 6))
-        pylab.subplot(2, 1, 1)
-        pylab.semilogx(t, y[:, 2] / total_sites)
-        pylab.ylabel('Surface coverage')
-        pylab.legend(['HX'], loc=4)
-        pylab.subplot(2, 1, 2)
-        pylab.semilogx(t, species_rates)
-        pylab.legend(['H2', 'X', 'HX'], loc=4)
-        pylab.xlabel('Time (s)')
-        pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
-        # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
-        pylab.tight_layout()
-        # pylab.show()
-        pylab.savefig('surfaceTestH2covdep.pdf')
+        # # Visualize the simulation results
+        # import pylab
+        # fig = pylab.figure(figsize=(6, 6))
+        # pylab.subplot(2, 1, 1)
+        # pylab.semilogx(t, y[:, 2] / total_sites)
+        # pylab.ylabel('Surface coverage')
+        # pylab.legend(['HX'], loc=4)
+        # pylab.subplot(2, 1, 2)
+        # pylab.semilogx(t, species_rates)
+        # pylab.legend(['H2', 'X', 'HX'], loc=4)
+        # pylab.xlabel('Time (s)')
+        # pylab.ylabel('Rate (mol/m$^\\mathdefault{3 or 2}$*s)')
+        # # fig.subplots_adjust(left=0.21, bottom=0.10, right=0.95, top=0.95, wspace=0.20, hspace=0.35)
+        # pylab.tight_layout()
+        # # pylab.show()
+        # pylab.savefig('surfaceTestH2covdep.pdf')
 
     def test_solve_ch3_coverage_dependence(self):
         """

--- a/rmgpy/solver/surfaceTest.py
+++ b/rmgpy/solver/surfaceTest.py
@@ -546,7 +546,6 @@ class SurfaceReactorCheck(unittest.TestCase):
             initial_surface_coverages={x: 1.0},
             surface_volume_ratio=(1., 'm^-1'),
             surface_site_density=(2.72e-9, 'mol/cm^2'),
-            coverage_dependence=False,
             termination=[])
 
         rxn_system.initialize_model(core_species, core_reactions, edge_species, edge_reactions)
@@ -582,5 +581,5 @@ class SurfaceReactorCheck(unittest.TestCase):
         self.assertAlmostEqual(species_rates_off[-1, 0], 0.0, delta=1e-2)
 
         # Check that coverages are different
-        self.assertFalse(np.array_equal(y,y_off))
-        self.assertFalse(np.array_equal(species_rates, species_rates_off))
+        self.assertFalse(np.allclose(y,y_off))
+        self.assertFalse(np.allclose(species_rates, species_rates_off))

--- a/rmgpy/test_data/testing_database/kinetics/libraries/surface-example/reactions.py
+++ b/rmgpy/test_data/testing_database/kinetics/libraries/surface-example/reactions.py
@@ -19,6 +19,7 @@ entry(
         Ea=(1.5E3, 'J/mol'),
         Tmin = (200, 'K'),
         Tmax = (3000, 'K'),
+        coverage_dependence = {'OX': {'E': (0.0, 'J/mol'), 'm':0.0, 'a':0.0},}
     ),
     shortDesc = u"""Default""",
     longDesc = u"""Made up""",


### PR DESCRIPTION
### Motivation or Problem
Coverage dependent effects are found in many surface mechanisms, and we have been unable to use them.  These effects can become significant at high temperatures and pressures. Additionally, some models would have too much O2 adsorbing to the surface too quickly, blocking anything else from happening.

### Description of Changes
A new kinetics attribute called `coverage_dependence` was added that is a dictionary of dictionaries that holds the Species the parameters correspond to and the coverage dependent parameters. 

### Testing
Unit tests to make sure RMG can read in kinetics entries with coverage dependent parameters, write chemkin and cantera output files with the coverage parameters, and use the parameters correctly. We've built a few models with it, and it seems to be working.

### Note: dual PR with database.
Goes with https://github.com/ReactionMechanismGenerator/RMG-database/pull/462
The commits that add this to the CI testing should be removed from both PRs before merging.