### PR TITLE
an empty surface site template group should only match an empty surface site

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1743,6 +1743,7 @@ class KineticsFamily(Database):
             struct = template_reactant
 
         reactant_contains_surface_site = reactant.contains_surface_site()
+        reactant_is_surface_site = reactant.is_surface_site()
 
         if isinstance(struct, LogicNode):
             mappings = []
@@ -1753,6 +1754,9 @@ class KineticsFamily(Database):
                 mappings.extend(reactant.find_subgraph_isomorphisms(child_structure, save_order=self.save_order))
             return mappings
         elif isinstance(struct, Group):
+            if struct.is_surface_site() != reactant_is_surface_site:
+                # An empty surface site group should not match an adsorbate
+                return []
             if struct.contains_surface_site() != reactant_contains_surface_site:
                 # An adsorbed template can't match a gas-phase species and vice versa
                 return []

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -1016,6 +1016,28 @@ multiplicity 2
         reaction_list = self.database.kinetics.families['Surface_Adsorption_Dissociative'].generate_reactions(reactants)
         self.assertEquals(len(reaction_list), 0)
 
+    def test_match_reactant_to_template_surface_site(self):
+        """
+        Test that an empty surface site template group matches an empty surface site Molecule and does not match
+        a vdW adsorbate
+        """
+        family = self.database.kinetics.families['Surface_Adsorption_Dissociative']
+        empty_surface_site_template_group = [r.item for r in family.forward_template.reactants if r.item.is_surface_site()][0]
+
+        empty_surface_site_mol = Molecule().from_adjacency_list('1 X u0')
+        vdW_adsorbate = Molecule().from_adjacency_list("""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 X u0 p0 c0
+""")
+        empty_surface_site_matches = family._match_reactant_to_template(empty_surface_site_mol, empty_surface_site_template_group)
+        vdW_matches = family._match_reactant_to_template(vdW_adsorbate, empty_surface_site_template_group)
+        self.assertEqual(len(empty_surface_site_matches), 1)
+        self.assertEqual(len(vdW_matches), 0)
+
     def test_reactant_num_mismatch_2(self):
         """Test that we get no reactions for reactant/template size mismatch
 
@@ -1038,3 +1060,8 @@ multiplicity 2
         reacts = [Molecule(smiles='*[CH2]'),Molecule(smiles='*[CH2]')]
         reaction_list = family.generate_reactions(reacts)
         self.assertEqual(len(reaction_list),0)
+
+################################################################################
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -78,14 +78,14 @@ class TestFamily(unittest.TestCase):
         Test the get_backbone_roots() function
         """
         backbones = self.family.get_backbone_roots()
-        self.assertEquals(backbones[0].label, "RnH")
+        self.assertEqual(backbones[0].label, "RnH")
 
     def test_get_end_roots(self):
         """
         Test the get_end_roots() function
         """
         ends = self.family.get_end_roots()
-        self.assertEquals(len(ends), 2)
+        self.assertEqual(len(ends), 2)
         self.assertIn(self.family.groups.entries["Y_rad_out"], ends)
         self.assertIn(self.family.groups.entries["XH_out"], ends)
 
@@ -94,7 +94,7 @@ class TestFamily(unittest.TestCase):
         Test the get_top_level_groups() function
         """
         top_groups = self.family.get_top_level_groups(self.family.groups.entries["RnH"])
-        self.assertEquals(len(top_groups), 4)
+        self.assertEqual(len(top_groups), 4)
         self.assertIn(self.family.groups.entries["R5Hall"], top_groups)
         self.assertIn(self.family.groups.entries["R6Hall"], top_groups)
         self.assertIn(self.family.groups.entries["R2Hall"], top_groups)
@@ -702,13 +702,13 @@ class TestTreeGeneration(unittest.TestCase):
         """
         self.family.clean_tree()
         ents = [ent for ent in self.family.groups.entries.values() if ent.index != -1]
