### PR TITLE
Added additional features to preserve atom order and template labels when generating reactions

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2074,8 +2074,8 @@ class KineticsFamily(Database):
                         else:
                             if product_structures is not None:
                                 rxn = self._create_reaction(reactant_structures, product_structures, forward)
-                                if rxn: rxn_list.append(rxn)
-
+                                if rxn:
+                                    rxn_list.append(rxn)
         # Bimolecular reactants: A + B --> products
         elif len(reactants) == 2 and len(template_reactants) == 2:
 
@@ -2115,7 +2115,8 @@ class KineticsFamily(Database):
                                 else:
                                     if product_structures is not None:
                                         rxn = self._create_reaction(reactant_structures, product_structures, forward)
-                                        if rxn: rxn_list.append(rxn)
+                                        if rxn:
+                                            rxn_list.append(rxn)
 
                         # Only check for swapped reactants if they are different
                         if reactants[0] is not reactants[1]:

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -831,7 +831,7 @@ class TestGenerateReactions(unittest.TestCase):
             reaction_libraries=[],
             kinetics_families=['H_Abstraction', 'R_Addition_MultipleBond', 'Singlet_Val6_to_triplet', 'R_Recombination',
                                'Baeyer-Villiger_step1_cat', 'Surface_Adsorption_Dissociative',
-                               'Surface_Abstraction_vdW', 'Surface_Dissociation_vdW'],
+                               'Surface_Abstraction_vdW', 'Surface_Dissociation_vdW', 'intra_H_migration'],
             depository=False,
             solvation=False,
             surface=False,
@@ -1073,6 +1073,23 @@ multiplicity 2
         reacts = [Molecule(smiles='*[CH2]'), Molecule(smiles='*[CH2]')]
         reaction_list = family.generate_reactions(reacts)
         self.assertEqual(len(reaction_list), 0)
+
+    def test_retaining_atom_labels_in_template_reaction(self):
+        """
+        Test that atom labels are not deleted from a TemplateReaction if so requested.
+        """
+        family = self.database.kinetics.families['intra_H_migration']
+        reacts = [Molecule(smiles='C[CH]C')]
+        reaction_list_1 = family.generate_reactions(reacts)
+        self.assertFalse(hasattr(reaction_list_1[0], 'labeled_atoms'))
+        reaction_list_2 = family.generate_reactions(reacts, delete_labels=False, relabel_atoms=False)
+        self.assertTrue(hasattr(reaction_list_2[0], 'labeled_atoms'))
+        self.assertEqual([(label, str(atom)) for label, atom in
+                          reaction_list_2[0].labeled_atoms['reactants'].items()],
+                         [('*2', 'C'), ('*1', 'C.'), ('*3', 'H')])
+        self.assertEqual([(label, str(atom)) for label, atom in
+                          reaction_list_2[0].labeled_atoms['products'].items()],
+                         [('*1', 'C'), ('*2', 'C.'), ('*3', 'H')])
 
 
 ################################################################################

--- a/rmgpy/data/kinetics/familyTest.py
+++ b/rmgpy/data/kinetics/familyTest.py
@@ -703,9 +703,9 @@ class TestTreeGeneration(unittest.TestCase):
         self.family.clean_tree()
         ents = [ent for ent in self.family.groups.entries.values() if ent.index != -1]
         self.assertEqual(len(ents), 1,
-                          'more than one relevant group left in groups after preparing tree for generation')
+                         'more than one relevant group left in groups after preparing tree for generation')
         self.assertEqual(len(self.family.rules.entries), 1,
-                          'more than one group in rules.entries after preparing tree for generation')
+                         'more than one group in rules.entries after preparing tree for generation')
         root = self.family.groups.entries[list(self.family.rules.entries.keys())[0]]
         self.assertEqual([root], self.family.forward_template.reactants)
         self.assertEqual([root], self.family.groups.top)
@@ -830,8 +830,8 @@ class TestGenerateReactions(unittest.TestCase):
             thermo_libraries=[],
             reaction_libraries=[],
             kinetics_families=['H_Abstraction', 'R_Addition_MultipleBond', 'Singlet_Val6_to_triplet', 'R_Recombination',
-                              'Baeyer-Villiger_step1_cat', 'Surface_Adsorption_Dissociative', 'Surface_Abstraction_vdW',
-                              'Surface_Dissociation_vdW'],
+                               'Baeyer-Villiger_step1_cat', 'Surface_Adsorption_Dissociative',
+                               'Surface_Abstraction_vdW', 'Surface_Dissociation_vdW'],
             depository=False,
             solvation=False,
             surface=False,
@@ -869,11 +869,11 @@ class TestGenerateReactions(unittest.TestCase):
 
     def test_molecule_forbidden(self):
 
-        forbidden_mol = Molecule(smiles='*CC.[*]') # vdw bidentate
+        forbidden_mol = Molecule(smiles='*CC.[*]')  # vdw bidentate
 
