### PR TITLE
correct barrier for library reactions

### DIFF
--- a/ipython/correct_barriers_in_kinetics_libraries.ipynb
+++ b/ipython/correct_barriers_in_kinetics_libraries.ipynb
@@ -1,0 +1,271 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "505f2fc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rmgpy.data.rmg import RMGDatabase\n",
+    "from rmgpy.thermo.thermoengine import submit\n",
+    "from rmgpy.thermo import ThermoData\n",
+    "from copy import deepcopy\n",
+    "from rmgpy import settings\n",
+    "\n",
+    "from IPython.display import display\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcf7c9e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = settings['database.directory']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed58ea38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enter your kinetics library or libraries\n",
+    "reaction_libraries = ['Surface/CPOX_Pt/Deutschmann2006']\n",
+    "# Enter your kinetics family or families\n",
+    "families = \"None\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcdb5d60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optional - choose metal binding energies for surface library\n",
+    "metal = 'Pt111'\n",
+    "# optional - choose to display the reactions that are fixed\n",
+    "display_reactions = False\n",
+    "# optioal - choose which reactions to correct barrier\n",
+    "prompt = True\n",
+    "show_thermo = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "644f89b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the database\n",
+    "\n",
+    "database = RMGDatabase()\n",
+    "database.load(\n",
+    "    path,\n",
+    "    thermo_libraries=['2-BTP','primaryThermoLibrary','Klippenstein_Glarborg2016', 'BurkeH2O2', 'thermo_DFT_CCSDTF12_BAC', 'DFT_QCI_thermo',\n",
+    "                         'primaryThermoLibrary', 'primaryNS', 'NitrogenCurran', 'NOx2018', 'FFCM1(-)',\n",
+    "                         'SulfurLibrary', 'SulfurGlarborgH2S', 'SABIC_aromatics',\n",
+    "                     'SurfaceThermoPt111'], # can add more\n",
+    "    transport_libraries=[],\n",
+    "    reaction_libraries=reaction_libraries,\n",
+    "    seed_mechanisms=[],\n",
+    "    kinetics_families= families,\n",
+    "    kinetics_depositories=[],\n",
+    "    statmech_libraries=[],\n",
+    "    depository=False,\n",
+    "    solvation=False,\n",
+    "    surface=True,\n",
+    "    testing=False,\n",
+    ")\n",
+    "if metal:\n",
+    "    database.thermo.set_binding_energies(metal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b0c4832",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_prompt():\n",
+    "    \n",
+    "    success = False\n",
+    "    while not success:\n",
+    "        choice = input('Would you like to correct this barrier? (y/n) ')\n",
+    "        if choice in ['y', 'n', '']:\n",
+    "            success = True\n",
+    "        else:\n",
+    "            print('Invalid choice.')\n",
+    "\n",
+    "    if choice in ['y','']:\n",
+    "        return True\n",
+    "    elif choice == 'n':\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "080f16f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_thermo(reaction):\n",
+    "    print(\"-\"*50,\"THERMO\",\"-\"*50)\n",
+    "    for spcs in reaction.reactants + reaction.products:\n",
+    "        print(\"\\t\" + spcs.label)\n",
+    "        print(\"\\t\\t \" + spcs.thermo.comment)\n",
+    "        print(f\"\\t\\t E0: {spcs.thermo.E0.value_si/4184:.2f} kcal/mol\")\n",
+    "        print(f\"\\t\\t H298: {spcs.thermo.get_enthalpy(298)/4184:.2f} kcal/mol\")\n",
+    "        print(f\"\\t\\t S298: {spcs.thermo.get_entropy(298)/4.184:.2f} cal/mol/K\")\n",
+    "    print(\"-\"*108)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "883ab62d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fix barrier for kinetics families training reactions\n",
+    "\n",
+    "for family_name, family in database.kinetics.families.items():\n",
+    "    library = family.get_training_depository()\n",
+    "    for label,entry in library.entries.items():\n",
+    "        if entry.item.reversible:\n",
+    "            reaction = entry.item\n",
+    "            reaction.kinetics =  deepcopy(entry.data)\n",
+    "            for spcs in reaction.reactants + reaction.products:\n",
+    "                if not spcs.thermo:\n",
+    "                    labels = spcs.molecule[0].get_all_labeled_atoms()\n",
+    "                    spcs.molecule[0].clear_labeled_atoms()\n",
+    "                    spcs.generate_resonance_structures()\n",
+    "                    submit(spcs)\n",
+    "                    for label,atom in labels.items():\n",
+    "                        if isinstance(atom,list):\n",
+    "                            for a in atom:\n",
+    "                                a.label=label\n",
+    "                        else:\n",
+    "                            atom.label = label\n",
+    "            reaction.fix_barrier_height()\n",
+    "            if \"Ea raised\" in reaction.kinetics.comment:\n",
+    "                print(\"=\"*49,\"REACTION\",\"=\"*49)\n",
+    "                print(f'{label} {reaction}')\n",
+    "                if display_reactions:\n",
+    "                    display(reaction)\n",
+    "                print(reaction.kinetics)\n",
+    "                response = True\n",
+    "                if show_thermo:\n",
+    "                    display_thermo(reaction)\n",
+    "                if prompt:\n",
+    "                    response = display_prompt()\n",
+    "                if response:\n",
+    "                    print(\"*** Barrier corrected\")\n",
+    "                    n_reactions_fixed += 1\n",
+    "                    entry.data = reaction.kinetics\n",
+    "                else:\n",
+    "                    print(\"*** Barrier NOT corrected\")\n",
+    "    print('*' * 100)\n",
+    "    print(f\"FIXED {n_reactions_fixed} barriers in {family_name}\")\n",
+    "    print('*'* 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "762ea611",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save training reactions\n",
+    "for family_name, family in database.kinetics.families.items():\n",
+    "    library = family.get_training_depository()\n",
+    "    lib_path = os.path.join(path,'kinetics','families',library.name,'reactions.py')\n",
+    "    library.save(lib_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c41bb8be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fix barrier for library reactions\n",
+    "\n",
+    "for library_name, library in database.kinetics.libraries.items():\n",
+    "    n_reactions_fixed = 0\n",
+    "    for label,entry in library.entries.items():\n",
+    "        if entry.item.reversible:\n",
+    "            reaction = entry.item\n",
+    "            reaction.kinetics = deepcopy(entry.data)\n",
+    "            for spcs in reaction.reactants + reaction.products:\n",
+    "                if not spcs.thermo:\n",
+    "                    submit(spcs)\n",
+    "            reaction.fix_barrier_height()\n",
+    "            if \"Ea raised\" in reaction.kinetics.comment:\n",
+    "                print(\"=\"*49,\"REACTION\",\"=\"*49)\n",
+    "                print(f'{label} {reaction}')\n",
+    "                if display_reactions:\n",
+    "                    display(reaction)\n",
+    "                print(reaction.kinetics)\n",
+    "                response = True\n",
+    "                if show_thermo:\n",
+    "                    display_thermo(reaction)\n",
+    "                if prompt:\n",
+    "                    response = display_prompt()\n",
+    "                if response:\n",
+    "                    print(\"*** Barrier corrected\")\n",
+    "                    entry.data = reaction.kinetics\n",
+    "                    n_reactions_fixed += 1\n",
+    "                else:\n",
+    "                    print(\"*** Barrier NOT corrected\")\n",
+    "    print('*' * 100)\n",
+    "    print(f\"FIXED {n_reactions_fixed} barriers in {library_name}\")\n",
+    "    print('*'* 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7277b7a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save libraries\n",
+    "for library_name, library in database.kinetics.libraries.items():\n",
+    "    lib_path = os.path.join(path,'kinetics','libraries',library_name,'reactions.py')\n",
+    "    library.save(lib_path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -778,7 +778,7 @@ def pressure_dependence(
 def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None,
             generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False,
             saveEdgeSpecies=False, keepIrreversible=False, trimolecularProductReversible=True, wallTime='00:00:00:00',
