### PR TITLE
optionally `generate_resonance_structures` when loading species dicts

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -799,12 +799,13 @@ def read_reaction_comments(reaction, comments, read=True):
 ################################################################################
 
 
-def load_species_dictionary(path):
+def load_species_dictionary(path, generate_resonance_structures=True):
     """
     Load an RMG dictionary - containing species identifiers and the associated
     adjacency lists - from the file located at `path` on disk. Returns a dict
-    mapping the species identifiers to the loaded species. Resonance isomers
-    for each species are automatically generated.
+    mapping the species identifiers to the loaded species.
+    If `generate_resonance_structures` is True (default if omitted)
+    then resonance isomers for each species are generated.
     """
     species_dict = {}
 
@@ -815,7 +816,8 @@ def load_species_dictionary(path):
             if line.strip() == '' and adjlist.strip() != '':
                 # Finish this adjacency list
                 species = Species().from_adjacency_list(adjlist)
-                species.generate_resonance_structures()
+                if generate_resonance_structures:
+                    species.generate_resonance_structures()
                 label = species.label
                 for inert in inerts:
                     if inert.is_isomorphic(species):
@@ -833,7 +835,8 @@ def load_species_dictionary(path):
         else:  #reach end of file
             if adjlist.strip() != '':
                 species = Species().from_adjacency_list(adjlist)
-                species.generate_resonance_structures()
+                if generate_resonance_structures:
+                    species.generate_resonance_structures()
                 label = species.label
                 for inert in inerts:
                     if inert.is_isomorphic(species):
@@ -894,11 +897,13 @@ def load_transport_file(path, species_dict):
 
 
 def load_chemkin_file(path, dictionary_path=None, transport_path=None, read_comments=True, thermo_path=None,
-                      use_chemkin_names=False, check_duplicates=True):
+                      use_chemkin_names=False, check_duplicates=True, generate_resonance_structures=True):
     """
     Load a Chemkin input file located at `path` on disk to `path`, returning lists of the species
     and reactions in the Chemkin file. The 'thermo_path' point to a separate thermo file, or, if 'None' is
-    specified, the function will look for the thermo database within the chemkin mechanism file
+    specified, the function will look for the thermo database within the chemkin mechanism file.
+    If `generate_resonance_structures` is True (default if omitted) then resonance isomers for
+    each species are generated.
     """
     species_list = []
     species_dict = {}
@@ -910,7 +915,7 @@ def load_chemkin_file(path, dictionary_path=None, transport_path=None, read_comm
     # as N2, or else the species objects will not store any structures for the final
     # HTML output.
     if dictionary_path:
-        species_dict = load_species_dictionary(dictionary_path)
+        species_dict = load_species_dictionary(dictionary_path, generate_resonance_structures=generate_resonance_structures)
 
     with open(path, 'r') as f:
         previous_line = f.tell()


### PR DESCRIPTION
Resonance structure generation can slow down loading of species dictionaries.  Usually this is not significant, but it can be if you are loading a very large species dictionary from a model's edge.  This PR makes it optional (with defaulting to True), similar to how it is for `get_species` method for database