### PR TITLE
Pyrms Reactor Bugfixes and Liquid-Surface Reactor for RMG Electrocat

### DIFF
--- a/examples/rmg/liquid_cat/input.py
+++ b/examples/rmg/liquid_cat/input.py
@@ -1,0 +1,74 @@
+# Data sources
+database(
+    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC','DFT_QCI_thermo'], # 'surfaceThermoPt' is the default. Thermo data is derived using bindingEnergies for other metals
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = ['surface','default'],
+    kineticsEstimator = 'rate rules',
+
+)
+
+catalystProperties(
+    metal = 'Pt111'
+)
+
+# List of species
+species(
+    label='ethylene-glycol',
+    reactive=True,
+    structure=SMILES("OCCO"),
+)
+
+
+species(
+   label='O2',
+   reactive=True,
+   structure=adjacencyList(
+       """
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+"""),
+)
+
+species(
+    label='vacantX',
+    reactive=True,
+    structure=adjacencyList("1 X u0"),
+)
+
+
+liquidSurfaceReactor(
+    temperature=(450,'K'),
+    initialConcentrations={
+        "ethylene-glycol": (1.7935e-2,'mol/cm^3'),
+        "O2": (4.953e-6,'mol/cm^3'),
+    },
+	initialSurfaceCoverages={
+        "vacantX": 1.0,
+    },
+    surfaceVolumeRatio=(1.0e5, 'm^-1'),
+    terminationTime=(10.0,'sec'),
+    terminationConversion={'ethylene-glycol': 0.90},
+    constantSpecies=['O2'],
+)
+
+solvation(
+	solvent='ethane-1,2-diol'
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=1E-20,
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    maximumEdgeSpecies=100000
+)
+
+options(
+    units='si',
+)

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -476,6 +476,9 @@ class SoluteData(object):
         the contibutions in this function are in cm3/mol, and the division by 100 is done at the very end.
         """
         molecule = species.molecule[0]  # any will do, use the first.
+        if molecule.contains_surface_site():
+            molecule = molecule.get_desorbed_molecules()[0]
+            molecule.saturate_unfilled_valence()
         Vtot = 0.0
 
         for atom in molecule.atoms:
@@ -1066,6 +1069,11 @@ class SolvationDatabase(object):
         """
 
         # Check the library first
+        if species.molecule[0].contains_surface_site(): #desorb and saturate s
+            molecule = species.molecule[0].get_desorbed_molecules()[0]
+            molecule.saturate_unfilled_valence()
+            species = Species(molecule=[molecule])
+
         solute_data = None
         if not skip_library:
             solute_data = self.get_solute_data_from_library(species, self.libraries['solute'])

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -46,7 +46,7 @@ from rmgpy.solver.simple import SimpleReactor
 from rmgpy.solver.surface import SurfaceReactor
 from rmgpy.util import as_list
 from rmgpy.data.surface import MetalDatabase
-from rmgpy.rmg.reactors import Reactor, ConstantVIdealGasReactor
+from rmgpy.rmg.reactors import Reactor, ConstantVIdealGasReactor, ConstantTLiquidSurfaceReactor
 
 ################################################################################
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -642,7 +642,7 @@ class RMG(util.Subject):
         # advantages to write it here: this is run only once (as species indexes does not change over the generation)
         if self.solvent is not None:
             for index, reaction_system in enumerate(self.reaction_systems):
-                if reaction_system.const_spc_names is not None:  # if no constant species provided do nothing
+                if not isinstance(reaction_system, Reactor) and reaction_system.const_spc_names is not None:  # if no constant species provided do nothing
                     reaction_system.get_const_spc_indices(
                         self.reaction_model.core.species)  # call the function to identify indices in the solver
 

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -265,8 +265,8 @@ class RMG(util.Subject):
 
         if self.surface_site_density:
             self.reaction_model.surface_site_density = self.surface_site_density
-            self.reaction_model.core.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si()
-            self.reaction_model.edge.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si()
+            self.reaction_model.core.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si
+            self.reaction_model.edge.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si
         self.reaction_model.coverage_dependence = self.coverage_dependence
             
         self.reaction_model.verbose_comments = self.verbose_comments

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1434,20 +1434,22 @@ class CoreEdgeReactionModel:
         if rxn not in self.core.reactions:
             self.core.reactions.append(rxn)
             if not self.core.phase_system.in_nose:
+                rms_species_list = self.core.phase_system.get_rms_species_list()
+                species_names = self.core.phase_system.get_species_names()
                 bits = np.array([spc.molecule[0].contains_surface_site() for spc in rxn.reactants+rxn.products])
                 in_edge = rxn in self.edge.reactions
                 if all(bits):
-                    self.core.phase_system.phases["Surface"].add_reaction(rxn,self.core.species)
+                    self.core.phase_system.phases["Surface"].add_reaction(rxn)
                     if not in_edge:
