### PR TITLE
Fix RMS Object Construction

### DIFF
--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -414,10 +414,10 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
         return rms.PDepArrhenius(Ps, arrs)
     elif isinstance(obj, MultiArrhenius):
         arrs = [to_rms(arr) for arr in obj.arrhenius]
-        return rms.MultiArrhenius(arrs)
+        return rms.MultiArrhenius(arrs, rms.EmptyRateUncertainty())
     elif isinstance(obj, MultiPDepArrhenius):
         parrs = [to_rms(parr) for parr in obj.arrhenius]
-        return rms.MultiPdepArrhenius(parrs)
+        return rms.MultiPdepArrhenius(parrs, rms.EmptyRateUncertainty())
     elif isinstance(obj, Chebyshev):
         Tmin = obj.Tmin.value_si
         Tmax = obj.Tmax.value_si

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -189,6 +189,7 @@ class Phase:
         self.reactions = []
         self.names = []
         self.species_dict = dict()
+        self.rmg_species = []
         if solvent:
             self.solvent = to_rms(solvent)
         if site_density:
@@ -227,6 +228,8 @@ class Phase:
             label = spc.label
             logging.debug(f"species {label} was already in phase skipping...")
             return
+
+        self.rmg_species.append(spc)
 
         label = spc.label
         spec = to_rms(spc)
@@ -382,7 +385,7 @@ class ConstantTLiquidSurfaceReactor(Reactor):
         react,y0,p = rms.Reactor((domainliq,domaincat), (y0liq,y0cat), (0.0, self.tf), [inter], (pliq,pcat,pinter))
         return react, (domainliq,domaincat), [inter], p
 
-def to_rms(obj, species_names=None, rms_species_list=None):
+def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
     """
     Generate corresponding rms object
     """

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -411,7 +411,7 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
     elif isinstance(obj, PDepArrhenius):
         Ps = obj._pressures.value_si
         arrs = [to_rms(arr) for arr in obj.arrhenius]
-        return rms.PdepArrhenius(Ps, arrs)
+        return rms.PdepArrhenius(Ps, arrs, rms.EmptyRateUncertainty())
     elif isinstance(obj, MultiArrhenius):
         arrs = [to_rms(arr) for arr in obj.arrhenius]
         return rms.MultiArrhenius(arrs, rms.EmptyRateUncertainty())

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -217,10 +217,10 @@ class Phase:
         add a reaction to the phase
         """
         if self.add_later_reactions != []:
-            for rxn in self.add_later_reactions:
+            for reaction in self.add_later_reactions[:]:
                 try:
-                    self.reactions.append(to_rms(rxn, species_names=self.names, rms_species_list=self.species, rmg_species=self.rmg_species))
-                    self.add_later_reactions.remove(rxn)
+                    self.reactions.append(to_rms(reaction, species_names=self.names, rms_species_list=self.species, rmg_species=self.rmg_species))
+                    self.add_later_reactions.remove(reaction)
                 except ValueError:
                     pass
         try:

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -411,7 +411,7 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
     elif isinstance(obj, PDepArrhenius):
         Ps = obj._pressures.value_si
         arrs = [to_rms(arr) for arr in obj.arrhenius]
-        return rms.PDepArrhenius(Ps, arrs)
+        return rms.PdepArrhenius(Ps, arrs)
     elif isinstance(obj, MultiArrhenius):
         arrs = [to_rms(arr) for arr in obj.arrhenius]
         return rms.MultiArrhenius(arrs, rms.EmptyRateUncertainty())


### PR DESCRIPTION
This fixes a few different bugs related to construction of RMS objects for more complex kinetics types particularly Multi/Pdep/Arrhenius and falloff types. 

Best test is to run RMG with libraries containing these kinetic types. 
