### PR TITLE
check multiplicity of reverse products if the family template reactants have multiplicity constraints (vdW groups)

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1602,6 +1602,34 @@ class KineticsFamily(Database):
                 lowest_labels.append(min(labels))
             product_structures = [s for _, s in sorted(zip(lowest_labels, product_structures))]
 
+        # if applying the family in reverse and the template reactants restrict multiplicity, we need to make sure that
+        # a reverse product matches the multiplicity-constrained template reactant because the forward template products
+        # do not enforce the multiplicity restriction
+        if not forward and isinstance(reactant_structure, Molecule):
+            for template in self.forward_template.reactants:
+                # iterate through the template reactants and check to see if they have a multiplicity constraint
+                if isinstance(template.item, Group):
+                    if template.item.multiplicity != []:
+                        # this template restricts multiplicity and needs to be checked
+                        for struct in product_structures:
+                            # iterate through the product structures to make sure that
+                            # it matches a mulitplicity-constrained template reactant
+                            match = self._match_reactant_to_template(struct, template)
+                            if match:
+                                # A product structure matches the template! 
+                                break
+                        if not match:
+                            # No product matched the template reactant
+                            # Therefore, this reaction is invalid
+                            logging.debug(
+                                f'No product structures matched {template} which has a multiplicity of {template.item.multiplicity}\n\n'
+                                'Template:\n\n'
+                                f'{template.item.to_adjacency_list()}\n\n'
+                                'Product structures:\n')
+                            for struct in product_structures:
+                                logging.debug(f'{struct}\n{struct.to_adjacency_list()}\n')
+                            return None
+
         # Return the product structures
         return product_structures
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1602,9 +1602,10 @@ class KineticsFamily(Database):
                 lowest_labels.append(min(labels))
             product_structures = [s for _, s in sorted(zip(lowest_labels, product_structures))]
 
-        # if applying the family in reverse and the template reactants restrict multiplicity, we need to make sure that
-        # a reverse product matches the multiplicity-constrained template reactant because the forward template products
-        # do not enforce the multiplicity restriction
+        # If applying the family in reverse and the template reactants restrict multiplicity,
+        # we need to make sure that a reverse product matches the multiplicity-constrained
+        # template reactant because the forward template products do not enforce the
+        # multiplicity restriction.
         if not forward and isinstance(reactant_structure, Molecule):
             for template in self.forward_template.reactants:
                 # iterate through the template reactants and check to see if they have a multiplicity constraint
@@ -1616,18 +1617,19 @@ class KineticsFamily(Database):
                             # it matches a mulitplicity-constrained template reactant
                             match = self._match_reactant_to_template(struct, template)
                             if match:
-                                # A product structure matches the template! 
+                                # A product structure matches the template!
                                 break
                         if not match:
                             # No product matched the template reactant
                             # Therefore, this reaction is invalid