-                        self.edge.phase_system.phases["Surface"].add_reaction(rxn,self.core.species)
+                        self.edge.phase_system.phases["Surface"].add_reaction(rxn)
                 elif all(bits==False):
-                    self.core.phase_system.phases["Default"].add_reaction(rxn,self.core.species)
+                    self.core.phase_system.phases["Default"].add_reaction(rxn)
                     if not in_edge:
-                        self.edge.phase_system.phases["Default"].add_reaction(rxn,self.core.species)
+                        self.edge.phase_system.phases["Default"].add_reaction(rxn)
                 else:
-                    self.core.phase_system.interfaces[frozenset({"Default","Surface"})].add_reaction(rxn,self.core.species)
+                    self.core.phase_system.interfaces[frozenset({"Default","Surface"})].add_reaction(rxn,species_names,rms_species_list)
                     if not in_edge:
-                        self.edge.phase_system.interfaces[frozenset({"Default","Surface"})].add_reaction(rxn,self.core.species)
+                        self.edge.phase_system.interfaces[frozenset({"Default","Surface"})].add_reaction(rxn,species_names,rms_species_list)
 
         if rxn in self.edge.reactions:
             self.edge.reactions.remove(rxn)
@@ -1462,14 +1464,16 @@ class CoreEdgeReactionModel:
         """
         self.edge.reactions.append(rxn)
         if not self.edge.phase_system.in_nose:
+            rms_species_list = self.edge.phase_system.get_rms_species_list()
+            species_names = self.edge.phase_system.get_species_names()
             bits = np.array([spc.molecule[0].contains_surface_site() for spc in rxn.reactants+rxn.products])
             if all(bits):
-                self.edge.phase_system.phases["Surface"].add_reaction(rxn,self.core.species+self.edge.species)
+                self.edge.phase_system.phases["Surface"].add_reaction(rxn)
             elif all(bits==False):
-                self.edge.phase_system.phases["Default"].add_reaction(rxn,self.core.species+self.edge.species)
+                self.edge.phase_system.phases["Default"].add_reaction(rxn)
             else:
-                self.edge.phase_system.interfaces[set(["Default","Surface"])].add_reaction(rxn,self.core.species+self.edge.species)
-            
+                self.edge.phase_system.interfaces[frozenset(["Default","Surface"])].add_reaction(rxn,species_names,rms_species_list)
+
     def get_model_size(self):
         """
         Return the numbers of species and reactions in the model core and edge.

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -38,6 +38,7 @@ import itertools
 try:
     from pyrms import rms
     from diffeqpy import de
+    from julia import Main
 except:
     pass
 

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -163,6 +163,13 @@ class PhaseSystem:
         else:
             return None
 
+    def get_rms_species_list(self):
+        rms_species_list = []
+        for phase in self.phases.values():
+            rms_species_list += phase.species
+
+        return rms_species_list
+
 class Phase:
     """
     Class containing all species, reactions and properties necessary to describe

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -201,7 +201,7 @@ class Phase:
         try:
             ind = self.names.index(label)
             return self.species[ind]
-        except IndexError:
+        except (IndexError, ValueError):
             return None
 
     def set_solvent(self, solvent):

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -425,11 +425,16 @@ def to_rms(obj, species_names=None, rms_species_list=None):
             else:
                 atomnums[atm.element.symbol] = 1
         bondnum = len(obj.molecule[0].get_all_edges())
-        rad = rms.getspeciesradius(atomnums, bondnum)
-        diff = rms.StokesDiffusivity(rad)
-        th = obj.get_thermo_data()
-        thermo = to_rms(th)
-        return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, diff, rad, obj.molecule[0].multiplicity-1, obj.molecular_weight.value_si)
+        if not obj.molecule[0].contains_surface_site():
+            rad = rms.getspeciesradius(atomnums, bondnum)
+            diff = rms.StokesDiffusivity(rad)
+            th = obj.get_thermo_data()
+            thermo = to_rms(th)
+            return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, diff, rad, obj.molecule[0].multiplicity-1, obj.molecular_weight.value_si)
+        else:
+            th = obj.get_thermo_data()
+            thermo = to_rms(th)
+            return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, rms.EmptyDiffusivity(), 0.0, obj.molecule[0].multiplicity-1, 0.0)
     elif isinstance(obj, Reaction):
         reactantinds = [species_names.index(spc.label) for spc in obj.reactants]
         productinds = [species_names.index(spc.label) for spc in obj.products]

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -101,13 +101,15 @@ class PhaseSystem:
             if len(out) > 0:
                 phaseinv.append(phase)
 
+        rms_species_list = self.get_rms_species_list()
+
         if len(phaseinv) == 1:
-            phaseinv[0].add_reaction(rxn, species_list)
+            phaseinv[0].add_reaction(rxn, species_list, rms_species_list)
         else:
             phases = set(phaseinv)
             for interface in self.interfaces:
                 if interface.phaseset == phases:
-                    interface.add_reaction(rxn, species_list)
+                    interface.add_reaction(rxn, species_list, rms_species_list)
                     break
 
     def pass_species(self, label, phasesys):
@@ -207,11 +209,11 @@ class Phase:
         """
         self.solvent = to_rms(solvent)
 