-        self.assertEquals(len(ents), 1,
+        self.assertEqual(len(ents), 1,
                           'more than one relevant group left in groups after preparing tree for generation')
-        self.assertEquals(len(self.family.rules.entries), 1,
+        self.assertEqual(len(self.family.rules.entries), 1,
                           'more than one group in rules.entries after preparing tree for generation')
         root = self.family.groups.entries[list(self.family.rules.entries.keys())[0]]
-        self.assertEquals([root], self.family.forward_template.reactants)
-        self.assertEquals([root], self.family.groups.top)
+        self.assertEqual([root], self.family.forward_template.reactants)
+        self.assertEqual([root], self.family.groups.top)
 
     def test_b_generate_tree(self):
         """
@@ -751,7 +751,7 @@ class TestTreeGeneration(unittest.TestCase):
             if len(rs) == 1:
                 c += 1
 
-        self.assertEquals(c, 6, 'incorrect number of kinetics information, expected 6 found {0}'.format(c))
+        self.assertEqual(c, 6, 'incorrect number of kinetics information, expected 6 found {0}'.format(c))
 
     def test_d_regularization_dims(self):
         """
@@ -998,11 +998,11 @@ multiplicity 2
         reaction_list = self.database.kinetics.families['R_Recombination'].generate_reactions(reactant)
         for rxn in reaction_list:
             for product in rxn.products:
-                self.assertEquals(product.get_net_charge(), 0)
+                self.assertEqual(product.get_net_charge(), 0)
 
         reactant = [Molecule(smiles='[O-][N+]#N')]
         reaction_list = self.database.kinetics.families['R_Recombination'].generate_reactions(reactant)
-        self.assertEquals(len(reaction_list), 0)
+        self.assertEqual(len(reaction_list), 0)
 
     def test_reactant_num_mismatch(self):
         """Test that we get no reactions for reactant/template size mismatch
@@ -1010,11 +1010,11 @@ multiplicity 2
         This happens often because we test every combo of molecules against all families."""
         reactants = [Molecule(smiles='C'), Molecule(smiles='[OH]')]
         reaction_list = self.database.kinetics.families['Singlet_Val6_to_triplet'].generate_reactions(reactants)
-        self.assertEquals(len(reaction_list), 0)
+        self.assertEqual(len(reaction_list), 0)
         reaction_list = self.database.kinetics.families['Baeyer-Villiger_step1_cat'].generate_reactions(reactants)
-        self.assertEquals(len(reaction_list), 0)
+        self.assertEqual(len(reaction_list), 0)
         reaction_list = self.database.kinetics.families['Surface_Adsorption_Dissociative'].generate_reactions(reactants)
-        self.assertEquals(len(reaction_list), 0)
+        self.assertEqual(len(reaction_list), 0)
 
     def test_match_reactant_to_template_surface_site(self):
         """
@@ -1048,9 +1048,9 @@ multiplicity 2
             Molecule().from_adjacency_list('1 X u0'),
         ]
         # reaction_list = self.database.kinetics.families['Surface_Adsorption_Dissociative'].generate_reactions(reactants)
-        # self.assertEquals(len(reaction_list), 14)
+        # self.assertEqual(len(reaction_list), 14)
         reaction_list = self.database.kinetics.families['Surface_Dissociation_vdW'].generate_reactions(reactants)
-        self.assertEquals(len(reaction_list), 0)
+        self.assertEqual(len(reaction_list), 0)
 
     def test_apply_recipe_multiplicity_check(self):
         """


### PR DESCRIPTION

### Motivation or Problem
Currently, empty surface site template groups match with vdw adsorbates since they both have the `Xv` atomtype.  This creates problems when generating reactions when a vdw adsorbate matches with the `Xv` group that is meant to be an empty site.  This problem has occurred in the reverse direction for the `Surface_Addition_Single_vdW` family which generates this reaction from its reverse template:

<img width="441" alt="Screen Shot 2021-05-13 at 6 43 51 PM" src="https://user-images.githubusercontent.com/32377555/118200745-dbd5a980-b423-11eb-8917-8ca5142f07d2.png">


### Description of Changes
Added a check to make sure that if the template group is an empty surface site, it should only match a structure that is an empty surface site

### Testing
the `Surface_Addition_Single_vdW`  no longer generates the reaction above.




<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
