### PR TITLE
Halogens thermo - missing group test

### DIFF
--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -613,10 +613,10 @@ multiplicity 2
     def test_identifying_missing_group(self):
         """Test identifying a missing GAV group"""
         # this test should be updated once data is added to the missing group
-        spc = Species(smiles='CN(C)CCCN1C2=CC=CC=C2CCC3=CC=CC=C31')
+        spc = Species(smiles='C[N+]#[C-]')
         spc.generate_resonance_structures()
         thermo_gav = self.database.get_thermo_data_from_groups(spc)
-        self.assertIn('missing(N3s-CbCbCs)', thermo_gav.comment)
+        self.assertIn('missing(N5tc-C2tcCs)', thermo_gav.comment)
 
     def test_adsorbate_thermo_generation_gav(self):
         """Test thermo generation for adsorbate from Group Additivity value.


### PR DESCRIPTION
simultaneous with https://github.com/ReactionMechanismGenerator/RMG-database/pull/473

This PR changes the molecule to use for missing thermo group test since the thermo group for the old molecule is no longer missing (so the test was failing)