### PR TITLE
autogen trees with halogens

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -3872,7 +3872,7 @@ class KineticsFamily(Database):
         grp = node.item
         rxns = template_rxn_map[node.label]
 
-        R = ['H', 'C', 'N', 'O', 'Si', 'S', 'Cl']  # set of possible R elements/atoms
+        R = ['H', 'C', 'N', 'O', 'Si', 'S', 'Cl', 'F', 'Br']  # set of possible R elements/atoms
         R = [ATOMTYPES[x] for x in R]
 
         RnH = R[:]

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1553,6 +1553,11 @@ class KineticsFamily(Database):
                 atom_labels['*2'].label = '*4'
                 atom_labels['*4'].label = '*2'
 
+            # Use the family's reverse map if it has one
+            elif self.reverse_map:
+                for label0,label1 in self.reverse_map.items():
+                    atom_labels[label0] = label1
+
         if not forward:
             template = self.reverse_template
             product_num = self.reactant_num or len(template.products)

--- a/rmgpy/molecule/element.py
+++ b/rmgpy/molecule/element.py
@@ -331,6 +331,7 @@ element_list = [
 # (C,C,2.5) is C#C - (CbenzeneC - C-C)
 # P=P value is from: https://www2.chemistry.msu.edu/faculty/reusch/OrgPage/bndenrgy.htm
 # C#S is the value for [C+]#[S-] from 10.1002/chem.201002840 referenced relative to 0 K
+# X-O and X-X (X=F,Cl,Br) taken from https://labs.chem.ucsb.edu/zakarian/armen/11---bonddissociationenergy.pdf
 # The reference state is gaseous state at 298 K, but some of the values in the bde_dict might be coming from 0 K.
 # The bond dissociation energy at 298 K is greater than the bond dissociation energy at 0 K by 0.6 to 0.9 kcal/mol
 # (between RT and 3/2 RT), and this difference is usually much smaller than the uncertainty in the bond dissociation
@@ -371,7 +372,10 @@ bde_dict = {('H', 'H', 1.0): (432.0, 'kJ/mol'), ('H', 'C', 1): (411.0, 'kJ/mol')
             ('S', 'S', 1): (226.0, 'kJ/mol'), ('S', 'S', 2): (425.0, 'kJ/mol'),
             ('S', 'Cl', 1): (255.0, 'kJ/mol'),
             ('F', 'F', 1): (155.0, 'kJ/mol'), ('Cl', 'Cl', 1): (240.0, 'kJ/mol'),
-            ('Br', 'Br', 1): (190.0, 'kJ/mol'), ('I', 'I', 1): (148.0, 'kJ/mol')}
+            ('Br', 'Br', 1): (190.0, 'kJ/mol'), ('I', 'I', 1): (148.0, 'kJ/mol'),
+            ('F', 'O', 1): (222.0, 'kJ/mol'), ('Cl', 'O', 1): (272.0, 'kJ/mol'),
+            ('Br', 'O', 1): (235.1, 'kJ/mol'), ('Cl', 'F', 1): (250.54, 'kJ/mol'),
+            ('Br', 'F', 1): (233.8, 'kJ/mol'), ('Br', 'Cl', 1): (218.84, 'kJ/mol')}
 
 bdes = {}
 for key, value in bde_dict.items():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This PR adds a few changes needed to run the autogen tree script for halogen families.  This branch was used to generate the trees for this RMG-database PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/510


### Description of Changes
- Added BDEs for X-O (X=halogen)
- Added F and Br to R elements in `simple_regularization` method
- use family.reverse_map instead of hard coded changes to swap labels for own reverse families when applying the reaction recipe



<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