-                            logging.debug(
-                                f'No product structures matched {template} which has a multiplicity of {template.item.multiplicity}\n\n'
-                                'Template:\n\n'
-                                f'{template.item.to_adjacency_list()}\n\n'
-                                'Product structures:\n')
-                            for struct in product_structures:
-                                logging.debug(f'{struct}\n{struct.to_adjacency_list()}\n')
+                            if logging.getLogger().isEnabledFor(logging.DEBUG):
+                                logging.debug(
+                                    'No product structures matched %s which has a multiplicity of %r\n'
+                                    'Template:\n%s\n'
+                                    'Product structures:\n',
+                                    template, template.item.multiplicity, template.item.to_adjacency_list() )
+                                for struct in product_structures:
+                                    logging.debug(f'{struct}\n{struct.to_adjacency_list()}\n')
                             return None
 
         # Return the product structures

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1339,7 +1339,7 @@ class KineticsFamily(Database):
     def apply_recipe(self, reactant_structures, forward=True, unique=True):
         """
         Apply the recipe for this reaction family to the list of
-        :class:`Molecule` objects `reactant_structures`. The atoms
+        :class:`Molecule` or :class:`Group` objects `reactant_structures`. The atoms
         of the reactant structures must already be tagged with the appropriate
         labels. Returns a list of structures corresponding to the products
         after checking that the correct number of products was produced.

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -830,7 +830,7 @@ class TestGenerateReactions(unittest.TestCase):
             thermo_libraries=[],
             reaction_libraries=[],
             kinetics_families=['H_Abstraction', 'R_Addition_MultipleBond', 'Singlet_Val6_to_triplet', 'R_Recombination',
-                              'Baeyer-Villiger_step1_cat', 'Surface_Adsorption_Dissociative',
+                              'Baeyer-Villiger_step1_cat', 'Surface_Adsorption_Dissociative', 'Surface_Abstraction_vdW',
                               'Surface_Dissociation_vdW'],
             depository=False,
             solvation=False,
@@ -1029,3 +1029,12 @@ multiplicity 2
         # self.assertEquals(len(reaction_list), 14)
         reaction_list = self.database.kinetics.families['Surface_Dissociation_vdW'].generate_reactions(reactants)
         self.assertEquals(len(reaction_list), 0)
+
+    def test_apply_recipe_multiplicity_check(self):
+        """
+        Test that the multiplicity check is working correctly in the apply_recipe function
+        """
+        family = self.database.kinetics.families['Surface_Abstraction_vdW']
+        reacts = [Molecule(smiles='*[CH2]'),Molecule(smiles='*[CH2]')]
+        reaction_list = family.generate_reactions(reacts)
+        self.assertEqual(len(reaction_list),0)

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -217,15 +217,15 @@ class GroupAtom(Vertex):
 
         The 'radicalElectron' attribute can be an empty list if we use the wildcard
         argument ux in the group definition. In this case, we will have this
-        function set the atom's 'radicalElectron' to a list allowing 1, 2, 3,
-        or 4 radical electrons.
+        function set the atom's 'radicalElectron' to a list allowing from `radical`
+        up to 4 radical electrons.
         """
         radical_electrons = []
         if any([len(atomtype.increment_radical) == 0 for atomtype in self.atomtype]):
             raise ActionError('Unable to update GroupAtom due to GAIN_RADICAL action: '
                               'Unknown atom type produced from set "{0}".'.format(self.atomtype))
         if not self.radical_electrons:
-            radical_electrons = [1, 2, 3, 4]
+            radical_electrons = [1, 2, 3, 4][radical-1:]
         else:
             for electron in self.radical_electrons:
                 radical_electrons.append(electron + radical)
@@ -276,7 +276,7 @@ class GroupAtom(Vertex):
 
         # Add a lone pair to a group atom with none
         if not self.lone_pairs:
