### PR TITLE
SurfaceArrhenius <=> StickingCoefficient

### DIFF
--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -561,12 +561,19 @@ class KineticsRules(Database):
         Hence we average n, Ea, and alpha arithmetically, but we
         average log A (geometric average) 
         """
+
+        kinetics_type = None
         logA = 0.0
         n = 0.0
         E0 = 0.0
         alpha = 0.0
         count = len(kinetics_list)
         for kinetics in kinetics_list:
+            if kinetics_type is None:
+                kinetics_type = type(kinetics)
+            else:
+                if type(kinetics) != kinetics_type:
+                    raise KineticsError(f"Unable to average kinetics with mixed kinetics types ({kinetics_type} != {type(kinetics)})")
             logA += math.log10(kinetics.A.value_si)
             n += kinetics.n.value_si
             alpha += kinetics.alpha.value_si

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -99,6 +99,8 @@ cdef class Reaction:
 
     cpdef double get_surface_rate_coefficient(self, double T, double surface_site_density) except -2
 
+    cpdef surface_arrhenius_to_sticking_coeff(self, double surface_site_density, Tmin=?, Tmax=?)
+
     cpdef fix_barrier_height(self, bint force_positive=?)
 
     cpdef reverse_arrhenius_rate(self, Arrhenius k_forward, str reverse_units, Tmin=?, Tmax=?)

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -101,6 +101,8 @@ cdef class Reaction:
 
     cpdef surface_arrhenius_to_sticking_coeff(self, double surface_site_density, Tmin=?, Tmax=?)
 
+    cpdef sticking_coeff_to_surface_arrhenius(self, double surface_site_density, Tmin=?, Tmax=?)
+
     cpdef fix_barrier_height(self, bint force_positive=?)
 
     cpdef reverse_arrhenius_rate(self, Arrhenius k_forward, str reverse_units, Tmin=?, Tmax=?)


### PR DESCRIPTION
### Motivation or Problem
Some surface reaction families have training data with mixed kinetics types (SurfaceArrhenius and StickingCoeff).  We need methods to convert SurfaceArrhenius to StickingCoeff and vice versa so that we can convert the training data to the same kinetics type so that we can average them.

### Description of Changes
- created methods to convert StickingCoeff to SurfaceArrhneius and SurfaceArrhenius to StickingCoeff
- added a check to make sure that the kinetics types are all the same when averaging kinetics 


### Testing
- Built a model with the DB branch for this PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/479, where we have mixed kinetics types in training
- tested the Surf Arrh <--> StickingCoeff method in Jupyter notebook, but have not added unit tests yet



<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
