### PR TITLE
Improve conda installation instructions

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,22 +4,26 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
-#. Download and install `Anaconda Individual Edition <https://www.anaconda.com/products/individual#Downloads>`.
+#. Install the `conda` package manager. Select one of the following options:
 
-   The download will be a .sh file with a name like ``Anaconda3-2023.03-Linux-x86_64.sh``. Open a terminal in the same
+   a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
+
+    sudo dnf install conda
+
+   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`.
+
+   The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``. Open a terminal in the same
    directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
 
-    bash Anaconda3-2023.03-Linux-x86_64.sh
+    bash Miniconda3-latest-Linux-x86_64.sh
 
-   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Anaconda folder inside your home
-   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac). When prompted, you do not
-   need to install Microsoft VSCode (but feel free to if you are looking for a lightweight IDE).
+   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Conda folder inside your home
+   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
 
-   Note that you should restart your terminal in order for the changes to take effect, as the installer will tell you.
+   Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
-#. There are a few system-level dependencies which are required and should not be installed via Anaconda. These include
-   `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, 
-   and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
+#. There are a few system-level dependencies which are required and should not be installed via Conda. These include
+   `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
 
    For Linux users, you can check whether these are already installed by simply calling them via the command line, which
    will let you know if they are missing. To install any missing packages, you should use the appropriate package manager

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,23 +4,26 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
-#. Install the `conda` package manager. Select one of the following options:
+#. Install the `conda` package manager, if you do not already have it (or Anaconda).
+   Select one of the following options:
 
    a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
 
-    sudo dnf install conda
+       sudo dnf install conda
 
-   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`.
+   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 
-   The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``. Open a terminal in the same
-   directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
+      The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``.
+      Open a terminal in the same directory as this file, and type the following to install Conda
+      (replace the name of your .sh file below). ::
 
-    bash Miniconda3-latest-Linux-x86_64.sh
+       bash Miniconda3-latest-Linux-x86_64.sh
 
