### PR TITLE
added method to write rate const to HTML for sticking rxns

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1437,6 +1437,35 @@ class Reaction:
         """
         raise NotImplementedError("generate_high_p_limit_kinetics is not implemented for all Reaction subclasses.")
 
+    def reaction_to_html(self, surface_site_density=None):   
+        """
+        Return an HTML rendering.
+        """
+        if isinstance(self.kinetics, StickingCoefficient):
+
+            Tdata = [500, 1000, 1500, 2000]
+            if surface_site_density is None: 
+                site_density = 0 # 2.483e-09 # use platinum value
+            else: 
+                site_density = surface_site_density
+
+            string = '<table class="KineticsData">\n<tr class="KineticsData_Tdata"><th>T/[K]</th>\n'
+            try:
+                for T in Tdata:
+                    string += '<td>{0:.0f}</td>'.format(T)
+
+                string += '\n</tr><tr class="KineticsData_kdata"><th>log<sub>10</sub>(k/[mole,m,s])\n    '
+
+                for T in Tdata:
+                    string += '<td>{0:+.1f}</td>'.format(np.log10(self.get_rate_coefficient(T=T, surface_site_density=site_density)))
+            except:
+                string += '<td>An error occurred in processing kinetics</td>'
+            string += '\n</tr></table>'
+            string += "<span class='KineticsData_repr'>{0!r}</span>".format(self.kinetics)
+
+        else:
+            string = self.kinetics.to_html()
+        return string
 
 def same_species_lists(list1, list2, check_identical=False, only_check_label=False, generate_initial_map=False,
                        strict=True, save_order=False):

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -68,8 +68,7 @@ def save_output_html(path, reaction_model, part_core_edge='core'):
     dirname = os.path.dirname(path)
 
     # Prepare parameters to pass to jinja template
-    title = 'RMG Output'
-
+    title = 'RMG Output' 
     if part_core_edge == 'core':
         species = reaction_model.core.species[:] + reaction_model.output_species_list
     elif part_core_edge == 'edge':
@@ -126,6 +125,12 @@ def save_output_html(path, reaction_model, part_core_edge='core'):
     families = list(family_count.keys())
     families.sort()
 
+    # site density (will be none if not a surface reaction)
+    if reaction_model.surface_site_density:
+        surface_site_density = reaction_model.surface_site_density.value_si
+    else: 
+        surface_site_density = None
+    
     ## jinja2 filters etc.
     to_remove_from_css_names = re.compile(r'[/.\-+,]')
 
@@ -484,7 +489,7 @@ $(document).ready(function() {
 </tr>
 <tr class="kinetics {{ rxn.get_source()|csssafe }} hide_kinetics">
     <td></td>
-    <td colspan="4">{{ rxn.kinetics.to_html() }}</td>
+    <td colspan="4">{{ rxn.reaction_to_html(surface_site_density) }}</td>
 </tr>
 <tr class="energy {{ rxn.get_source()|csssafe }} hide_energy">
     <td></td>
@@ -510,7 +515,7 @@ $(document).ready(function() {
     f = open(path, 'w')
     f.write(template.render(title=title, species=species, reactions=reactions, families=families,
                             family_count=family_count, get_species_identifier=get_species_identifier,
-                            textwrap=textwrap))
+                            surface_site_density=surface_site_density, textwrap=textwrap))
     f.close()
 
 
@@ -1245,7 +1250,7 @@ $(document).ready(function() {
     </tr>
     <tr class="kinetics {{ rxn.get_source()|csssafe }}">
         <td></td>
-        <td colspan="4">{{ rxn.kinetics.to_html() }}</td>
+        <td colspan="4">{{ rxn.reaction_to_html(surface_site_density) }}</td>
     </tr>
     <tr class="energy {{ rxn.get_source()|csssafe }} hide_energy">
     <td></td>
@@ -1279,7 +1284,7 @@ $(document).ready(function() {
     </tr>
     <tr class="kinetics {{ rxn.get_source()|csssafe }}">
         <td></td>
-        <td colspan="4">{{ rxn.kinetics.to_html() }}</td>
+        <td colspan="4">{{ rxn.reaction_to_html(surface_site_density) }}</td>
     </tr>
     <tr class="energy {{ rxn.get_source()|csssafe }} hide_energy">
     <td></td>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
When viewing an HTML output file for an RMG job, sticking coefficient type reactions will display the following: 

![image](https://user-images.githubusercontent.com/56306881/119583959-b2a70880-bd95-11eb-8955-02f50f3646a5.png)

with the message "an error occurred in processing kinetics" where the rate constants at 500, 1000, 1500, and 2000 should be. 
### Description of Changes
The reaction_to_html method was added to the rmgpy.reaction.Reaction object. This is similar to the get_rate_coefficient in the Reaction object; they both take an argument for "surface_site_density", and have special handling for the sticking coefficient reaction type. 

additional updates in the rmgpy.rmg.output save_output_html() method were required, to extract the surface site density property from a running model. 

### Testing
there is currently already unittesting for writing HTML output files, but only for the eg6 example. to perform the same test for a surface mechanism, we need to be able to use the load_chemkin_file() method for surface chemkin files, which is currently not working properly and will require another PR to fix. 

### Reviewer Tips
This appears to be an ok workaround, but if you have more robust fixes please comment. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
