### PR TITLE
Change rmgrc to a template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ RMG_Py.egg-info/*
 
 # deleted files
 **/.fuse_hidden*
+
+# RMG configuration file
+rmgpy/rmgrc

--- a/rmgpy/rmgrc_template
+++ b/rmgpy/rmgrc_template
@@ -2,10 +2,11 @@
 #
 #   This is a configuration file for RMG-Py. 
 #
-#   A copy of this file is always available from site-packages/rmgpy/rmgrc. 
-#   Note that any changes made to that file will likely be overridden when 
-#   installing an updated version of RMG-Py. If you want to keep a permanent 
-#   local copy that will not be over-written, place it in $HOME/.rmg/rmgrc 
+#   A copy of this file is always available from rmgpy/rmgrc_template.
+#   To use this file, make a copy and place in rmgpy/rmgrc.
+#   Do not make any changes to the template file, which will be overridden when
+#   installing an updated version of RMG-Py. If you want to keep a user-wide
+#   local copy, you can also copy the template to $HOME/.rmg/rmgrc
 #   (Unix-based systems) or C:\Documents and Settings\yourname\.rmg\rmgrc 
 #   (Windows systems).
 #


### PR DESCRIPTION
This allows the user to make changes without these changes being reset. The previous solution of storing a permanent copy in $HOME/.rmg/rmgrc still works, but this is not a good solution when a user has multiple RMG installations that each point to different database locations

### Motivation or Problem
If a user wanted to point RMG to use a database at a non-default location, one way they can accomplish this is by changing this setting in the rmgrc file. Because we track this file though, any changes the user makes are likely to get overwritten constantly. This PR moves the file to a "template file" location. This allows the user to make their own rmgrc file, which is no longer tracked and in the .gitignore file. This approach has the advantage that multiple RMG installations on the same computer can be supported in this way. For example, this is useful for a git worktrees approach.