-   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Conda folder inside your home
-   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
+      **When prompted to append Anaconda to your PATH, select or type Yes**. 
+      Install the Conda folder inside your home directory 
+      (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
 
-   Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
+      Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
 #. There are a few system-level dependencies which are required and should not be installed via Conda. These include
    `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -31,29 +31,29 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    For Linux users, you can check whether these are already installed by simply calling them via the command line, which
    will let you know if they are missing. To install any missing packages, you should use the appropriate package manager
    for your system.
-   
-   On Ubuntu and Debian the package manager is ``apt`` ::
 
-    sudo apt install git gcc g++ make
-    
-   On Fedora and Red Hat derivatives (RHEL 8+) the package manager is ``dnf`` ::
-   
-    sudo dnf install git gcc gcc-c++ make
+   a. On Ubuntu and Debian the package manager is ``apt`` ::
 
-   Replace ``dnf`` with ``yum`` in the preceding for Red Hat 7 and lower.
+       sudo apt install git gcc g++ make
 
-   On openSUSE the package manager is ``zypper``::
+   b. On Fedora and Red Hat derivatives (RHEL 8+) the package manager is ``dnf`` ::
 
-    sudo zypper install git gcc gcc-c++ make
+       sudo dnf install git gcc gcc-c++ make
 
-   On Manjaro or Arch Linux the package manager is ``pacman`` ::
+   c. For Red Hat 7 and lower, replace ``dnf`` with ``yum`` in the preceding.
 
-    sudo pacman -S git gcc make
+   d. On openSUSE the package manager is ``zypper``::
 
-   For MacOS users, the above packages will not come preinstalled but can be easily obtained by installing the XCode Command Line Tools.
-   These are a set of packages relevant for software development which have been bundled together by Apple. The easiest way
-   to install this is to simply run one of the commands in the terminal, e.g. ``git``. The terminal will then prompt you on
-   whether or not you would like to install the Command Line Tools.
+       sudo zypper install git gcc gcc-c++ make
+
+   e. On Manjaro or Arch Linux the package manager is ``pacman`` ::
+
+       sudo pacman -S git gcc make
+
+   f. For MacOS users, the above packages can be easily obtained by installing the XCode Command Line Tools.
+      These are a set of packages relevant for software development which have been bundled together by Apple.
+      The easiest way to install this is to simply run one of the commands in the terminal, e.g. ``git``.
+      The terminal will then prompt you to install the Command Line Tools.
 
 #. Install the latest versions of RMG and RMG-database through cloning the source code via Git. Make sure to start in an
    appropriate local directory where you want both RMG-Py and RMG-database folders to exist.

--- a/documentation/source/users/rmg/installation/anacondaUser.rst
+++ b/documentation/source/users/rmg/installation/anacondaUser.rst
@@ -5,14 +5,23 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 ****************************************************************************
 
 
-#. Download and install the `Anaconda Python Platform <https://www.anaconda.com/download/>`_ for Python 3.7.
+#. Install the `conda` package manager. Select one of the following options:
 
-   The download will be a .sh file with a name like ``Anaconda3-2019.07-Linux-x86_64.sh``. Open a terminal in the same
+   a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
+
+    sudo dnf install conda
+
+   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`.
+
+   The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``. Open a terminal in the same
    directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
 
-    bash Anaconda3-2019.07-Linux-x86_64.sh
+    bash Miniconda3-latest-Linux-x86_64.sh
 
-   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Anaconda folder inside your home directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac). When prompted, you do not need to install Microsoft VSCode (but feel free to if you are looking for a lightweight IDE).
+   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Conda folder inside your home
+   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
+
+   Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
 #. Install both RMG and the RMG-database binaries through the terminal.   Dependencies will be installed automatically. It is safest to make a new conda environment for RMG and its dependencies. Type the following command into the terminal to create the new environment named 'rmg_env' containing the latest stable version of the RMG program and its database. ::
 
@@ -20,7 +29,7 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 
    Whenever you wish to use it you must first activate the environment::
 
-    source activate rmg_env
+    conda activate rmg_env
 
 #. You may now run an RMG test job. Save the `Minimal Example Input File <https://raw.githubusercontent.com/ReactionMechanismGenerator/RMG-Py/master/examples/rmg/minimal/input.py>`_
    to a local directory.  Use the terminal to run your RMG job inside that folder using the following command ::

--- a/documentation/source/users/rmg/installation/anacondaUser.rst
+++ b/documentation/source/users/rmg/installation/anacondaUser.rst
@@ -5,23 +5,26 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 ****************************************************************************
 
 
-#. Install the `conda` package manager. Select one of the following options:
+#. Install the `conda` package manager, if you do not already have it (or Anaconda).
+   Select one of the following options:
 
    a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
 
-    sudo dnf install conda
+       sudo dnf install conda
 
-   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`.
+   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 
-   The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``. Open a terminal in the same
-   directory as this file, and type the following to install Anaconda (replace the name of your .sh file below). ::
+      The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``.
+      Open a terminal in the same directory as this file, and type the following to install Conda
+      (replace the name of your .sh file below). ::
 
-    bash Miniconda3-latest-Linux-x86_64.sh
+       bash Miniconda3-latest-Linux-x86_64.sh
 
-   **When prompted to append Anaconda to your PATH, select or type Yes**.  Install the Conda folder inside your home
-   directory (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
+      **When prompted to append Anaconda to your PATH, select or type Yes**. 
+      Install the Conda folder inside your home directory 
+      (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
 
-   Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
+      Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
 #. Install both RMG and the RMG-database binaries through the terminal.   Dependencies will be installed automatically. It is safest to make a new conda environment for RMG and its dependencies. Type the following command into the terminal to create the new environment named 'rmg_env' containing the latest stable version of the RMG program and its database. ::
 


### PR DESCRIPTION
### Motivation or Problem
Writing the documentation to only reference Anaconda is inflexible and bloated as compared with utilizing Miniconda or Conda available in system repositories. This is of particular relevance of storage-limited systems, such as shared high-performance resources where RMG is often installed (which also frequently run RHEL or another Enterpise Linux which includes `conda` in the repositories, easing administrative burden).

### Description of Changes
- Use repositories over Ananconda for proper locations, updates
- switch to Miniconda to reduce download and installation size by 10x
- replace deprecated `source` with `conda` in activating environments

### Testing
Environments created and RMG-Py, RMG-database installed and tested on Fedora and EL systems
