### PR TITLE
Added a save_order attribute to some methods, and make sure it is properly being passed around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ external/Q2DTor
 
 # egg files (pip install -e)
 RMG_Py.egg-info/*
+
+# deleted files
+**/.fuse_hidden*

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -223,7 +223,7 @@ def ensure_independent_atom_ids(input_species, resonance=True):
 
 
 def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kinetics_database=None,
-                              kinetics_family=None):
+                              kinetics_family=None, save_order=False):
     """
     Given a list of Reaction objects, this method combines degenerate
     reactions and increments the reaction degeneracy value. For multiple
@@ -248,6 +248,7 @@ def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kine
         template (list, optional):                      specify a specific template to filter by
         kinetics_database (KineticsDatabase, optional): provide a KineticsDatabase instance for calculating degeneracy
         kinetics_family (KineticsFamily, optional):     provide a KineticsFamily instance for calculating degeneracy
+        save_order (bool, optional):                    reset atom order after performing atom isomorphism
 
     Returns:
         Reaction list with degenerate reactions combined with proper degeneracy values
@@ -270,7 +271,7 @@ def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kine
     # with degenerate transition states
     sorted_rxns = []
     for rxn0 in selected_rxns:
-        rxn0.ensure_species()
+        rxn0.ensure_species(save_order=save_order)
         if len(sorted_rxns) == 0:
             # This is the first reaction, so create a new sublist
             sorted_rxns.append([rxn0])
@@ -283,10 +284,10 @@ def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kine
                 same_template = True
                 for rxn in sub_list:
                     isomorphic = rxn0.is_isomorphic(rxn, check_identical=False, strict=False,
-                                                    check_template_rxn_products=True)
+                                                    check_template_rxn_products=True, save_order=save_order)
                     if isomorphic:
                         identical = rxn0.is_isomorphic(rxn, check_identical=True, strict=False,
-                                                       check_template_rxn_products=True)
+                                                       check_template_rxn_products=True, save_order=save_order)
                         if identical:
                             # An exact copy of rxn0 is already in our list, so we can move on
                             break

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1731,7 +1731,7 @@ class KineticsFamily(Database):
         """
 
         # Make sure the products are in fact different than the reactants
-        if same_species_lists(reactants, products):
+        if same_species_lists(reactants, products, save_order=self.save_order):
             return None
 
         # Create and return template reaction object
@@ -2351,7 +2351,7 @@ class KineticsFamily(Database):
                 products0 = reaction.products if forward else reaction.reactants
                 # Only keep reactions which give the requested products
                 # If prod_resonance=True, then use strict=False to consider all resonance structures
-                if same_species_lists(products, products0, strict=not prod_resonance):
+                if same_species_lists(products, products0, strict=not prod_resonance, save_order=self.save_order):
                     rxn_list.append(reaction)
 
         # Determine the reactant-product pairs to use for flux analysis
@@ -2824,7 +2824,7 @@ class KineticsFamily(Database):
                 pass
             else:
                 if product_structures is not None:
-                    if same_species_lists(list(products), list(product_structures)):
+                    if same_species_lists(list(products), list(product_structures), save_order=self.save_order):
                         return reactant_structures, product_structures
                     else:
                         continue
@@ -2836,7 +2836,7 @@ class KineticsFamily(Database):
 
         return None, None
 
-    def add_atom_labels_for_reaction(self, reaction, output_with_resonance=True):
+    def add_atom_labels_for_reaction(self, reaction, output_with_resonance=True, save_order=False):
         """
         Apply atom labels on a reaction using the appropriate atom labels from
         this reaction family.
@@ -2844,10 +2844,11 @@ class KineticsFamily(Database):
         The reaction is modified in place containing species objects with the
         atoms labeled. If output_with_resonance is True, all resonance structures
         are generated with labels. If false, only the first resonance structure
-        sucessfully able to map to the reaction is used. None is returned.
+        successfully able to map to the reaction is used. None is returned.
+        If ``save_order`` is ``True`` the atom order is reset after performing atom isomorphism.
         """
         # make sure we start with reaction with species objects
-        reaction.ensure_species(reactant_resonance=False, product_resonance=False)
+        reaction.ensure_species(reactant_resonance=False, product_resonance=False, save_order=save_order)
 
         reactants = reaction.reactants
         products = reaction.products
@@ -3166,7 +3167,7 @@ class KineticsFamily(Database):
             rs = template_rxn_map[parent.label]
             for q, rxn in enumerate(rs):
                 for j in range(q):
-                    if not same_species_lists(rxn.reactants, rs[j].reactants, generate_initial_map=True):
+                    if not same_species_lists(rxn.reactants, rs[j].reactants, generate_initial_map=True, save_order=self.save_order):
                         for p, atm in enumerate(parent.item.atoms):
                             if atm.reg_dim_atm[0] != atm.reg_dim_atm[1]:
                                 logging.error('atom violation')

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -251,7 +251,7 @@ cdef class Molecule(Graph):
 
     cpdef float calculate_symmetry_number(self) except -1
 
-    cpdef list generate_resonance_structures(self, bint keep_isomorphic=?, bint filter_structures=?)
+    cpdef list generate_resonance_structures(self, bint keep_isomorphic=?, bint filter_structures=?, bint save_order=?)
 
     cpdef update_lone_pairs(self)
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2130,10 +2130,12 @@ class Molecule(Graph):
 
         return total == aryl
 
