### PR TITLE
Handle string data properly when averaging children solute

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -1703,7 +1703,7 @@ class SolvationDatabase(object):
 
         while node is not None and node.data is None:
             # do average of its children
-            success, averaged_solute_data = self._average_children_solute(node)
+            success, averaged_solute_data = self._average_children_solute(node, ring_database)
             if success:
                 node.data = averaged_solute_data
             else:
@@ -1727,7 +1727,7 @@ class SolvationDatabase(object):
             # By setting verbose=True, we turn on the comments of ring correction to pass the unittest.
             # Typically this comment is very short and also very helpful to check if the ring correction is calculated correctly.
 
-    def _average_children_solute(self, node):
+    def _average_children_solute(self, node, database):
         """
         Use children's solute data to guess solute data of parent `node`
         that doesn't have solute data built-in in tree yet.
@@ -1745,11 +1745,14 @@ class SolvationDatabase(object):
             children_solute_data_list = []
             for child in node.children:
                 if child.data is None:
-                    success, child_solute_data_average = self._average_children_solute(child)
+                    success, child_solute_data_average = self._average_children_solute(child, database)
                     if success:
                         children_solute_data_list.append(child_solute_data_average)
                 else:
-                    children_solute_data_list.append(child.data)
+                    data = child.data
+                    while isinstance(data, str):
+                        data = database.entries[data].data
+                    children_solute_data_list.append(data)
             if children_solute_data_list:
                 return True, average_solute_data(children_solute_data_list)
             else:

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -2465,7 +2465,7 @@ class ThermoDatabase(object):
 
         while node is not None and node.data is None:
             # do average of its children
-            success, averaged_thermo_data = self._average_children_thermo(node)
+            success, averaged_thermo_data = self._average_children_thermo(node, ring_database)
             if success:
                 node.data = averaged_thermo_data
             else:
@@ -2489,7 +2489,7 @@ class ThermoDatabase(object):
             # By setting verbose=True, we turn on the comments of ring correction to pass the unittest.
             # Typically this comment is very short and also very helpful to check if the ring correction is calculated correctly.
 
-    def _average_children_thermo(self, node):
+    def _average_children_thermo(self, node, database):
         """
         Use children's thermo data to guess thermo data of parent `node` 
         that doesn't have thermo data built-in in tree yet. 
@@ -2507,11 +2507,14 @@ class ThermoDatabase(object):
             children_thermo_data_list = []
             for child in node.children:
                 if child.data is None:
-                    success, child_thermo_data_average = self._average_children_thermo(child)
+                    success, child_thermo_data_average = self._average_children_thermo(child, database)
                     if success:
                         children_thermo_data_list.append(child_thermo_data_average)
                 else:
-                    children_thermo_data_list.append(child.data)
+                    data = child.data
+                    while isinstance(data, str):
+                        data = database.entries[data].data
+                    children_thermo_data_list.append(data)
             if children_thermo_data_list:
                 return True, average_thermo_data(children_thermo_data_list)
             else:


