### PR TITLE
Pdep Sensitivity and Explorer Fixes

### DIFF
--- a/arkane/explorer.py
+++ b/arkane/explorer.py
@@ -278,8 +278,9 @@ class ExplorerJob(object):
                         index = int(s1[7:])
                         N_isomers = int(s2.split('.')[0]) 
                         if index == network.index and N_isomers == len(network.isomers):
+                            netind = self.networks.index(network)
                             shutil.copy(os.path.join(path0, name),
-                                      os.path.join(path, 'network{}_full.py'.format(self.networks.index(network))))
+                                      os.path.join(path, f'network{netind}_full.py'))
 
         warns = []
 

--- a/arkane/pdep.py
+++ b/arkane/pdep.py
@@ -107,7 +107,7 @@ class PressureDependenceJob(object):
                  maximumGrainSize=None, minimumGrainCount=0,
                  method=None, interpolationModel=None, maximumAtoms=None,
                  activeKRotor=True, activeJRotor=True, rmgmode=False, sensitivity_conditions=None,
-                 sensitivity_perturbation=0):
+                 sensitivity_perturbation=None):
 
         if network and network.products and len(network.products) > 0:
             if "simulation least squares" in method:
@@ -125,8 +125,8 @@ class PressureDependenceJob(object):
         self.Tmin = Tmin
         self.Tmax = Tmax
         self.Tcount = Tcount
-        if sensitivity_perturbation == 0:
-            self.sensitivity_perturbation = quantity.Quantity(2.0,'kcal/mol')
+        if sensitivity_perturbation is None:
+            self.sensitivity_perturbation = quantity.Quantity(2.0, 'kcal/mol')
         else:
             self.sensitivity_perturbation = quantity.Quantity(sensitivity_perturbation)
 

--- a/arkane/sensitivity.py
+++ b/arkane/sensitivity.py
@@ -336,10 +336,12 @@ class PDepSensitivity(object):
                     # if rxn.transition_state is not None:
                     transition_states.append(rxn.transition_state)
                 entry = (wells+transition_states)[j]
+                label = entry.label
+                pertubation = self.perturbation
                 if entry in wells:
-                    logging.info("\n\nPerturbing well '{0}' by {1}:".format(entry, self.perturbation))
+                    logging.info(f"\n\nPerturbing well '{entry}' by {perturbation}:")
                 else:
-                    logging.info("\n\nPerturbing TS '{0}' by {1}:".format(entry.label, self.perturbation))
+                    logging.info(f"\n\nPerturbing TS '{label}' by {perturbation}:")
                 self.perturb(entry)
                 try:
                     self.job.execute(output_file=None, plot=False, print_summary=False)  # run the perturbed job
@@ -349,13 +351,18 @@ class PDepSensitivity(object):
                     self.unperturb(entry)
                     c += 1
                     self.perturbation = quantity.Quantity(self.perturbation.value/2.0, self.perturbation.units)
+<<<<<<< HEAD
                     logging.error("Decreasing perturbation to {}".format(self.perturbation))
                     
+=======
+                    logging.error(f"Decreasing perturbation to {perturbation}")
+
+>>>>>>> f854ec486 (switch to f-strings)
             if c == self.max_iters:
                 if entry in wells:
-                    logging.error("Perturbation of well '{0}' has failed".format(entry))
+                    logging.error(f"Perturbation of well '{entry}' has failed")
                 else:
-                    logging.error("Perturbation of TS '{0}' has failed".format(entry.label))
+                    logging.error(f"Perturbation of TS '{label}' has failed")
                 failed = True
             for rxn in self.job.network.net_reactions:
                 if failed:

--- a/arkane/sensitivity.py
+++ b/arkane/sensitivity.py
@@ -345,8 +345,6 @@ class PDepSensitivity(object):
                 self.perturb(entry)
                 try:
                     self.job.execute(output_file=None, plot=False, print_summary=False)  # run the perturbed job
-                    self.unperturb(entry)
-                    break
                 except (InvalidMicrocanonicalRateError, ModifiedStrongCollisionError) as e:
                     self.unperturb(entry)
                     c += 1
@@ -356,8 +354,14 @@ class PDepSensitivity(object):
                     
 =======
                     logging.error(f"Decreasing perturbation to {perturbation}")
+<<<<<<< HEAD
 
 >>>>>>> f854ec486 (switch to f-strings)
+=======
+                else:
+                    self.unperturb(entry)
+                    break
+>>>>>>> 142a95714... move unperturb and break to an else
             if c == self.max_iters:
                 if entry in wells:
                     logging.error(f"Perturbation of well '{entry}' has failed")

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -72,7 +72,7 @@ class Network(object):
     `grain_count`           Minimum number of descrete energies separated
     `E0`                    A list of ground state energies of isomers, reactants, and products (J/mol)
     `Emax`                  Highest energy level considered in graining before padding
-    `Emin`                  Minimum energy levell considered in graining
+    `Emin`                  Minimum energy level considered in graining
     `active_k_rotor`        ``True`` if the K-rotor is treated as active, ``False`` if treated as adiabatic
     `active_j_rotor`        ``True`` if the J-rotor is treated as active, ``False`` if treated as adiabatic
     `rmgmode`               ``True`` if in RMG mode, ``False`` otherwise

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -512,7 +512,8 @@ class Network(object):
             e_max = np.max(self.E0)
             for rxn in self.path_reactions:
                 E0 = float(rxn.transition_state.conformer.E0.value_si)
-                if E0 > e_max: e_max = E0
+                if E0 > e_max:
+                    e_max = E0
         else:
             e_max = self.Emax
 

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -583,7 +583,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                 os.mkdir(path)
             for name in os.listdir(path0):
                 if name.endswith('.py') and '_' in name:
-                    s1,s2 = name.split('_')
+                    s1,s2 = name.split('_') #ex: network1_6.py
                     index = int(s1[7:])
                     N_isomers = int(s2.split('.')[0]) 
                     if index == self.index and N_isomers == len(self.isomers):


### PR DESCRIPTION
This PR fixes issues with pdep sensitivity that cause sensitivity analysis fallbacks to fail and pdep sensitivities to show sensitivity to unimportant barriers and wells. This enables the user to set the pdep sensitivity perturbation, fixes an issue with explorer reduced mechanism saving and an issue with plotting.