-    def generate_resonance_structures(self, keep_isomorphic=False, filter_structures=True):
+    def generate_resonance_structures(self, keep_isomorphic=False, filter_structures=True, save_order=False):
         """Returns a list of resonance structures of the molecule."""
         return resonance.generate_resonance_structures(self, keep_isomorphic=keep_isomorphic,
-                                                       filter_structures=filter_structures)
+                                                       filter_structures=filter_structures,
+                                                       save_order=save_order,
+                                                       )
 
     def get_url(self):
         """

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -32,7 +32,7 @@ cpdef list populate_resonance_algorithms(dict features=?)
 
 cpdef dict analyze_molecule(Molecule mol)
 
-cpdef list generate_resonance_structures(Molecule mol, bint clar_structures=?, bint keep_isomorphic=?, bint filter_structures=?)
+cpdef list generate_resonance_structures(Molecule mol, bint clar_structures=?, bint keep_isomorphic=?, bint filter_structures=?, bint save_order=?)
 
 cpdef list _generate_resonance_structures(list mol_list, list method_list, bint keep_isomorphic=?, bint copy=?, bint filter_structures=?)
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -147,7 +147,8 @@ def analyze_molecule(mol):
     return features
 
 
-def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=False, filter_structures=True):
+def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=False,
+                                  filter_structures=True, save_order=False):
     """
     Generate and return all of the resonance structures for the input molecule.
 
@@ -237,7 +238,7 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
                                    filter_structures=filter_structures)
 
     if filter_structures:
-        return filtration.filter_structures(mol_list, features=features)
+        return filtration.filter_structures(mol_list, features=features, save_order=save_order)
 
     return mol_list
 

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -125,7 +125,7 @@ cdef class Reaction:
 
     cpdef copy(self)
 
-    cpdef ensure_species(self, bint reactant_resonance=?, bint product_resonance=?)
+    cpdef ensure_species(self, bint reactant_resonance=?, bint product_resonance=?, bint save_order=?)
 
     cpdef list check_collision_limit_violation(self, float t_min, float t_max, float p_min, float p_max)
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1286,7 +1286,7 @@ class Reaction:
 
         return other
 
-    def ensure_species(self, reactant_resonance=False, product_resonance=False):
+    def ensure_species(self, reactant_resonance=False, product_resonance=False, save_order=False):
         """
         Ensure the reaction contains species objects in its reactant and product
         attributes. If the reaction is found to hold molecule objects, it
@@ -1296,6 +1296,7 @@ class Reaction:
         Generates resonance structures for Molecules if the corresponding options,
         reactant_resonance and/or product_resonance, are True. Does not generate
         resonance for reactants or products that start as Species objects.
+        If ``save_order`` is ``True`` the atom order is reset after performing atom isomorphism.
         """
         from rmgpy.data.kinetics.common import ensure_species
         # if already species' objects, return none
@@ -1315,11 +1316,11 @@ class Reaction:
             for reactant, product in self.pairs:
                 new_pair = []
                 for reactant0 in self.reactants:
-                    if reactant0.is_isomorphic(reactant):
+                    if reactant0.is_isomorphic(reactant, save_order=save_order):
                         new_pair.append(reactant0)
                         break
                 for product0 in self.products:
-                    if product0.is_isomorphic(product):
+                    if product0.is_isomorphic(product, save_order=save_order):
                         new_pair.append(product0)
                         break
                 new_pairs.append(new_pair)

--- a/rmgpy/species.pxd
+++ b/rmgpy/species.pxd
@@ -57,7 +57,7 @@ cdef class Species:
     cdef str _inchi
     cdef str _smiles
 
-    cpdef generate_resonance_structures(self, bint keep_isomorphic=?, bint filter_structures=?)
+    cpdef generate_resonance_structures(self, bint keep_isomorphic=?, bint filter_structures=?, bint save_order=?)
     
     cpdef bint is_isomorphic(self, other, bint generate_initial_map=?, bint save_order=?, bint strict=?) except -2
 

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -263,18 +263,21 @@ class Species(object):
     def molecular_weight(self, value):
         self._molecular_weight = quantity.Mass(value)
 
-    def generate_resonance_structures(self, keep_isomorphic=True, filter_structures=True):
+    def generate_resonance_structures(self, keep_isomorphic=True, filter_structures=True, save_order=False):
         """
         Generate all of the resonance structures of this species. The isomers are
         stored as a list in the `molecule` attribute. If the length of
         `molecule` is already greater than one, it is assumed that all of the
         resonance structures have already been generated.
+        If ``save_order`` is ``True`` the atom order is reset after performing atom isomorphism.
         """
         if len(self.molecule) == 1 or not self.molecule[0].atom_ids_valid():
             if not self.molecule[0].atom_ids_valid():
                 self.molecule[0].assign_atom_ids()
             self.molecule = self.molecule[0].generate_resonance_structures(keep_isomorphic=keep_isomorphic,
-                                                                           filter_structures=filter_structures)
+                                                                           filter_structures=filter_structures,
+                                                                           save_order=save_order
+                                                                           )
 
     def is_isomorphic(self, other, generate_initial_map=False, save_order=False, strict=True):
         """


### PR DESCRIPTION
### Motivation or Problem
We try to perform atom labeling for species participating in a reaction while keeping the atom order constant (in the context of ARC). However, not all current methods support passing the (already existing) `save_order` argument around.

### Description of Changes
The `save_order` argument was added to methods that were identified as "problematic", and is now being passed on (eventually to the vf2 algorithm) appropriately.

### Testing
These additions were tested separately via ARC, yet unit tests were not added. This is a relatively "minor" modification, but I'm happy to hear thoughts on implementing tests.
