### PR TITLE
Check for two-parameter Troe reaction when converting to Cantera

### DIFF
--- a/rmgpy/kinetics/falloff.pyx
+++ b/rmgpy/kinetics/falloff.pyx
@@ -396,5 +396,8 @@ cdef class Troe(PDepKineticsModel):
         A = self.alpha
         T3 = self.T3.value_si
         T1 = self.T1.value_si
-        T2 = self.T2.value_si
-        ct_reaction.falloff = ct.TroeFalloff(params=[A, T3, T1, T2])
+        if self.T2 is None:
+            ct_reaction.falloff = ct.TroeFalloff(params=[A, T3, T1]) 
+        else:
+            T2 = self.T2.value_si
+            ct_reaction.falloff = ct.TroeFalloff(params=[A, T3, T1, T2])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG fails when trying to convert 2-parameter Troe reactions to Cantera reactions because it has assumed a 3-parameter version. One of the parameters, T2, is optional

### Description of Changes
I added an if statement to check whether the optional parameter has been set. If so, it calls the 3-parameter version, and if not, it calls the 2-parameter version

### Testing
I built this version and confirmed that I can convert 2-parameter Troe reactions from RMG to Cantera.

The example I used was this reaction from [RMG-database/input/kinetics/libraries/BurkeH2O2inN2/reactions.py](https://github.com/ReactionMechanismGenerator/RMG-database/blob/main/input/kinetics/libraries/BurkeH2O2inN2/reactions.py)
```
entry(
    index = 20,
    label = "H2O2 <=> OH + OH",
    degeneracy = 1,
    kinetics = Troe(
        arrheniusHigh = Arrhenius(A=(2e+12, 's^-1'), n=0.9, Ea=(48749, 'cal/mol'), T0=(1, 'K')),
        arrheniusLow = Arrhenius(A=(2.49e+24, 'cm^3/(mol*s)'), n=-2.3, Ea=(48749, 'cal/mol'), T0=(1, 'K')),
        alpha = 0.43,
        T3 = (1e-30, 'K'),
        T1 = (1e+30, 'K'),
        efficiencies = {'[H][H]': 3.7, 'O': 7.5, '[O][O]': 1.2, 'N#N': 1.5, '[C-]#[O+]': 2.8, 'OO': 7.7, 'O=C=O': 1.6, '[He]': 0.65},
    ),
    shortDesc = u"""Troe, Combust. Flame, 158:594-601 (2011)""",
    longDesc = 
u"""
Rate constant is for Ar
Efficiencies for H2 and CO taken from Li et al., Int. J. Chem. Kinet. 36:566-575 (2004)
""",
)
```

