### PR TITLE
Halogens pdep

### DIFF
--- a/rmgpy/data/statmech.py
+++ b/rmgpy/data/statmech.py
@@ -338,7 +338,7 @@ class StatmechGroups(Database):
         # Generate estimate of thermodynamics
         for atom in molecule.atoms:
             # Iterate over heavy (non-hydrogen) atoms
-            if atom.is_hydrogen(): continue
+            if atom.is_hydrogen() or atom.is_halogen(): continue
             if molecule.is_atom_in_cycle(atom):
                 # Atom is in cycle
                 # Add each C-H bond to the ringCH group

--- a/rmgpy/data/statmech.py
+++ b/rmgpy/data/statmech.py
@@ -482,6 +482,7 @@ class StatmechDatabase(object):
             'HinderedRotor': HinderedRotor,
             'IdealGasTranslation': IdealGasTranslation,
             'GroupFrequencies': GroupFrequencies,
+            'Conformer' : Conformer,
         }
         self.global_context = {}
 

--- a/rmgpy/data/statmech.py
+++ b/rmgpy/data/statmech.py
@@ -407,22 +407,23 @@ class StatmechGroups(Database):
             else:
                 groups_removed = 0
                 freqs_removed = 0
+                total_freqs_removed = 0
                 freq_count = len(frequencies)
                 while freq_count > num_vibrations:
                     min_entry = min((entry for entry in group_count if group_count[entry] > 0),
                                     key=lambda x: x.data.symmetry)
-                    min_degeneracy = min_entry.data.symmetry
                     if group_count[min_entry] > 1:
                         group_count[min_entry] -= 1
                     else:
                         del group_count[min_entry]
                     groups_removed += 1
-                    freqs_removed += min_degeneracy
-                    freq_count -= min_degeneracy
+                    freqs_removed = len(min_entry.data.generate_frequencies())
+                    total_freqs_removed += freqs_removed
+                    freq_count -= freqs_removed
                 # Log warning
                 logging.warning('For {0}, more characteristic frequencies were generated than '
                                 'vibrational modes allowed. Removed {1:d} groups ({2:d} frequencies) to '
-                                'compensate.'.format(molecule.to_smiles(), groups_removed, freqs_removed))
+                                'compensate.'.format(molecule.to_smiles(), groups_removed, total_freqs_removed))
                 # Regenerate characteristic frequencies
                 frequencies = []
                 for entry, count in group_count.items():

--- a/rmgpy/pdep/configuration.pxd
+++ b/rmgpy/pdep/configuration.pxd
@@ -37,6 +37,7 @@ cdef class Configuration(object):
     cdef public np.ndarray sum_states
     cdef public bint active_j_rotor
     cdef public bint active_k_rotor
+    cdef public float energy_correction
 
     cpdef cleanup(self)
 

--- a/rmgpy/pdep/configuration.pyx
+++ b/rmgpy/pdep/configuration.pyx
@@ -60,6 +60,7 @@ cdef class Configuration(object):
         self.sum_states = None
         self.active_j_rotor = False
         self.active_k_rotor = False
+        self.energy_correction = 0.0
 
     def __str__(self):
         return ' + '.join([str(spec) for spec in self.species])
@@ -78,7 +79,7 @@ cdef class Configuration(object):
     property E0:
         """The ground-state energy of the configuration in J/mol."""
         def __get__(self):
-            return sum([float(spec.conformer.E0.value_si) for spec in self.species])
+            return sum([float(spec.conformer.E0.value_si) for spec in self.species]) + self.energy_correction 
 
     cpdef cleanup(self):
         """
@@ -147,6 +148,7 @@ cdef class Configuration(object):
         cdef double h = 0.0
         for spec in self.species:
             h += spec.get_enthalpy(T)
+        h += self.energy_correction
         return h
 
     cpdef double get_entropy(self, double T) except -100000000:
@@ -166,6 +168,7 @@ cdef class Configuration(object):
         cdef double g = 0.0
         for spec in self.species:
             g += spec.get_free_energy(T)
+        g += self.energy_correction
         return g
 
     cpdef double calculate_collision_frequency(self, double T, double P, dict bath_gas) except -1:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -379,7 +379,7 @@ class RMG(util.Subject):
             seed_mechanisms=self.seed_mechanisms,
             kinetics_families=self.kinetics_families,
             kinetics_depositories=self.kinetics_depositories,
-            # frequenciesLibraries = self.statmech_libraries,
+            statmech_libraries = self.statmech_libraries,
             depository=False,  # Don't bother loading the depository information, as we don't use it
         )
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This PR makes it possible to run pdep for halogen models.
It is simultaneous with https://github.com/ReactionMechanismGenerator/RMG-database/pull/522 which adds halogens frequency data and groups.

### Description of Changes
1) get statmech data for halogens by skipping over halogen atoms (since the are not treated as center atoms, similar to hydrogen)
2) fixed bug for change in number of freqs removed when a group is removed
3) added support for loading statmech libraries
4) added `energy_correction` to pdep network

### Testing
Was able to get a model running with Pdep for `C=C(F)C(F)(F)F` combustion.

### Reviewer Tips
test pdep model for other types of models.  See if we get same results with new `energy_correction`.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
