### PR TITLE
Training reactions constraints

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -827,6 +827,26 @@ def generated_species_constraints(**kwargs):
 
         rmg.species_constraints[key] = value
 
+def training_reactions_constraints(**kwargs):
+    valid_constraints = [
+        'metal',
+        'facet',
+        'elements',
+        'forward_only'
+    ]
+
+    for key, value in kwargs.items():
+        if key not in valid_constraints:
+            raise InputError('Invalid generated species constraint {0!r}.'.format(key))
+        if key == 'forward_only':
+            if not isinstance(value, bool):
+                raise InputError('Invalid value for `forward_only` constraint {0!r}. Value must be a bool (True or False)'.format(value))
+            rmg.training_reactions_constraints[key] = value
+            continue
+        if not isinstance(value, list):
+            value = [value]
+        rmg.training_reactions_constraints[key] = [str(v) for v in value]
+
 
 def thermo_central_database(host,
                             port,
@@ -968,6 +988,7 @@ def read_input_file(path, rmg0):
         'pressureDependence': pressure_dependence,
         'options': options,
         'generatedSpeciesConstraints': generated_species_constraints,
+        'trainingReactionsConstraints': training_reactions_constraints,
         'thermoCentralDatabase': thermo_central_database,
         'uncertainty': uncertainty,
         'restartFromSeed': restart_from_seed,
@@ -1213,6 +1234,14 @@ def save_input_file(path, rmg):
     if rmg.species_constraints:
         f.write('generatedSpeciesConstraints(\n')
         for constraint, value in sorted(list(rmg.species_constraints.items()), key=lambda constraint: constraint[0]):
+            if value is not None:
+                f.write('    {0} = {1},\n'.format(constraint, value))
+        f.write(')\n\n')
+
+    # Training Reactions Constraints
+    if rmg.training_reactions_constraints:
+        f.write('trainingReactionsConstraints(\n')
+        for constraint, value in sorted(list(rmg.training_reactions_constraints.items()), key=lambda constraint: constraint[0]):
             if value is not None:
                 f.write('    {0} = {1},\n'.format(constraint, value))
         f.write(')\n\n')

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -417,7 +417,7 @@ class RMG(util.Subject):
                 self.species_constraints = {}
                 for family in self.database.kinetics.families.values():
                     if not family.auto_generated:
-                        family.add_rules_from_training(thermo_database=self.database.thermo)
+                        family.add_rules_from_training(thermo_database=self.database.thermo, constraints=self.training_reactions_constraints)
 
                     # If requested by the user, write a text file for each kinetics family detailing the source of each entry
                     if self.kinetics_datastore:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -221,6 +221,7 @@ class RMG(util.Subject):
         self.ml_estimator = None
         self.ml_settings = None
         self.species_constraints = {}
+        self.training_reactions_constraints = {}
         self.walltime = '00:00:00:00'
         self.save_seed_modulus = -1
         self.max_iterations = None


### PR DESCRIPTION
This PR added a `constraints` param to the `add_rules_from_training` method so that the user can use certain criteria to pick and choose which training reactions to include (and exclude) when creating rate rules for non-auto gen families when the rules are compiled at the start of an RMG job.  The constraints are:
-   `metal` : list of allowed metals (e.g ['Pt'])
-   `facet` : list of allowed facets (e.g ['111'])
-  `elements` : list of allowed elements (e.g ['C','H','O'])
-  `forward_only` : True/False, if True, only reactions in the forward direction are allowed 

Using these constraints will allow us to customize the kinetics trees for individual RMG jobs.  For example, we know that the facet can have a profound affect on activation barriers (https://www.nature.com/articles/s41467-019-12858-3 shows example with CO2), and using a `facet` constraint will enable use to constrain which facets we want to include when creating rate rules.

Although we don't have many surface training reactions in the database right now, adding constraints will be more useful as we continue to add more training data (as we are doing in the PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/479)

### Testing
I have not added any unit tests yet, but I built a few surface ammonium oxidation models with and without training reactions constraints.



<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
