### PR TITLE
Remove Surface_Recombination family from documentation.

### DIFF
--- a/documentation/source/users/rmg/database/kinetics.rst
+++ b/documentation/source/users/rmg/database/kinetics.rst
@@ -347,8 +347,6 @@ There are currently 58 reaction families in RMG:
     :scale: 40%
 .. |f66| image:: images/kinetics_families/Surface_Dissociation_vdW.png
     :scale: 40%
-.. |f67| image:: images/kinetics_families/Surface_Recombination.png
-    :scale: 40%
 .. |f68| image:: images/kinetics_families/intra_H_migration.png
     :scale: 40%
 .. |f69| image:: images/kinetics_families/intra_NO2_ONO_conversion.png
@@ -439,7 +437,6 @@ There are currently 58 reaction families in RMG:
     **Surface_Bidentate_Dissociation**                    |f64|
     **Surface_Dissociation**                              |f65|
     **Surface_Dissociation_vdW**                          |f66|
-    **Surface_Recombination**                             |f67|
     **intra_H_migration**                                 |f68|
     **intra_NO2_ONO_conversion**                          |f69|
     **intra_OH_migration**                                |f70|


### PR DESCRIPTION
### Motivation or Problem
This family was deleted in https://github.com/ReactionMechanismGenerator/RMG-database/pull/457
so should not be listed in the documentation.

### Description of Changes
Removes the mention from the table.

### Discussion
I think some other families have been recently added without appearing here.
I'm not sure whether this table can be automatically generated, and/or when it should be updated. 
Begs a bigger question about documentation reflecting the latest development version or the previous release. 
And more generally about how the documentation describes the contents of the database.
But I'll leave that discussion for a separate issue.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
