### PR TITLE
Thermo engine metal support

### DIFF
--- a/rmgpy/data/surface.py
+++ b/rmgpy/data/surface.py
@@ -233,8 +233,9 @@ class MetalDatabase(object):
 
     def find_binding_energies(self, metal):
         """
-        Tries to find a match in the database when given a metal and/or facet and returns the binding energies or a
-        best guess of binding energies.
+        Tries to find a match in the database when given a metal and/or facet (str).
+
+        Returns: (`database entry label (str)`, `atomic binding_energies (dict)`)
         """
         if metal is None:
             raise DatabaseError("Cannot search for nothing.")
@@ -245,6 +246,7 @@ class MetalDatabase(object):
         if facet is not None:
             try:
                 metal_binding_energies = self.libraries['surface'].get_binding_energies(metal)
+                db_label = metal
             except DatabaseError:
                 # no exact match was found, so continue on as if no facet was given
                 logging.warning("Requested metal %r not found in database.", metal)
@@ -257,16 +259,18 @@ class MetalDatabase(object):
             metal_entry_matches = self.libraries['surface'].get_all_entries_on_metal(metal)
 
             if len(metal_entry_matches) == 1:
-                metal_binding_energies = self.libraries['surface'].get_binding_energies(metal_entry_matches[0])
+                db_label = metal_entry_matches[0]
+                metal_binding_energies = self.libraries['surface'].get_binding_energies(db_label)
             elif metal_entry_matches is None:  # no matches
                 raise DatabaseError(f"No metal {metal} found in metal database.")
             else:  # multiple matches
                 # average the binding energies together? just pick the first one?
                 # just picking the first one for now...
-                logging.warning(f"Found multiple binding energies for {metal!r}. Using {metal_entry_matches[0]!r}.")
-                metal_binding_energies = self.libraries['surface'].get_binding_energies(metal_entry_matches[0])
+                db_label = metal_entry_matches[0]
+                logging.warning(f"Found multiple binding energies for {metal!r}. Using {db_label!r}.")
+                metal_binding_energies = self.libraries['surface'].get_binding_energies(db_label)
 
-        return metal_binding_energies
+        return db_label, metal_binding_energies
 
     def add_entry(self, entry):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1432,7 +1432,7 @@ class ThermoDatabase(object):
         if isinstance(binding_energies, str):
             if not self.surface:
                 self.load_surface()
-            binding_energies = self.surface['metal'].find_binding_energies(binding_energies)
+            metal_label, binding_energies = self.surface['metal'].find_binding_energies(binding_energies)
 
         for element, energy in binding_energies.items():
             binding_energies[element] = rmgpy.quantity.Energy(energy)
@@ -1457,12 +1457,12 @@ class ThermoDatabase(object):
         if metal_to_scale_to is None:
             metal_to_scale_to_binding_energies = self.binding_energies
         else:
-            metal_to_scale_to_binding_energies = self.surface['metal'].find_binding_energies(metal_to_scale_to)
+            metal_to_scale_to, metal_to_scale_to_binding_energies = self.surface['metal'].find_binding_energies(metal_to_scale_to)
 
         if metal_to_scale_from is None:
             metal_to_scale_from_binding_energies = self.binding_energies
         else:
-            metal_to_scale_from_binding_energies = self.surface['metal'].find_binding_energies(metal_to_scale_from)
+            metal_to_scale_from, metal_to_scale_from_binding_energies = self.surface['metal'].find_binding_energies(metal_to_scale_from)
 
         delta_atomic_adsorption_energy = {
             'C': rmgpy.quantity.Energy(0.0, 'eV/molecule'),
@@ -1520,6 +1520,8 @@ class ThermoDatabase(object):
                 thermo.H298.value_si += change_in_binding_energy
                 comments.append(f'{normalized_bonds[element]:.2f}{element}')
         thermo.comment += " Binding energy corrected by LSR ({}) from {}".format('+'.join(comments), metal_to_scale_from)
+        if metal_to_scale_to:
+            thermo.comment += " to {}".format(metal_to_scale_to)
         return thermo
 
     def get_thermo_data_for_surface_species(self, species):

--- a/rmgpy/thermo/thermoengine.py
+++ b/rmgpy/thermo/thermoengine.py
@@ -102,7 +102,7 @@ def process_thermo_data(spc, thermo0, thermo_class=NASA, solvent_name=''):
     return thermo
 
 
-def generate_thermo_data(spc, thermo_class=NASA, solvent_name=''):
+def generate_thermo_data(spc, thermo_class=NASA, solvent_name='', metal=None):
     """
     Generates thermo data, first checking Libraries, then using either QM or Database.
     
@@ -122,7 +122,7 @@ def generate_thermo_data(spc, thermo_class=NASA, solvent_name=''):
         logging.debug('Could not obtain the thermo database. Not generating thermo...')
         return None
 
-    thermo0 = thermodb.get_thermo_data(spc)
+    thermo0 = thermodb.get_thermo_data(spc, metal_to_scale_to=metal)
 
     # 1. maybe only submit cyclic core
     # 2. to help radical prediction, HBI should also
@@ -143,7 +143,7 @@ def generate_thermo_data(spc, thermo_class=NASA, solvent_name=''):
     return process_thermo_data(spc, thermo0, thermo_class, solvent_name)
 
 
-def evaluator(spc, solvent_name=''):
+def evaluator(spc, solvent_name='', metal=None):
     """
     Module-level function passed to workers.
 
@@ -157,12 +157,12 @@ def evaluator(spc, solvent_name=''):
     logging.debug("Evaluating spc %s ", spc)
 
     spc.generate_resonance_structures()
-    thermo = generate_thermo_data(spc, solvent_name=solvent_name)
+    thermo = generate_thermo_data(spc, solvent_name=solvent_name, metal=metal)
 
     return thermo
 
 
-def submit(spc, solvent_name=''):
+def submit(spc, solvent_name='', metal=None):
     """
     Submits a request to calculate chemical data for the Species object.
 
@@ -172,4 +172,4 @@ def submit(spc, solvent_name=''):
     the result.
 
     """
-    spc.thermo = evaluator(spc, solvent_name=solvent_name)
+    spc.thermo = evaluator(spc, solvent_name=solvent_name, metal=metal)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The thermo engine `submit` function is often used to get thermo from the DB, but currently it does not support different metals.  Therefore, we can only get adsorbate thermo on the default thermoDB metal 'Pt111' when using the thermo engine.


### Description of Changes
- added `metal` to the thermo engine's functions.  
- revised the `find_binding_energies` method to return the label of the metal entry so we know that we can report what metal we scaled to when correcting the binding energy using LSRs


### Testing
tested in notebook
<img width="741" alt="Screen Shot 2021-07-01 at 1 25 22 PM" src="https://user-images.githubusercontent.com/32377555/124165481-d8e45600-da6f-11eb-952b-629a4f345498.png">



<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
