### PR TITLE
Check for sticking coeff rxns > 1 in rules.py

### DIFF
--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -750,7 +750,13 @@ class KineticsRules(Database):
         kinetics.A.value_si *= degeneracy
         if degeneracy > 1:
             kinetics.comment += "\n"
-            kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
+            # Ensure sticking coefficient reactions do not exceed 1
+            if isinstance(kinetics, StickingCoefficientBEP) and kinetics.A.value_si > 1:
+                kinetics.A.value_si = 1
+                kinetics.comment += "Reaction path degeneracy ({0}) resulted in sticking coefficient > 1. resetting to 1".format(
+                    degeneracy)
+            else:
+                kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
 
         kinetics.comment += "\n"
         kinetics.comment += "family: {0}".format(self.label.replace('/rules', ''))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Issue #1981: sometimes rule-generated sticking coefficients can exceed 1, because of the reaction path degeneracy calculations. For example, a rate rule of A = 0.5  applied to ethane losing a hydrogen, increases the sticking coefficient by 6 (A=3.0): 
<img width="804" alt="image" src="https://user-images.githubusercontent.com/56306881/149184460-6175c036-a875-45d4-a5bb-6c2fa32b4b35.png">

### Description of Changes
changed the rules.py file to cap the sticking coefficient at 1.0, and to include a message in the reaction comments detailing why: 
<img width="797" alt="image" src="https://user-images.githubusercontent.com/56306881/149185570-8ecbb2ee-6626-4a8b-aaba-e13dd79fc9b1.png">


### Testing
Unit tests run successfully. I'd be open to adding a test but I think it would require changing the setup for rmgpy/data/kineticsTest.py.

### Reviewer Tips
Run a surface mechanism with it. I forced my example to have the same problem by changing the corresponding surface dissociation rule from 0.1 to 0.5. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
