### PR TITLE
Remove stale template matching for Bimolec hydroperoxide decomposition

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1384,40 +1384,6 @@ class KineticsFamily(Database):
             reactant_structure = reactant_structure.merge(s.copy(deep=True))
 
         if forward:
-            # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
-            # '*2' has to be changed to '*4' for the second reactant and '*1' has to be
-            # changed to '*6'. '*3' has to be changed to '*5' for the first reactant.
-            # '*5' and '*6' do no participate in the reaction but are required for
-            # relabeling in the reverse direction.
-            if label == 'bimolec_hydroperoxide_decomposition':
-                identical_center_counter1 = identical_center_counter2 = identical_center_counter3 = 0
-                for atom in reactant_structure.atoms:
-                    if atom.label == '*1':
-                        identical_center_counter1 += 1
-                        if identical_center_counter1 > 1:
-                            atom.label = '*6'
-                    elif atom.label == '*2':
-                        identical_center_counter2 += 1
-                        if identical_center_counter2 > 1:
-                            atom.label = '*4'
-                    elif atom.label == '*3':
-                        identical_center_counter3 += 1
-                        if identical_center_counter3 == 1:
-                            atom.label = '*5'
-                msg = 'Trying to apply recipe for reaction family {}:'.format(label)
-                error = False
-                if identical_center_counter1 != 2:
-                    msg += ' Only one occurrence of "*1" found.'
-                    error = True
-                if identical_center_counter2 != 2:
-                    msg += ' Only one occurrence of "*2" found.'
-                    error = True
-                if identical_center_counter3 != 2:
-                    msg += ' Only one occurrence of "*3" found.'
-                    error = True
-                if error:
-                    raise KineticsError(msg)
-
             # Generate the product structure by applying the recipe
             self.forward_recipe.apply_forward(reactant_structure, unique)
         else:
@@ -1436,19 +1402,6 @@ class KineticsFamily(Database):
                 # If there is an analagous aliphatic group in the family, then the product template will be identical
                 # There should NOT be any families that consist solely of aromatic reactant templates
                 return []
-
-        if not forward:
-            # Hardcoding of reaction family for bimolecular hydroperoxide decomposition
-            # '*5' has to be changed back to '*3', '*6' has to be changed to '*1', and
-            # '*4' has to be changed to '*2'
-            if label == 'bimolec_hydroperoxide_decomposition':
-                for atom in product_structure.atoms:
-                    if atom.label == '*5':
-                        atom.label = '*3'
-                    elif atom.label == '*6':
-                        atom.label = '*1'
-                    elif atom.label == '*4':
-                        atom.label = '*2'
 
         # If reaction family is its own reverse, relabel atoms
         # This allows comparison of the product species to forbidden

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -131,9 +131,8 @@ class KineticsGroups(Database):
 
         # Descend reactant trees as far as possible
         template = []
-        special_cases = ['bimolec_hydroperoxide_decomposition']
         if (len(forward_template) == 1 and len(reaction.reactants) > len(forward_template) and
-                self.label.lower().split('/')[0] not in special_cases):
+                self.label.lower().split('/')[0]):
             entry = forward_template[0]
             group = entry.item
 
@@ -184,8 +183,6 @@ class KineticsGroups(Database):
 
             # Get fresh templates (with duplicate nodes back in)
             forward_template = self.top[:]
-            if self.label.lower().startswith('bimolec_hydroperoxide_decomposition'):
-                forward_template.append(forward_template[0])
 
         # Check that we were able to match the template.
         # template is a list of the actual matched nodes

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -1428,26 +1428,6 @@ Origin Group AdjList:
                     # Just check none of this throws errors
                     species = rmgpy.species.Species(index=1,molecule=[molecule])
                     species.generate_resonance_structures()
-        elif len(sample_reactants) == 1 and len(family.forward_template.reactants) == 2:
-            # eg. Bimolec_Hydroperoxide_Decomposition and Peroxyl_Disproportionation
-            # use the same group twice.
-            reactant_lists = [sample_reactants[k] for k in family.forward_template.reactants ]
-            pairs = zip(*reactant_lists)
-            for reactant1, reactant2 in pairs:
-                try:
-                    products = family.apply_recipe([reactant1, reactant2])
-                except Exception as e:
-                    test1.append(make_error_message([reactant1, reactant2],
-                          message=f"During apply_recipe had an {type(e)!s}: {e!s}"))
-                    continue
-                if products is None:
-                    test1.append(make_error_message([reactant1, reactant2],
-                        message="apply_recipe returned None, indicating wrong number of products or a charged product."))
-                    continue
-                for molecule in products:
-                    # Just check none of this throws errors
-                    species = rmgpy.species.Species(index=1,molecule=[molecule])
-                    species.generate_resonance_structures()
         elif len(sample_reactants) == 2:
             sr = list(sample_reactants.values())
             # Every combination may be prohibitively slow (N*M reactions),

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -140,7 +140,8 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
                 yield test, family_name
 
             # these families have some sort of difficulty which prevents us from testing accessibility right now
-            difficult_families = ['Diels_alder_addition', 'Intra_R_Add_Exocyclic', 'Intra_R_Add_Endocyclic', 'Retroene']
+            # See RMG-Py PR #2232 for reason why adding Bimolec_Hydroperoxide_Decomposition here. Bsically some nodes need to be in a ring, but the sampled molecule is not.
+            difficult_families = ['Diels_alder_addition', 'Intra_R_Add_Exocyclic', 'Intra_R_Add_Endocyclic', 'Retroene','Bimolec_Hydroperoxide_Decomposition']
 
             if len(family.forward_template.reactants) < len(family.groups.top) and family_name not in difficult_families:
                 test = lambda x: self.kinetics_check_unimolecular_groups(family_name)


### PR DESCRIPTION
### Motivation or Problem
This is a twin PR for RMG-database PR #545.

### Description of Changes
It removes stale template matching code for Bimolec hydroperoxide decomposition.