### PR TITLE
Cat fixes - vdw radicals, bidentates, resonance

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1714,6 +1714,13 @@ class KineticsFamily(Database):
         if self.forbidden is not None and self.forbidden.is_molecule_forbidden(molecule):
             return True
 
+        # forbid vdw multi-dentate molecules for surface families
+        if "surface" in self.label.lower():
+            if molecule.get_num_atoms('X') > 1:
+                for atom in molecule.atoms:
+                    if atom.atomtype.label == 'Xv':
+                        return True
+
         return False
 
     def _create_reaction(self, reactants, products, is_forward):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1527,6 +1527,14 @@ class KineticsFamily(Database):
                 atom_labels['*3'].label = '*1'
                 atom_labels['*5'].label = '*2'
 
+            elif label == 'surface_abstraction_single_vdw':
+                # *3 migrates from *2-*1 to *4-*5
+                # so swap *1 with *5, swap *2 with *4
+                atom_labels['*1'].label = '*5'
+                atom_labels['*5'].label = '*1'
+                atom_labels['*2'].label = '*4'
+                atom_labels['*4'].label = '*2'
+
         if not forward:
             template = self.reverse_template
             product_num = self.reactant_num or len(template.products)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1616,12 +1616,16 @@ class KineticsFamily(Database):
                 lowest_labels.append(min(labels))
             product_structures = [s for _, s in sorted(zip(lowest_labels, product_structures))]
 
-        # If applying the family in reverse and the template reactants restrict multiplicity,
-        # we need to make sure that a reverse product matches the multiplicity-constrained
-        # template reactant because the forward template products do not enforce the
-        # multiplicity restriction.
-        if not forward and isinstance(reactant_structure, Molecule):
-            for template in self.forward_template.reactants:
+        # If the template restricts multiplicity, we need to make sure that
+        # a product matches the multiplicity-constrained template
+        # because the template does not ensure that the
+        # multiplicity restriction is obeyed
+        if isinstance(reactant_structure, Molecule):
+            if forward:
+                template_groups = self.forward_template.products
+            else:
+                template_groups = self.forward_template.reactants
+            for template in template_groups:
                 # iterate through the template reactants and check to see if they have a multiplicity constraint
                 if isinstance(template.item, Group):
                     if template.item.multiplicity != []:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1521,6 +1521,12 @@ class KineticsFamily(Database):
                 atom_labels['*2'].label = '*3'
                 atom_labels['*3'].label = '*2'
 
+            elif label == 'surface_abstraction':
+                atom_labels['*1'].label = '*3'
+                atom_labels['*2'].label = '*5'
+                atom_labels['*3'].label = '*1'
+                atom_labels['*5'].label = '*2'
+
         if not forward:
             template = self.reverse_template
             product_num = self.reactant_num or len(template.products)

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -867,6 +867,19 @@ class TestGenerateReactions(unittest.TestCase):
                       'used as a reactant in the reverse direction.'),
         ])
 
