### PR TITLE
log conditions before generating new ones

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -834,8 +834,8 @@ class RMG(util.Subject):
                             raise
 
                         self.rmg_memories[index].add_t_conv_N(t, x, len(obj))
-                        self.rmg_memories[index].generate_cond()
                         log_conditions(self.rmg_memories, index)
+                        self.rmg_memories[index].generate_cond()
 
                         reactor_done = self.reaction_model.add_new_surface_objects(obj, new_surface_species,
                                                                                    new_surface_reactions, reaction_system)


### PR DESCRIPTION
It appears that we are generating new conditions after a simluation and logging that the conditions chosen for the reactor simulation were the newly generated conditions.  We should be logging the conditions first, then generating new ones for next simulation.

I have not tested this yet

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
