### PR TITLE
Save metal attrs in rms yaml

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -118,6 +118,7 @@ def catalyst_properties(bindingEnergies=None,
     if metal:
         try:
             logging.info("Using catalyst surface properties from metal %r.", metal)
+            rmg.metal = metal
             rmg.binding_energies = metal_db.get_binding_energies(metal)
             rmg.surface_site_density = metal_db.get_surface_site_density(metal)
         except DatabaseError:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -183,6 +183,7 @@ class RMG(util.Subject):
         self.kinetics_estimator = 'group additivity'
         self.solvent = None
         self.diffusion_limiter = None
+        self.metal = None
         self.surface_site_density = None
         self.binding_energies = None
 

--- a/rmgpy/yml.py
+++ b/rmgpy/yml.py
@@ -56,8 +56,15 @@ def convert_chemkin_to_yml(chemkin_path, dictionary_path=None, output="chem.rms"
     write_yml(spcs, rxns, path=output)
 
 
-def write_yml(spcs, rxns, solvent=None, solvent_data=None, path="chem.yml"):
+def write_yml(spcs, rxns, solvent=None, solvent_data=None, metal=None, binding_energies=None, 
+              surface_site_density=None, path="chem.yml"):
     result_dict = get_mech_dict(spcs, rxns, solvent=solvent, solvent_data=solvent_data)
+    if metal:
+        result_dict['metal'] = metal
+    if binding_energies:
+        result_dict['binding_energies_eV'] = {element:energy.value_si/energy.conversionFactors['eV/molecule'] for element,energy in binding_energies.items()}
+    if surface_site_density:
+        result_dict['surface_site_density_mol_m2'] = surface_site_density.value_si
     with open(path, 'w') as f:
         yaml.dump(result_dict, stream=f)
 
@@ -242,4 +249,5 @@ class RMSWriter(object):
         if rmg.solvent:
             solvent_data = rmg.database.solvation.get_solvent_data(rmg.solvent)
         write_yml(rmg.reaction_model.core.species, rmg.reaction_model.core.reactions, solvent=rmg.solvent, solvent_data=solvent_data,
+                  metal = rmg.metal, binding_energies=rmg.binding_energies, surface_site_density=rmg.surface_site_density,
                   path=os.path.join(self.output_directory, 'rms', 'chem{}.rms').format(len(rmg.reaction_model.core.species)))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
May be useful to include the metal, binding energies, and surface_site_density used in RMG job in the RMS yaml.  This information could be used to determine which metal to use when running DFT jobs on surface species in automated pipeline, for example.

### Description of Changes
added `metal` attr to RMG class and added `metal`, `binding_energies`, and `surface_site_density` to `write_yml` method used to make RMS yaml.

### Testing
Built a model with this branch and the metal information was saved in yaml

<img width="399" alt="Screen Shot 2021-06-16 at 2 41 47 PM" src="https://user-images.githubusercontent.com/32377555/122274804-fc74a180-ceb0-11eb-8fdd-fa0baabc263a.png">
