### PR TITLE
Documentation updates for developer install and update

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,12 +4,12 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
-#. Download and install the `Anaconda Python Platform <https://www.anaconda.com/download/>`_ for Python 3.7.
+#. Download and install `Anaconda Individual Edition <https://www.anaconda.com/products/individual/>`.
 
-   The download will be a .sh file with a name like ``Anaconda3-2019.07-Linux-x86_64.sh``. Open a terminal in the same
+   The download will be a .sh file with a name like ``Anaconda3-2021.05-Linux-x86_64.sh``. Open a terminal in the same
    directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
 
-    bash Anaconda3-2019.07-Linux-x86_64.sh
+    bash Anaconda3-2021.05-Linux-x86_64.sh
 
    **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Anaconda folder inside your home
    directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac). When prompted, you do not

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -57,17 +57,27 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    For linux users julia will be installed automatically.
 
 #. Install the latest versions of RMG and RMG-database through cloning the source code via Git. Make sure to start in an
-   appropriate local directory where you want both RMG-Py and RMG-database folders to exist. ::
+   appropriate local directory where you want both RMG-Py and RMG-database folders to exist.
+   Github has deprecated password authentication from the command line, so it
+   is preferred to clone the repositories using ``ssh``::
 
+    git clone git@github.com:ReactionMechanismGenerator/RMG-Py.git
+    git clone git@github.com:ReactionMechanismGenerator/RMG-database.git
+
+   It is still possible to clone the repositories using ``https`` if you are
+   unfamiliar with ``ssh``::
+   
     git clone https://github.com/ReactionMechanismGenerator/RMG-Py.git
     git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
+
+   For information on using ``ssh`` with GitHub see the `Connecting to GitHub with SSH <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_
 
 #. Now create the conda environment for RMG-Py ::
 
     cd RMG-Py
     conda env create -f environment.yml
 
-   If the command errors due to being unable to find the `conda` command, try either close and reopen your terminal to refresh your environment variables, or type the following command.
+   If the command returns an error due to being unable to find the ``conda`` command, try either close and reopen your terminal to refresh your environment variables, or type the following command.
 
    If on Linux or pre-Catalina MacOS ::
 

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -77,7 +77,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     cd RMG-Py
     conda env create -f environment.yml
 
-   If the command returns an error due to being unable to find the ``conda`` command, try either close and reopen your terminal to refresh your environment variables, or type the following command.
+   If the command returns an error due to being unable to find the ``conda`` command, try to either close and reopen your terminal to refresh your environment variables or type the following command.
 
    If on Linux or pre-Catalina MacOS ::
 
@@ -96,17 +96,6 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    standardize operation across different operating systems. However, a prerequisite to using the new syntax is having
    run the ``conda init`` setup routine, which can be done at the end of the install procedure if the user requests.
     
-#. Install and Link Julia dependencies ::
-
-     python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
-
-     julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
-
-   Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
-   interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation
-   in a different conda environment. However, if convenient you can undo this linking by replacing python-jl with
-   python3 in the second command above. Just make sure to rerun the linking command once you are done.
-
 #. Compile RMG-Py after activating the conda environment ::
 
     make
@@ -126,6 +115,16 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
    Be sure to either close and reopen your terminal to refresh your environment variables (``source ~/.bashrc`` or ``source ~/.zshrc``).
 
+#. Install and Link Julia dependencies ::
+
+     python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
+
+     julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
+
+   Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
+   interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation
+   in a different conda environment. However, if convenient you can undo this linking by replacing python-jl with
+   python3 in the second command above. Just make sure to rerun the linking command once you are done.
 
 #. Finally, you can run RMG from any location by typing the following (given that you have prepared the input file as ``input.py`` in the current folder). ::
 
@@ -156,7 +155,7 @@ There are a number of basic tests you can run on the newly installed RMG.  It is
     make test-functional
 
 
-#. **Database test suite**: this will run the database unit tests to ensure that groups, rate rules, and libraries are well formed ::
+#. **Database test suite**: this will run the database unit tests to ensure that groups, rate rules, and libraries are well-formed ::
 
     cd RMG-Py
     make test-database

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,7 +4,7 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
-#. Download and install `Anaconda Individual Edition <https://www.anaconda.com/products/individual/>`.
+#. Download and install `Anaconda Individual Edition <https://www.anaconda.com/products/individual#Downloads>`.
 
    The download will be a .sh file with a name like ``Anaconda3-2021.05-Linux-x86_64.sh``. Open a terminal in the same
    directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::

--- a/documentation/source/users/rmg/installation/linuxSubsystem.rst
+++ b/documentation/source/users/rmg/installation/linuxSubsystem.rst
@@ -20,20 +20,20 @@ Installing the Linux Subsystem
    distributions.
 
 2. Once the Linux subsystem is installed, open a web browser in Windows and go to the
