### PR TITLE
Updating documentation and input file using metal database

### DIFF
--- a/documentation/source/users/rmg/surfaces.rst
+++ b/documentation/source/users/rmg/surfaces.rst
@@ -24,6 +24,7 @@ This block should also contain the reference adatom binding energies
 
 One can also specify a specific metal of interest, and RMG will load corresponding binding energies from the
 metal database by using ``metal``.
+The full database of available metals can be found in ``input/surface/libraries/metal.py``.
 
 
 Here is an example catalyst properties block for Pt(111)::
@@ -356,4 +357,3 @@ Other things to update:
 .. [Mazeau2019] \ E.J. Mazeau, P. Satupte, K. Blondal, C.F. Goldsmith and R.H. West. "Linear Scaling Relationships and Sensitivity Analyses in RMG-Cat." *Unpublished*.
 
 .. [Abild2007] \ F. Abild-Pedersen, J. Greeley, F. Studt, J. Rossmeisl, T.R. Munter, P.G. Moses, E. Skúlason, T. Bligaard, and J.K. Nørskov. "Scaling Properties of Adsorption Energies for Hydrogen-Containing Molecules on Transition-Metal Surfaces." *Phys. Rev. Lett.* **99(1)**, p. 4-7 (2007).
-

--- a/documentation/source/users/rmg/surfaces.rst
+++ b/documentation/source/users/rmg/surfaces.rst
@@ -22,7 +22,17 @@ It varies depending on the catalyst in question, but is held constant across sim
 This block should also contain the reference adatom binding energies 
 (see linear scaling section below).
 
+One can also specify a specific metal of interest, and RMG will load corresponding binding energies from the
+metal database by using ``metal``.
+
+
 Here is an example catalyst properties block for Pt(111)::
+
+    catalystProperties(
+        metal = Pt111
+    )
+
+Here is an example custom catalyst properties block for Pt(111)::
 
     catalystProperties(
         bindingEnergies = {

--- a/examples/rmg/catalysis/ch4_o2/input.py
+++ b/examples/rmg/catalysis/ch4_o2/input.py
@@ -10,13 +10,7 @@ database(
 )
 
 catalystProperties(
-    bindingEnergies = {  # default values for Pt(111)    
-                          'H': (-2.754, 'eV/molecule'),
-                          'O': (-3.811, 'eV/molecule'),
-                          'C': (-7.025, 'eV/molecule'),
-                          'N': (-4.632, 'eV/molecule'),
-                      },
-    surfaceSiteDensity=(2.483e-9, 'mol/cm^2'), # Default for Pt(111)
+    metal = 'Pt111'
 )
 
 species(


### PR DESCRIPTION
This PR updates the surface documentation with instructions on how to use the metal database to specify certain metals instead of having to manually enter in binding energies and surface site density.

I also changed the ch4_o2 example input file to call `Pt111` in place of listing out Pt111 binding energies and surface site density