-        mol1 = Molecule(smiles='*CC*') # bidentate
-        mol2 = Molecule(smiles='C.*') # vdw
-        mol3 = Molecule(smiles='CC*') # chemisorbed
+        mol1 = Molecule(smiles='*CC*')  # bidentate
+        mol2 = Molecule(smiles='C.*')  # vdw
+        mol3 = Molecule(smiles='CC*')  # chemisorbed
 
         fam = self.database.kinetics.families['Surface_Dissociation_vdW']
         self.assertTrue(fam.is_molecule_forbidden(forbidden_mol))
@@ -1070,11 +1070,13 @@ multiplicity 2
         Test that the multiplicity check is working correctly in the apply_recipe function
         """
         family = self.database.kinetics.families['Surface_Abstraction_vdW']
-        reacts = [Molecule(smiles='*[CH2]'),Molecule(smiles='*[CH2]')]
+        reacts = [Molecule(smiles='*[CH2]'), Molecule(smiles='*[CH2]')]
         reaction_list = family.generate_reactions(reacts)
-        self.assertEqual(len(reaction_list),0)
+        self.assertEqual(len(reaction_list), 0)
+
 
 ################################################################################
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/rmgpy/molecule/filtration.py
+++ b/rmgpy/molecule/filtration.py
@@ -413,10 +413,6 @@ def mark_unreactive_structures(filtered_list, mol_list, save_order=False):
         # been filtered out. However, for processing reactions (e.g., degeneracy calculations) it should be kept
         # (e.g., [::N]O <=> [::N][::O.] + [H.], where [::N][::O.] should be recognized as [:N.]=[::O]).
         mol = mol_list[0]
-        logging.debug("Setting the unrepresentative resonance structure {0} as unreactive in species {1}.".format(
-            mol.to_smiles(), filtered_list[0].to_smiles()))
-        logging.debug("Unreactive structure:\n{0}\nA representative reactive structure in this species:\n{1}\n".format(
-            mol.to_adjacency_list(), filtered_list[0].to_adjacency_list()))
         mol.reactive = False
         filtered_list.append(mol)
 

--- a/rmgpy/molecule/filtration.py
+++ b/rmgpy/molecule/filtration.py
@@ -74,8 +74,8 @@ def filter_structures(mol_list, mark_unreactive=True, allow_expanded_octet=True,
         filtered_list = aromaticity_filtration(filtered_list, features)
 
     if not filtered_list:
-        raise ResonanceError('Could not determine representative localized structures for species {0}'.format(
-            mol_list[0].to_smiles()))
+        raise ResonanceError(f'Could not determine representative localized structures for species '
+                             f'{mol_list[0].to_smiles()}')
 
     if mark_unreactive:
         # Mark selected unreactive structures if OS and/or adjacent birad unidirectional transitions were used
@@ -428,9 +428,9 @@ def check_reactive(filtered_list):
     """
     if not any([mol.reactive for mol in filtered_list]):
         logging.info('\n\n')
-        logging.error('No reactive structures were attributed to species {0}'.format(filtered_list[0].to_smiles()))
+        logging.error(f'No reactive structures were attributed to species {filtered_list[0].to_smiles()}')
         for mol in filtered_list:
-            logging.info('Structure: {0}\n{1}Reactive: {2}'.format(mol.to_smiles(), mol.to_adjacency_list(), mol.reactive))
+            logging.info(f'Structure: {mol.to_smiles()}\n{mol.to_adjacency_list()}Reactive: {mol.reactive}')
         logging.info('\n')
-        raise ResonanceError('Each species must have at least one reactive structure. Something probably went wrong'
-                             ' when exploring resonance structures for species {0}'.format(filtered_list[0].to_smiles()))
+        raise ResonanceError(f'Each species must have at least one reactive structure. Something probably went wrong '
+                             f'when exploring resonance structures for species {filtered_list[0].to_smiles()}')

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -176,7 +176,7 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
     # Check that mol is a valid structure in terms of atomTypes and net charge. Since SMILES with hypervalance
     # heteroatoms are not always read correctly, print a suggestion to input the structure using an adjList.
     try:
-        mol.update()
+        mol.update(sort_atoms=not save_order)
     except AtomTypeError:
         logging.error("The following molecule has at least one atom with an undefined atomtype:\n{0}"
                       "\nIf this structure was entered in SMILES, try using the adjacencyList format for an unambiguous"

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -102,7 +102,7 @@ def populate_resonance_algorithms(features=None):
             method_list.append(generate_adj_lone_pair_multiple_bond_resonance_structures)
             method_list.append(generate_adj_lone_pair_radical_multiple_bond_resonance_structures)
             if not features['is_aromatic']:
-                # The generate_lone_pair_multiple_bond_resonance_structures method may purturb the electronic
+                # The generate_lone_pair_multiple_bond_resonance_structures method may perturb the electronic
                 # configuration of a conjugated aromatic system, causing a major slow-down (two orders of magnitude
                 # slower in one observed case), and it doesn't necessarily result in new representative localized
                 # structures. Here we forbid it for all structures bearing at least one aromatic ring as a "good enough"
@@ -255,8 +255,8 @@ def _generate_resonance_structures(mol_list, method_list, keep_isomorphic=False,
         copy                if False, append new resonance structures to input list (default)
                             if True, make a new list with all of the resonance structures
     """
-    cython.declare(index=cython.int, molecule=Molecule, new_mol_list=list, new_mol=Molecule, mol=Molecule, input_charge=cython.int,
-                    x=Atom)
+    cython.declare(index=cython.int, molecule=Molecule, new_mol_list=list, new_mol=Molecule, mol=Molecule,
+                   input_charge=cython.int, x=Atom)
 
     if copy:
         # Make a copy of the list so we don't modify the input list
@@ -275,7 +275,7 @@ def _generate_resonance_structures(mol_list, method_list, keep_isomorphic=False,
         # (a +2 distance from the minimal deviation is used, octet deviations per species are in increments of 2)
         # Sometimes rearranging the structure requires an additional higher charge span structure, so allow
         # structures with a +1 higher charge span compared to the minimum, e.g., [O-]S#S[N+]#N
-        # This is run by default even if filter_structures=False.
+        # Filtration is always called.
         octet_deviation = filtration.get_octet_deviation(molecule)
         charge_span = molecule.get_charge_span()
         if octet_deviation <= min_octet_deviation + 2 and charge_span <= min_charge_span + 1:
@@ -308,22 +308,22 @@ def _generate_resonance_structures(mol_list, method_list, keep_isomorphic=False,
         if mol.get_net_charge() != input_charge:
             mol_list.remove(mol)
             logging.debug('Resonance generation created a molecule %s with a net charge of %d '
-                            'which does not match the input mol charge of %d.\n'
-                            'Removing it from resonance structures',mol.smiles,mol.get_net_charge(),input_charge)
+                          'which does not match the input mol charge of %d.\n'
+                          'Removing it from resonance structures', mol.smiles, mol.get_net_charge(), input_charge)
         if mol.contains_surface_site():
             for x in [atom for atom in mol.atoms if atom.is_surface_site()]:
                 if x.radical_electrons != 0:
                     mol_list.remove(mol)
                     logging.debug('Resonance generation created a molecule %s with %d radicals on %s.\n'
-                    'Removing it from resonance structures',mol.smiles,x.radical_electrons,x.symbol)
+                                  'Removing it from resonance structures', mol.smiles, x.radical_electrons, x.symbol)
                 elif x.lone_pairs != 0:
                     mol_list.remove(mol)
                     logging.debug('Resonance generation created a molecule %s with %d lone pairs on %s.\n'
-                    'Removing it from resonance structures',mol.smiles,x.lone_pairs,x.symbol)
+                                  'Removing it from resonance structures', mol.smiles, x.lone_pairs, x.symbol)
                 elif x.charge != 0:
                     mol_list.remove(mol)
                     logging.debug('Resonance generation created a molecule %s with a charge of %d on %s.\n'
-                    'Removing it from resonance structures',mol.smiles,x.charge,x.symbol)
+                                  'Removing it from resonance structures', mol.smiles, x.charge, x.symbol)
 
     return mol_list
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1460,14 +1460,14 @@ def same_species_lists(list1, list2, check_identical=False, only_check_label=Fal
     """
 
     def same(object1, object2, _check_identical=check_identical, _only_check_label=only_check_label,
-             _generate_initial_map=generate_initial_map, _strict=strict, save_order=save_order):
+             _generate_initial_map=generate_initial_map, _strict=strict, _save_order=save_order):
         if _only_check_label:
             return str(object1) == str(object2)
         elif _check_identical:
             return object1.is_identical(object2, strict=_strict)
         else:
             return object1.is_isomorphic(object2, generate_initial_map=_generate_initial_map,
-                                         strict=_strict, save_order=save_order)
+                                         strict=_strict, save_order=_save_order)
 
     if len(list1) == len(list2) == 1:
         if same(list1[0], list2[0]):


### PR DESCRIPTION
### Motivation or Problem
To assist in atom-mapping RMG reactions, some relatively minor modifications were made.

### Description of Changes
-  Use the save_order argument in generate_resonance_structures() 
- Added labeled_reactant/product_atom attribute to TemplateReaction
- Added relabel_atoms and delete_labels arguments to methods of KineticsFamily. These are used to optionally avoid relabeling atoms and to optionally avoid deleting atom labels, respectively. The original behavior is preserved.

In all cases, the original behavior was preserved.

### Testing
A test of retaining atom labels in a template reaction was added.