-    def add_reaction(self, rxn, species_list):
+    def add_reaction(self, rxn):
         """
         add a reaction to the phase
         """
-        self.reactions.append(to_rms(rxn, species_list=species_list, rms_species_list=self.species))
+        self.reactions.append(to_rms(rxn, species_names=self.names, rms_species_list=self.species))
 
     def add_species(self, spc, edge_phase=None):
         """
@@ -267,11 +269,11 @@ class Interface:
         self.reactions = reactions or []
         self.phaseset = set(phases)
 
-    def add_reaction(self, rxn, species_list):
+    def add_reaction(self, rxn, species_names, rms_species_list):
         """
         add a reaction to the interface
         """
-        self.reactions.append(to_rms(rxn, species_list=species_list, rms_species_list=self.reactions))
+        self.reactions.append(to_rms(rxn, species_names=species_names, rms_species_list=rms_species_list))
 
     def remove_species(self, spc):
         """

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -412,7 +412,7 @@ def to_rms(obj, species_names=None, rms_species_list=None):
             A = obj._A.value_si
         n = obj._n.value_si
         Ea = obj._Ea.value_si
-        return rms.StickingCoefficient(A, n, Ea)
+        return rms.StickingCoefficient(A, n, Ea, rms.EmptyRateUncertainty())
     elif isinstance(obj, NASAPolynomial):
         return rms.NASApolynomial(obj.coeffs, obj.Tmin.value_si, obj.Tmax.value_si)
     elif isinstance(obj, NASA):

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -184,6 +184,7 @@ class Phase:
     kinetics within a specific phase of a simulation
     """
     def __init__(self, label="", solvent=None, site_density=None):
+        self.label = label
         self.species = []
         self.reactions = []
         self.names = []

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -296,10 +296,11 @@ class Reactor:
     Subclasses implement generate_reactor methods for
     generating the necessary RMS phase/domain/reactor objects
     """
-    def __init__(self, core_phase_system, edge_phase_system, initial_conditions, terminations):
+    def __init__(self, core_phase_system, edge_phase_system, initial_conditions, terminations, constant_species=[]):
         self.core_phase_system = core_phase_system
         self.edge_phase_system = edge_phase_system
         self.initial_conditions = initial_conditions
+        self.const_spc_names = constant_species
         self.n_sims = 1
         self.tf = 1.0e6
         for term in terminations:

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -170,6 +170,12 @@ class PhaseSystem:
 
         return rms_species_list
 
+    def get_species_names(self):
+        names = []
+        for phase in self.phases.values():
+            names += phase.names
+        return names
+
 class Phase:
     """
     Class containing all species, reactions and properties necessary to describe

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -345,8 +345,8 @@ class Reactor:
         return terminated, resurrected, invalid_objects, unimolecular_threshold, bimolecular_threshold, trimolecular_threshold, max_edge_species_rate_ratios, t, x
 
 class ConstantVIdealGasReactor(Reactor):
-    def __init__(self, core_phase_system, edge_phase_system, initial_conditions, terminations):
-        super().__init__(core_phase_system, edge_phase_system, initial_conditions, terminations)
+    def __init__(self, core_phase_system, edge_phase_system, initial_conditions, terminations, constant_species=[]):
+        super().__init__(core_phase_system, edge_phase_system, initial_conditions, terminations, constant_species=[])
 
     def generate_reactor(self, phase_system):
         """

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -354,7 +354,7 @@ class ConstantVIdealGasReactor(Reactor):
         react = rms.Reactor(domain, y0, (0.0, self.tf), p)
         return react, domain, [], p
 
-def to_rms(obj, species_list=None, rms_species_list=None):
+def to_rms(obj, species_names=None, rms_species_list=None):
     """
     Generate corresponding rms object
     """
@@ -427,8 +427,8 @@ def to_rms(obj, species_list=None, rms_species_list=None):
         thermo = to_rms(th)
         return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, diff, rad, obj.molecule[0].multiplicity-1, obj.molecular_weight.value_si)
     elif isinstance(obj, Reaction):
-        reactantinds = [species_list.index(spc) for spc in obj.reactants]
-        productinds = [species_list.index(spc) for spc in obj.products]
+        reactantinds = [species_names.index(spc.label) for spc in obj.reactants]
+        productinds = [species_names.index(spc.label) for spc in obj.products]
         reactants = [rms_species_list[i] for i in reactantinds]
         products = [rms_species_list[i] for i in productinds]
         kinetics = to_rms(obj.kinetics)


### PR DESCRIPTION
This PR implements a liquid-surface reactor within RMG that can be used to model solid-electrolyte interfaces. Along the way fixing a number of bugs related to surface handling within the new framework. For now the solvent correction for a surface species is calculated from the desorbed saturated form of that species. 
