### PR TITLE
Better Github Actions workflow for dual Py/Database updates.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
+    env: # update this if needed to match a pull request on the RMG-database
+      RMG_DATABASE_BRANCH: master
     defaults:
       run:
         shell: bash -l {0}
@@ -38,7 +40,7 @@ jobs:
       - name: Install and compile RMG
         run: |
           cd ..
-          git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
+          git clone -b $RMG_DATABASE_BRANCH https://github.com/ReactionMechanismGenerator/RMG-database.git
           cd RMG-Py
           git clone -b arkanepy3 https://github.com/mjohnson541/Q2DTor.git external/Q2DTor
           make

--- a/trigger-rmg-tests.sh
+++ b/trigger-rmg-tests.sh
@@ -12,6 +12,7 @@ BRANCH=${GITHUB_REF#refs/heads/}
 
 echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
 echo "BRANCH: $BRANCH"
+echo "RMG_DATABASE_BRANCH: $RMG_DATABASE_BRANCH"
 
 # URL for the official RMG-tests repository
 REPO=https://${GH_TOKEN}@github.com/ReactionMechanismGenerator/RMG-tests.git
@@ -29,14 +30,24 @@ cd $TARGET_DIR
 
 # create a new branch in RMG-tests with the name equal to
 # the branch name of the tested RMG-Py branch:
-RMGTESTSBRANCH=rmgpy-$BRANCH
+if ["$RMG_DATABASE_BRANCH" == "master"]
+then
+  RMGTESTSBRANCH=rmgpy-$BRANCH
+else
+  RMGTESTSBRANCH=rmgpydb-$BRANCH
+fi
 
-git checkout -b $RMGTESTSBRANCH || true 
+git checkout -b $RMGTESTSBRANCH || true
 git checkout $RMGTESTSBRANCH
 
-# create an empty commit with the SHA-ID of the 
+# create an empty commit with the SHA-ID of the
 # tested commit of the RMG-Py branch:
-git commit --allow-empty -m rmgpy-$REV
+if ["$RMG_DATABASE_BRANCH" == "master"]
+then
+  git commit --allow-empty -m rmgpy-$REV
+else
+  git commit --allow-empty -m rmgpydb-$REV-${RMG_DATABASE_BRANCH}
+fi
 
 # push to the branch to the RMG/RMG-tests repo:
 git push -f $REPO $RMGTESTSBRANCH > /dev/null


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Dual PRs that update both RMG-Py and RMG-database simultaneously cannot currently be tested since we moved continous integration to Github Actions.

My goal is there's just one spot to update the required branch, and it's a single environment variable in the CI.yml file.


### Description of Changes
I changed the CI workflow. I'm making similar changes to the RMG-database, and updating the RMG-tests repo too.
Also will be updating the instructions at https://github.com/ReactionMechanismGenerator/RMG-Py/wiki/Simultaneous-Update-of-RMG-Py-and-RMG-database

If it works as I hope, it should be quite straightforward, and symmetrical.

### Testing
Will see if it works...