-            self.lone_pairs = [1, 2, 3, 4]  # set to a wildcard of any number greater than 0
+            self.lone_pairs = [1, 2, 3, 4][pair-1:]  # set to a wildcard of any number greater than or equal to `pair`
         # Add a lone pair to a group atom that already has at least one lone pair
         else:
             for x in self.lone_pairs:

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/groups.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/groups.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Abstraction_vdW/groups"
+shortDesc = u""
+longDesc = u"""
+A vdW species splitting, adsorbing to the surface, and transferring a functional group to a double, triple, or
+quadruple bonded surface species.
+
+ *2-*3  *4             *2     *4-*3
+  :     ||     ---->    |      |
+~*1~ + ~*5~~          ~*1~ + ~*5~~
+
+The rate, which should be in mol/m2/s,
+will be given by k * (mol/m2) * (mol/m2)
+so k should be in (m2/mol/s).
+
+"""
+
+template(reactants=["AdsorbateVdW","Adsorbate1"], products=["Adsorbate2","Adsorbate3"], ownReverse=False)
+
+reverse = "Surface_Reverse_Abstraction_vdW"  # maybe needs a better name?
+
+reactantNum=2
+productNum=2
+
+recipe(actions=[
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['CHANGE_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*4', -1, '*5'],
+    ['FORM_BOND', '*3', 1, '*4'],
+])
+
+entry(
+    index = 1,
+    label = "AdsorbateVdW",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 R  ux px cx {3,S}
+3 *3 R  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "Adsorbate1",
+    group =
+"""
+1 *5 X   u0 p0 c0 {2,[D,T,Q]}
+2 *4 R!H ux px cx {1,[D,T,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
+    label = "O-R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  ux p2 cx {3,S}
+3 *3 R  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 4,
+    label = "C-R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 C  ux px cx {3,S}
+3 *3 R  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
+    label = "*=O",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 O u0 p2 c0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 6,
+    label = "*C",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,[D,T,Q]}
+2 *4 C ux px cx {1,[D,T,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 7,
+    label = "H-H",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 H  u0 p0 c0 {3,S}
+3 *3 H  u0 p0 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 8,
+    label = "N-R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 N  ux px cx {3,S}
+3 *3 R  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 9,
+    label = "*N",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,[D,T]}
+2 *4 N ux px cx {1,[D,T]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 10,
+    label = "*=C",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 C ux px cx {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 11,
+    label = "*#C",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,T}
+2 *4 C u0 p0 c0 {1,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 12,
+    label = "*$C",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,Q}
+2 *4 C u0 p0 c0 {1,Q}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 13,
+    label = "*#CH",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,T}
+2 *4 C u0 p0 c0 {1,T} {3,S}
+3    H u0 p0 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "*=C=R",
+    group =
+"""
+1 *5 X   u0 p0 c0 {2,D}
+2 *4 C   u0 p0 c0 {1,D} {3,D}
+3    R!H ux px cx {2,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "*=C-2R",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3    R ux px cx {2,S}
+4    R ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "*=N",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 N u0 p1 c0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "*#N",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,T}
+2 *4 N u0 p1 c0 {1,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 18,
+    label = "*=NH",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 N u0 p1 c0 {1,D} {3,S}
+3    H u0 p0 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 19,
+    label = "*=NO",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 N u0 p1 c0 {1,D} {3,S}
+3    O u0 p2 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 20,
+    label = "*=NOH",
+    group =
+"""
+1 *5 X u0 p0 c0 {2,D}
+2 *4 N u0 p1 c0 {1,D} {3,S}
+3    O u0 p2 c0 {2,S} {4,S}
+4    H u0 p0 c0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 21,
+    label = "O-O",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S}
+3 *3 O  u0 p2 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 22,
+    label = "HO-OH",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S} {5,S}
+3 *3 O  u0 p2 c0 {2,S} {4,S}
+4    H  u0 p0 c0 {3,S}
+5    H  u0 p0 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 23,
+    label = "O-N",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S}
+3 *3 N  u0 p1 c0 {2,S} {4,[S,D]}
+4    R  ux px cx {3,[S,D]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 24,
+    label = "O-C",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S}
+3 *3 C  u0 p0 c0 {2,S} {4,[S,D,T]}
+4    R  ux px cx {3,[S,D,T]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 25,
+    label = "O-C-3R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S}
+3 *3 C  u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4    R  ux px cx {3,S}
+5    R  ux px cx {3,S}
+6    R  ux px cx {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 26,
+    label = "O-C=R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv  u0 p0 c0
+2 *2 O   u0 p2 c0 {3,S}
+3 *3 C   u0 p0 c0 {2,S} {4,D} {5,S}
+4    R!H ux px cx {3,D}
+5    R   ux px cx {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 27,
+    label = "O-C#R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv  u0 p0 c0
+2 *2 O   u0 p2 c0 {3,S}
+3 *3 C   u0 p0 c0 {2,S} {4,T}
+4    R!H ux px cx {3,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 28,
+    label = "O-N-2R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S}
+3 *3 N  u0 p1 c0 {2,S} {4,S} {5,S}
+4    R  ux px cx {3,S}
+5    R  ux px cx {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 29,
+    label = "O-NHH",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 O  u0 p2 c0 {3,S}
+3 *3 N  u0 p1 c0 {2,S} {4,S} {5,S}
+4    H  u0 p0 c0 {3,S}
+5    H  u0 p0 c0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 30,
+    label = "O-N=R",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv  u0 p0 c0
+2 *2 O   u0 p2 c0 {3,S}
+3 *3 N   u0 p1 c0 {2,S} {4,D}
+4    R!H ux px cx {3,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 31,
+    label = "C-C",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 C  ux px cx {3,S}
+3 *3 C  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 32,
+    label = "C-O",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 C  ux px cx {3,S}
+3 *3 O  ux p2 cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 33,
+    label = "C-N",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 C  ux px cx {3,S}
+3 *3 N  u0 p1 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 34,
+    label = "C-OH",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 C  ux px cx {3,S}
+3 *3 O  u0 p2 c0 {2,S} {4,S}
+4    H  u0 p0 c0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 35,
+    label = "N-N",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 N  ux px cx {3,S}
+3 *3 N  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 36,
+    label = "N-O",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 N  ux px cx {3,S}
+3 *3 O  u0 p2 c0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 37,
+    label = "N-C",
+    group =
+"""
+multiplicity [1]
+1 *1 Xv u0 p0 c0
+2 *2 N  ux px cx {3,S}
+3 *3 C  ux px cx {2,S}
+""",
+    kinetics = None,
+)
+
+tree(
+"""
+L1: AdsorbateVdW
+    L2: H-H
+    L2: O-R
+        L3: O-O
+            L4: HO-OH
+        L3: O-N
+            L4: O-N-2R
+                L5: O-NHH
+            L4: O-N=R
+        L3: O-C
+            L4: O-C-3R
+            L4: O-C=R
+            L4: O-C#R
+    L2: C-R
+        L3: C-C
+        L3: C-O
+            L4: C-OH
+        L3: C-N
+    L2: N-R
+        L3: N-N
+        L3: N-O
+        L3: N-C
+
+L1: Adsorbate1
+    L2: *=O
+    L2: *C
+        L3: *=C
+            L4: *=C=R
+            L4: *=C-2R
+        L3: *#C
+            L4:*#CH
+        L3: *$C
+    L2: *N
+        L3: *=N
+            L4: *=NH
+            L4: *=NO
+                L5: *=NOH
+        L3: *#N
+"""
+)

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/rules.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/rules.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Abstraction_vdW/rules"
+shortDesc = u""
+longDesc = u"""
+A vdW double bonded species dissociatively adsorbing to the surface with double
+bonds.
+"""
+
+entry(
+    index = 1,
+    label = "AdsorbateVdW;Adsorbate1",
+    kinetics = SurfaceArrheniusBEP(
+        A = (1.0e13, 'm^2/(mol*s)'),
+        n = 0,
+        alpha = 0.5,
+        E0 = (0, 'kcal/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""Default""",
+    longDesc = u"""Made up"""
+)

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/training/dictionary.txt
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/training/dictionary.txt
@@ -1,0 +1,95 @@
+OH_2*
+1 *2 O u0 p2 c0 {2,S} {3,S}
+2    H u0 p0 c0 {1,S}
+3 *1 X u0 p0 c0 {1,S}
+
+OH_4*
+1 *4 O u0 p2 c0 {2,S} {3,S}
+2 *3 H u0 p0 c0 {1,S}
+3 *5 X u0 p0 c0 {1,S}
+
+H2O*
+1 *2 O u0 p2 c0 {2,S} {3,S}
+2 *3 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4 *1 X u0 p0 c0
+
+O*
+1 *4 O u0 p2 c0 {2,D}
+2 *5 X u0 p0 c0 {1,D}
+
+HCO*
+1    O u0 p2 c0 {2,D}
+2 *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 *3 H u0 p0 c0 {2,S}
+4 *5 X u0 p0 c0 {2,S}
+
+CO*
+1    O u0 p2 c0 {2,D}
+2 *4 C u0 p0 c0 {1,D} {3,D}
+3 *5 X u0 p0 c0 {2,D}
+
+HCOO_1*
+1 *2 O u0 p2 c0 {3,S} {5,S}
+2    O u0 p2 c0 {3,D}
+3    C u0 p0 c0 {1,S} {2,D} {4,S}
+4    H u0 p0 c0 {3,S}
+5 *1 X u0 p0 c0 {1,S}
+
+HCOOH*
+1 *2 O u0 p2 c0 {3,S} {5,S}
+2    O u0 p2 c0 {3,D}
+3    C u0 p0 c0 {1,S} {2,D} {4,S}
+4    H u0 p0 c0 {3,S}
+5 *3 H u0 p0 c0 {1,S}
+6 *1 X u0 p0 c0
+
+CH3O*
+1 *2 O u0 p2 c0 {2,S} {6,S}
+2    C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3    H u0 p0 c0 {2,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6 *1 X u0 p0 c0 {1,S}
+
+CH3OH*
+1 *2 O u0 p2 c0 {2,S} {6,S}
+2    C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3    H u0 p0 c0 {2,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6 *3 H u0 p0 c0 {1,S}
+7 *1 X u0 p0 c0
+
+HCOOCH3*
+1    O u0 p2 c0 {2,D}
+2 *3 C u0 p0 c0 {1,D} {3,S} {5,S}
+3 *2 O u0 p2 c0 {2,S} {4,S}
+4    C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9 *1 X u0 p0 c0
+
+HCOO_5*
+1 *4 O u0 p2 c0 {3,S} {5,S}
+2    O u0 p2 c0 {3,D}
+3 *3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4    H u0 p0 c0 {3,S}
+5 *5 X u0 p0 c0 {1,S}
+
+CH4*
+1 *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 *3 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6 *1 X u0 p0 c0
+
+CH3*
+1 *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5 *1 X u0 p0 c0 {1,S}

--- a/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/training/reactions.py
+++ b/rmgpy/test_data/testing_database/kinetics/families/Surface_Abstraction_vdW/training/reactions.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Abstraction_vdW/training"
+shortDesc = u"Reaction kinetics used to generate rate rules"
+longDesc = u"""
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
+"""
+
+# reverse of 16, below
+# entry(
+#     index = 34,
+#     label = "H2O* + O* <=> OH_2* + OH_4*",
+#     degeneracy = 2,
+#     kinetics = SurfaceArrhenius(
+#         A = (8.14E20, 'm^2/(mol*s)'),
+#         n = -0.274,
+#         Ea = (218400, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     rank = 10,
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R34
+#     test surface mechanism: based upon Olaf Deutschmann's work:
+#     "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+#     Delgado et al
+#     Catalysts, 2015, 5, 871-904""",
+# 	  metal = "Ni",
+# )
+
+# reverse of 34, above
+entry(
+    index = 16,
+    label = "OH_2* + OH_4* <=> H2O* + O*",
+    degeneracy = 2,
+    kinetics = SurfaceArrhenius(
+        A = (5.691e16, 'm^2/(mol*s)'),
+        n = 0.,
+        Ea = (14.0669343, 'kcal/mol'),
+        Tmin = (298, 'K'),
+        Tmax = (2000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""
+Reaction 16 from table 2 in "Mechanism of Methanol Synthesis on Cu through CO2
+and CO Hydrogenation", Grabow and Mavrikakis.  doi:10.1021/cs200055d
+
+A factor from paper / surface site density of Cu
+1.675e12 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 5.691e16 m^2/(mol*s)
+""",
+    metal = "Cu",
+)
+
+entry(
+    index = 21,
+    label = "CH4* + O* <=> CH3* + OH_4*",
+    degeneracy = 4,
+    kinetics = SurfaceArrhenius(
+        A = (5.62E20, 'm^2/(mol*s)'),
+        n = -0.101,
+        Ea = (92700, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""R21
+    test surface mechanism: based upon Olaf Deutschmann's work:
+    "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+    Delgado et al
+    Catalysts, 2015, 5, 871-904""",
+	metal = "Ni",
+)
+
+entry(
+    index = 40,
+    label = "OH_2* + HCO* <=> H2O* + CO*",
+    degeneracy = 1,
+    kinetics = SurfaceArrhenius(
+        A = (3.261e17, 'm^2/(mol*s)'),
+        n = 0.,
+        Ea = (6.9181644, 'kcal/mol'),
+        Tmin = (298, 'K'),
+        Tmax = (2000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""
+Reaction 40 from table 2 in "Mechanism of Methanol Synthesis on Cu through CO2
+and CO Hydrogenation", Grabow and Mavrikakis.  doi:10.1021/cs200055d
+
+A factor from paper / surface site density of Cu
+9.597e12 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 3.261e17 m^2/(mol*s)
+""",
+    metal = "Cu",
+)
+
+entry(
+    index = 41,
+    label = "HCOO_1* + HCO* <=> HCOOH* + CO*",
+    degeneracy = 1,
+    kinetics = SurfaceArrhenius(
+        A = (7.475e18, 'm^2/(mol*s)'),
+        n = 0.,
+        Ea = (13.8363288, 'kcal/mol'),
+        Tmin = (298, 'K'),
+        Tmax = (2000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""
+Reaction 41 from table 2 in "Mechanism of Methanol Synthesis on Cu through CO2
+and CO Hydrogenation", Grabow and Mavrikakis.  doi:10.1021/cs200055d
+
+A factor from paper / surface site density of Cu
+2.2e14 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 7.475e18 m^2/(mol*s)
+""",
+    metal = "Cu",
+)
+
+entry(
+    index = 45,
+    label = "CH3O* + HCO* <=> CH3OH* + CO*",
+    degeneracy = 1,
+    kinetics = SurfaceArrhenius(
+        A = (6.572e16, 'm^2/(mol*s)'),
+        n = 0.,
+        Ea = (8.76300824, 'kcal/mol'),
+        Tmin = (298, 'K'),
+        Tmax = (2000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""
+Reaction 45 from table 2 in "Mechanism of Methanol Synthesis on Cu through CO2
+and CO Hydrogenation", Grabow and Mavrikakis.  doi:10.1021/cs200055d
+
+A factor from paper / surface site density of Cu
+1.934e12 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 6.572e16 m^2/(mol*s)
+""",
+    metal = "Cu",
+)
+
+entry(
+    index = 46,
+    label = "CH3O* + HCOO_5* <=> HCOOCH3* + O*",
+    degeneracy = 1,
+    kinetics = SurfaceArrhenius(
+        A = (2.356e16, 'm^2/(mol*s)'),
+        n = 0.,
+        Ea = (28.5950795, 'kcal/mol'),
+        Tmin = (298, 'K'),
+        Tmax = (2000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""
+Reaction 46 from table 2 in "Mechanism of Methanol Synthesis on Cu through CO2
+and CO Hydrogenation", Grabow and Mavrikakis.  doi:10.1021/cs200055d
+
+A factor from paper / surface site density of Cu
+6.934e11 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 2.356e16 m^2/(mol*s)
+""",
+    metal = "Cu",
+)


### PR DESCRIPTION
This PR attempt to fix this issue https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2122

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
If we are applying a family in reverse and the template reactants restrict multiplicity, we need to make sure that
a reverse product matches the multiplicity-constrained template reactant because the forward template products
do not enforce the multiplicity restriction.  Without this check, we get an `UndeterminableKineticsError` if the reverse products have a multiplicity that does not match the multiplicity constraint of the template reactants.

### Description of Changes
Added a multiplicity check when applying the template in reverse.

### Testing
Need to add unit test.  Tested a few reactions which had `UndeterminableKineticsError` but now are no longer generated since they don't satisfy the multiplicity constraints in the template.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
