### PR TITLE
Fix load_chemkin_file read of surface species

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1147,10 +1147,18 @@ def read_species_block(f, species_dict, species_aliases, species_list):
             continue  # there may be more than one SPECIES statement
         if token_upper == 'END':
             break
+
+        site_token = token.split('/')[0]
+        if site_token.upper() == 'SDEN':
+            continue  # TODO actually read in the site density
+
         processed_tokens.append(token)
         if token in species_dict:
             logging.debug("Re-using species {0} already in species_dict".format(token))
             species = species_dict[token]
+        elif site_token in species_dict:
+            logging.debug("Re-using species {0} already in species_dict".format(site_token))
+            species = species_dict[site_token]
         else:
             species = Species(label=token)
             species_dict[token] = species


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Original issue [https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2275](https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2275)
The load_chemkin_file() function gets tripped up by the site density info at the top of the SITE block for surface chemkin files as well as the bidentate/number-of-sites info (all of the /2/ 's):
```
SITE   SDEN/2.7200E-09/ ! mol/cm^2
    vacantX(3)
    HX(5)
    OX(6)
    CH3X(7)
    HOX(8)
    H2OX(9)
    OCX(13)
    CX(15)
    CH2X(16)
    CHX(17)
    CH4X(27)
    O2X2(28)/2/
    O2X(29)
    CH3OX(30)
    C2H6X(31)
    H2X(33)
    HO2X(37)
    CH4OX(40)
    H2O2X(42)
    CH2OX2(44)/2/
    CH2OX(45)
    C2H5X(46)
    CH3OX(47)
    C2H4X2(49)/2/
    C2H4X(50)
    CH2X(51)
    CH4O2X(56)
    CH3O2X(59)
    CH3O2X(63)
    C2H6OX(71)
    CHOX2(77)/2/
    C2H4X(78)
    CH2OX(79)
    C2H3X2(80)/2/
    CHOX(87)
    COX2(94)/2/
    SX(104)
    CHOX(115)
END

```

### Description of Changes
I added an if statement to skip over the SDEN/site-density-info token
I added an if statement to read in the SPECIES/number-of-sites tokens

### Testing
After rebuilding, this successfully reads in the surface species without including SDEN as its own separate species. It also reads in bidentate species like "CH2OX2(44)/2/" using the species dictionary entry "CH2OX2(44)" like it's supposed to.