+    def test_molecule_forbidden(self):
+
+        forbidden_mol = Molecule(smiles='*CC.[*]') # vdw bidentate
+
+        mol1 = Molecule(smiles='*CC*') # bidentate
+        mol2 = Molecule(smiles='C.*') # vdw
+        mol3 = Molecule(smiles='CC*') # chemisorbed
+
+        fam = self.database.kinetics.families['Surface_Dissociation_vdW']
+        self.assertTrue(fam.is_molecule_forbidden(forbidden_mol))
+        for allowed_mol in (mol1, mol2, mol3):
+            self.assertFalse(fam.is_molecule_forbidden(allowed_mol))
+
     def test_add_atom_labels_for_reaction(self):
         """Test that we can add atom labels to an existing reaction"""
         reactants = [Species().from_smiles('C=C'), Species().from_smiles('[OH]')]

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -306,22 +306,22 @@ def _generate_resonance_structures(mol_list, method_list, keep_isomorphic=False,
     for mol in mol_list[1:]:
         if mol.get_net_charge() != input_charge:
             mol_list.remove(mol)
-            logging.warning('Resonance generation created a molecule {0} with a net charge of {1}\n'
+            logging.debug('Resonance generation created a molecule {0} with a net charge of {1}\n'
                             'which does not match the input mol charge of {2}'
                             'Removing {0} from resonance structures'.format(mol.smiles,mol.get_net_charge(),input_charge))
         if mol.contains_surface_site():
             for x in [atom for atom in mol.atoms if atom.is_surface_site()]:
                 if x.radical_electrons != 0:
                     mol_list.remove(mol)
-                    logging.warning('Resonance generation created a molecule {0} with {1} radicals on {2}\n'
+                    logging.debug('Resonance generation created a molecule {0} with {1} radicals on {2}\n'
                     'Removing {0} from resonance structures'.format(mol.smiles,x.radical_electrons,x.symbol))
                 elif x.lone_pairs != 0:
                     mol_list.remove(mol)
-                    logging.warning('Resonance generation created a molecule {0} with {1} lone pairs on {2}\n'
+                    logging.debug('Resonance generation created a molecule {0} with {1} lone pairs on {2}\n'
                     'Removing {0} from resonance structures'.format(mol.smiles,x.lone_pairs,x.symbol))
                 elif x.charge != 0:
                     mol_list.remove(mol)
-                    logging.warning('Resonance generation created a molecule {0} with a charge of {1} on {2}\n'
+                    logging.debug('Resonance generation created a molecule {0} with a charge of {1} on {2}\n'
                     'Removing {0} from resonance structures'.format(mol.smiles,x.charge,x.symbol))
 
     return mol_list

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -306,23 +306,23 @@ def _generate_resonance_structures(mol_list, method_list, keep_isomorphic=False,
     for mol in mol_list[1:]:
         if mol.get_net_charge() != input_charge:
             mol_list.remove(mol)
-            logging.debug('Resonance generation created a molecule {0} with a net charge of {1}\n'
-                            'which does not match the input mol charge of {2}'
-                            'Removing {0} from resonance structures'.format(mol.smiles,mol.get_net_charge(),input_charge))
+            logging.debug('Resonance generation created a molecule %s with a net charge of %d '
+                            'which does not match the input mol charge of %d.\n'
+                            'Removing it from resonance structures',mol.smiles,mol.get_net_charge(),input_charge)
         if mol.contains_surface_site():
             for x in [atom for atom in mol.atoms if atom.is_surface_site()]:
                 if x.radical_electrons != 0:
                     mol_list.remove(mol)
-                    logging.debug('Resonance generation created a molecule {0} with {1} radicals on {2}\n'
-                    'Removing {0} from resonance structures'.format(mol.smiles,x.radical_electrons,x.symbol))
+                    logging.debug('Resonance generation created a molecule %s with %d radicals on %s.\n'
+                    'Removing it from resonance structures',mol.smiles,x.radical_electrons,x.symbol)
                 elif x.lone_pairs != 0:
                     mol_list.remove(mol)
-                    logging.debug('Resonance generation created a molecule {0} with {1} lone pairs on {2}\n'
-                    'Removing {0} from resonance structures'.format(mol.smiles,x.lone_pairs,x.symbol))
+                    logging.debug('Resonance generation created a molecule %s with %d lone pairs on %s.\n'
+                    'Removing it from resonance structures',mol.smiles,x.lone_pairs,x.symbol)
                 elif x.charge != 0:
                     mol_list.remove(mol)
-                    logging.debug('Resonance generation created a molecule {0} with a charge of {1} on {2}\n'
-                    'Removing {0} from resonance structures'.format(mol.smiles,x.charge,x.symbol))
+                    logging.debug('Resonance generation created a molecule %s with a charge of %d on %s.\n'
+                    'Removing it from resonance structures',mol.smiles,x.charge,x.symbol)
 
     return mol_list
 

--- a/rmgpy/molecule/resonanceTest.py
+++ b/rmgpy/molecule/resonanceTest.py
@@ -1419,6 +1419,13 @@ class ClarTest(unittest.TestCase):
 2 O u0 p2 c0 {1,D}"""))
         self.assertEquals(len(mol_list), 1)
 
+    def test_surface_radical(self):
+        """Test resonance structure generation for radical on surface
+
+        Should not put radical on X atom"""
+        mol_list = generate_resonance_structures(Molecule(smiles='*=C[CH]C'))
+        self.assertEquals(len(mol_list), 1)
+
     def test_sulfur_triple_bond(self):
         """
         Test the prevention of S#S formation through the find_lone_pair_multiplebond_paths and 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem and Description of Changes


1) vdw radicals - We previously implemented a multiplicity check to ensure products in the reverse direction match the multiplicity of the template reactants . However, we are getting vdw products that do not obey multiplicity restriction in the forward direction (https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2122) , so we also need to check this direction as well. 

2) radicals on X - if resonance generation puts radicals/lone pairs/or a formal charge on `X`, RMG crashes.  I added a commit on this PR to filter out these structures

3) bidentate vdw - We were getting bidentate vdw structures. This PR makes them forbidden for surface families

### Testing
added unit test for forbidden vdw bidentates and successfully built an ammonia cat oxidation model that was previously crashing.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
