### PR TITLE
More robust conformer embed in QM module

### DIFF
--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -52,11 +52,11 @@ from rmgpy.thermo import ThermoData
 class Geometry(object):
     """
     A geometry, used for quantum calculations.
-    
+
     Created from a molecule. Geometry estimated by RDKit.
-    
+
     The attributes are:
-    
+
     =================== ======================= ====================================
     Attribute           Type                    Description
     =================== ======================= ====================================
@@ -65,7 +65,7 @@ class Geometry(object):
     `molecule`          :class:`Molecule`       RMG Molecule object
     `unique_id_long`      ``str``                 A long, truly unique ID such as an augmented InChI
     =================== ======================= ====================================
-    
+
     """
 
     def __init__(self, settings, unique_id, molecule, unique_id_long=None):
@@ -99,7 +99,7 @@ class Geometry(object):
     def get_file_path(self, extension, scratch=True):
         """
         Returns the path to the file with the given extension.
-        
+
         The provided extension should include the leading dot.
         If called with `scratch=False` then it will be in the `fileStore` directory,
         else `scratch=True` is assumed and it will be in the `scratchDirectory` directory.
@@ -206,9 +206,9 @@ class Geometry(object):
 def load_thermo_data_file(file_path):
     """
     Load the specified thermo data file and return the dictionary of its contents.
-    
+
     Returns `None` if the file is invalid or missing.
-    
+
     Checks that the returned dictionary contains at least InChI, adjacencyList, thermoData.
     """
     if not os.path.exists(file_path):
@@ -248,18 +248,18 @@ def load_thermo_data_file(file_path):
 
 
 class QMMolecule(object):
-    """ 
+    """
     A base class for QM Molecule calculations.
-    
+
     Specific programs and methods should inherit from this and define some
     extra attributes and methods:
-    
+
      * outputFileExtension
      * inputFileExtension
      * generate_qm_data() ...and whatever else is needed to make this method work.
-     
+
     The attributes are:
-    
+
     =================== ======================= ====================================
     Attribute           Type                    Description
     =================== ======================= ====================================
@@ -268,7 +268,7 @@ class QMMolecule(object):
     `unique_id`         ``str``                 A short ID such as an augmented InChI Key
     `unique_id_long`    ``str``                 A long, truly unique ID such as an augmented InChI
     =================== ======================= ====================================
-    
+
     """
 
     def __init__(self, molecule, settings):
@@ -281,7 +281,7 @@ class QMMolecule(object):
     def get_file_path(self, extension, scratch=True):
         """
         Returns the path to the file with the given extension.
-        
+
         The provided extension should include the leading dot.
         If called with `scratch=False` then it will be in the `fileStore` directory,
         else `scratch=True` is assumed and it will be in the `scratchDirectory` directory.
@@ -372,8 +372,8 @@ class QMMolecule(object):
 
     def generate_thermo_data(self):
         """
-        Generate Thermo Data via a QM calc. 
-        
+        Generate Thermo Data via a QM calc.
+
         Returns None if it fails.
         """
         self.initialize()
@@ -452,7 +452,7 @@ class QMMolecule(object):
     def get_mol_file_path_for_calculation(self, attempt):
         """
         Get the path to the MOL file of the geometry to use for calculation `attempt`.
-        
+
         If attempt <= self.script_attempts then we use the refined coordinates,
         then we start to use the crude coordinates.
         """
@@ -464,7 +464,7 @@ class QMMolecule(object):
     def determine_point_group(self):
         """
         Determine point group using the SYMMETRY Program
-        
+
         Stores the resulting :class:`PointGroup` in self.point_group
         """
         assert self.qm_data, "Need QM Data first in order to calculate point group."
@@ -483,7 +483,7 @@ class QMMolecule(object):
     def calculate_thermo_data(self):
         """
         Calculate the thermodynamic properties.
-        
+
         Stores and returns a ThermoData object as self.thermo.
         self.qm_data and self.point_group need to be generated before this method is called.
         """

--- a/rmgpy/qm/moleculeTest.py
+++ b/rmgpy/qm/moleculeTest.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2021 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+import os
+import shutil
+import unittest
+
+from rdkit import Chem
+from rmgpy.molecule import Molecule
+from rmgpy.qm.main import QMSettings
+from rmgpy.qm.molecule import Geometry
+
+scratch_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'scratch')
+
+class TestQMMolecule(unittest.TestCase):
+    """
+    Contains unit tests for the Geometry class in the qm module.
+    """
+
+    def test_rd_embed_common_species(self):
+        """
+        Test that rd_embed() works for various commmon molecules.
+        """
+        for smi in ['O', 'C', '[CH2]', '[CH3]',
+                    '[OH]', 'O=C=O', '[CH3+]', '[OH-]',
+                    'N', 'N#N', '[NH2]', 'CO[O]',]:
+            mol = Molecule().from_smiles(smi)
+            geom = Geometry(settings=QMSettings(
+                                scratchDirectory=scratch_dir,
+                            ),
+                            unique_id='0',
+                            molecule=mol)
+            rdmol, _ = geom.rd_build()
+            rdmol, _ = geom.rd_embed(rdmol, num_conf_attempts=20)
+            self.assertEqual(rdmol.GetNumConformers(), 20)
+        shutil.rmtree(scratch_dir)
+
+    def test_rd_embed_uncommon_species(self):
+        """
+        Test that rd_embed() works for species that ETKDG fails to embed conformers for.
+        """
+        for smi in ['[N:1](=[C-:2][C@@:3]1([H:8])[O:4][C@@:5]2([H:9])[C:6]([H:10])([H:11])[C+:7]12)[H:12]',
+                    '[N+:1]1#[C:2][C@@:3]2([H:8])[O:4][C-:5]([H:9])[C:6]([H:10])([H:11])[C@@:7]12[H:12]',]:
+            # RMG has difficulty converting these charged species into RDKit Mol.
+            # Directly, generating rdmol using RDKit here.
+            # So far, this shouldn't be a concern since RMG doesn't work for charged species
+            # And these species are only to test the `rd_embed`` method
+            geom = Geometry(settings=QMSettings(
+                                scratchDirectory=scratch_dir,
+                            ),
+                            unique_id='0',
+                            molecule=None)
+            rdmol = Chem.rdmolops.AddHs(Chem.MolFromSmiles(smi))
+            rdmol, _ = geom.rd_embed(rdmol, num_conf_attempts=20)
+            self.assertEqual(rdmol.GetNumConformers(), 20)
+        shutil.rmtree(scratch_dir)
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
This PR aims to partially solve issue #2138, by implementing a more robust conformed embedding scheme. The RDKit Default algorithm ETKDG may fail some time, which causes no conformers actually created in `rd_embed` functions that further raises an error when `GetConformer` at line 196.

The fix implements two backup algorithms to embed conformers: embedding using random coordinates, and embedding using 2D geometries. Since there is a following force field optimization step, it shouldn't be too bad an idea.