### PR TITLE
Mol to group with atom labels

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2302,7 +2302,8 @@ class Molecule(Graph):
             group_atoms[atom] = gr.GroupAtom(atomtype=[atom.atomtype],
                                              radical_electrons=[atom.radical_electrons],
                                              charge=[atom.charge],
-                                             lone_pairs=[atom.lone_pairs]
+                                             lone_pairs=[atom.lone_pairs],
+                                             label=atom.label,
                                              )
 
         group = gr.Group(atoms=list(group_atoms.values()), multiplicity=[self.multiplicity])

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2331,6 +2331,8 @@ multiplicity 2
         Test if we can convert a Molecule object into a Group object.
         """
         mol = Molecule().from_smiles('CC(C)CCCC(C)C1CCC2C3CC=C4CC(O)CCC4(C)C3CCC12C')  # cholesterol
+        mol.atoms[0].label = '*1'
+        mol.atoms[1].label = '*2'
         group = mol.to_group()
 
         self.assertTrue(isinstance(group, Group))
@@ -2343,6 +2345,7 @@ multiplicity 2
 
         for i, molAt in enumerate(mol.atoms):
             group_atom = group.atoms[i]
+            self.assertEqual(group_atom.label, molAt.label)
             atom_types = [groupAtomType.equivalent(molAt.atomtype) for groupAtomType in group_atom.atomtype]
             self.assertTrue(any(atom_types))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
There have been a couple of instances where I wanted to keep the atom labels when converting a molecule to a group.  However, the molecule `to_group` method does not include the atom labels


### Description of Changes
added atom labels to `to_group` method

### Testing
added atom labels to `test_to_group`unit test.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
