### PR TITLE
bond dissociation energies for surface bonds

### DIFF
--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -168,6 +168,8 @@ cdef class Molecule(Graph):
 
     cpdef remove_van_der_waals_bonds(self)
 
+    cpdef add_van_der_waals_bond(self)
+
     cpdef sort_atoms(self)
     
     cpdef str get_formula(self)

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -118,6 +118,8 @@ cdef class Bond(Edge):
 
     cpdef bint is_van_der_waals(self) except -2
 
+    cpdef bint is_surface_bond(self) except -2
+
     cpdef bint is_single(self) except -2
 
     cpdef bint is_double(self) except -2

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -672,7 +672,29 @@ class Bond(Edge):
                 binding_energy = metal_binding_energies[adatom]
                 max_bond_order = {'C': 4., 'O': 2., 'N': 3., 'H': 1.}
                 normalized_bond_order = self.order / max_bond_order[adatom]
-                binding_energy = quantity.Energy(binding_energy).value_si * normalized_bond_order
+                # intercepts estimated from DOI:10.1103/PhysRevLett.99.016105
+                intercepts = {
+                    'C' : {
+                        1 : 0,
+                        2 : -1.3,
+                        3 : -1.1,
+                        4 : 0,
+                    },
+                    'N' : {
+                        1 : -0.5,
+                        2 : -0.75,
+                        3 : 0
+                    },
+                    'O' : {
+                        1 : -0.5,
+                        2 : 0
+                    },
+                    'H' : {
+                        1 : 0
+                    }
+                }
+                intercept = intercepts[adatom][self.order]
+                binding_energy = quantity.Energy(binding_energy).value_si * normalized_bond_order + intercept
                 return -1 * binding_energy
 
     def equivalent(self, other):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -45,13 +45,14 @@ from urllib.parse import quote
 import cython
 import numpy as np
 
+import rmgpy.quantity as quantity
 import rmgpy.constants as constants
 import rmgpy.molecule.converter as converter
 import rmgpy.molecule.element as elements
 import rmgpy.molecule.group as gr
 import rmgpy.molecule.resonance as resonance
 import rmgpy.molecule.translator as translator
-from rmgpy.exceptions import DependencyError
+from rmgpy.exceptions import DependencyError, DatabaseError
 from rmgpy.molecule.adjlist import Saturator
 from rmgpy.molecule.atomtype import AtomType, ATOMTYPES, get_atomtype, AtomTypeError
 from rmgpy.molecule.element import bdes
@@ -627,16 +628,52 @@ class Bond(Edge):
                 self.atom1.number if self.atom1 is not None else 0,
                 self.atom2.number if self.atom2 is not None else 0)
 
-    def get_bde(self):
+    def get_bde(self, metal='Pt111'):
         """
         estimate the bond dissociation energy in J/mol of the bond based on the order of the bond
         and the atoms involved in the bond
+
+        If the bond involves a surface site, the atomic binding energies from the `metal` (str) 
+        will be use to estimate the bond dissociation energy.
         """
         try:
             return bdes[(self.atom1.element.symbol, self.atom2.element.symbol, self.order)]
         except KeyError:
-            raise KeyError('Bond Dissociation energy not known for combination: '
-                           '({0},{1},{2})'.format(self.atom1.element.symbol, self.atom2.element.symbol, self.order))
+            if not self.is_surface_bond():
+                raise KeyError('Bond Dissociation energy not known for combination: '
+                               '({0},{1},{2})'.format(self.atom1.element.symbol, self.atom2.element.symbol, self.order))
+            else:
+                if self.atom1.is_surface_site():
+                    adatom = self.atom2.element.symbol
+                else:
+                    adatom = self.atom1.element.symbol
+                if self.is_van_der_waals():
+                    if adatom == 'O':
+                        binding_energy = quantity.Energy(-0.189,'eV/molecule') # binding energy for H2O_ads in surfaceThermoPt111
+                    elif adatom == 'N':
+                        binding_energy = quantity.Energy(-0.673,'eV/molecule') # binding energy for NH3_ads in surfaceThermoPt111
+                    elif adatom == 'C':
+                        binding_energy = quantity.Energy(-0.122,'eV/molecule') # binding energy for CH4_ads in surfaceThermoPt111
+                    elif adatom == 'H':
+                        binding_energy = quantity.Energy(-0.054,'eV/molecule') # binding energy for H2_ads in surfaceThermoPt111
+                    else:
+                        binding_energy = quantity.Energy(-0.2,'eV/molecule') # default vdw binding energy
+                    return -1 * binding_energy.value_si
+                try:
+                    from rmgpy.data.rmg import get_db
+                    tdb = get_db('thermo')
+                    metal_db = tdb.surface['metal']
+                except (DatabaseError, KeyError):
+                    from rmgpy.data.surface import MetalDatabase
+                    from rmgpy import settings
+                    metal_db = MetalDatabase()
+                    metal_db.load(os.path.join(settings['database.directory'], 'surface'))
+                metal_binding_energies = metal_db.find_binding_energies(metal=metal)
+                binding_energy = metal_binding_energies[adatom]
+                max_bond_order = {'C': 4., 'O': 2., 'N': 3., 'H': 1.}
+                normalized_bond_order = self.order / max_bond_order[adatom]
+                binding_energy = quantity.Energy(binding_energy).value_si * normalized_bond_order
+                return -1 * binding_energy
 
     def equivalent(self, other):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1118,6 +1118,19 @@ class Molecule(Graph):
             if bond.is_van_der_waals():
                 self.remove_bond(bond)
 
+    def add_van_der_waals_bond(self):
+        """
+        Adds a single van der Waals bond to the graph to connect a surface site to the physisorbed absorbate.
+        """
+        cython.declare(bond=Bond,fragment=Molecule,fragments=list)
+
+        if self.contains_surface_site():
+            fragments = self.split()
+            if len(fragments) == 2:
+                if any([fragment.is_surface_site() for fragment in fragments]):
+                    bond = Bond(fragments[0].atoms[0],fragments[1].atoms[0],0.0)
+                    self.add_bond(bond)
+
     def sort_atoms(self):
         """
         Sort the atoms in the graph. This can make certain operations, e.g.

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1168,14 +1168,40 @@ class Molecule(Graph):
     def add_van_der_waals_bond(self):
         """
         Adds a single van der Waals bond to the graph to connect a surface site to the physisorbed absorbate.
+        If the adsorbate has lone pairs, the vdw bond will be added to an atom with lone pairs.
+        Atoms will be selected in the folowing order:
+            1) Nitrogen with lone pairs
+            2) Oxygen with lone pairs
+            3) atoms without lone pairs (C and H)
         """
-        cython.declare(bond=Bond,fragment=Molecule,fragments=list)
+        cython.declare(bond=Bond, fragment=Molecule, adsorbate=Molecule,
+            surface_site=Molecule,fragments=list, has_surface_site=cython.bint, atom=Atom, lone_pair_atoms=list)
 
         if self.contains_surface_site():
             fragments = self.split()
             if len(fragments) == 2:
-                if any([fragment.is_surface_site() for fragment in fragments]):
-                    bond = Bond(fragments[0].atoms[0],fragments[1].atoms[0],0.0)
+                has_surface_site = False
+                for fragment in fragments:
+                    if fragment.is_surface_site():
+                        has_surface_site = True
+                        surface_site = fragment
+                    else:
+                        adsorbate = fragment
+                if has_surface_site:
+                    lone_pair_atoms = [atom for atom in adsorbate.atoms if atom.lone_pairs > 0]
+                    if len(lone_pair_atoms) == 1:
+                        # only one atom with a lone pair, so pick this one
+                        atom = lone_pair_atoms[0]
+                    elif len(lone_pair_atoms) > 1:
+                        # more than one atom with lone pair
+                        # sort by element symbol and pick the first (pick nitrogen before oxygen)
+                        lone_pair_atoms.sort(key = lambda atom: atom.symbol)
+                        atom = lone_pair_atoms[0]
+                    else:
+                        # no lone pairs, so pick the first atom
+                        atom = adsorbate.atoms[0]
+                    # create and add the vdw bond
+                    bond = Bond(atom, surface_site.atoms[0],0.0)
                     self.add_bond(bond)
 
     def sort_atoms(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -741,6 +741,16 @@ class Bond(Edge):
         """
         return self.is_order(0)
 
