### PR TITLE
Pdep bugfix - removing edge species

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -275,6 +275,9 @@ class RMG(util.Subject):
         if self.quantum_mechanics:
             self.reaction_model.quantum_mechanics = self.quantum_mechanics
 
+        for reaction_system in self.reaction_systems:
+            self.reaction_model.reaction_systems.append(reaction_system)
+
     def load_thermo_input(self, path=None):
         """
         Load an Thermo Estimation job from a thermo input file located at `input_file`, or

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -834,8 +834,6 @@ class PDepNetwork(rmgpy.pdep.network.Network):
             job.save_input_file(
                 os.path.join(output_directory, 'pdep', 'network{0:d}_{1:d}.py'.format(self.index, len(self.isomers))))
 
-        self.log_summary(level=logging.INFO)
-
         # Calculate the rate coefficients
         self.initialize(Tmin, Tmax, Pmin, Pmax, maximum_grain_size, minimum_grain_count, active_j_rotor, active_k_rotor,
                         rmgmode)
@@ -940,6 +938,8 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                                             '{3:g} bar'.format(net_reaction, K[t, p, i, j] / kinf, Tlist[t], Plist[p] / 1e5))
                             logging.info('    k(T,P) = {0:9.2e}    k(T) = {1:9.2e}'.format(K[t, p, i, j], kinf))
                         break
+
+        self.log_summary(level=logging.INFO)
 
         # Delete intermediate arrays to conserve memory
         self.cleanup()


### PR DESCRIPTION
### Motivation or Problem
This PR is an attempt to fix this issue https://github.com/ReactionMechanismGenerator/RMG-Py/issues/1725.
```
'Attempted to explore isomer {0}, but that species not found in product channels.'.format(isomer))
Exception: Attempted to explore isomer cO4(812), but that species not found in product channels.
```
When multiple species in a pdep network are removed from edge, we can run into this bug.  
This happened for this pdep network where both `[O]OO[O](251)` and `cO4(812)` are forbidden.
```
========================================================================
PDepNetwork #463 network information
------------------------------------
Isomers:
    [O]OO[O](251)                                         9.48859 kJ/mol
Reactant channels:
    O=O(149) + O=O(149)                                  -47.6628 kJ/mol
Product channels:
    O(5) + [O]O[O](229)                                   216.546 kJ/mol
    cO4(812)                                               166.36 kJ/mol
    O(5) + cO3(250)                                       286.387 kJ/mol
Path reactions:
    [O]OO[O](251) <=> O=O(149) + O=O(149)                 9.48858 kJ/mol
    O(5) + [O]O[O](229) <=> [O]OO[O](251)                 216.546 kJ/mol
    [O]OO[O](251) <=> cO4(812)                            167.434 kJ/mol
    [O]OO[O](251) <=> O(5) + cO3(250)                     291.452 kJ/mol
Net reactions:
========================================================================
```
RMG tried to add ` [O]OO[O](251) ` to the core first, but since it's forbidden, it removed it from the edge. Since `[O]OO[O](251)` is in every path reaction, all the path reactions for this network were removed.  However, there are some net reactions that do not have ` [O]OO[O](251) ` such as `O=O(149) + O=O(149)  <=> cO4(812)`.  Then, RMG tried to add `cO4(812) ` to the core, but it's forbidden and so it was removed from edge.  Now, there are no path reactions in this network with `cO4(812) ` but there is at least one net reaction with it.  Since the length of path reactions with `cO4(812) `  is 0, RMG does not check the net reactions.  I think this is causing the bug when later RMG tries to explore this network and is grabs `cO4(812)` for this net reaction `O=O(149) + O=O(149)  <=> cO4(812)`.

### Description of Changes
- Check the networks net reactions when removing a species, regardless if the species is in any path reactions
- remove empty pdep networks after removing forbidden edge species
- log the pdep summary later so we can see the net reactions in log file
- I also cherrypicked this bugfix commit https://github.com/ReactionMechanismGenerator/RMG-Py/commit/0669f23021e0206d2bf52776edbb39fec168f771 from this PR https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2185 because I think its also important to get into master

### Testing
I am currently rebuilding the model that crashed, but it takes a couple of hours to reach the bug
UPDATE: The test model completed without crashing


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with master?
-->
