### PR TITLE
Exclude surf training

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -697,7 +697,7 @@ class KineticsFamily(Database):
                 if entry.nodal_distance is None:
                     entry.nodal_distance = tree_distances[top_entry.label]
 
-    def load(self, path, local_context=None, global_context=None, depository_labels=None):
+    def load(self, path, local_context=None, global_context=None, depository_labels=None, exclude_training=False):
         """
         Load a kinetics database from a file located at `path` on disk.
         
@@ -707,6 +707,7 @@ class KineticsFamily(Database):
         
         If depository_labels is None then load 'training' first then everything else.
         If depository_labels is not None then load in the order specified in depository_labels.
+        if exclude_training is True then exclude the training data depository for this family
         """
         local_context['recipe'] = self.load_recipe
         local_context['template'] = self.load_template
@@ -805,7 +806,7 @@ class KineticsFamily(Database):
                     depository_labels.append('training')
 
         for name in depository_labels:
-            if name == '!training':
+            if name == '!training' or exclude_training:
                 continue
             label = '{0}/{1}'.format(self.label, name)
             # f = name+'.py'

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -102,6 +102,8 @@ class TestKineticsDatabase(unittest.TestCase):
             database.load_families(path, families=['!H_Abstraction', 'Disproportionation'])
         with self.assertRaises(DatabaseError):
             database.load_families(path, families=['fake_family'])
+        with self.assertRaises(DatabaseError):
+            database.load_families(path, families={'!H_Abstraction':True, '!Disproportionation':False})
 
     def test_load_families_correct(self):
         """Test valid methods for loading kinetics families."""
@@ -149,6 +151,25 @@ class TestKineticsDatabase(unittest.TestCase):
         except DatabaseError:
             self.fail("Unable to load families using list ['H_Abstraction', 'pah']")
 
+        try:
+            database.load_families(path, families={'H_Abstraction':False, 'pah':True})
+        except DatabaseError:
+            self.fail(
+                "Unable to load families using dict {'H_Abstraction':False, 'pah':True}")
+        
+        try:
+            database.load_families(
+                path, families={'R_Addition_MultipleBond': False, 'default': True})
+        except DatabaseError:
+            self.fail(
+                "Unable to load families using dict {'R_Addition_MultipleBond':False, 'default':True}")
+        
+        try:
+            database.load_families(
+                path, families={'!H_Abstraction': True, '!pah': True})
+        except DatabaseError:
+            self.fail(
+                "Unable to load families using dict {'!H_Abstraction':True, '!pah':True}")
 
 class TestReactionDegeneracy(unittest.TestCase):
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -99,7 +99,9 @@ def database(
         if not isinstance(kineticsFamilies, list):
             raise InputError("kineticsFamilies should be either 'default', 'all', 'none', or a list of names eg. "
                              "['H_Abstraction','R_Recombination'] or ['!Intra_Disproportionation'].")
-        rmg.kinetics_families = kineticsFamilies
+        # rmg.kinetics_families = kineticsFamilies
+        rmg.kinetics_families = dict((name, False) if not isinstance(
+            name, tuple) else name for name in kineticsFamilies)
 
 
 def catalyst_properties(bindingEnergies=None,

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -441,7 +441,7 @@ class RMG(util.Subject):
                 copy_species_constraints = copy.copy(self.species_constraints)
                 self.species_constraints = {}
                 for name,family in self.database.kinetics.families.items():
-                    if not self.kinetics_families[name]:
+                    if name not in self.kinetics_families.keys():
                         if self.kinetics_depositories:
                             if not family.auto_generated:
                                 family.add_rules_from_training(thermo_database=self.database.thermo)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -441,7 +441,8 @@ class RMG(util.Subject):
                 copy_species_constraints = copy.copy(self.species_constraints)
                 self.species_constraints = {}
                 for name,family in self.database.kinetics.families.items():
-                    if name not in self.kinetics_families.keys():
+                    # if we exclude a family in the input file, don't add rules from training
+                    if not self.kinetics_families[name]:
                         if self.kinetics_depositories:
                             if not family.auto_generated:
                                 family.add_rules_from_training(thermo_database=self.database.thermo)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation
In some cases, in particular for surface systems, it is advantageous to exclude the training data for a given family, and only rely on the more general rules. This in part due to the heterogeneity of the data obtained from different sources, which can also throw off estimates for systems that may be different from the training data (i.e. a different metals or facets). It is also useful for performing correlated uncertainty for Catalytic systems, such as the study performed by [Krietz et al.](https://pubs.acs.org/doi/abs/10.1021/jacsau.1c00276).

### Description of Changes
The following change makes it so that an RMG input file can accept arguments for the  "kineticsFamilies" input similar to the ones used for reactionLibraries:

```python
kineticsFamilies =[
        'Surface_Adsorption_Single',
        ('Surface_Dissociation', True), # True to exclude training data
]
```

This makes selectively including/excluding training data from specific families much easier. it can also be done for groups of families:
```python
kineticsFamilies =[
        ('surface', True),
        'default',
]
```

Functionally, if training data is completely excluded, exact matches with training data will be ignored, and the kinetics family tree is filled in by averaging. This PR basically does what adding "!Training" to `kineticsDepositories` does, just more selectively.

### Testing
I have added to the unit tests to ensure that the existing methods for adding data are still functional. The `set` methods implemented by max are a little slower as a result of introducing a dictionary, so the tests are a little longer. 

I have also run several mechanisms on this to ensure that *only* the families I want to exclude training data for exclusively use the rate rules specified in rules.py.  I have attached the input file and results of one such test [here](https://github.com/ReactionMechanismGenerator/RMG-Py/files/7824757/exclude_training.zip).

### Reviewer Tips
I would like initial feedback on 
- how to make it more pythonic
- how to make it faster, if possible or necessary (it does not slow down execution very much) 
- what other unit tests I might have missed.
<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