-   `Anaconda Python Platform Downloads Page <https://www.anaconda.com/products/individual#Downloads`_. Go to the tab for the
-   **Linux Installer**, and **right click** on the download icon for Python 3.7 to copy the link location. Open an Ubuntu
+   `Anaconda Python Platform Downloads Page <https://www.anaconda.com/products/individual#Downloads>`_. Go to the tab for the
+   **Linux Installer**, and **right click** on the download icon for Python to copy the link location. Open an Ubuntu
    terminal (type in ``Ubuntu`` into the Windows search bar if you are unsure where to find it) and paste the link
    into the terminal immediately after typing the ``wget`` command, so that your terminal looks like the following: ::
 
-    wget https://repo.anaconda.com/archive/Anaconda3-2019.07-Linux-x86_64.sh
+    wget https://repo.anaconda.com/archive/Anaconda3-2021.05-Linux-x86_64.sh
 
    Your exact link will look similar to the one above, but may be a more recent version of the installer. Execute this
    command in the terminal to begin downloading the installer.
 
 3. Once the Anaconda installer has downloaded, execute the following commands in the Ubuntu terminal, changing the name
-   of ``Anaconda3-2019.07-Linux-x86_64.sh`` to match the name of the script you downloaded. ::
+   of ``Anaconda3-2021.05-Linux-x86_64.sh`` to match the name of the script you downloaded. ::
 
-    bash Anaconda3-2019.07-Linux-x86_64.sh
+    bash Anaconda3-2021.05-Linux-x86_64.sh
 
    Install the anaconda3 folder inside your home directory (it should be the default location when it asks for a location
    to install). **When prompted to append Anaconda to your PATH, select or type Yes**. When prompted, do NOT install
@@ -42,10 +42,7 @@ Installing the Linux Subsystem
 
 4. Execute the following commands to make sure that all of the required packages in Ubuntu are also installed: ::
 
-    sudo apt install gcc
-    sudo apt install g++
-    sudo apt install make
-    sudo apt-get install graphviz 
+    sudo apt install gcc g++ make graphviz 
 
    Note: installing graphviz as a system package makes sure that rendering libraries that are not included
    in the WSL version of Ubuntu are installed. Unfortunately, the graphviz conda package does not install

--- a/documentation/source/users/rmg/installation/updatingSourceCode.rst
+++ b/documentation/source/users/rmg/installation/updatingSourceCode.rst
@@ -11,12 +11,25 @@ To update your source code, you can "pull" the latest changes from the official 
 Command Prompt ::
 
     cd RMG-Py
+    git pull git@github.com:ReactionMechanismGenerator/RMG-Py.git main
+
+If you are not using ``ssh`` (yet), it is still possible to pull the code using
+``https``::
+    
     git pull https://github.com/ReactionMechanismGenerator/RMG-Py.git main
 
 We also recommend updating the RMG-database regularly.  The repo itself can be found at https://github.com/ReactionMechanismGenerator/RMG-database/ ::
 
     cd RMG-database
+    git pull git@github.com:ReactionMechanismGenerator/RMG-database.git main
+
+Again, for those (still) using ``https``, the command is instead::
+
     git pull https://github.com/ReactionMechanismGenerator/RMG-database.git main
 
 For more information about how to use the Git workflow to make changes to the source code, please
 refer to the handy `Git Tutorial <http://git-scm.com/docs/gittutorial>`_
+
+For information on updating your local repository from ``https`` to ``ssh``,
+please see `Managing remote repositories
+<https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories>`_

--- a/documentation/source/users/rmg/installation/updatingSourceCode.rst
+++ b/documentation/source/users/rmg/installation/updatingSourceCode.rst
@@ -11,12 +11,12 @@ To update your source code, you can "pull" the latest changes from the official 
 Command Prompt ::
 
     cd RMG-Py
-    git pull https://github.com/ReactionMechanismGenerator/RMG-Py.git master
+    git pull https://github.com/ReactionMechanismGenerator/RMG-Py.git main
 
 We also recommend updating the RMG-database regularly.  The repo itself can be found at https://github.com/ReactionMechanismGenerator/RMG-database/ ::
 
     cd RMG-database
-    git pull https://github.com/ReactionMechanismGenerator/RMG-database.git master
+    git pull https://github.com/ReactionMechanismGenerator/RMG-database.git main
 
 For more information about how to use the Git workflow to make changes to the source code, please
 refer to the handy `Git Tutorial <http://git-scm.com/docs/gittutorial>`_


### PR DESCRIPTION
### Description of Changes
Three commits which are incremental improvements:
1) Update `master` to `main` on update page since the current instructions are erroneous
2) Update the Anaconda web address and Python version for download to reflect the current website - users should be able to figure things out as currently listed, but this makes it clearer
3) Add instructions to clone and pull via `ssh` including links to GitHub documentation on setting up and using `ssh` and converting remote from `https` to `ssh` as password authentication at the command line is deprecated
