### PR TITLE
`a_dict` bugfix in `get_w0`

### DIFF
--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -1096,14 +1096,13 @@ def get_w0(actions, rxn):
     and wb (total bond energy of bonds broken) with w0 = (wf+wb)/2
     """
     mol = None
-    a_dict = {}
     for r in rxn.reactants:
         m = r.molecule[0]
-        a_dict.update(m.get_all_labeled_atoms())
         if mol:
             mol = mol.merge(m)
         else:
             mol = m.copy(deep=True)
+    a_dict = mol.get_all_labeled_atoms()
 
     recipe = actions
 
@@ -1128,7 +1127,8 @@ def get_w0(actions, rxn):
                         mol2 = mol2.merge(m)
                     else:
                         mol2 = m.copy(deep=True)
-                bd2 = mol2.get_bond(a_dict[act[1]], a_dict[act[3]])
+                a_dict_mol2 = mol2.get_all_labeled_atoms()
+                bd2 = mol2.get_bond(a_dict_mol2[act[1]], a_dict_mol2[act[3]])
             else:
                 bd2 = Bond(a_dict[act[1]], a_dict[act[3]], bd1.order + act[2])
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -1110,14 +1110,23 @@ def get_w0(actions, rxn):
     wf = 0.0
     for act in recipe:
 
+        if act[0] in ['BREAK_BOND','FORM_BOND','CHANGE_BOND']:
+
+            if act[1] == act[3]: # the labels are the same
+                atom1 = a_dict[act[1]][0]
+                atom2 = a_dict[act[3]][1]
+            else:
+                atom1 = a_dict[act[1]]
+                atom2 = a_dict[act[3]]
+
         if act[0] == 'BREAK_BOND':
-            bd = mol.get_bond(a_dict[act[1]], a_dict[act[3]])
+            bd = mol.get_bond(atom1, atom2)
             wb += bd.get_bde()
         elif act[0] == 'FORM_BOND':
-            bd = Bond(a_dict[act[1]], a_dict[act[3]], act[2])
+            bd = Bond(atom1, atom2, act[2])
             wf += bd.get_bde()
         elif act[0] == 'CHANGE_BOND':
-            bd1 = mol.get_bond(a_dict[act[1]], a_dict[act[3]])
+            bd1 = mol.get_bond(atom1, atom2)
 
             if act[2] + bd1.order == 0.5:
                 mol2 = None
@@ -1128,9 +1137,16 @@ def get_w0(actions, rxn):
                     else:
                         mol2 = m.copy(deep=True)
                 a_dict_mol2 = mol2.get_all_labeled_atoms()
-                bd2 = mol2.get_bond(a_dict_mol2[act[1]], a_dict_mol2[act[3]])
+                if act[1] == act[3]: # the labels are the same
+                    atom1_mol2 = a_dict_mol2[act[1]][0]
+                    atom2_mol2 = a_dict_mol2[act[3]][1]
+                else:
+                    atom1_mol2 = a_dict_mol2[act[1]]
+                    atom2_mol2 = a_dict_mol2[act[3]]
+
+                bd2 = mol2.get_bond(atom1_mol2, atom2_mol2)
             else:
-                bd2 = Bond(a_dict[act[1]], a_dict[act[3]], bd1.order + act[2])
+                bd2 = Bond(atom1, atom2, bd1.order + act[2])
 
             if bd2.order == 0:
                 bd2_bde = 0.0


### PR DESCRIPTION
a_dict needs to be retrieved after mol is made because we are deep copying the reactant mol (and therefore the atoms are different)

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
I was getting this unit test error here https://github.com/ReactionMechanismGenerator/RMG-database/pull/499/checks?check_run_id=3138777551
```
5977
======================================================================
5978
ERROR: test that there are six rules and each is under a different group
5979
----------------------------------------------------------------------
5980
multiprocessing.pool.RemoteTraceback: 
5981
"""
5982
Traceback (most recent call last):
5983
  File "/usr/share/miniconda/envs/rmg_env/lib/python3.7/multiprocessing/pool.py", line 121, in worker
5984
    result = (True, func(*args, **kwds))
5985
  File "/usr/share/miniconda/envs/rmg_env/lib/python3.7/multiprocessing/pool.py", line 44, in mapstar
5986
    return list(map(*args))
5987
  File "/home/runner/work/RMG-database/RMG-Py/rmgpy/data/kinetics/family.py", line 4781, in _make_rule
5988
    kin = ArrheniusBM().fit_to_reactions(rxns, recipe=recipe)
5989
  File "rmgpy/kinetics/arrhenius.pyx", line 598, in rmgpy.kinetics.arrhenius.ArrheniusBM.fit_to_reactions
5990
    w0s = get_w0s(recipe, rxns)
5991
  File "rmgpy/kinetics/arrhenius.pyx", line 1163, in rmgpy.kinetics.arrhenius.get_w0s
5992
    return [get_w0(actions, rxn) for rxn in rxns]
5993
  File "rmgpy/kinetics/arrhenius.pyx", line 1133, in rmgpy.kinetics.arrhenius.get_w0
5994
    raise ('Attempted to change a nonexistent bond.')
5995
TypeError: raise: exception class must be a subclass of BaseException
5996
"""
5997

5998
The above exception was the direct cause of the following exception:
5999

6000
Traceback (most recent call last):
6001
  File "/home/runner/work/RMG-database/RMG-Py/rmgpy/data/kinetics/familyTest.py", line 746, in test_f_rules
6002
    self.family.make_bm_rules_from_template_rxn_map(template_rxn_map)
6003
  File "/home/runner/work/RMG-database/RMG-Py/rmgpy/data/kinetics/family.py", line 3742, in make_bm_rules_from_template_rxn_map
6004
    kinetics_list = np.array(pool.map(_make_rule, inputs[inds]))
6005
  File "/usr/share/miniconda/envs/rmg_env/lib/python3.7/multiprocessing/pool.py", line 268, in map
6006
    return self._map_async(func, iterable, mapstar, chunksize).get()
6007
  File "/usr/share/miniconda/envs/rmg_env/lib/python3.7/multiprocessing/pool.py", line 657, in get
6008
    raise self._value
6009
TypeError: raise: exception class must be a subclass of BaseException
6010

```
### Description of Changes
fixed it by creating the atom dict after generating merged mol

### Testing
test passes


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