-            saveSeedModulus=-1):
+            correctLibraryKinetics=False, saveSeedModulus=-1):
     if saveRestartPeriod:
         logging.warning("`saveRestartPeriod` flag was set in the input file, but this feature has been removed. Please "
                         "remove this line from the input file. This will throw an error after RMG-Py 3.1. For "
@@ -803,6 +803,7 @@ def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=Fals
     rmg.trimolecular_product_reversible = trimolecularProductReversible
     rmg.walltime = wallTime
     rmg.save_seed_modulus = saveSeedModulus
+    rmg.reaction_model.correct_library_kinetics = correctLibraryKinetics
 
 
 def generated_species_constraints(**kwargs):

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -228,6 +228,7 @@ class CoreEdgeReactionModel:
         self.new_surface_rxns_loss = set()
         self.solvent_name = ''
         self.surface_site_density = None
+        self.correct_library_kinetics = False
         self.unrealgroups = [Group().from_adjacency_list("""
             1  O u0 p2 c0 {2,S} {4,S}
             2  O u0 p2 c0 {1,S} {3,S}
@@ -1549,6 +1550,9 @@ class CoreEdgeReactionModel:
                     submit(spec, self.solvent_name)
 
                 rxn.fix_barrier_height(force_positive=True)
+            elif self.correct_library_kinetics and rxn.reversible:
+                rxn.fix_barrier_height()
+
             self.add_reaction_to_core(rxn)
 
         # Check we didn't introduce unmarked duplicates
@@ -1643,6 +1647,8 @@ class CoreEdgeReactionModel:
             # Note that we haven't actually evaluated any fluxes at this point
             # Instead, we remove the comment below if the reaction is moved to
             # the core later in the mechanism generation
+            if self.correct_library_kinetics and rxn.reversible:
+                rxn.fix_barrier_height()
             if not (self.pressure_dependence and rxn.elementary_high_p and rxn.is_unimolecular()
                     and isinstance(rxn, LibraryReaction) and isinstance(rxn.kinetics, Arrhenius) and \
                     (self.pressure_dependence.maximum_atoms is None or self.pressure_dependence.maximum_atoms >= \


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
We do not correct the barriers for library reactions.  For some library reactions, the Ea < H0 of reaction with RMG thermo which means the forward rate is too fast and the reverse rate is way way too fast.  This is particularly a problem for the `X + CHX -> HX + CX` in the Deutchmann kinetics library.


### Description of Changes
added an input file option `correct_library_kinetics` (default False) which when turned on, corrects the barriers for library reactions based on the thermo.

<img width="897" alt="Screen Shot 2021-06-25 at 4 01 42 PM" src="https://user-images.githubusercontent.com/32377555/123481468-c54d7100-d5d1-11eb-80cb-14bcb5efc178.png">

### Testing
Tested this with @mazeau CPOX model, and the barrier for the Deutchmann reaction was corrected.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
