### PR TITLE
Add Nitrogen groups to transport 

### DIFF
--- a/rmgpy/data/transportTest.py
+++ b/rmgpy/data/transportTest.py
@@ -148,6 +148,8 @@ class TestTransportDatabase(unittest.TestCase):
             ['acetone', 'CC(=O)C', Length(5.36421, 'angstroms'), Energy(3.20446, 'kJ/mol'), "Epsilon & sigma estimated with Tc=500.53 K, Pc=47.11 bar (from Joback method)"],
             ['cyclopenta-1,2-diene', 'C1=C=CCC1', None, None, None],  # not sure what to expect, we just want to make sure it doesn't crash
             ['benzene', 'c1ccccc1', None, None, None],
+            ['N-methylmethanamine', 'CNC', None, None, None],
+            ['imidazole', 'c1ncc[nH]1', None, None, None],
         ]
 
         # values calculate from joback's estimations


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The transport groups were previously missing nitrogen. The nitrogen groups for the transport GAV have been added to the RMG-database. Two nitrogen molecules have been added to the `transportTest.py`.

Note that this PR needs simultaneous update of RMG-Py and RMG-database. (Twin RMG-database PR is: [#566](https://github.com/ReactionMechanismGenerator/RMG-database/pull/566))

### Description of Changes
Several nonring and ring nitrogen groups are added to `RMG-database/input/transport/groups/`.
These group values are obtained from Joback's Ph.D. thesis Table 3 and Table 13. These values can be also found [here](https://en.wikipedia.org/wiki/Joback_method#Critical_temperature). The nitrogen groups with any missing values were not added to the RMG-database. 

### Testing
Two molecules with SMILES `CNC` and `c1ncc[nH]1` have been added to the `transportTest.py`. 

### Reviewer Tips
You can run the unittests to check.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
