### PR TITLE
Enabling use of pyrms for RMG Simulations and Edge Analysis

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,13 @@ jobs:
       - name: Conda info
         run: |
           conda info
-          conda list
+          conda list  
+      - name: Install and link Julia dependencies 
+        run: |
+          julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl\", rev=\"master\"))"
+          julia -e "using Pkg; Pkg.add(\"PyCall\"); Pkg.add(\"DifferentialEquations\")"
+          python -c "import julia; julia.install()"
+          ln -sfn $(which python-jl) $(which python)
       - name: Install MOPAC
         env:
           MOPACKEY: ${{ secrets.MOPACKEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,12 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install and link Julia dependencies 
+        run: |
+          julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl\", rev=\"master\"))"
+          julia -e "using Pkg; Pkg.add(\"PyCall\"); Pkg.add(\"DifferentialEquations\")"
+          python -c "import julia; julia.install()"
+          ln -sfn $(which python-jl) $(which python)
       - name: Install and compile RMG
         run: |
           cd ..

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -41,11 +41,20 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    On Manjaro or Arch Linux the package manager is ``pacman`` ::
 
     sudo pacman -S git gcc make
-    
-   For MacOS users, these packages will not come preinstalled, but can be easily obtained by installing the XCode Command Line Tools.
+
+   For MacOS users, the above packages will not come preinstalled, but can be easily obtained by installing the XCode Command Line Tools.
    These are a set of packages relevant for software development which have been bundled together by Apple. The easiest way
    to install this is to simply run one of the commands in the terminal, e.g. ``git``. The terminal will then prompt you on
    whether or not you would like to install the Command Line Tools.
+
+   For MacOS users only, download and install the latest macOS julia from here: <https://julialang.org/downloads/>. Then add julia to PATH by running the following command replacing 1.6 with the first two numbers in the Julia version designation (ex: 1.6.2->1.6, 1.1.1->1.1):
+
+     echo 'export PATH="/Applications/Julia-1.6.app/Contents/Resources/julia/bin:$PATH"' >> ~/.bash_profile
+
+     export PATH="/Applications/Julia-1.6.app/Contents/Resources/julia/bin:$PATH"
+
+   Note that this julia install will not respect conda environmental boundaries this means only one conda environment can be linked to it at a time.
+   For linux users julia will be installed automatically.
 
 #. Install the latest versions of RMG and RMG-database through cloning the source code via Git. Make sure to start in an
    appropriate local directory where you want both RMG-Py and RMG-database folders to exist. ::
@@ -68,15 +77,29 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     source ~/.zshrc
 
-#. Compile RMG-Py after activating the conda environment ::
+#. Activate conda environment ::
 
     conda activate rmg_env
-    make
+    
+    Note regarding differences between conda versions: Prior to Anaconda 4.4, the command to activate an environment was
+    ``source activate rmg_env``. It has since been changed to ``conda activate rmg_env`` due to underlying changes to
+    standardize operation across different operating systems. However, a prerequisite to using the new syntax is having
+    run the ``conda init`` setup routine, which can be done at the end of the install procedure if the user requests.
+    
+#. Install and Link Julia dependencies ::
 
-   Note regarding differences between conda versions: Prior to Anaconda 4.4, the command to activate an environment was
-   ``source activate rmg_env``. It has since been changed to ``conda activate rmg_env`` due to underlying changes to
-   standardize operation across different operating systems. However, a prerequisite to using the new syntax is having
-   run the ``conda init`` setup routine, which can be done at the end of the install procedure if the user requests.
+   python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
+
+   julia -e 'using Pkg; Pkg.add(PackageSpec("ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
+
+   Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
+   interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation
+   in a different conda environment. However, if convenient you can undo this linking by replacing python-jl with
+   python3 in the second command above. Just make sure to rerun the linking command once you are done.
+
+#. Compile RMG-Py after activating the conda environment ::
+
+    make
 
 #. Modify environment variables. Add RMG-Py to the PYTHONPATH to ensure that you can access RMG modules from any folder.
    Also, add your RMG-Py folder to PATH to launch ``rmg.py`` from any folder.
@@ -96,8 +119,8 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
 #. Finally, you can run RMG from any location by typing the following (given that you have prepared the input file as ``input.py`` in the current folder). ::
 
-    rmg.py input.py
-   
+    python-jl replace/with/path/to/rmg.py input.py
+
 #. Optional: If you wish to use the :ref:`QMTP interface <qm>` with `MOPAC <http://openmopac.net/>`_ to run quantum mechanical calculations for improved thermochemistry estimates of cyclic species, please obtain a legal license through the `MOPAC License Request Form <http://openmopac.net/form.php>`_.  Once you have it, type the following into your terminal ::
     
     mopac password_string_here    

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -47,7 +47,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    to install this is to simply run one of the commands in the terminal, e.g. ``git``. The terminal will then prompt you on
    whether or not you would like to install the Command Line Tools.
 
-   For MacOS users only, download and install the latest macOS julia from here: <https://julialang.org/downloads/>. Then add julia to PATH by running the following command replacing 1.6 with the first two numbers in the Julia version designation (ex: 1.6.2->1.6, 1.1.1->1.1):
+   For MacOS users only, download and install the latest macOS julia from here: <https://julialang.org/downloads/>. Then add julia to PATH by running the following command replacing 1.6 with the first two numbers in the Julia version designation (ex: 1.6.2->1.6, 1.1.1->1.1) ::
 
      echo 'export PATH="/Applications/Julia-1.6.app/Contents/Resources/julia/bin:$PATH"' >> ~/.bash_profile
 
@@ -81,16 +81,16 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     conda activate rmg_env
     
-    Note regarding differences between conda versions: Prior to Anaconda 4.4, the command to activate an environment was
-    ``source activate rmg_env``. It has since been changed to ``conda activate rmg_env`` due to underlying changes to
-    standardize operation across different operating systems. However, a prerequisite to using the new syntax is having
-    run the ``conda init`` setup routine, which can be done at the end of the install procedure if the user requests.
+   Note regarding differences between conda versions: Prior to Anaconda 4.4, the command to activate an environment was
+   ``source activate rmg_env``. It has since been changed to ``conda activate rmg_env`` due to underlying changes to
+   standardize operation across different operating systems. However, a prerequisite to using the new syntax is having
+   run the ``conda init`` setup routine, which can be done at the end of the install procedure if the user requests.
     
 #. Install and Link Julia dependencies ::
 
-   python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
+     python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
-   julia -e 'using Pkg; Pkg.add(PackageSpec("ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
+     julia -e 'using Pkg; Pkg.add(PackageSpec("ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
 
    Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
    interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation
@@ -114,7 +114,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
    NOTE: Make sure to change ``YourFolder`` to the path leading to the ``RMG-Py`` code. Not doing so will lead to an error stating that python cannot find the module ``rmgpy``.
 
-   Be sure to either close and reopen your terminal to refresh your environment variables (`source ~/.bashrc` or `source ~/.zshrc`).
+   Be sure to either close and reopen your terminal to refresh your environment variables (``source ~/.bashrc`` or ``source ~/.zshrc``).
 
 
 #. Finally, you can run RMG from any location by typing the following (given that you have prepared the input file as ``input.py`` in the current folder). ::

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -90,7 +90,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
      python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
-     julia -e 'using Pkg; Pkg.add(PackageSpec("ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
+     julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
 
    Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
    interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation

--- a/documentation/source/users/rmg/installation/anacondaUser.rst
+++ b/documentation/source/users/rmg/installation/anacondaUser.rst
@@ -17,13 +17,13 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 #. Install both RMG and the RMG-database binaries through the terminal.   Dependencies will be installed automatically. It is safest to make a new conda environment for RMG and its dependencies. Type the following command into the terminal to create the new environment named 'rmg_env' containing the latest stable version of the RMG program and its database. ::
 
     conda create -c defaults -c rmg -c rdkit -c cantera -c pytorch -c conda-forge --name rmg_env rmg rmgdatabase
-    
+
    Whenever you wish to use it you must first activate the environment::
-    
+
     source activate rmg_env
-    
+
 #. Optional: If you wish to use the :ref:`QMTP interface <qm>` with `MOPAC <http://openmopac.net/>`_ to run quantum mechanical calculations for improved thermochemistry estimates of cyclic species, please obtain a legal license through the `MOPAC License Request Form <http://openmopac.net/form.php>`_.  Once you have it, type the following into your terminal ::
-    
+
     mopac password_string_here
 
 #. You may now run an RMG test job. Save the `Minimal Example Input File <https://raw.githubusercontent.com/ReactionMechanismGenerator/RMG-Py/master/examples/rmg/minimal/input.py>`_
@@ -41,4 +41,4 @@ If you had previously installed a binary version of the RMG package, you may
 check and update your installation to the latest stable version available on Anaconda by typing the following command on the terminal ::
 
     source activate rmg_env
-    conda update rmg rmgdatabase -c rmg 
+    conda update rmg rmgdatabase -c rmg

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - coolprop
   - coverage
   - cython >=0.25.2
+  - rmg::diffeqpy
   - ffmpeg
   - rmg::gprof2dot
   - graphviz
@@ -37,6 +38,7 @@ dependencies:
   - pymongo
   - pyparsing
   - rmg::pyrdl
+  - rmg::pyrms
   - python >=3.7
   - pyyaml
   - rmg::quantities

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - mpmath
   - rmg::muq2
   - networkx
+  - nomkl
   - nose
   - rmg::numdifftools
   - numpy >=1.10.0
@@ -35,6 +36,7 @@ dependencies:
   - rmg::pydas >=1.0.2
   - pydot
   - rmg::pydqed >=1.0.1
+  - rmg::pyjulia
   - pymongo
   - pyparsing
   - rmg::pyrdl

--- a/examples/rmg/rms_constant_V/input.py
+++ b/examples/rmg/rms_constant_V/input.py
@@ -1,0 +1,55 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = ['H_Abstraction','Disproportionation','R_Recombination',
+                        'Birad_recombination', 'Birad_R_Recombination'],
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='H2',
+    reactive=True,
+    structure=SMILES("[H][H]"),
+)
+species(
+   label='O2',
+   reactive=True,
+   structure=SMILES("[O][O]"),
+)
+
+# Reaction systems
+constantVIdealGasReactor(
+    temperature=(1000,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        'H2':.67, 'O2':.33,
+    },
+    terminationConversion={
+        'H2': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.001,
+    toleranceInterruptSimulation=0.001,
+    maximumEdgeSpecies=100000,
+)
+
+options(
+    units='si',
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveEdgeSpecies=True,
+    saveSimulationProfiles=False,
+)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -39,13 +39,14 @@ from rmgpy.molecule import Molecule
 from rmgpy.quantity import Quantity, Energy, RateCoefficient, SurfaceConcentration
 from rmgpy.rmg.model import CoreEdgeReactionModel
 from rmgpy.rmg.settings import ModelSettings, SimulatorSettings
-from rmgpy.solver.base import TerminationTime, TerminationConversion, TerminationRateRatio
+from rmgpy.solver.termination import TerminationTime, TerminationConversion, TerminationRateRatio
 from rmgpy.solver.liquid import LiquidReactor
 from rmgpy.solver.mbSampled import MBSampledReactor
 from rmgpy.solver.simple import SimpleReactor
 from rmgpy.solver.surface import SurfaceReactor
 from rmgpy.util import as_list
 from rmgpy.data.surface import MetalDatabase
+from rmgpy.rmg.reactors import Reactor, ConstantVIdealGasReactor
 
 ################################################################################
 
@@ -350,6 +351,106 @@ def simple_reactor(temperature,
                              'be negative in some cases which is not allowed, either reduce the maximum mole fractions '
                              'or dont use balanceSpecies')
 
+def constant_V_ideal_gas_reactor(temperature,
+                   pressure,
+                   initialMoleFractions,
+                   terminationConversion=None,
+                   terminationTime=None,
+                   terminationRateRatio=None,
+                   balanceSpecies=None):
+    logging.debug('Found ConstantVIdealGasReactor reaction system')
+
+    for key, value in initialMoleFractions.items():
+        if not isinstance(value, list):
+            initialMoleFractions[key] = float(value)
+            if value < 0:
+                raise InputError('Initial mole fractions cannot be negative.')
+        else:
+            if len(value) != 2:
+                raise InputError("Initial mole fraction values must either be a number or a list with 2 entries")
+            initialMoleFractions[key] = [float(value[0]), float(value[1])]
+            if value[0] < 0 or value[1] < 0:
+                raise InputError('Initial mole fractions cannot be negative.')
+            elif value[1] < value[0]:
+                raise InputError('Initial mole fraction range out of order: {0}'.format(key))
+
+    if not isinstance(temperature, list):
+        T = Quantity(temperature).value_si
+    else:
+        raise InputError("Condition ranges not supported for this reaction type")
+        if len(temperature) != 2:
+            raise InputError('Temperature and pressure ranges can either be in the form of (number,units) or a list '
+                             'with 2 entries of the same format')
+        T = [Quantity(t) for t in temperature]
+
+    if not isinstance(pressure, list):
+        P = Quantity(pressure).value_si
+    else:
+        raise InputError("Condition ranges not supported for this reaction type")
+        if len(pressure) != 2:
+            raise InputError('Temperature and pressure ranges can either be in the form of (number,units) or a list '
+                             'with 2 entries of the same format')
+        P = [Quantity(p) for p in pressure]
+
+    if not isinstance(temperature, list) and not isinstance(pressure, list) and all(
+            [not isinstance(x, list) for x in initialMoleFractions.values()]):
+        nSims = 1
+
+    # normalize mole fractions if not using a mole fraction range
+    if all([not isinstance(x, list) for x in initialMoleFractions.values()]):
+        total_initial_moles = sum(initialMoleFractions.values())
+        if total_initial_moles != 1:
+            logging.warning('Initial mole fractions do not sum to one; normalizing.')
+            logging.info('')
+            logging.info('Original composition:')
+            for spec, molfrac in initialMoleFractions.items():
+                logging.info('{0} = {1}'.format(spec, molfrac))
+            for spec in initialMoleFractions:
+                initialMoleFractions[spec] /= total_initial_moles
+            logging.info('')
+            logging.info('Normalized mole fractions:')
+            for spec, molfrac in initialMoleFractions.items():
+                logging.info('{0} = {1}'.format(spec, molfrac))
+            logging.info('')
+
+    termination = []
+    if terminationConversion is not None:
+        for spec, conv in terminationConversion.items():
+            termination.append((species_dict[spec], conv))
+    if terminationTime is not None:
+        termination.append(TerminationTime(Quantity(terminationTime)))
+    if terminationRateRatio is not None:
+        termination.append(TerminationRateRatio(terminationRateRatio))
+    if len(termination) == 0:
+        raise InputError('No termination conditions specified for reaction system #{0}.'.format(len(rmg.reaction_systems) + 2))
+    
+    initial_cond = initialMoleFractions
+    initial_cond["T"] = T 
+    initial_cond["P"] = P
+    system = ConstantVIdealGasReactor(rmg.reaction_model.core.phase_system,rmg.reaction_model.edge.phase_system,initial_cond,termination)
+    system.T = Quantity(T)
+    system.P = Quantity(P)
+    system.Trange = None
+    system.Prange = None
+    system.sensitive_species = []
+    rmg.reaction_systems.append(system)
+
+    assert balanceSpecies is None or isinstance(balanceSpecies, str), 'balanceSpecies should be the string corresponding to a single species'
+    rmg.balance_species = balanceSpecies
+    if balanceSpecies:  # check that the balanceSpecies can't be taken to zero
+        total = 0.0
+        for key, item in initialMoleFractions.items():
+            if key == balanceSpecies:
+                assert not isinstance(item, list), 'balanceSpecies must not have a defined range'
+                xbspcs = item
+            if isinstance(item, list):
+                total += item[1] - item[0]
+
+        if total > xbspcs:
+            raise ValueError('The sum of the differences in the ranged mole fractions is greater than the mole '
+                             'fraction of the balance species, this would require the balanceSpecies mole fraction to '
+                             'be negative in some cases which is not allowed, either reduce the maximum mole fractions '
+                             'or dont use balanceSpecies')
 
 # Reaction systems
 def liquid_reactor(temperature,
@@ -965,6 +1066,7 @@ def read_input_file(path, rmg0):
         'adjacencyList': adjacency_list,
         'react': react,
         'simpleReactor': simple_reactor,
+        'constantVIdealGasReactor' : constant_V_ideal_gas_reactor,
         'liquidReactor': liquid_reactor,
         'surfaceReactor': surface_reactor,
         'mbsampledReactor': mb_sampled_reactor,

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1104,7 +1104,8 @@ def read_input_file(path, rmg0):
 
     # convert keys from species names into species objects.
     for reactionSystem in rmg.reaction_systems:
-        reactionSystem.convert_initial_keys_to_species_objects(species_dict)
+        if not isinstance(reactionSystem, Reactor):
+            reactionSystem.convert_initial_keys_to_species_objects(species_dict)
 
     if rmg.quantum_mechanics:
         rmg.quantum_mechanics.set_default_output_directory(rmg.output_directory)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -187,9 +187,7 @@ def species(label, structure, reactive=True):
     if not is_new:
         raise InputError("Species {0} is a duplicate of {1}. Species in input file must be unique".format(label,
                                                                                                           spec.label))
-    # Force RMG to add the species to edge first, prior to where it is added to the core, in case it is found in 
-    # any reaction libraries along the way
-    rmg.reaction_model.add_species_to_edge(spec)
+
     rmg.initial_species.append(spec)
     species_dict[label] = spec
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1101,9 +1101,9 @@ def read_input_file(path, rmg0):
     rmg.species_constraints['explicitlyAllowedMolecules'] = []
 
     # convert keys from species names into species objects.
-    for reactionSystem in rmg.reaction_systems:
-        if not isinstance(reactionSystem, Reactor):
-            reactionSystem.convert_initial_keys_to_species_objects(species_dict)
+    for reaction_system in rmg.reaction_systems:
+        if not isinstance(reaction_system, Reactor):
+            reaction_system.convert_initial_keys_to_species_objects(species_dict)
 
     if rmg.quantum_mechanics:
         rmg.quantum_mechanics.set_default_output_directory(rmg.output_directory)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -78,6 +78,7 @@ from rmgpy.thermo.thermoengine import submit
 from rmgpy.tools.plot import plot_sensitivity
 from rmgpy.tools.uncertainty import Uncertainty, process_local_results
 from rmgpy.yml import RMSWriter
+from rmgpy.rmg.reactors import Reactor
 
 ################################################################################
 
@@ -672,6 +673,9 @@ class RMG(util.Subject):
         if self.save_simulation_profiles:
 
             for index, reaction_system in enumerate(self.reaction_systems):
+                if isinstance(reaction_system, Reactor):
+                    typ = type(reaction_system)
+                    raise InputError(f"save_simulation_profiles=True not compatible with reactor of type {typ}")
                 reaction_system.attach(SimulationProfileWriter(
                     self.output_directory, index, self.reaction_model.core.species))
                 reaction_system.attach(SimulationProfilePlotter(

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -2306,10 +2306,13 @@ class RMG_Memory(object):
                 assert key != 'T' and key != 'P', 'naming a species T or P is forbidden'
                 if isinstance(value, list):
                     self.Ranges[key] = [v.value_si for v in value]
-
-        for term in reaction_system.termination:
-            if isinstance(term, TerminationTime):
-                self.tmax = term.time.value_si
+        
+        if isinstance(reaction_system, Reactor):
+            self.tmax = reaction_system.tf
+        else:
+            for term in reaction_system.termination:
+                if isinstance(term, TerminationTime):
+                    self.tmax = term.time.value_si
 
         self.reaction_system = reaction_system
         self.condition_list = []

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -94,9 +94,9 @@ maxproc = 1
 
 class RMG(util.Subject):
     """
-    A representation of a Reaction Mechanism Generator (RMG) job. The 
+    A representation of a Reaction Mechanism Generator (RMG) job. The
     attributes are:
-    
+
     =================================== ================================================
     Attribute                           Description
     =================================== ================================================
@@ -150,7 +150,7 @@ class RMG(util.Subject):
     `initialization_time`               The time at which the job was initiated, in seconds since the epoch (i.e. from time.time())
     `done`                              Whether the job has completed (there is nothing new to add)
     =================================== ================================================
-    
+
     """
 
     def __init__(self, input_file=None, output_directory=None, profiler=None, stats_file=None):
@@ -264,8 +264,10 @@ class RMG(util.Subject):
 
         if self.surface_site_density:
             self.reaction_model.surface_site_density = self.surface_site_density
-
+            self.reaction_model.core.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si()
+            self.reaction_model.edge.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si()
         self.reaction_model.coverage_dependence = self.coverage_dependence
+            
         self.reaction_model.verbose_comments = self.verbose_comments
         self.reaction_model.save_edge_species = self.save_edge_species
 
@@ -465,7 +467,7 @@ class RMG(util.Subject):
             import rmgpy.rmg.input
             rmgpy.rmg.input.restart_from_seed(path=kwargs['restart'])
 
-        # Check input file 
+        # Check input file
         self.check_input()
 
         # Properly set filter_reactions to initialize flags properly
@@ -490,20 +492,20 @@ class RMG(util.Subject):
             pass
 
         if maxproc > psutil.cpu_count():
-            raise ValueError("""Invalid input for user defined maximum number of processes {0}; 
-            should be an integer and smaller or equal to your available number of 
+            raise ValueError("""Invalid input for user defined maximum number of processes {0};
+            should be an integer and smaller or equal to your available number of
             processors {1}""".format(maxproc, psutil.cpu_count()))
 
         # Load databases
         self.load_database()
-        
+
         for spec in self.initial_species:
             self.reaction_model.add_species_to_edge(spec)
-        
+
         for reaction_system in self.reaction_systems:
             if isinstance(reaction_system, Reactor):
                 reaction_system.finish_termination_criteria()
-                
+
         # Load restart seed mechanism (if specified)
         if self.restart:
             # Copy the restart files to a separate folder so that the job does not overwrite it
@@ -648,7 +650,7 @@ class RMG(util.Subject):
 
     def register_listeners(self):
         """
-        Attaches listener classes depending on the options 
+        Attaches listener classes depending on the options
         found in the RMG input file.
         """
 
@@ -993,7 +995,7 @@ class RMG(util.Subject):
                     logging.info('The current model core has %s species and %s reactions' % (core_spec, core_reac))
                     logging.info('The current model edge has %s species and %s reactions' % (edge_spec, edge_reac))
                     return
-                    
+
             if max_num_spcs_hit:  # resets maxNumSpcsHit and continues the settings for loop
                 logging.info('The maximum number of species ({0}) has been hit, Exiting stage {1} ...'.format(
                     model_settings.max_num_species, q + 1))
@@ -1142,7 +1144,7 @@ class RMG(util.Subject):
                                                     'must be specified in the uncertainty options block for global uncertainty'
                                                     'analysis.')
 
-                                    
+
                             Tlist = ([reaction_system.sens_conditions['T']], 'K')
                             try:
                                 Plist = ([reaction_system.sens_conditions['P']], 'Pa')
@@ -1717,7 +1719,7 @@ class RMG(util.Subject):
                         self.bimolecular_react[:num_restart_spcs, :num_restart_spcs] = False
                         if self.trimolecular:
                             self.trimolecular_react[:num_restart_spcs, :num_restart_spcs, :num_restart_spcs] = False
-                
+
     def react_init_tuples(self):
         """
         Reacts tuples given in the react block
@@ -1739,18 +1741,18 @@ class RMG(util.Subject):
             elif len(tup) == 2:
                 inds = sorted([sts.index(it) for it in tup])
                 if not self.bimolecular_threshold[inds[0], inds[1]]:
-                    self.bimolecular_react[inds[0], inds[1]] = True 
+                    self.bimolecular_react[inds[0], inds[1]] = True
                     self.bimolecular_threshold[inds[0], inds[1]] = True
             elif self.trimolecular and len(tup) == 3:
                 inds = sorted([sts.index(it) for it in tup])
                 if not self.trimolecular_threshold[inds[0], inds[1], inds[2]]:
-                    self.trimolecular_react[inds[0], inds[1], inds[2]] = True 
+                    self.trimolecular_react[inds[0], inds[1], inds[2]] = True
                     self.trimolecular_threshold[inds[0], inds[1], inds[2]] = True
         self.reaction_model.enlarge(react_edge=True,
                                     unimolecular_react=self.unimolecular_react,
                                     bimolecular_react=self.bimolecular_react,
                                     trimolecular_react=self.trimolecular_react)
-        
+
     def update_reaction_threshold_and_react_flags(self,
                                                   rxn_sys_unimol_threshold=None,
                                                   rxn_sys_bimol_threshold=None,
@@ -2248,7 +2250,7 @@ class RMG_Memory(object):
 
     def add_t_conv_N(self, t, conv, N):
         """
-        adds the completion time and conversion and the number of objects added 
+        adds the completion time and conversion and the number of objects added
         from a given run to the memory
         """
         if hasattr(self, 'tmax'):
@@ -2267,8 +2269,8 @@ class RMG_Memory(object):
 
     def calculate_cond(self, obj, Ndims, Ns=20):
         """
-        Weighted Stochastic Grid Sampling algorithm 
-        obj is evaluated at a grid of points and the evaluations are normalized 
+        Weighted Stochastic Grid Sampling algorithm
+        obj is evaluated at a grid of points and the evaluations are normalized
         and then sampled randomly based on their normalized value
         then a random step of length 1/(2*Ns) is taken from that point to give a final condition point
         if this process were to impact runtime under some conditions you could decrease the value of Ns to speed it up
@@ -2370,7 +2372,7 @@ def log_conditions(rmg_memories, index):
 
 class Tee(object):
     """A simple tee to create a stream which prints to many streams.
-    
+
     This is used to report the profiling statistics to both the log file
     and the standard output.
     """
@@ -2426,11 +2428,11 @@ def process_profile_stats(stats_file, log_file):
 def make_profile_graph(stats_file, force_graph_generation=False):
     """
     Uses gprof2dot to create a graphviz dot file of the profiling information.
-    
+
     This requires the gprof2dot package available via `pip install gprof2dot`.
     Render the result using the program 'dot' via a command like
     `dot -Tps2 input.dot -o output.ps2`.
-    
+
     Rendering the ps2 file to pdf requires an external pdf converter
     `ps2pdf output.ps2` which produces a `output.ps2.pdf` file.
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -828,19 +828,50 @@ class RMG(util.Subject):
                             prune = False
 
                         try:
-                            terminated, resurrected, obj, new_surface_species, new_surface_reactions, t, x = reaction_system.simulate(
-                                core_species=self.reaction_model.core.species,
-                                core_reactions=self.reaction_model.core.reactions,
-                                edge_species=self.reaction_model.edge.species,
-                                edge_reactions=self.reaction_model.edge.reactions,
-                                surface_species=self.reaction_model.surface.species,
-                                surface_reactions=self.reaction_model.surface.reactions,
-                                pdep_networks=self.reaction_model.network_list,
-                                prune=prune,
-                                model_settings=model_settings,
-                                simulator_settings=simulator_settings,
-                                conditions=self.rmg_memories[index].get_cond()
-                            )
+                            if isinstance(reaction_system, Reactor):
+                                terminated,resurrected,obj,unimolecular_threshold,bimolecular_threshold,trimolecular_threshold,max_edge_species_rate_ratios,t,x = reaction_system.simulate(model_settings=model_settings,
+                                    simulator_settings=simulator_settings,
+                                    conditions=self.rmg_memories[index].get_cond()
+                                )
+                                reaction_system.unimolecular_threshold = unimolecular_threshold
+                                reaction_system.bimolecular_threshold = bimolecular_threshold
+                                reaction_system.trimolecular_threshold = trimolecular_threshold
+                                if hasattr(reaction_system,"max_edge_species_rate_ratios"):
+                                    max_edge_species_rate_ratios_temp = np.zeros(len(max_edge_species_rate_ratios))
+                                    for i in range(len(max_edge_species_rate_ratios)):
+                                        if i < len(reaction_system.max_edge_species_rate_ratios):
+                                            max_edge_species_rate_ratios_temp[i] = max(reaction_system.max_edge_species_rate_ratios[i],max_edge_species_rate_ratios[i])
+                                        else:
+                                            max_edge_species_rate_ratios_temp[i] = max_edge_species_rate_ratios[i]
+                                    reaction_system.max_edge_species_rate_ratios = max_edge_species_rate_ratios_temp
+                                else:
+                                    reaction_system.max_edge_species_rate_ratios = max_edge_species_rate_ratios
+                                new_surface_species = []
+                                new_surface_reactions =  []
+                                obj_temp = []
+                                for item in obj:
+                                    if hasattr(item,"name"):
+                                        obj_temp.append(self.reaction_model.edge.phase_system.species_dict[item.name])
+                                    else: #Reaction
+                                        for val in item.reactants:
+                                            obj_temp.append(self.reaction_model.edge.phase_system.species_dict[val.name])
+                                        for val in item.products:
+                                            obj_temp.append(self.reaction_model.edge.phase_system.species_dict[val.name])
+                                obj = obj_temp
+                            else:
+                                terminated, resurrected, obj, new_surface_species, new_surface_reactions, t, x = reaction_system.simulate(
+                                    core_species=self.reaction_model.core.species,
+                                    core_reactions=self.reaction_model.core.reactions,
+                                    edge_species=self.reaction_model.edge.species,
+                                    edge_reactions=self.reaction_model.edge.reactions,
+                                    surface_species=self.reaction_model.surface.species,
+                                    surface_reactions=self.reaction_model.surface.reactions,
+                                    pdep_networks=self.reaction_model.network_list,
+                                    prune=prune,
+                                    model_settings=model_settings,
+                                    simulator_settings=simulator_settings,
+                                    conditions=self.rmg_memories[index].get_cond()
+                                )
                         except:
                             logging.error("Model core reactions:")
                             if len(self.reaction_model.core.reactions) > 5:
@@ -885,18 +916,50 @@ class RMG(util.Subject):
                             temp_model_settings.tol_keep_in_edge = 0
                             if not resurrected:
                                 try:
-                                    reaction_system.simulate(
-                                        core_species=self.reaction_model.core.species,
-                                        core_reactions=self.reaction_model.core.reactions,
-                                        edge_species=[],
-                                        edge_reactions=[],
-                                        surface_species=self.reaction_model.surface.species,
-                                        surface_reactions=self.reaction_model.surface.reactions,
-                                        pdep_networks=self.reaction_model.network_list,
-                                        model_settings=temp_model_settings,
-                                        simulator_settings=simulator_settings,
-                                        conditions=self.rmg_memories[index].get_cond()
-                                    )
+                                    if isinstance(reaction_system, Reactor):
+                                        terminated,obj,unimolecular_threshold,bimolecular_threshold,trimolecular_threshold,max_edge_species_rate_ratios,t,x = reaction_system.simulate(model_settings=model_settings,
+                                            simulator_settings=simulator_settings,
+                                            conditions=self.rmg_memories[index].get_cond()
+                                        )
+                                        reaction_system.unimolecular_threshold = unimolecular_threshold
+                                        reaction_system.bimolecular_threshold = bimolecular_threshold
+                                        reaction_system.trimolecular_threshold = trimolecular_threshold
+                                        if hasattr(reaction_system,"max_edge_species_rate_ratios"):
+                                            max_edge_species_rate_ratios_temp = np.zeros(len(max_edge_species_rate_ratios))
+                                            for i in range(len(max_edge_species_rate_ratios)):
+                                                if i < len(reaction_system.max_edge_species_rate_ratios):
+                                                    max_edge_species_rate_ratios_temp[i] = max(reaction_system.max_edge_species_rate_ratios[i],max_edge_species_rate_ratios[i])
+                                                else:
+                                                    max_edge_species_rate_ratios_temp[i] = max_edge_species_rate_ratios[i]
+                                            reaction_system.max_edge_species_rate_ratios = max_edge_species_rate_ratios_temp
+                                        else:
+                                            reaction_system.max_edge_species_rate_ratios = max_edge_species_rate_ratios
+                                        new_surface_species = []
+                                        new_surface_reactions =  []
+                                        resurrected = False
+                                        obj_temp = []
+                                        for item in obj:
+                                            if hasattr(item,"name"):
+                                                obj_temp.append(self.reaction_model.edge.phase_system.species_dict[item.name])
+                                            else: #Reaction
+                                                for val in item.reactants:
+                                                    obj_temp.append(self.reaction_model.edge.phase_system.species_dict[val.name])
+                                                for val in item.products:
+                                                    obj_temp.append(self.reaction_model.edge.phase_system.species_dict[val.name])
+                                        obj = obj_temp
+                                    else:
+                                        reaction_system.simulate(
+                                            core_species=self.reaction_model.core.species,
+                                            core_reactions=self.reaction_model.core.reactions,
+                                            edge_species=[],
+                                            edge_reactions=[],
+                                            surface_species=self.reaction_model.surface.species,
+                                            surface_reactions=self.reaction_model.surface.reactions,
+                                            pdep_networks=self.reaction_model.network_list,
+                                            model_settings=temp_model_settings,
+                                            simulator_settings=simulator_settings,
+                                            conditions=self.rmg_memories[index].get_cond()
+                                        )
                                 except:
                                     self.update_reaction_threshold_and_react_flags(
                                         rxn_sys_unimol_threshold=reaction_system.unimolecular_threshold,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -533,6 +533,10 @@ class RMG(util.Subject):
         # Do all liquid-phase startup things:
         if self.solvent:
             solvent_data = self.database.solvation.get_solvent_data(self.solvent)
+            if not self.reaction_model.core.phase_system.in_nose:
+                self.reaction_model.core.phase_system.phases["Default"].set_solvent(solvent_data)
+                self.reaction_model.edge.phase_system.phases["Default"].set_solvent(solvent_data)
+
             diffusion_limiter.enable(solvent_data, self.database.solvation)
             logging.info("Setting solvent data for {0}".format(self.solvent))
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -496,7 +496,14 @@ class RMG(util.Subject):
 
         # Load databases
         self.load_database()
-
+        
+        for spec in self.initial_species:
+            self.reaction_model.add_species_to_edge(spec)
+        
+        for reaction_system in self.reaction_systems:
+            if isinstance(reaction_system, Reactor):
+                reaction_system.finish_termination_criteria()
+                
         # Load restart seed mechanism (if specified)
         if self.restart:
             # Copy the restart files to a separate folder so that the job does not overwrite it

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1131,6 +1131,14 @@ class CoreEdgeReactionModel:
         Add a species `spec` to the reaction model edge.
         """
         self.edge.species.append(spec)
+        if not self.edge.phase_system.in_nose:
+            if spec.molecule[0].contains_surface_site():
+                self.edge.phase_system.phases["Surface"].add_species(spec)
+                self.edge.phase_system.species_dict[spec.label] = spec
+            else:
+                self.edge.phase_system.phases["Default"].add_species(spec)
+                self.edge.phase_system.species_dict[spec.label] = spec
+                
 
     def set_thermodynamic_filtering_parameters(self, Tmax, thermo_tol_keep_spc_in_edge,
                                                min_core_size_for_prune, maximum_edge_species, reaction_systems):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1351,6 +1351,7 @@ class CoreEdgeReactionModel:
         # remove the species
         self.edge.species.remove(spec)
         self.index_species_dict.pop(spec.index)
+        self.edge.phase_system.remove_species(spec)
 
         # clean up species references in reaction_systems
         for reaction_system in reaction_systems:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1094,7 +1094,8 @@ class CoreEdgeReactionModel:
 
         rxn_list = []
         if spec in self.edge.species:
-
+            if not self.edge.phase_system.in_nose:
+                self.edge.phase_system.pass_species(spec.label,self.core.phase_system)
             # If species was in edge, remove it
             logging.debug("Removing species %s from edge.", spec)
             self.edge.species.remove(spec)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1117,6 +1117,13 @@ class CoreEdgeReactionModel:
             for rxn in rxn_list:
                 self.add_reaction_to_core(rxn)
                 logging.debug("Moving reaction from edge to core: %s", rxn)
+        else:
+            if not self.core.phase_system.in_nose:
+                if spec.molecule[0].contains_surface_site():
+                    self.core.phase_system.phases["Surface"].add_species(spec,edge_phase=self.edge.phase_system.phases["Surface"])
+                else:
+                    self.core.phase_system.phases["Default"].add_species(spec,edge_phase=self.edge.phase_system.phases["Default"])
+            
         return rxn_list
 
     def add_species_to_edge(self, spec):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1461,7 +1461,15 @@ class CoreEdgeReactionModel:
         edge).
         """
         self.edge.reactions.append(rxn)
-
+        if not self.edge.phase_system.in_nose:
+            bits = np.array([spc.molecule[0].contains_surface_site() for spc in rxn.reactants+rxn.products])
+            if all(bits):
+                self.edge.phase_system.phases["Surface"].add_reaction(rxn,self.core.species+self.edge.species)
+            elif all(bits==False):
+                self.edge.phase_system.phases["Default"].add_reaction(rxn,self.core.species+self.edge.species)
+            else:
+                self.edge.phase_system.interfaces[set(["Default","Surface"])].add_reaction(rxn,self.core.species+self.edge.species)
+            
     def get_model_size(self):
         """
         Return the numbers of species and reactions in the model core and edge.

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -56,7 +56,7 @@ from rmgpy.rmg.react import react_all
 from rmgpy.species import Species
 from rmgpy.thermo.thermoengine import submit
 from rmgpy.rmg.decay import decay_species
-
+from rmgpy.rmg.reactors import PhaseSystem, Phase, Interface
 
 ################################################################################
 
@@ -66,9 +66,13 @@ class ReactionModel:
     a list of species, and `reactions`, a list of reactions.
     """
 
-    def __init__(self, species=None, reactions=None):
+    def __init__(self, species=None, reactions=None, phases=None, interfaces={}):
         self.species = species or []
         self.reactions = reactions or []
+        if phases is None:
+            phases = {"Default":Phase(),"Surface":Phase()}
+            interfaces = {frozenset({"Default","Surface"}):Interface(list(phases.values()))}
+        self.phase_system = PhaseSystem(phases,interfaces)
 
     def __reduce__(self):
         """

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1433,6 +1433,22 @@ class CoreEdgeReactionModel:
         """
         if rxn not in self.core.reactions:
             self.core.reactions.append(rxn)
+            if not self.core.phase_system.in_nose:
+                bits = np.array([spc.molecule[0].contains_surface_site() for spc in rxn.reactants+rxn.products])
+                in_edge = rxn in self.edge.reactions
+                if all(bits):
+                    self.core.phase_system.phases["Surface"].add_reaction(rxn,self.core.species)
+                    if not in_edge:
+                        self.edge.phase_system.phases["Surface"].add_reaction(rxn,self.core.species)
+                elif all(bits==False):
+                    self.core.phase_system.phases["Default"].add_reaction(rxn,self.core.species)
+                    if not in_edge:
+                        self.edge.phase_system.phases["Default"].add_reaction(rxn,self.core.species)
+                else:
+                    self.core.phase_system.interfaces[frozenset({"Default","Surface"})].add_reaction(rxn,self.core.species)
+                    if not in_edge:
+                        self.edge.phase_system.interfaces[frozenset({"Default","Surface"})].add_reaction(rxn,self.core.species)
+
         if rxn in self.edge.reactions:
             self.edge.reactions.remove(rxn)
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -324,6 +324,16 @@ class CoreEdgeReactionModel:
         # This may change later after getting thermo in self.generate_thermo()
         if not spec.label:
             spec.label = spec.smiles
+        
+        #ensure species labels are unique
+        orilabel = spec.label 
+        label = orilabel
+        i = 2
+        while any([label in phase.names for phase in self.edge.phase_system.phases.values()]):
+            label = orilabel + "-" + str(i)
+            i += 1
+        spec.label = label
+
         logging.debug('Creating new species %s', spec.label)
 
         formula = molecule.get_formula()

--- a/rmgpy/rmg/modelTest.py
+++ b/rmgpy/rmg/modelTest.py
@@ -155,7 +155,7 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         rxns += list(itertools.chain.from_iterable(react([((spcs[0], spcs[1]), ['H_Abstraction'])], procnum)))
 
         for rxn in rxns:
-            cerm.make_new_reaction(rxn)
+            cerm.make_new_reaction(rxn, generate_thermo=False, generate_kinetics=False)
 
         cerm.core.species = [spcA] + spcs
 
@@ -260,7 +260,7 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
         cerm = CoreEdgeReactionModel()
 
         for rxn in rxns:
-            cerm.make_new_reaction(rxn)
+            cerm.make_new_reaction(rxn, generate_thermo=False, generate_kinetics=False)
 
         """
         3 expected H-abstraction reactions:
@@ -344,7 +344,7 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
             family='H_Abstraction',
         )
 
-        cerm.process_new_reactions(new_reactions=[reaction], new_species=[])  # adds CH2 and O to edge
+        cerm.process_new_reactions(new_reactions=[reaction], new_species=[], generate_kinetics=False, generate_thermo=False)  # adds CH2 and O to edge
 
         for spc in cerm.core.species + cerm.edge.species:
             spc.thermo = thermo_dict[spc.molecule[0].to_smiles()]  # assign thermo
@@ -439,7 +439,7 @@ class TestCoreEdgeReactionModel(unittest.TestCase):
                                     reversible=True,
                                     family='H_Abstraction')
 
-        cerm.process_new_reactions(new_reactions=[reaction], new_species=[])  # add CH2 and O to edge
+        cerm.process_new_reactions(new_reactions=[reaction], new_species=[], generate_thermo=False, generate_kinetics=False)  # add CH2 and O to edge
 
         for spc in cerm.core.species + cerm.edge.species:
             spc.thermo = thermo_dict[spc.molecule[0].to_smiles()]  # assign thermo

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -244,6 +244,35 @@ class Phase:
 
         return spc
 
+class Interface:
+    """
+    Class containing all reactions and properties necessary to describe
+    kinetics within an interface between two phases in a simulation
+    """
+    def __init__(self, phases, reactions=[]):
+        self.reactions = reactions or []
+        self.phaseset = set(phases)
+
+    def add_reaction(self, rxn, species_list):
+        """
+        add a reaction to the interface
+        """
+        self.reactions.append(to_rms(rxn, species_list=species_list, rms_species_list=self.reactions))
+
+    def remove_species(self, spc):
+        """
+        Remove reactions associated with the input species from the interface
+        """
+        rxninds = []
+        for i, rxn in enumerate(self.reactions):
+            for spc2 in itertools.chain(rxn.reactants, rxn.products):
+                if spc.name == spc2.name:
+                    rxninds.append(i)
+                    break
+        for ind in reversed(rxninds):
+            del self.reactions[ind]
+        return
+
 def to_rms(obj, species_list=None, rms_species_list=None):
     """
     Generate corresponding rms object

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -326,6 +326,20 @@ class Reactor:
 
         return terminated, resurrected, invalid_objects, unimolecular_threshold, bimolecular_threshold, trimolecular_threshold, max_edge_species_rate_ratios, t, x
 
+class ConstantVIdealGasReactor(Reactor):
+    def __init__(self, core_phase_system, edge_phase_system, initial_conditions, terminations):
+        super().__init__(core_phase_system, edge_phase_system, initial_conditions, terminations)
+
+    def generate_reactor(self, phase_system):
+        """
+        Setup an RMS simulation for EdgeAnalysis
+        """
+        phase = phase_system.phases["Default"]
+        ig = rms.IdealGas(phase.species, phase.reactions)
+        domain, y0, p = rms.ConstantVDomain(phase=ig, initialconds=self.initial_conditions)
+        react = rms.Reactor(domain, y0, (0.0, self.tf), p)
+        return react, domain, [], p
+
 def to_rms(obj, species_list=None, rms_species_list=None):
     """
     Generate corresponding rms object

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2021 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+"""
+Contains classes for building RMS simulations
+Note since rms currently can't be imported inside nosetests
+This most of this can't be tested using nosetests
+"""
+import numpy as np
+import sys
+import logging
+import itertools
+try:
+    from pyrms import rms
+    from diffeqpy import de
+except:
+    pass
+
+from rmgpy.species import Species
+from rmgpy.reaction import Reaction
+from rmgpy.thermo.nasa import NASAPolynomial, NASA
+from rmgpy.thermo.wilhoit import Wilhoit
+from rmgpy.thermo.thermodata import ThermoData
+from rmgpy.kinetics.arrhenius import Arrhenius, ArrheniusEP, ArrheniusBM, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius
+from rmgpy.kinetics.kineticsdata import KineticsData
+from rmgpy.kinetics.falloff import Troe, ThirdBody, Lindemann
+from rmgpy.kinetics.chebyshev import Chebyshev
+from rmgpy.data.solvation import SolventData
+from rmgpy.kinetics.surface import StickingCoefficient
+from rmgpy.solver.termination import TerminationTime, TerminationConversion, TerminationRateRatio
+from rmgpy.data.kinetics.family import TemplateReaction
+from rmgpy.data.kinetics.depository import DepositoryReaction

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -55,3 +55,98 @@ from rmgpy.kinetics.surface import StickingCoefficient
 from rmgpy.solver.termination import TerminationTime, TerminationConversion, TerminationRateRatio
 from rmgpy.data.kinetics.family import TemplateReaction
 from rmgpy.data.kinetics.depository import DepositoryReaction
+
+def to_rms(obj, species_list=None, rms_species_list=None):
+    """
+    Generate corresponding rms object
+    """
+    if isinstance(obj, Arrhenius):
+        if obj._T0.value_si != 1:
+            A = obj._A.value_si / (obj._T0.value_si) ** obj._n.value_si
+        else:
+            A = obj._A.value_si
+        n = obj._n.value_si
+        Ea = obj._Ea.value_si
+        return rms.Arrhenius(A, n, Ea, rms.EmptyRateUncertainty())
+    elif isinstance(obj, PDepArrhenius):
+        Ps = obj._pressures.value_si
+        arrs = [to_rms(arr) for arr in obj.arrhenius]
+        return rms.PDepArrhenius(Ps, arrs)
+    elif isinstance(obj, MultiArrhenius):
+        arrs = [to_rms(arr) for arr in obj.arrhenius]
+        return rms.MultiArrhenius(arrs)
+    elif isinstance(obj, MultiPDepArrhenius):
+        parrs = [to_rms(parr) for parr in obj.arrhenius]
+        return rms.MultiPdepArrhenius(parrs)
+    elif isinstance(obj, Chebyshev):
+        Tmin = obj.Tmin.value_si
+        Tmax = obj.Tmax.value_si
+        Pmin = obj.Pmin.value_si
+        Pmax = obj.Pmax.value_si
+        coeffs = obj.coeffs.value_si.tolist()
+        return rms.Chebyshev(coeffs, Tmin, Tmax, Pmin, Pmax)
+    elif isinstance(obj, ThirdBody):
+        arr = to_rms(obj.arrheniusLow)
+        efficiencies = {spc.label: float(val) for spc, val in obj.efficiencies.items() if val != 1}
+        return rms.ThirdBody(arr, nameefficiencies=efficiencies)
+    elif isinstance(obj, Lindemann):
+        arrlow = to_rms(obj.arrheniusLow)
+        arrhigh = to_rms(obj.arrheniusHigh)
+        efficiencies = {spc.label: float(val) for spc, val in obj.efficiencies.items() if val != 1}
+        return rms.Lindemann(arrhigh, arrlow, nameefficiencies=efficiencies)
+    elif isinstance(obj, Troe):
+        arrlow = to_rms(obj.arrheniusLow)
+        arrhigh = to_rms(obj.arrheniusHigh)
+        efficiencies = {spc.label: float(val) for spc, val in obj.efficiencies.items() if val != 1}
+        alpha = obj.alpha
+        T1 = obj._T1.value_si if obj._T1 is not None else 0.0
+        T2 = obj._T2.value_si if obj._T2 is not None else 0.0
+        T3 = obj._T3.value_si if obj._T3 is not None else 0.0
+        return rms.Troe(arrhigh, arrlow, alpha, T3, T1, T2, nameefficiencies=efficiencies)
+    elif isinstance(obj, StickingCoefficient):
+        if obj._T0.value_si != 1:
+            A = obj._A.value_si / (obj._T0.value_si) ** obj._n.value_si
+        else:
+            A = obj._A.value_si
+        n = obj._n.value_si
+        Ea = obj._Ea.value_si
+        return rms.StickingCoefficient(A, n, Ea)
+    elif isinstance(obj, NASAPolynomial):
+        return rms.NASApolynomial(obj.coeffs, obj.Tmin.value_si, obj.Tmax.value_si)
+    elif isinstance(obj, NASA):
+        return rms.NASA([to_rms(poly) for poly in obj.polynomials], rms.EmptyThermoUncertainty())
+    elif isinstance(obj, Species):
+        atomnums = dict()
+        for atm in obj.molecule[0].atoms:
+            if atomnums.get(atm.element.symbol):
+                atomnums[atm.element.symbol] += 1
+            else:
+                atomnums[atm.element.symbol] = 1
+        bondnum = len(obj.molecule[0].get_all_edges())
+        rad = rms.getspeciesradius(atomnums, bondnum)
+        diff = rms.StokesDiffusivity(rad)
+        th = obj.get_thermo_data()
+        thermo = to_rms(th)
+        return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, diff, rad, obj.molecule[0].multiplicity-1, obj.molecular_weight.value_si)
+    elif isinstance(obj, Reaction):
+        reactantinds = [species_list.index(spc) for spc in obj.reactants]
+        productinds = [species_list.index(spc) for spc in obj.products]
+        reactants = [rms_species_list[i] for i in reactantinds]
+        products = [rms_species_list[i] for i in productinds]
+        kinetics = to_rms(obj.kinetics)
+        radchange = sum([spc.molecule[0].multiplicity-1 for spc in obj.products]) - sum([spc.molecule[0].multiplicity-1 for spc in obj.reactants])
+        electronchange = 0 #for now
+        return rms.ElementaryReaction(obj.index, reactants, reactantinds, products, productinds, kinetics, electronchange, radchange, obj.reversible, [])
+    elif isinstance(obj, SolventData):
+        return rms.Solvent("solvent", rms.RiedelViscosity(float(obj.A), float(obj.B), float(obj.C), float(obj.D), float(obj.E)))
+    elif isinstance(obj, TerminationTime):
+        return rms.TerminationTime(obj.time.value_si)
+    elif isinstance(obj, TerminationConversion):
+        return rms.TerminationConversion(to_rms(obj.species), obj.conversion)
+    elif isinstance(obj, TerminationRateRatio):
+        return rms.TerminationRateRatio(obj.ratio)
+    elif isinstance(obj, tuple): #Handle TerminationConversion when the obj doesn't have thermo yet
+        return obj
+    else:
+        errortype = type(obj)
+        raise ValueError(f"Couldn't convert object of type {errortype} to an RMS object")

--- a/rmgpy/solver/base.pyx
+++ b/rmgpy/solver/base.pyx
@@ -56,7 +56,7 @@ from rmgpy.chemkin import get_species_identifier
 from rmgpy.reaction import Reaction
 from rmgpy.quantity import Quantity
 from rmgpy.species import Species
-
+from rmgpy.solver.termination import TerminationTime, TerminationConversion, TerminationRateRatio
 ################################################################################
 
 cdef class ReactionSystem(DASx):
@@ -1399,41 +1399,3 @@ cdef class ReactionSystem(DASx):
         rate_deriv = V * rate_deriv
 
         return rate_deriv
-
-
-################################################################################
-
-class TerminationTime:
-    """
-    Represent a time at which the simulation should be terminated. This class
-    has one attribute: the termination `time` in seconds.
-    """
-
-    def __init__(self, time=(0.0, 's')):
-        self.time = Quantity(time)
-
-
-################################################################################
-
-class TerminationConversion:
-    """
-    Represent a conversion at which the simulation should be terminated. This
-    class has two attributes: the `species` to monitor and the fractional
-    `conversion` at which to terminate.
-    """
-
-    def __init__(self, spec=None, conv=0.0):
-        self.species = spec
-        self.conversion = conv
-
-
-class TerminationRateRatio:
-    """
-    Represent a fraction of the maximum characteristic rate of the simulation
-    at which the simulation should be terminated.  This class has one attribute
-    the ratio between the current and maximum characteristic rates at which
-    to terminate
-    """
-
-    def __init__(self, ratio=0.01):
-        self.ratio = ratio

--- a/rmgpy/solver/termination.py
+++ b/rmgpy/solver/termination.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2021 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+from rmgpy.quantity import Quantity
+"""
+Contains classes for termination criteria
+"""
+class TerminationTime:
+    """
+    Represent a time at which the simulation should be terminated. This class
+    has one attribute: the termination `time` in seconds.
+    """
+
+    def __init__(self, time=(0.0, 's')):
+        self.time = Quantity(time)
+
+
+################################################################################
+
+class TerminationConversion:
+    """
+    Represent a conversion at which the simulation should be terminated. This
+    class has two attributes: the `species` to monitor and the fractional
+    `conversion` at which to terminate.
+    """
+
+    def __init__(self, spec=None, conv=0.0):
+        self.species = spec
+        self.conversion = conv
+
+
+class TerminationRateRatio:
+    """
+    Represent a fraction of the maximum characteristic rate of the simulation
+    at which the simulation should be terminated.  This class has one attribute
+    the ratio between the current and maximum characteristic rates at which
+    to terminate
+    """
+
+    def __init__(self, ratio=0.01):
+        self.ratio = ratio

--- a/rmgpy/statmech/ndTorsions.py
+++ b/rmgpy/statmech/ndTorsions.py
@@ -335,7 +335,7 @@ end_temperatures                   #
         use Q2DTor to generate a .ics file the Q2DTor file that
         has torsional information
         """
-        out = subprocess.check_call(['python', self.q2dtor_path, self.name, '--init'],
+        out = subprocess.check_call(['python3', self.q2dtor_path, self.name, '--init'],
                                     cwd=self.q2dtor_dir)
 
     def fit_fourier(self):
@@ -343,14 +343,14 @@ end_temperatures                   #
         use Q2DTor to fit fourier coefficients
         to the potential
         """
-        out = subprocess.check_call(['python', self.q2dtor_path, self.name, '--fourier'],
+        out = subprocess.check_call(['python3', self.q2dtor_path, self.name, '--fourier'],
                                     cwd=self.q2dtor_dir)
 
     def get_splist_file(self):
         """
         use Q2DTor to generate a .splist file
         """
-        out = subprocess.check_call(['python', self.q2dtor_path, self.name, '--findsp'],
+        out = subprocess.check_call(['python3', self.q2dtor_path, self.name, '--findsp'],
                                     cwd=self.q2dtor_dir)
 
     def get_eigvals(self):
@@ -359,7 +359,7 @@ end_temperatures                   #
         rotors
         writes a .evals file and reads it to fill self.evals and self.energy
         """
-        out = subprocess.check_call(['python', self.q2dtor_path, self.name, '--tor2dns'],
+        out = subprocess.check_call(['python3', self.q2dtor_path, self.name, '--tor2dns'],
                                     cwd=self.q2dtor_dir)
         self.read_eigvals()
 


### PR DESCRIPTION
This PR integrates pyrms into RMG enabling us to very easily write new reactor types running simulations and Edge Analysis in RMS.  

There's a lot of small details that are worth mentioning: 

Potentially farther reaching changes:
  - Species labels are forced to be unique
  - Kinetics and thermo are generated when the Species/Reaction objects are created instead of later in enlarge
 
As far as I can tell we seem to be unable to mix pyjulia and nosetests. This put some significant constraints on the structure of these changes. I managed to limit all the rms function calls to the new reactors.py file so this has almost no impact on our current testing infrastructure, however it does mean that the infrastructure in the reactors.py file can't be tested using our current nosetests framework. (This also means codecov is not going to like this PR). 

Things this PR does not enable for RMS reactors: 
  - Ranged reactors
  - Pressure dependence
  - Sensitivity analysis
  - save_simulation_profile
  - Surface (core-edge-surface) functionality (plan is to deprecate this since the branching algorithm is both simpler and     more effective)

Since this PR is already very complex I elected to initially avoid some of the more complex RMG integrations, however none of these (apart from the surface one we were already planning to get rid of) will be very hard to do in the near future. 

This PR is dependent on https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/pull/149 and will only pass tests once that RMS PR is merged. 