+    def is_surface_bond(self):
+        """
+        Return ``True`` if the bond represents a surface bond or 
+        ``False`` if not.
+        """
+        if self.atom1.is_surface_site() or self.atom2.is_surface_site():
+            return True
+        else:
+            return False
+
     def is_order(self, other_order):
         """
         Return ``True`` if the bond is of order other_order or ``False`` if

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2775,12 +2775,13 @@ multiplicity 2
 
     def test_add_van_der_waals_bond(self):
         """Test we can add a van-der-Waals bond"""
-        mol = Molecule(smiles='*.[H][H]')
-        self.assertEqual(len(mol.get_all_edges()), 1)
+        mol = Molecule(smiles='*.NOC')
         mol.add_van_der_waals_bond()
-        self.assertEqual(len(mol.get_all_edges()), 2)
         vdw_bonds = [b for b in mol.get_all_edges() if b.is_van_der_waals()]
         self.assertEqual(len(vdw_bonds), 1)
+        vdw_bond = vdw_bonds[0]
+        self.assertEqual(vdw_bond.atom1.symbol,'N')
+
 
 ################################################################################
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2759,6 +2759,15 @@ multiplicity 2
         mol.remove_van_der_waals_bonds()
         self.assertEqual(len(mol.get_all_edges()), 1)
 
+    def test_add_van_der_waals_bond(self):
+        """Test we can add a van-der-Waals bond"""
+        mol = Molecule(smiles='*.[H][H]')
+        self.assertEqual(len(mol.get_all_edges()), 1)
+        mol.add_van_der_waals_bond()
+        self.assertEqual(len(mol.get_all_edges()), 2)
+        vdw_bonds = [b for b in mol.get_all_edges() if b.is_van_der_waals()]
+        self.assertEqual(len(vdw_bonds), 1)
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -840,6 +840,20 @@ class TestBond(unittest.TestCase):
         bond = Bond(atom1=Atom(element=get_element(1)), atom2=Atom(element=get_element(6)), order=1)
         self.assertEqual(bond.get_bond_string(), 'C-H')
 
+    def test_get_bde(self):
+
+        bonds = [Bond(atom1=Atom(element=get_element('X')), atom2=Atom(element=get_element(6)), order=0),
+                Bond(atom1=Atom(element=get_element('X')), atom2=Atom(element=get_element(6)), order=1),
+                Bond(atom1=Atom(element=get_element('X')), atom2=Atom(element=get_element(6)), order=2),
+                Bond(atom1=Atom(element=get_element('X')), atom2=Atom(element=get_element(6)), order=3),
+                Bond(atom1=Atom(element=get_element('X')), atom2=Atom(element=get_element(6)), order=4)]
+
+        bde = 0
+        for bond in bonds:
+            bde_bond = bond.get_bde('Pt111')
+            self.assertGreater(bde_bond, bde)
+            bde = bde_bond
+
 ################################################################################
 
 


### PR DESCRIPTION

### Motivation or Problem
Bond dissociation energies (bdes) are needed for surface bonds in order to fit BM rules during automated tree gen.  However, we cannot currently get bdes for X-A (surface_site - adsorbate) bonds

### Description of Changes
Added 2 new `Bond` methods (`add_van_der_waals_bond` and `is_surface_bond`)
 and modified the `get_bde` method to use provided `metal` (default Pt111) to estimate the bdes based on the metal's
atomic binding energies from the surface metal library.

### Testing
Added a couple unit tests and tested getting bdes for adsorbates in jupyter notebook. Have not tried generating trees yet

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
