### PR TITLE
selecting kinetics that match metal attrs

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2616,18 +2616,29 @@ class KineticsFamily(Database):
                     kinetics.comment += "\nsite: {}".format(entry.site)
         return kinetics_list
 
-    def _select_best_kinetics(self, kinetics_list):
+    def _select_best_kinetics(self, kinetics_list, metal=None, facet=None):
         """
         For a given set of kinetics `kinetics_list`, return the kinetics deemed
         to be the "best". This is determined to be the one with the lowest
         non-zero rank that occurs first (has the lowest index).
         """
+        if metal:
+            # select only the reactions that match metals
+            _kinetics_list = [k for k in kinetics_list if k[1].metal == metal]
+            if _kinetics_list:
+                kinetics_list = _kinetics_list
+        if facet:
+            # select only the reactions that match facets
+            _kinetics_list = [k for k in kinetics_list if k[1].facet == facet]
+            if _kinetics_list:
+                kinetics_list = _kinetics_list
         if any([x[1].rank == 0 for x in kinetics_list]) and not all([x[1].rank == 0 for x in kinetics_list]):
             kinetics_list = [x for x in kinetics_list if x[1].rank != 0]
         kinetics_list.sort(key=lambda x: (x[1].rank, x[1].index))
         return kinetics_list[0]
 
-    def get_kinetics(self, reaction, template_labels, degeneracy=1, estimator='', return_all_kinetics=True):
+    def get_kinetics(self, reaction, template_labels, degeneracy=1, estimator='', return_all_kinetics=True,
+                    metal=None, facet=None):
         """
         Return the kinetics for the given `reaction` by searching the various
         depositories as well as generating a result using the user-specified `estimator`
@@ -2655,7 +2666,7 @@ class KineticsFamily(Database):
         for depository in depositories:
             kinetics_list0 = self.get_kinetics_from_depository(depository, reaction, template, degeneracy)
             if len(kinetics_list0) > 0 and not return_all_kinetics:
-                kinetics, entry, is_forward = self._select_best_kinetics(kinetics_list0)
+                kinetics, entry, is_forward = self._select_best_kinetics(kinetics_list0, metal=metal, facet=facet)
                 return kinetics, depository, entry, is_forward
             else:
                 for kinetics, entry, is_forward in kinetics_list0:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2609,11 +2609,11 @@ class KineticsFamily(Database):
                     '[{0}]'.format(';'.join([g.label for g in template])))
                 kinetics.comment += "\nfamily: {}".format(self.label)
                 if entry.metal:
-                    kinetics.comment += "\nmetal: {}".format(self.metal)
+                    kinetics.comment += "\nmetal: {}".format(entry.metal)
                 if entry.facet:
-                    kinetics.comment += "\nfacet: {}".format(self.facet)
-                if entry.facet:
-                    kinetics.comment += "\nsite: {}".format(self.site)
+                    kinetics.comment += "\nfacet: {}".format(entry.facet)
+                if entry.site:
+                    kinetics.comment += "\nsite: {}".format(entry.site)
         return kinetics_list
 
     def _select_best_kinetics(self, kinetics_list):

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -118,6 +118,7 @@ def catalyst_properties(bindingEnergies=None,
     if metal:
         try:
             logging.info("Using catalyst surface properties from metal %r.", metal)
+            rmg.metal = metal
             rmg.binding_energies = metal_db.get_binding_energies(metal)
             rmg.surface_site_density = metal_db.get_surface_site_density(metal)
         except DatabaseError:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -265,6 +265,9 @@ class RMG(util.Subject):
         if self.surface_site_density:
             self.reaction_model.surface_site_density = self.surface_site_density
 
+        if self.metal:
+            self.reaction_model.metal = self.metal
+
         self.reaction_model.verbose_comments = self.verbose_comments
         self.reaction_model.save_edge_species = self.save_edge_species
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -183,6 +183,7 @@ class RMG(util.Subject):
         self.kinetics_estimator = 'group additivity'
         self.solvent = None
         self.diffusion_limiter = None
+        self.metal = None
         self.surface_site_density = None
         self.binding_energies = None
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -35,6 +35,7 @@ import gc
 import itertools
 import logging
 import os
+import re
 
 import numpy as np
 
@@ -231,6 +232,7 @@ class CoreEdgeReactionModel:
             3  R!H u1 px c0 {2,S}
             4  H u0 p0  c0 {1,S}
             """)]
+        self.metal = None # (str with metal and facet, i.e Pt111)
 
     def check_for_existing_species(self, molecule):
         """
@@ -896,11 +898,20 @@ class CoreEdgeReactionModel:
 
         family = get_family_library_object(reaction.family)
 
+        metal = self.metal
+        facet = None
+        if metal:
+            facet = re.search('\d+', metal)
+            if facet:
+                metal = metal[:facet.span()[0]]
+                facet = facet.group(0)
+
         # Get the kinetics for the reaction
         kinetics, source, entry, is_forward = family.get_kinetics(reaction, template_labels=reaction.template,
                                                                   degeneracy=reaction.degeneracy,
                                                                   estimator=self.kinetics_estimator,
-                                                                  return_all_kinetics=False)
+                                                                  return_all_kinetics=False, 
+                                                                  metal=metal, facet=facet)
         # Get the gibbs free energy of reaction at 298 K
         G298 = reaction.get_free_energy_of_reaction(298)
         gibbs_is_positive = G298 > -1e-8
@@ -914,7 +925,8 @@ class CoreEdgeReactionModel:
                                                                                           template_labels=reaction.reverse.template,
                                                                                           degeneracy=reaction.reverse.degeneracy,
                                                                                           estimator=self.kinetics_estimator,
-                                                                                          return_all_kinetics=False)
+                                                                                          return_all_kinetics=False,
+                                                                                          metal=metal, facet=facet)
                 # Now decide which direction's kinetics to keep
                 keep_reverse = False
                 if entry is not None and rev_entry is None:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
When there are multiple isomorphic rxns in a kinetics depository, only the rank is considered when selecting the best kinetics for the reaction, the metal and facet are ignore.  If we build a model on `Pt111`, we should select the kinetics with Pt111 metal attrs over other reactions on different metals.

### Description of Changes
added `metal` as attr for CoreEdgeModel and added `metal` and `facet` to the `get_kinetics` and `_select_best_kinetics`

### Testing
built a model on `Pt1111 and 21 of 26 kinetics with metal attrs were Pt111
should write unit test however

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
