### PR TITLE
Switch to newer cclib?

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - cairo
   - cairocffi
   - rmg::cantera >=2.3.0
-  - cclib
+  - conda-forge::cclib >=1.6.3
   - rmg::chemprop
   - coolprop
   - coverage

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -331,8 +331,12 @@ class QMMolecule(object):
         """
         parser = self.get_parser(self.output_file_path)
         parser.logger.setLevel(logging.ERROR)  # cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
+        parser.rotcons = [] # give it an attribute and it won't delete it, leaving it on the parser object
+        parser.molmass = None # give it an attribute and it won't delete it, leaving it on the parser object
         cclib_data = parser.parse()
         radical_number = self.molecule.get_radical_count()
+        cclib_data.rotcons = parser.rotcons # this hack required because rotcons not part of a default cclib data object
+        cclib_data.molmass = parser.molmass # this hack required because rotcons not part of a default cclib data object
         qm_data = parse_cclib_data(cclib_data, radical_number + 1)  # Should `radical_number+1` be `self.molecule.multiplicity` in the next line of code? It's the electronic ground state degeneracy.
         return qm_data
 

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -463,7 +463,12 @@ class QMMolecule(object):
         assert self.qm_data, "Need QM Data first in order to calculate thermo."
         assert self.point_group, "Need Point Group first in order to calculate thermo."
 
-        trans = rmgpy.statmech.IdealGasTranslation(mass=self.qm_data.molecularMass)
+        mass = getattr(self.qm_data, 'molecularMass', None)
+        if mass is None:
+            # If using a cclib that doesn't read molecular mass, for example
+            mass = sum(rmgpy.molecule.element.get_element(int(a)).mass for a in self.qm_data.atomicNumbers)
+            mass = rmgpy.quantity.Mass(mass, 'kg/mol')
+        trans = rmgpy.statmech.IdealGasTranslation(mass=mass)
         if self.point_group.linear:
             # there should only be one rotational constant for a linear rotor
             rotational_constant = rmgpy.quantity.Frequency(max(self.qm_data.rotationalConstants.value),

--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -227,7 +227,7 @@ class Mopac(object):
         """
         Returns the appropriate cclib parser.
         """
-        return cclib.parser.Mopac(output_file)
+        return cclib.parser.MOPAC(output_file)
 
 
 class MopacMol(QMMolecule, Mopac):

--- a/rmgpy/qm/qmdata.py
+++ b/rmgpy/qm/qmdata.py
@@ -92,7 +92,10 @@ def parse_cclib_data(cclib_data, ground_state_degeneracy):
     """
     try:
         number_of_atoms = cclib_data.natom
-        molecular_mass = (cclib_data.molmass, 'amu')
+        if hasattr(cclib_data, 'molmass'):
+            molecular_mass = (cclib_data.molmass, 'amu')
+        else:
+            molecular_mass = None
         energy = (cclib_data.scfenergies[-1], 'eV/molecule')
         atomic_numbers = cclib_data.atomnos
         rotational_constants = ([i * 1e9 for i in cclib_data.rotcons[-1]], 'hertz')

--- a/rmgpy/qm/qmdata.py
+++ b/rmgpy/qm/qmdata.py
@@ -98,7 +98,7 @@ def parse_cclib_data(cclib_data, ground_state_degeneracy):
             molecular_mass = None
         energy = (cclib_data.scfenergies[-1], 'eV/molecule')
         atomic_numbers = cclib_data.atomnos
-        rotational_constants = ([i * 1e9 for i in cclib_data.rotcons[-1]], 'hertz')
+        rotational_constants = (cclib_data.rotcons[-1], 'cm^-1')
         atom_coords = (cclib_data.atomcoords[-1], 'angstrom')
         frequencies = (cclib_data.vibfreqs, 'cm^-1')
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
As mentioned in https://github.com/ReactionMechanismGenerator/RMG-Py/issues/756 it would be nice to use the official [cclib](https://github.com/cclib/cclib) rather than a fork that we need (but fail) to maintain. For example the current fork has some bugs like #1864 #1875, and is incompatible with OpenBabel 3+, delaying #2088, and we don't even have [conda binaries](https://anaconda.org/rmg/cclib) for Mac OS X, meaning Mopac etc. has I think been broken for Mac OS users for ages.

### Description of Changes
Currently a work in progress, but the aim is to use the official cclib.

- switch the environment.yml to specify the conda-forge channel
- change the name of the MOPAC parser
- calculate molar mass if it's not parsed
- parse the molar mass from MOPAC files

### Testing
Running unit tests.
At one point an entropy calculated from MOPAC result changed 376.91 != 334.50 J/mol/K but Mark fixed the units in the rotational constants.

There may be other things that don't have good test coverage though. 
Is Gaussian parsing tested?

<!--
### Reviewer Tips

Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
