### PR TITLE
Change default branch to `main`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,5 +22,5 @@ Checklist before submission:
  - Is your code commented and understandable?
  - Have you updated related documentation?
  - Are the commits logically organized and informative?
- - Is your branch up to date with master?
+ - Is your branch up to date with main?
 -->

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - main
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
 jobs:
   build-and-test-linux:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 5
     env: # update this if needed to match a pull request on the RMG-database
-      RMG_DATABASE_BRANCH: master
+      RMG_DATABASE_BRANCH: main
     defaults:
       run:
         shell: bash -l {0}
@@ -31,7 +31,7 @@ jobs:
           conda list  
       - name: Install and link Julia dependencies 
         run: |
-          julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl\", rev=\"master\"))"
+          julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl\", rev=\"main\"))"
           julia -e "using Pkg; Pkg.add(\"PyCall\"); Pkg.add(\"DifferentialEquations\")"
           python -c "import julia; julia.install()"
           ln -sfn $(which python-jl) $(which python)
@@ -51,7 +51,7 @@ jobs:
           git clone -b arkanepy3 https://github.com/mjohnson541/Q2DTor.git external/Q2DTor
           make
       - name: Trigger RMG-tests
-        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/stable' }} # only push events to branches other than master and stable
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/stable' }} # only push events to branches other than main and stable
         env:
           GH_TOKEN: ${{ secrets.RMG_DEV_TOKEN }}
         run: ./trigger-rmg-tests.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Build Documentation
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
           conda list
       - name: Install and link Julia dependencies 
         run: |
-          julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl\", rev=\"master\"))"
+          julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl\", rev=\"main\"))"
           julia -e "using Pkg; Pkg.add(\"PyCall\"); Pkg.add(\"DifferentialEquations\")"
           python -c "import julia; julia.install()"
           ln -sfn $(which python-jl) $(which python)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# <img align="top" src="https://raw.githubusercontent.com/ReactionMechanismGenerator/RMG-Py/master/documentation/source/_static/rmg-logo-small.png"> Reaction Mechanism Generator (RMG)
+# <img align="top" src="https://raw.githubusercontent.com/ReactionMechanismGenerator/RMG-Py/main/documentation/source/_static/rmg-logo-small.png"> Reaction Mechanism Generator (RMG)
 
-[![Build status](https://img.shields.io/travis/ReactionMechanismGenerator/RMG-Py/master.svg)](https://travis-ci.org/ReactionMechanismGenerator/RMG-Py)
-[![Codecov report](https://img.shields.io/codecov/c/github/ReactionMechanismGenerator/RMG-Py/master.svg)](https://codecov.io/gh/ReactionMechanismGenerator/RMG-Py)
-[![Codacy report](https://img.shields.io/codacy/grade/5c12cecf3d01400a92ea20e14ca0b880/master.svg)](https://www.codacy.com/app/ReactionMechanismGenerator/RMG-Py/dashboard)
+[![Build status](https://img.shields.io/travis/ReactionMechanismGenerator/RMG-Py/main.svg)](https://travis-ci.org/ReactionMechanismGenerator/RMG-Py)
+[![Codecov report](https://img.shields.io/codecov/c/github/ReactionMechanismGenerator/RMG-Py/main.svg)](https://codecov.io/gh/ReactionMechanismGenerator/RMG-Py)
+[![Codacy report](https://img.shields.io/codacy/grade/5c12cecf3d01400a92ea20e14ca0b880/main.svg)](https://www.codacy.com/app/ReactionMechanismGenerator/RMG-Py/dashboard)
 [![GitHub release](https://img.shields.io/github/release/ReactionMechanismGenerator/RMG-Py.svg)](https://github.com/ReactionMechanismGenerator/RMG-Py/releases)
 [![Anconda](https://img.shields.io/conda/v/rmg/rmg.svg)](https://anaconda.org/rmg/rmg)
 [![Gitter](https://img.shields.io/gitter/room/ReactionMechanismGenerator/RMG-Py.svg)](https://gitter.im/ReactionMechanismGenerator/RMG-Py)
@@ -28,9 +28,9 @@ You can either download the source from GitHub and compile yourself, or download
 Please see the [Download and Install](http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/installation/index.html) page for detailed instructions.
 
 ## Documentation
-- [RMG Documentation](http://ReactionMechanismGenerator.github.io/RMG-Py/users/rmg/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/master/documentation/RMG-Py_and_Arkane_Documentation.pdf))
-- [Arkane Documentation](http://ReactionMechanismGenerator.github.io/RMG-Py/users/arkane/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/master/documentation/RMG-Py_and_Arkane_Documentation.pdf))
-- [RMG API Reference](http://reactionmechanismgenerator.github.io/RMG-Py/reference/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/master/documentation/RMG-Py_API_Reference.pdf))
+- [RMG Documentation](http://ReactionMechanismGenerator.github.io/RMG-Py/users/rmg/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/main/documentation/RMG-Py_and_Arkane_Documentation.pdf))
+- [Arkane Documentation](http://ReactionMechanismGenerator.github.io/RMG-Py/users/arkane/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/main/documentation/RMG-Py_and_Arkane_Documentation.pdf))
+- [RMG API Reference](http://reactionmechanismgenerator.github.io/RMG-Py/reference/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/main/documentation/RMG-Py_API_Reference.pdf))
 
 ## How to Contribute
 Please see the [Contributor Guidelines](https://github.com/ReactionMechanismGenerator/RMG-Py/wiki/RMG-Contributor-Guidelines)

--- a/trigger-rmg-tests.sh
+++ b/trigger-rmg-tests.sh
@@ -30,7 +30,7 @@ cd $TARGET_DIR
 
 # create a new branch in RMG-tests with the name equal to
 # the branch name of the tested RMG-Py branch:
-if [ "$RMG_DATABASE_BRANCH" == "master" ]
+if [ "$RMG_DATABASE_BRANCH" == "main" ]
 then
   RMGTESTSBRANCH=rmgpy-$BRANCH
 else
@@ -42,7 +42,7 @@ git checkout $RMGTESTSBRANCH
 
 # create an empty commit with the SHA-ID of the
 # tested commit of the RMG-Py branch:
-if [ "$RMG_DATABASE_BRANCH" == "master" ]
+if [ "$RMG_DATABASE_BRANCH" == "main" ]
 then
   git commit --allow-empty -m rmgpy-$REV
 else


### PR DESCRIPTION
### Motivation or Problem
The default branch name is hard coded in a few different places. To make the switch to `main`, we need to
change the default branch name in these locations.

### Description of Changes
I searched the whole repo for `master` and replaced it with `main` where appropriate.

### Testing
Hopefully the tests pass?