### PR TITLE
Family atom labels

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -901,7 +901,7 @@ class KineticsFamily(Database):
                         ex_spec_labeled_atoms = ex_spec.molecule[0].get_all_labeled_atoms()
                         ex_spcs_labels = sorted(ex_spec_labeled_atoms.keys())
                         if spcs_labels != ex_spcs_labels:
-                            # the species have different labels, therefore not at match
+                            # the species have different labels, therefore not a match
                             continue
                         initial_map = {}
                         try:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The species In training reactions need to include atom labels.  
The `add_atom_labels_for_reaction` family method adds the atom labels for us, but if the family is its own reverse,
the product labels get relabeled as reactants.  Additionally, the `save_training_reactions` method is quite useful for adding new training reactions, but on rare occasions, the atom labels get mixed up.

### Description of Changes
- Added `relabel_atoms` option for `get_labeled_reactants_and_products` and `add_atom_labels_for_reaction`
- added atom label check to `save_training_reactions`

### Testing
Tested this in ipynb notebook and works as intended


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
