### PR TITLE
Changed call for rmgpy.tools.generate_reactions to rmgpy.tools.generatere…

### DIFF
--- a/ipython/generate_reactions.ipynb
+++ b/ipython/generate_reactions.ipynb
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "# Execute generate reactions\n",
-    "from rmgpy.tools.generate_reactions import RMG, execute\n",
+    "from rmgpy.tools.generatereactions import RMG, execute\n",
     "kwargs = {\n",
     "    'walltime': '00:00:00:00',\n",
     "    'kineticsdatastore': True\n",


### PR DESCRIPTION
Noticed issue where `generate_reactions` could not be located with `rmgpy.tools.generate_reactions`. After checking filenames, the author of the PR changed `rmgpy.tools.generate_reactions` to `rmgpy.tools.generatereactions` and confirmed the Jupyther notebook ran successfully.