### PR TITLE
Have WSL users install graphviz system wide

### DIFF
--- a/documentation/source/users/rmg/installation/linuxSubsystem.rst
+++ b/documentation/source/users/rmg/installation/linuxSubsystem.rst
@@ -45,7 +45,12 @@ Installing the Linux Subsystem
     sudo apt install gcc
     sudo apt install g++
     sudo apt install make
-    sudo apt-get install libxrender1
+    sudo apt-get install graphviz 
+
+   Note: installing graphviz as a system package makes sure that rendering libraries that are not included
+   in the WSL version of Ubuntu are installed. Unfortunately, the graphviz conda package does not install
+   these dependencies in the RMG conda environment (later in the installation), instead relying on system
+   libraries even in native Linux installations.
 
 5. Follow the instructions for either the binary (:ref:`anacondaUser`) or source installation (:ref:`anacondaDeveloper`)
    for the Linux Operating system. Follow these instructions from the point directly after installing Anaconda.


### PR DESCRIPTION
### Motivation or Problem
fixes #2141 . The graphviz dependency requires many render libraries to work properly. Unfortunately, these dependencies are not listed by this package, so conda does not
install them in the conda environment. Instead, the system wide libraries are used if
available. On most native Linux distro like Ubuntu, these libraries are installed by default.
However, these libraries are not installed by default in WSL versions of Ubuntu. This
means that WSL users are missing dependencies that they need to run many RMG
related scripts and features.

### Description of Changes
Updated WSL installation documentation to prompt user to install the graphviz package system wide. This is preferred over figuring out which dependencies graphviz needs that
are not currently installed by default, as these could change over time. In an ideal world
conda would deal with this for us, but the graphviz conda package does not do this, though
there appears to be some future work towards this end (see the discussion in #2141).

### Testing
I have confirmed that this solution works in a fresh WSL install, and this also fixed the
user's problem in #2141. I have also built the documentation locally to ensure the changes
look as desired.

### Reviewer Note
libxrender1 is a dependency of graphviz, and thus installed
together.
