### PR TITLE
Cantera issue in regression testing 

### DIFF
--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -154,7 +154,8 @@ def run(benchmarkDir, testDir, title, observables, setups, tol):
         title=title,
         old_dir=benchmarkDir,
         new_dir=testDir,
-        observables={'species': observables}
+        observables={'species': observables},
+        ck2cti=False,
     )
 
     reactor_types, temperatures, pressures, initial_mole_fractions_list, termination_times = setups


### PR DESCRIPTION
### Motivation or Problem
RMG tests gets an IO buffering issue as outlined in issue  #2228 on RMG-tests. it attempts to write an output cti file and gets the following error: 
```
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/testing/lib/python3.7/site-packages/julia/pseudo_python_cli.py", line 308, in main
    python(**vars(ns))
  File "/usr/share/miniconda/envs/testing/lib/python3.7/site-packages/julia/pseudo_python_cli.py", line 59, in python
    scope = runpy.run_path(script, run_name="__main__")
  File "/usr/share/miniconda/envs/testing/lib/python3.7/runpy.py", line 263, in run_path
    pkg_name=pkg_name, script_name=fname)
  File "/usr/share/miniconda/envs/testing/lib/python3.7/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/share/miniconda/envs/testing/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/RMG-tests/RMG-tests/code/testing/RMG-Py/rmgpy/tools/regression.py", line 199, in <module>
    main()
  File "/home/runner/work/RMG-tests/RMG-tests/code/testing/RMG-Py/rmgpy/tools/regression.py", line 195, in main
    run(benchmark, tested, *args)
  File "/home/runner/work/RMG-tests/RMG-tests/code/testing/RMG-Py/rmgpy/tools/regression.py", line 157, in run
    observables={'species': observables}
  File "/home/runner/work/RMG-tests/RMG-tests/code/testing/RMG-Py/rmgpy/tools/observablesregression.py", line 138, in __init__
    quiet=True)
  File "/home/runner/work/RMG-tests/RMG-tests/code/testing/RMG-Py/rmgpy/tools/canteramodel.py", line 305, in load_chemkin_model
    self.model = ct.Solution(out_name)
  File "interfaces/cython/cantera/base.pyx", line 29, in cantera._cantera._SolutionBase.__cinit__
  File "interfaces/cython/cantera/base.pyx", line 50, in cantera._cantera._SolutionBase._init_cti_xml
cantera._cantera.CanteraError: 
***********************************************************************
CanteraError thrown by ct2ctml_string:
Error converting input file "/home/runner/work/RMG-tests/RMG-tests/results/benchmark/rmg/nitrogen/chemkin/chem_annotated.cti" to CTML.
Python command was: '/usr/share/miniconda/envs/testing/bin/python'
The exit code was: 7
-------------- start of converter log --------------
Python 3.7.11 (default, Jul 27 2021, 14:35:47) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
Traceback (most recent call last):
  File "<console>", line 8, in <module>
  File "/usr/share/miniconda/envs/testing/lib/python3.7/site-packages/cantera/ctml_writer.py", line 2694, in convert
    write(outName)
  File "/usr/share/miniconda/envs/testing/lib/python3.7/site-packages/cantera/ctml_writer.py", line 377, in write
    x.write(sys.stdout)
  File "/usr/share/miniconda/envs/testing/lib/python3.7/site-packages/cantera/ctml_writer.py", line 152, in write
    filename.write(''.join(s))
BlockingIOError: [Errno 11] write could not complete without blocking
--------------- end of converter log ---------------
***********************************************************************
```
### Description of Changes
Make it so regression tests do not write an output cti file. It can load a cantera model internally for the regression test, generating one is currently not necessary. 

### Testing
Unit tests and the CI tests should be enough. if the continuous-integration/rmg-tests suite passes then the change was a success.


