### PR TITLE
set a maximum of 5 retries for model resurrection.

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -955,6 +955,8 @@ Setting ``trimolecularProductReversible`` to ``False`` will not allow families w
 
 Setting ``saveSeedModulus`` to ``-1`` will only save the seed from the last iteration at the end of an RMG job. Alternatively, the seed can be saved every ``n`` iterations by setting ``saveSeedModulus`` to ``n``.
 
+Setting ``solverRetries`` to an integer establishes a limit on how many retries RMG will attempt after a solver error. By default this is 5.
+
 Species Constraints
 =====================
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -985,7 +985,7 @@ def pressure_dependence(
 def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None,
             generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False,
             saveEdgeSpecies=False, keepIrreversible=False, trimolecularProductReversible=True, wallTime='00:00:00:00',
-            saveSeedModulus=-1):
+            saveSeedModulus=-1, solverRetries=5):
     if saveRestartPeriod:
         logging.warning("`saveRestartPeriod` flag was set in the input file, but this feature has been removed. Please "
                         "remove this line from the input file. This will throw an error after RMG-Py 3.1. For "
@@ -1010,6 +1010,7 @@ def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=Fals
     rmg.trimolecular_product_reversible = trimolecularProductReversible
     rmg.walltime = wallTime
     rmg.save_seed_modulus = saveSeedModulus
+    rmg.solver_retries = solverRetries
 
 
 def generated_species_constraints(**kwargs):
@@ -1440,6 +1441,7 @@ def save_input_file(path, rmg):
     f.write('    trimolecularProductReversible = {0},\n'.format(rmg.trimolecular_product_reversible))
     f.write('    verboseComments = {0},\n'.format(rmg.verbose_comments))
     f.write('    wallTime = {0},\n'.format(rmg.walltime))
+    f.write('    solverRetries = {0}\n'.format(rmg.solver_retries))
     f.write(')\n\n')
 
     f.close()

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -146,6 +146,7 @@ class RMG(util.Subject):
     `ml_settings`                       Settings for ML estimation
     `walltime`                          The maximum amount of CPU time in the form DD:HH:MM:SS to expend on this job; used to stop gracefully so we can still get profiling information
     `max_iterations`                    The maximum number of RMG iterations allowed, after which the job will terminate
+    `solver_retries`                    the maximum allowable DASPK solver errors that RMG will try to resurrect. Default is 5.
     `kinetics_datastore`                ``True`` if storing details of each kinetic database entry in text file, ``False`` otherwise
     ----------------------------------- ------------------------------------------------
     `initialization_time`               The time at which the job was initiated, in seconds since the epoch (i.e. from time.time())
@@ -227,6 +228,7 @@ class RMG(util.Subject):
         self.walltime = '00:00:00:00'
         self.save_seed_modulus = -1
         self.max_iterations = None
+        self.solver_retries = None
         self.initialization_time = 0
         self.kinetics_datastore = None
         self.restart = False
@@ -269,7 +271,6 @@ class RMG(util.Subject):
             self.reaction_model.core.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si
             self.reaction_model.edge.phase_system.phases["Surface"].site_density = self.surface_site_density.value_si
         self.reaction_model.coverage_dependence = self.coverage_dependence
-            
         self.reaction_model.verbose_comments = self.verbose_comments
         self.reaction_model.save_edge_species = self.save_edge_species
 
@@ -278,6 +279,7 @@ class RMG(util.Subject):
 
         for reaction_system in self.reaction_systems:
             self.reaction_model.reaction_systems.append(reaction_system)
+            reaction_system.max_retries = self.solver_retries
 
     def load_thermo_input(self, path=None):
         """

--- a/rmgpy/solver/base.pxd
+++ b/rmgpy/solver/base.pxd
@@ -114,6 +114,9 @@ cdef class ReactionSystem(DASx):
     cdef public np.ndarray bimolecular_threshold
     cdef public np.ndarray trimolecular_threshold
 
+    cdef public int retry
+    cdef public int max_retries
+
     # methods
     cpdef initialize_model(self, list core_species, list core_reactions, list edge_species, list edge_reactions,
         list surface_species=?, list surface_reactions=?, list pdep_networks=?, atol=?, rtol=?,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG can often become "stuck" if there is a particular reaction that is causing the solver to fail. to alleviate this, an edge species is added into the core. The problem is this continues indefinitely, and can cause RMG to add species indefinitely until the run is terminated, and can make a giant model that is mostly chemically irrelevant species. 

### Description of Changes
Added a hardcoded number of retries (5) so that RMG will eventually throw an error and crash. 

### Testing
I did not add a unit test per a conversation at developer hours, but I did test it by doing the following: 
add this reaction library to the eg0 input file:
```
reactionLibraries = ['BurkeH2O2inArHe'],
```
change the activation energy an A-factor in the first entry in that library to a very large value. Set the Ea to 0. 
```
entry(
    index = 1,
    label = "H + O2 <=> O + OH",
    degeneracy = 1,
    kinetics = Arrhenius(A=(1.04e+40, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
    shortDesc = u"""Hong et al., Proc. Comb. Inst. 33:309-316 (2011)""",
)
```

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
