### PR TITLE
Documentation - streamline *conda installation

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,20 +4,25 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
-#. Download and install `Anaconda Individual Edition <https://www.anaconda.com/products/individual#Downloads>`.
+#. Install the `conda` package manager. Select one of the following options:
 
-   The download will be a .sh file with a name like ``Anaconda3-2021.05-Linux-x86_64.sh``. Open a terminal in the same
+   a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
+
+    sudo dnf install conda
+
+   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`.
+
+   The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``. Open a terminal in the same
    directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
 
-    bash Anaconda3-2021.05-Linux-x86_64.sh
+    bash Miniconda3-latest-Linux-x86_64.sh
 
-   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Anaconda folder inside your home
-   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac). When prompted, you do not
-   need to install Microsoft VSCode (but feel free to if you are looking for a lightweight IDE).
+   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Conda folder inside your home
+   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
 
-   Note that you should restart your terminal in order for the changes to take effect, as the installer will tell you.
+   Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
-#. There are a few system-level dependencies which are required and should not be installed via Anaconda. These include
+#. There are a few system-level dependencies which are required and should not be installed via Conda. These include
    `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
 
    For Linux users, you can check whether these are already installed by simply calling them via the command line, which

--- a/documentation/source/users/rmg/installation/anacondaUser.rst
+++ b/documentation/source/users/rmg/installation/anacondaUser.rst
@@ -5,14 +5,23 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 ****************************************************************************
 
 
-#. Download and install the `Anaconda Python Platform <https://www.anaconda.com/download/>`_ for Python 3.7.
+#. Install the `conda` package manager. Select one of the following options:
 
-   The download will be a .sh file with a name like ``Anaconda3-2019.07-Linux-x86_64.sh``. Open a terminal in the same
+   a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
+
+    sudo dnf install conda
+
+   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`.
+
+   The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``. Open a terminal in the same
    directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
 
-    bash Anaconda3-2019.07-Linux-x86_64.sh
+    bash Miniconda3-latest-Linux-x86_64.sh
 
-   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Anaconda folder inside your home directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac). When prompted, you do not need to install Microsoft VSCode (but feel free to if you are looking for a lightweight IDE).
+   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Conda folder inside your home
+   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
+
+   Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
 #. Install both RMG and the RMG-database binaries through the terminal.   Dependencies will be installed automatically. It is safest to make a new conda environment for RMG and its dependencies. Type the following command into the terminal to create the new environment named 'rmg_env' containing the latest stable version of the RMG program and its database. ::
 
@@ -20,7 +29,7 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 
    Whenever you wish to use it you must first activate the environment::
 
-    source activate rmg_env
+    conda activate rmg_env
 
 #. Optional: If you wish to use the :ref:`QMTP interface <qm>` with `MOPAC <http://openmopac.net/>`_ to run quantum mechanical calculations for improved thermochemistry estimates of cyclic species, please obtain a legal license through the `MOPAC License Request Form <http://openmopac.net/form.php>`_.  Once you have it, type the following into your terminal ::
 


### PR DESCRIPTION
Improve conda installation instructions: use repositories over Ananconda for proper locations, updates; switch to Miniconda to reduce download and installation size by 10x; replace deprecated "source" with "conda"

### Motivation or Problem
`conda` is packaged for use already in many Linux distributions (no, not Ubuntu) and can be installed from repositories with the system package manager, which is generally the preferred way of doing things for updates, PATH, etc.
Further, for cases where users are downloading and installing *conda, Anaconda is overkill for the RMG use case where environment files are solved and the required packages are downloaded and installed, especially when installing to shared systems  or saving to a network profile where disk space is capped.

### Description of Changes
-Instructions are updated to reflect the option of installing conda from the system package manager
-Anaconda (500+ MB) is replaced with Miniconda (~50 MB)

### Testing
Both Miniconda and packaged conda installed and tested on Fedora Linux 35 and Rocky Linux 8.5 (RHEL clone)
