### PR TITLE
Primary thermo library - unit test change

### DIFF
--- a/arkane/explorerTest.py
+++ b/arkane/explorerTest.py
@@ -78,7 +78,7 @@ class TestExplorerJob(unittest.TestCase):
         """
         test that the right number of reactions are in output network
         """
-        self.assertEqual(len(self.explorer_job.networks[0].path_reactions), 6)
+        self.assertEqual(len(self.explorer_job.networks[0].path_reactions), 7)
 
     def test_isomers(self):
         """


### PR DESCRIPTION
Adding some species to the primaryThermoLibrary in  https://github.com/ReactionMechanismGenerator/RMG-database/pull/478 and improving their thermochemistry (better than group additive guesses) causes the number of reactions explored in an Arkane unit test to change, so this PR changes the "blessed" output in the unit test. Should be merged simultaneously with https://github.com/ReactionMechanismGenerator/RMG-database/pull/478