### PR DESCRIPTION
### Motivation or Problem
Following error trace shows up during my model generation. I found that it's related to the handling of string data node during averaging children solute data.
```
Traceback (most recent call last):
  File "/home/gridsan/hwpang/Software/RMG-Py/rmg.py", line 118, in <module>
    main()
  File "/home/gridsan/hwpang/Software/RMG-Py/rmg.py", line 112, in main
    rmg.execute(**kwargs)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/rmg/main.py", line 923, in execute
    trimolecular_react=self.trimolecular_react)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/rmg/model.py", line 641, in enlarge
    self.apply_thermo_to_species(procnum)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/rmg/model.py", line 853, in apply_thermo_to_species
    self.generate_thermo(spc, rename=True)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/rmg/model.py", line 860, in generate_thermo
    submit(spc, self.solvent_name)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/thermo/thermoengine.py", line 175, in submit
    spc.thermo = evaluator(spc, solvent_name=solvent_name)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/thermo/thermoengine.py", line 160, in evaluator
    thermo = generate_thermo_data(spc, solvent_name=solvent_name)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/thermo/thermoengine.py", line 143, in generate_thermo_data
    return process_thermo_data(spc, thermo0, thermo_class, solvent_name)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/thermo/thermoengine.py", line 66, in process_thermo_data
    solute_data = solvation_database.get_solute_data(spc)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1034, in get_solute_data
    solute_data = self.get_solute_data_from_groups(species)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1092, in get_solute_data_from_groups
    solute_data = self.estimate_solute_via_group_additivity(molecule)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1122, in estimate_solute_via_group_additivity
    solute_data = self.estimate_radical_solute_data_via_hbi(molecule, self.compute_group_additivity_solute)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1180, in estimate_radical_solute_data_via_hbi
    solute_data_sat = stable_solute_data_estimator(saturated_struct)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1420, in compute_group_additivity_solute
    self._add_polycyclic_correction_solute_data(solute_data, molecule, polyring)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1460, in _add_polycyclic_correction_solute_data
    self._add_poly_ring_correction_solute_data_from_heuristic(solute_data, polyring)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1484, in _add_poly_ring_correction_solute_data_from_heuristic
    estimated_bicyclic_solutedata = self.get_bicyclic_correction_solute_data_from_heuristic(bicyclic.atoms)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1564, in get_bicyclic_correction_solute_data_from_heuristic
    None, self.groups['ring'], submol, submol.atoms)[0]
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1643, in _add_ring_correction_solute_data_from_tree
    success, averaged_solute_data = self._average_children_solute(node)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 1691, in _average_children_solute
    return True, average_solute_data(children_solute_data_list)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 261, in average_solute_data
    averaged_solute_data = add_solute_data(averaged_solute_data, solute_data)
  File "/home/gridsan/hwpang/Software/RMG-Py/rmgpy/data/solvation.py", line 201, in add_solute_data
    solute_data1.A += solute_data2.A
AttributeError: 'str' object has no attribute 'A'
```

### Description of Changes
I added a while block to fetch the next data that string data points to, until it hits something that is not string.

### Testing
I used the following code to test my changes. Before the changes, it has the same error. After the changes, it averages data of string node succesfully.

```
from rmgpy.data.solvation import SolvationDatabase
from rmgpy import settings

import os

database = SolvationDatabase()
database.load(os.path.join(settings["database.directory"],"solvation"))

database._average_children_solute(database.groups["ring"].entries["SevenMember"])
```

Before the changes:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-79fa50ac5ade> in <module>
----> 1 database._average_children_solute(database.groups["ring"].entries["SevenMember"])

~/Software/RMG-Py/rmgpy/data/solvation.py in _average_children_solute(self, node)
   1777                     children_solute_data_list.append(data)
   1778             if children_solute_data_list:
-> 1779                 return True, average_solute_data(children_solute_data_list)
   1780             else:
   1781                 return False, None

~/Software/RMG-Py/rmgpy/data/solvation.py in average_solute_data(solute_data_list)
    259             averaged_solute_data = deepcopy(solute_data_list[0])
    260             for solute_data in solute_data_list[1:]:
--> 261                 averaged_solute_data = add_solute_data(averaged_solute_data, solute_data)
    262             averaged_solute_data.S /= num_values
    263             averaged_solute_data.B /= num_values

~/Software/RMG-Py/rmgpy/data/solvation.py in add_solute_data(solute_data1, solute_data2, group_additivity, verbose)
    199     If `verbose` is True, or solute_data2 is not a zero entry, add solute_data2.comment to solute_data1.comment.
    200     """
--> 201     solute_data1.A += solute_data2.A
    202     solute_data1.B += solute_data2.B
    203     solute_data1.L += solute_data2.L

AttributeError: 'str' object has no attribute 'A'
```

After the changes:

```
(True,
 SoluteData(S=-0.002964999999999999,B=-0.0048725,E=-0.01685,L=0.014062499999999993,A=-0.0001725,comment=''))
```

### Reviewer Tips
Run the code block above in a jupyter notebook.