### PR TITLE
Improve Rule Generation

### DIFF
--- a/rmgpy/constants.pxd
+++ b/rmgpy/constants.pxd
@@ -25,4 +25,4 @@
 #                                                                             #
 ###############################################################################
 
-cdef double pi, Na, kB, R, h, hbar, c, e, m_e, m_p, m_n, amu, a0, E_h
+cdef double pi, Na, kB, R, h, hbar, c, e, m_e, m_p, m_n, amu, a0, E_h, F

--- a/rmgpy/constants.py
+++ b/rmgpy/constants.py
@@ -110,6 +110,9 @@ m_p = 1.672621777e-27
 #: :math:`\pi = 3.14159 \ldots`      
 pi = float(math.pi)
 
+#: Faradays Constant F in C/mol
+F = 96485.3321233100184
+
 ################################################################################
 
 # Cython does not automatically place module-level variables into the module
@@ -130,4 +133,5 @@ globals().update({
     'm_n': m_n,
     'm_p': m_p,
     'pi': pi,
+    'F': F
 })

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -42,6 +42,7 @@ from collections import OrderedDict
 from rmgpy.data.reference import Reference, Article, Book, Thesis
 from rmgpy.exceptions import DatabaseError, InvalidAdjacencyListError
 from rmgpy.kinetics.uncertainties import RateUncertainty
+from rmgpy.kinetics.arrhenius import ArrheniusChargeTransfer, ArrheniusChargeTransferBM
 from rmgpy.molecule import Molecule, Group
 
 
@@ -228,6 +229,8 @@ class Database(object):
         local_context['shortDesc'] = self.short_desc
         local_context['longDesc'] = self.long_desc
         local_context['RateUncertainty'] = RateUncertainty
+        local_context['ArrheniusChargeTransfer'] = ArrheniusChargeTransfer
+        local_context['ArrheniusChargeTransferBM'] = ArrheniusChargeTransferBM
         local_context['metal'] = self.metal
         local_context['site'] = self.site
         local_context['facet'] = self.facet

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -48,7 +48,7 @@ from rmgpy.kinetics import Arrhenius, ArrheniusEP, ThirdBody, Lindemann, Troe, \
 from rmgpy.molecule import Molecule, Group
 from rmgpy.reaction import Reaction, same_species_lists
 from rmgpy.species import Species
-
+from rmgpy.data.solvation import SoluteData
 
 ################################################################################
 
@@ -79,7 +79,8 @@ class KineticsDatabase(object):
             'SurfaceArrhenius': SurfaceArrhenius,
             'SurfaceArrheniusBEP': SurfaceArrheniusBEP,
             'R': constants.R,
-            'ArrheniusBM': ArrheniusBM
+            'ArrheniusBM': ArrheniusBM,
+            'SoluteData': SoluteData,
         }
         self.global_context = {}
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4602,25 +4602,61 @@ def _make_rule(rr):
     rxns = np.array(rxns)
     data_mean = np.mean(np.log([r.kinetics.get_rate_coefficient(Tref) for r in rxns]))
     if n > 0:
-        kin = ArrheniusBM().fit_to_reactions(rxns, recipe=recipe)
-        if n == 1:
-            kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
+        if isinstance(rxns[0].kinetics, Arrhenius):
+            arr = ArrheniusBM
         else:
-            dlnks = np.array([
-                np.log(
-                    ArrheniusBM().fit_to_reactions(rxns[list(set(range(len(rxns))) - {i})], recipe=recipe)
+            arr = ArrheniusChargeTransferBM
+        if n > 1:
+            kin = arr().fit_to_reactions(rxns, recipe=recipe)
+        if n == 1 or kin.E0.value_si < 0.0:
+            kin = average_kinetics([r.kinetics for r in rxns])
+            #kin.comment = "Only one reaction or Arrhenius BM fit bad. Instead averaged from {} reactions.".format(n)
+            if n == 1:
+                kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
+            else:
+                dlnks = np.array([
+                    np.log(
+                            average_kinetics([r.kinetics for r in rxns[list(set(range(len(rxns))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
+                        ) for i, rxn in enumerate(rxns)
+                    ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
+                varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rxns]) / (2.0 * 8.314 * Tref)) ** 2
+                # weighted average calculations
+                ws = 1.0 / varis
+                V1 = ws.sum()
+                V2 = (ws ** 2).sum()
+                mu = np.dot(ws, dlnks) / V1
+                s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
+                kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
+                return kin
+        else:
+            if n == 1:
+                kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
+            else:
+                if isinstance(rxns[0].kinetics, Arrhenius):
+                    dlnks = np.array([
+                        np.log(
+                            arr().fit_to_reactions(rxns[list(set(range(len(rxns))) - {i})], recipe=recipe)
                     .to_arrhenius(rxn.get_enthalpy_of_reaction(Tref))
                     .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
                 ) for i, rxn in enumerate(rxns)
             ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rxns]) / (2.0 * 8.314 * Tref)) ** 2
-            # weighted average calculations
-            ws = 1.0 / varis
-            V1 = ws.sum()
-            V2 = (ws ** 2).sum()
-            mu = np.dot(ws, dlnks) / V1
-            s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
-            kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
+                else:
+                    dlnks = np.array([
+                        np.log(
+                            arr().fit_to_reactions(rxns[list(set(range(len(rxns))) - {i})], recipe=recipe)
+                            .to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(Tref))
+                            .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
+                        ) for i, rxn in enumerate(rxns)
+                    ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
+                varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rxns]) / (2.0 * 8.314 * Tref)) ** 2
+                # weighted average calculations
+
+                ws = 1.0 / varis
+                V1 = ws.sum()
+                V2 = (ws ** 2).sum()
+                mu = np.dot(ws, dlnks) / V1
+                s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
+                kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
         return kin
     else:
         return None

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -55,7 +55,8 @@ from rmgpy.data.kinetics.rules import KineticsRules
 from rmgpy.exceptions import ActionError, DatabaseError, InvalidActionError, KekulizationError, KineticsError, \
                              ForbiddenStructureException, UndeterminableKineticsError
 from rmgpy.kinetics import Arrhenius, SurfaceArrhenius, SurfaceArrheniusBEP, StickingCoefficient, \
-                           StickingCoefficientBEP, ArrheniusBM
+                           StickingCoefficientBEP, ArrheniusBM, SurfaceChargeTransfer, ArrheniusChargeTransfer, \
+                           ArrheniusChargeTransferBM
 from rmgpy.kinetics.uncertainties import RateUncertainty, rank_accuracy_map
 from rmgpy.molecule import Bond, GroupBond, Group, Molecule
 from rmgpy.molecule.atomtype import ATOMTYPES
@@ -308,7 +309,7 @@ class ReactionRecipe(object):
                         if info < 1:
                             raise InvalidActionError('Attempted to change a nonexistent bond.')
                         # If we do not have a bond, it might be because we are trying to change a vdW bond
-                        # Lets see if one of that atoms is a surface site, 
+                        # Lets see if one of that atoms is a surface site,
                         # If we have a surface site, we will make a single bond, then change it by info - 1
                         is_vdW_bond = False
                         for atom in (atom1, atom2):
@@ -444,8 +445,8 @@ class ReactionRecipe(object):
 
 class KineticsFamily(Database):
     """
-    A class for working with an RMG kinetics family: a set of reactions with 
-    similar chemistry, and therefore similar reaction rates. The attributes 
+    A class for working with an RMG kinetics family: a set of reactions with
+    similar chemistry, and therefore similar reaction rates. The attributes
     are:
 
     =================== =============================== ========================
@@ -699,11 +700,11 @@ class KineticsFamily(Database):
     def load(self, path, local_context=None, global_context=None, depository_labels=None):
         """
         Load a kinetics database from a file located at `path` on disk.
-        
+
         If `depository_labels` is a list, eg. ['training','PrIMe'], then only those
         depositories are loaded, and they are searched in that order when
         generating kinetics.
-        
+
         If depository_labels is None then load 'training' first then everything else.
         If depository_labels is not None then load in the order specified in depository_labels.
         """
@@ -796,7 +797,7 @@ class KineticsFamily(Database):
             # depository and add them to the RMG rate rules by default:
             depository_labels = ['training']
         if depository_labels:
-            # If there are depository labels, load them in the order specified, but 
+            # If there are depository labels, load them in the order specified, but
             # append the training reactions unless the user specifically declares it not
             # to be included with a '!training' flag
             if '!training' not in depository_labels:
@@ -835,7 +836,8 @@ class KineticsFamily(Database):
         for action in actions:
             action[0] = action[0].upper()
             valid_actions = [
-                'CHANGE_BOND', 'FORM_BOND', 'BREAK_BOND', 'GAIN_RADICAL', 'LOSE_RADICAL', 'GAIN_PAIR', 'LOSE_PAIR'
+                'CHANGE_BOND', 'FORM_BOND', 'BREAK_BOND', 'GAIN_RADICAL', 'LOSE_RADICAL',
+                'GAIN_CHARGE', 'LOSE_CHARGE', 'GAIN_PAIR', 'LOSE_PAIR'
             ]
             if action[0] not in valid_actions:
                 raise InvalidActionError('Action {0} is not a recognized action. '
@@ -862,12 +864,12 @@ class KineticsFamily(Database):
                                 rank=3):
         """
         This function takes a list of reactions appends it to the training reactions file.  It ignores the existence of
-        duplicate reactions.  
-        
-        The rank for each new reaction's kinetics is set to a default value of 3 unless the user specifies differently 
+        duplicate reactions.
+
+        The rank for each new reaction's kinetics is set to a default value of 3 unless the user specifies differently
         for those reactions.
-        
-        For each entry, the long description is imported from the kinetics comment. 
+
+        For each entry, the long description is imported from the kinetics comment.
         """
 
         if not isinstance(reference, list):
@@ -970,7 +972,7 @@ class KineticsFamily(Database):
 
     def save(self, path):
         """
-        Save the current database to the file at location `path` on disk. 
+        Save the current database to the file at location `path` on disk.
         """
         self.save_groups(os.path.join(path, 'groups.py'))
         self.rules.save(os.path.join(path, 'rules.py'))
@@ -987,7 +989,7 @@ class KineticsFamily(Database):
 
     def save_groups(self, path):
         """
-        Save the current database to the file at location `path` on disk. 
+        Save the current database to the file at location `path` on disk.
         """
         entries = self.groups.get_entries_to_save()
 
@@ -1023,7 +1025,7 @@ class KineticsFamily(Database):
             f.write('reactantNum = {0}\n\n'.format(self.reactant_num))
         if self.product_num is not None:
             f.write('productNum = {0}\n\n'.format(self.product_num))
-            
+
         if self.auto_generated is not None:
             f.write('autoGenerated = {0}\n\n'.format(self.auto_generated))
 
@@ -1147,14 +1149,14 @@ class KineticsFamily(Database):
 
     def has_rate_rule(self, template):
         """
-        Return ``True`` if a rate rule with the given `template` currently 
+        Return ``True`` if a rate rule with the given `template` currently
         exists, or ``False`` otherwise.
         """
         return self.rules.has_rule(template)
 
     def get_rate_rule(self, template):
         """
-        Return the rate rule with the given `template`. Raises a 
+        Return the rate rule with the given `template`. Raises a
         :class:`ValueError` if no corresponding entry exists.
         """
         entry = self.rules.get_rule(template)
@@ -1340,7 +1342,7 @@ class KineticsFamily(Database):
     def get_root_template(self):
         """
         Return the root template for the reaction family. Most of the time this
-        is the top-level nodes of the tree (as stored in the 
+        is the top-level nodes of the tree (as stored in the
         :class:`KineticsGroups` object), but there are a few exceptions (e.g.
         R_Recombination).
         """
@@ -1493,7 +1495,10 @@ class KineticsFamily(Database):
             product_num = self.product_num or len(template.products)
 
         # Split product structure into multiple species if necessary
-        product_structures = product_structure.split()
+        if self.auto_generated and isinstance(reactant_structures[0],Group) and self.product_num == 1:
+            product_structures = [product_structure]
+        else:
+            product_structures = product_structure.split()
 
         # Make sure we've made the expected number of products
         if product_num != len(product_structures):
@@ -1535,8 +1540,20 @@ class KineticsFamily(Database):
                     struct.update_charge()
             else:
                 raise TypeError('Expecting Molecule or Group object, not {0}'.format(struct.__class__.__name__))
-            product_net_charge += struc.get_net_charge()
-        if reactant_net_charge != product_net_charge:
+            product_net_charge += struct.get_net_charge()
+
+        if self.electrons < 0:
+            if forward:
+                reactant_net_charge += self.electrons
+            else:
+                product_net_charge += self.electrons
+        elif self.electrons > 0:
+            if forward:
+                product_net_charge -= self.electrons
+            else:
+                reactant_net_charge -= self.electrons
+
+        if reactant_net_charge != product_net_charge and is_molecule:
             logging.debug(
                 'The net charge of the reactants {0} differs from the net charge of the products {1} in reaction '
                 'family {2}. Not generating this reaction.'.format(reactant_net_charge, product_net_charge, self.label))
@@ -1659,10 +1676,10 @@ class KineticsFamily(Database):
     def is_molecule_forbidden(self, molecule):
         """
         Return ``True`` if the molecule is forbidden in this family, or
-        ``False`` otherwise. 
+        ``False`` otherwise.
         """
 
-        # check family-specific forbidden structures 
+        # check family-specific forbidden structures
         if self.forbidden is not None and self.forbidden.is_molecule_forbidden(molecule):
             return True
 
@@ -1706,7 +1723,7 @@ class KineticsFamily(Database):
 
     def _match_reactant_to_template(self, reactant, template_reactant):
         """
-        Return a complete list of the mappings if the provided reactant 
+        Return a complete list of the mappings if the provided reactant
         matches the provided template reactant, or an empty list if not.
         """
 
@@ -1882,8 +1899,8 @@ class KineticsFamily(Database):
         For a `reaction`  with `Molecule` or `Species` objects given in the direction in which
         the kinetics are defined, compute the reaction-path degeneracy.
 
-        This method by default adjusts for double counting of identical reactants. 
-        This should only be adjusted once per reaction. To not adjust for 
+        This method by default adjusts for double counting of identical reactants.
+        This should only be adjusted once per reaction. To not adjust for
         identical reactants (since you will be reducing them later in the algorithm), add
         `ignoreSameReactants= True` to this method.
         """
@@ -1957,7 +1974,7 @@ class KineticsFamily(Database):
         will return an empty list. Each item in the list of reactants should
         be a list of :class:`Molecule` objects, each representing a resonance
         structure of the species of interest.
-        
+
         This method returns all reactions, and degenerate reactions can then be
         found using `rmgpy.data.kinetics.common.find_degenerate_reactions`.
 
@@ -1982,7 +1999,7 @@ class KineticsFamily(Database):
 
         rxn_list = []
 
-        # Wrap each reactant in a list if not already done (this is done to 
+        # Wrap each reactant in a list if not already done (this is done to
         # allow for passing multiple resonance structures for each molecule)
         # This also makes a copy of the reactants list so we don't modify the
         # original
@@ -2303,7 +2320,7 @@ class KineticsFamily(Database):
         if not forward and ('adsorption' in self.label.lower() or 'eleyrideal' in self.label.lower()):
             # Desorption should have desorbed something (else it was probably bidentate)
             # so delete reactions that don't make a gas-phase desorbed product
-            # Eley-Rideal reactions should have one gas-phase product in the reverse direction 
+            # Eley-Rideal reactions should have one gas-phase product in the reverse direction
 
             # Determine how many surf reactants we expect based on the template
             n_surf_expected = len([r for r in self.forward_template.reactants if r.item.contains_surface_site()])
@@ -2373,7 +2390,7 @@ class KineticsFamily(Database):
         """
         pairs = []
         if len(reaction.reactants) == 1 or len(reaction.products) == 1:
-            # When there is only one reactant (or one product), it is paired 
+            # When there is only one reactant (or one product), it is paired
             # with each of the products (reactants)
             for reactant in reaction.reactants:
                 for product in reaction.products:
@@ -2542,7 +2559,7 @@ class KineticsFamily(Database):
         `template` and reaction-path `degeneracy`. There are two possible methods
         to use: 'group additivity' (new possible RMG-Py behavior) and 'rate rules' (old
         RMG-Java behavior, and default RMG-Py behavior).
-        
+
         Returns a tuple (kinetics, entry):
         If it's estimated via 'rate rules' and an exact match is found in the tree,
         then the entry is returned as the second element of the tuple.
@@ -2560,7 +2577,7 @@ class KineticsFamily(Database):
     def get_kinetics_from_depository(self, depository, reaction, template, degeneracy):
         """
         Search the given `depository` in this kinetics family for kinetics
-        for the given `reaction`. Returns a list of all of the matching 
+        for the given `reaction`. Returns a list of all of the matching
         kinetics, the corresponding entries, and ``True`` if the kinetics
         match the forward direction or ``False`` if they match the reverse
         direction.
@@ -2632,7 +2649,7 @@ class KineticsFamily(Database):
                 for kinetics, entry, is_forward in kinetics_list0:
                     kinetics_list.append([kinetics, depository, entry, is_forward])
 
-        # If estimator type of rate rules or group additivity is given, retrieve the kinetics. 
+        # If estimator type of rate rules or group additivity is given, retrieve the kinetics.
         if estimator:
             try:
                 kinetics, entry = self.get_kinetics_for_template(template, degeneracy, method=estimator)
@@ -2644,7 +2661,7 @@ class KineticsFamily(Database):
                 if not return_all_kinetics:
                     return kinetics, estimator, entry, True
                 kinetics_list.append([kinetics, estimator, entry, True])
-        # If no estimation method was given, prioritize rate rule estimation. 
+        # If no estimation method was given, prioritize rate rule estimation.
         # If returning all kinetics, add estimations from both rate rules and group additivity.
         else:
             try:
@@ -2674,7 +2691,7 @@ class KineticsFamily(Database):
         """
         Determine the appropriate kinetics for a reaction with the given
         `template` using group additivity.
-        
+
         Returns just the kinetics, or None.
         """
         warnings.warn("Group additivity is no longer supported and may be"
@@ -2698,7 +2715,7 @@ class KineticsFamily(Database):
         """
         Determine the appropriate kinetics for a reaction with the given
         `template` using rate rules.
-        
+
         Returns a tuple (kinetics, entry) where `entry` is the database
         entry used to determine the kinetics only if it is an exact match,
         and is None if some averaging or use of a parent node took place.
@@ -2709,8 +2726,8 @@ class KineticsFamily(Database):
 
     def get_reaction_template_labels(self, reaction):
         """
-        Retrieve the template for the reaction and 
-        return the corresponding labels for each of the 
+        Retrieve the template for the reaction and
+        return the corresponding labels for each of the
         groups in the template.
         """
         template = self.get_reaction_template(reaction)
@@ -2723,8 +2740,8 @@ class KineticsFamily(Database):
 
     def retrieve_template(self, template_labels):
         """
-        Reconstruct the groups associated with the 
-        labels of the reaction template and 
+        Reconstruct the groups associated with the
+        labels of the reaction template and
         return a list.
         """
         template = []
@@ -2735,9 +2752,9 @@ class KineticsFamily(Database):
 
     def get_labeled_reactants_and_products(self, reactants, products, relabel_atoms=True):
         """
-        Given `reactants`, a list of :class:`Molecule` objects, and products, a list of 
-        :class:`Molecule` objects, return two new lists of :class:`Molecule` objects with 
-        atoms labeled: one for reactants, one for products. Returned molecules are totally 
+        Given `reactants`, a list of :class:`Molecule` objects, and products, a list of
+        :class:`Molecule` objects, return two new lists of :class:`Molecule` objects with
+        atoms labeled: one for reactants, one for products. Returned molecules are totally
         new entities in memory so input molecules `reactants` and `products` won't be affected.
         If RMG cannot find appropriate labels, (None, None) will be returned.
         If ``relabel_atoms`` is ``True``, product atom labels of reversible families
@@ -2916,7 +2933,7 @@ class KineticsFamily(Database):
     def _split_reactions(self, rxns, newgrp):
         """
         divides the reactions in rxns between the new
-        group structure newgrp and the old structure with 
+        group structure newgrp and the old structure with
         label oldlabel
         returns a list of reactions associated with the new group
         the list of reactions associated with the old group
@@ -2941,14 +2958,14 @@ class KineticsFamily(Database):
                 comp.append(rxn)
 
         return new, comp, new_inds
-    
+
     def reaction_matches(self, rxn, grp):
         rmol = rxn.reactants[0].molecule[0]
         for r in rxn.reactants[1:]:
             rmol = rmol.merge(r.molecule[0])
         rmol.identify_ring_membership()
         return rmol.is_subgraph_isomorphic(grp, generate_initial_map=True, save_order=True)
-    
+
     def eval_ext(self, parent, ext, extname, template_rxn_map, obj=None, T=1000.0):
         """
         evaluates the objective function obj
@@ -2972,15 +2989,15 @@ class KineticsFamily(Database):
         finds the set of all extension groups to parent such that
         1) the extension group divides the set of reactions under parent
         2) No generalization of the extension group divides the set of reactions under parent
-                    
+
         We find this by generating all possible extensions of the initial group.  Extensions that split reactions are added
-        to the list.  All extensions that do not split reactions and do not create bonds are ignored 
+        to the list.  All extensions that do not split reactions and do not create bonds are ignored
         (although those that match every reaction are labeled so we don't search them twice).  Those that match
-        all reactions and involve bond creation undergo this process again.  
-        
-        Principle:  Say you have two elementary changes to a group ext1 and ext2 if applying ext1 and ext2 results in a 
+        all reactions and involve bond creation undergo this process again.
+
+        Principle:  Say you have two elementary changes to a group ext1 and ext2 if applying ext1 and ext2 results in a
         split at least one of ext1 and ext2 must result in a split
-        
+
         Speed of this algorithm relies heavily on searching non bond creation dimensions once.
         """
         out_exts = [[]]
@@ -2991,7 +3008,7 @@ class KineticsFamily(Database):
 
         n_splits = len(template_rxn_map[parent.label][0].reactants)
         iter = 0
-        
+
         while grps[iter] != []:
             grp = grps[iter][-1]
 
@@ -3110,7 +3127,7 @@ class KineticsFamily(Database):
             out_exts.append([])
             grps[iter].pop()
             names.pop()
-            
+
             for ind in ext_inds:  # collect the groups to be expanded
                 grpr, grpcr, namer, typr, indcr = exts[ind]
                 if len(grps) == iter+1:
@@ -3120,17 +3137,17 @@ class KineticsFamily(Database):
 
             if first_time:
                 first_time = False
-                
+
             if grps[iter] == [] and len(grps) != iter+1 and (not (any([len(x)>0 for x in out_exts]) and iter+1 > iter_max)):
                 iter += 1
                 if len(grps[iter]) > iter_item_cap:
                     logging.error("Recursion item cap hit not splitting {0} reactions at iter {1} with {2} items".format(len(template_rxn_map[parent.label]),iter,len(grps[iter])))
                     iter -= 1
                     gave_up_split = True
-                        
+
             elif grps[iter] == [] and len(grps) != iter+1 and (any([len(x)>0 for x in out_exts]) and iter+1 > iter_max):
                 logging.error("iter_max achieved terminating early")
-                
+
         out = []
         # compile all of the valid extensions together
         # may be some duplicates here, but I don't think it's currently worth identifying them
@@ -3141,7 +3158,7 @@ class KineticsFamily(Database):
 
     def extend_node(self, parent, template_rxn_map, obj=None, T=1000.0, iter_max=np.inf, iter_item_cap=np.inf):
         """
-        Constructs an extension to the group parent based on evaluation 
+        Constructs an extension to the group parent based on evaluation
         of the objective function obj
         """
         exts, gave_up_split = self.get_extension_edge(parent, template_rxn_map, obj=obj, T=T, iter_max=iter_max, iter_item_cap=iter_item_cap)
@@ -3197,10 +3214,10 @@ class KineticsFamily(Database):
                         parent.item.clear_reg_dims()  # this almost always solves the problem
                         return True
             return False
-        
+
         if gave_up_split:
             return False
-        
+
         vals = []
         for grp, grpc, name, typ, einds in exts:
             val, boo = self.eval_ext(parent, grp, name, template_rxn_map, obj, T)
@@ -3296,7 +3313,7 @@ class KineticsFamily(Database):
                         logging.error(prod.label)
                         logging.error(prod.to_adjacency_list())
                 raise ValueError
-        
+
         template_rxn_map[extname] = new_entries
 
         if complement:
@@ -3312,21 +3329,21 @@ class KineticsFamily(Database):
         """
         Generate a tree by greedy optimization based on the objective function obj
         the optimization is done by iterating through every group and if the group has
-        more than one training reaction associated with it a set of potential more specific extensions 
-        are generated and the extension that optimizing the objective function combination is chosen 
+        more than one training reaction associated with it a set of potential more specific extensions
+        are generated and the extension that optimizing the objective function combination is chosen
         and the iteration starts over at the beginning
-        
+
         additionally the tree structure is simplified on the fly by removing groups that have no kinetics data
         associated if their parent has no kinetics data associated and they either have only one child or
         have two children one of which has no kinetics data and no children
         (its parent becomes the parent of its only relevant child node)
-        
+
         Args:
             rxns: List of reactions to generate tree from (if None pull the whole training set)
             obj: Object to expand tree from (if None uses top node)
             thermo_database: Thermodynamic database used for reversing training reactions
             T: Temperature the tree is optimized for
-            nprocs: Number of process for parallel tree generation 
+            nprocs: Number of process for parallel tree generation
             min_splitable_entry_num: the minimum number of splitable reactions at a node in order to spawn
                 a new process solving that node
             min_rxns_to_spawn: the minimum number of reactions at a node to spawn a new process solving that node
@@ -3370,9 +3387,9 @@ class KineticsFamily(Database):
                                      min_splitable_entry_num=min_splitable_entry_num, min_rxns_to_spawn=min_rxns_to_spawn, extension_iter_max=extension_iter_max,
                                      extension_iter_item_cap=extension_iter_item_cap)
                 logging.error("built tree with {} nodes".format(len(list(self.groups.entries))))
-            
+
             self.auto_generated = True
-                
+
     def get_rxn_batches(self, rxns, T=1000.0, max_batch_size=800, outlier_fraction=0.02, stratum_num=8):
         """
         Breaks reactions into batches based on a modified stratified sampling scheme
@@ -3475,7 +3492,7 @@ class KineticsFamily(Database):
                     entries.remove(entry)
         else:
             psize = float(len(template_rxn_map[root.label]))
-            
+
         logging.error(psize)
         mult_completed_nodes = []  # nodes containing multiple identical training reactions
         boo = True  # if the for loop doesn't break becomes false and the while loop terminates
@@ -3635,7 +3652,7 @@ class KineticsFamily(Database):
         """
         Perform K-fold cross validation on an automatically generated tree at temperature T
         after finding an appropriate node for kinetics estimation it will move up the tree
-        iters times.  
+        iters times.
         Returns a dictionary mapping {rxn:Ln(k_Est/k_Train)}
         """
 
@@ -3688,13 +3705,17 @@ class KineticsFamily(Database):
                         entry = entry.parent
 
                 uncertainties[rxn] = self.rules.entries[entry.label][0].data.uncertainty
-                
+
                 if not ascend:
                     L = list(set(template_rxn_map[entry.label]) - set(rxns_test))
 
                     if L != []:
-                        kinetics = ArrheniusBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
-                        kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(T))
+                        if isinstance(L[0].kinetics,Arrhenius):
+                            kinetics = ArrheniusBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
+                            kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(T))
+                        else:
+                            kinetics = ArrheniusChargeTransferBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
+                            kinetics = kinetics.to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(T))
                         k = kinetics.get_rate_coefficient(T)
                         errors[rxn] = np.log(k / krxn)
                     else:
@@ -3706,7 +3727,7 @@ class KineticsFamily(Database):
                     logging.error("determining fold rate")
                     c = 1
                     while boo:
-                        parent = entry.parent 
+                        parent = entry.parent
                         if parent is None:
                             break
                         rlistparent = list(set(template_rxn_map[parent.label]) - set(rxns_test))
@@ -3720,11 +3741,11 @@ class KineticsFamily(Database):
                             c += 1
                         else:
                             boo = False
-                            
+
                     kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(T))
                     k = kinetics.get_rate_coefficient(T)
                     errors[rxn] = np.log(k / krxn)
-                    
+
         return errors, uncertainties
 
     def cross_validate_old(self, folds=5, T=1000.0, random_state=1, estimator='rate rules', thermo_database=None, get_reverse=False, uncertainties=True):
@@ -3734,7 +3755,7 @@ class KineticsFamily(Database):
         """
         errors = {}
         uncs = {}
-        
+
         kpu = KineticParameterUncertainty()
         rxns = np.array(self.get_training_set(remove_degeneracy=True,get_reverse=get_reverse))
 
@@ -3780,7 +3801,7 @@ class KineticsFamily(Database):
                     boo,source = self.extract_source_from_comments(testrxn)
                     sdict = {"Rate Rules":source}
                     uncs[rxn] = kpu.get_uncertainty_value(sdict)
-                    
+
         if uncertainties:
             return errors, uncs
         else:
@@ -3790,19 +3811,19 @@ class KineticsFamily(Database):
         """
         Simplest regularization algorithm
         All nodes are made as specific as their descendant reactions
-        Training reactions are assumed to not generalize 
+        Training reactions are assumed to not generalize
         For example if an particular atom at a node is Oxygen for all of its
         descendent reactions a reaction where it is Sulfur will never hit that node
-        unless it is the top node even if the tree did not split on the identity 
+        unless it is the top node even if the tree did not split on the identity
         of that atom
-        
-        The test option to this function determines whether or not the reactions 
-        under a node match the extended group before adding an extension. 
-        If the test fails the extension is skipped. 
-        
-        In general test=True is needed if the cascade algorithm was used 
+
+        The test option to this function determines whether or not the reactions
+        under a node match the extended group before adding an extension.
+        If the test fails the extension is skipped.
+
+        In general test=True is needed if the cascade algorithm was used
         to generate the tree and test=False is ok if the cascade algorithm
-        wasn't used. 
+        wasn't used.
         """
 
         for child in node.children:
@@ -4008,7 +4029,7 @@ class KineticsFamily(Database):
 
     def save_generated_tree(self, path=None):
         """
-        clears the rules and saves the family to its 
+        clears the rules and saves the family to its
         current location in database
         """
         if path is None:
@@ -4022,7 +4043,7 @@ class KineticsFamily(Database):
         """
         retrieves all reactions in the training set, assigns thermo to the species objects
         reverses reactions as necessary so that all reactions are in the forward direction
-        and returns the resulting list of reactions in the forward direction with thermo 
+        and returns the resulting list of reactions in the forward direction with thermo
         assigned
         """
 
@@ -4092,7 +4113,7 @@ class KineticsFamily(Database):
 
         root_labels = [x.label for x in root.atoms if x.label != '']
         root_label_set = set(root_labels)
-        
+
         for i, entry in enumerate(entries):
             if estimate_thermo:
                 # parse out the metal to scale to
@@ -4122,6 +4143,8 @@ class KineticsFamily(Database):
                 else:
                     mol = deepcopy(react.molecule[0])
 
+            mol.update_atomtypes()
+
             if fix_labels:
                 for prod in rxns[i].products:
                     fix_labels_mol(prod.molecule[0], root_labels)
@@ -4140,12 +4163,12 @@ class KineticsFamily(Database):
                             mol = mol.merge(react.molecule[0])
                         else:
                             mol = deepcopy(react.molecule[0])
-                    
+
                     if fix_labels:
                         mol_label_set = set([x.label for x in get_label_fixed_mol(mol, root_labels).atoms if x.label != ''])
                     else:
                         mol_label_set = set([x.label for x in mol.atoms if x.label != ''])
-                    
+
                     if mol_label_set == root_label_set and ((mol.is_subgraph_isomorphic(root, generate_initial_map=True) or
                             (not fix_labels and
                              get_label_fixed_mol(mol, root_labels).is_subgraph_isomorphic(root, generate_initial_map=True)))):
@@ -4207,6 +4230,8 @@ class KineticsFamily(Database):
                     else:
                         mol = deepcopy(react.molecule[0])
 
+                mol.update_atomtypes()
+
                 if (mol.is_subgraph_isomorphic(root, generate_initial_map=True) or
                         (not fix_labels and
                          get_label_fixed_mol(mol, root_labels).is_subgraph_isomorphic(root, generate_initial_map=True))):  # try product structures
@@ -4235,7 +4260,7 @@ class KineticsFamily(Database):
     def get_reaction_matches(self, rxns=None, thermo_database=None, remove_degeneracy=False, estimate_thermo=True,
                              fix_labels=False, exact_matches_only=False, get_reverse=False):
         """
-        returns a dictionary mapping for each entry in the tree:  
+        returns a dictionary mapping for each entry in the tree:
         (entry.label,entry.item) : list of all training reactions (or the list given) that match that entry
         """
         if rxns is None:
@@ -4328,10 +4353,10 @@ class KineticsFamily(Database):
         """
         Retrieves the original entry, be it a rule or training reaction, given
         the template label in the form 'group1;group2' or 'group1;group2;group3'
-        
+
         Returns tuple in the form
         (RateRuleEntry, TrainingReactionEntry)
-        
+
         Where the TrainingReactionEntry is only present if it comes from a training reaction
         """
         template_labels = template_label.split()[-1].split(';')
@@ -4348,13 +4373,13 @@ class KineticsFamily(Database):
         """
         Returns the set of rate rules and training reactions used to average this `template`.  Note that the tree must be
         averaged with verbose=True for this to work.
-        
+
         Returns a tuple of
         rules, training
-        
-        where rules are a list of tuples containing 
+
+        where rules are a list of tuples containing
         the [(original_entry, weight_used_in_average), ... ]
-        
+
         and training is a list of tuples containing
         the [(rate_rule_entry, training_reaction_entry, weight_used_in_average),...]
         """
@@ -4362,7 +4387,7 @@ class KineticsFamily(Database):
         def assign_weights_to_entries(entry_nested_list, weighted_entries, n=1):
             """
             Assign weights to an average of average nested list. Where n is the
-            number of values being averaged recursively.  
+            number of values being averaged recursively.
             """
             n = len(entry_nested_list) * n
             for entry in entry_nested_list:
@@ -4436,7 +4461,7 @@ class KineticsFamily(Database):
                             rules[rule_entry] += weight
                         else:
                             rules[rule_entry] = weight
-                # Each entry should now only appear once    
+                # Each entry should now only appear once
                 training = [(k[0], k[1], v) for k, v in training.items()]
                 rules = list(rules.items())
 
@@ -4447,11 +4472,11 @@ class KineticsFamily(Database):
         Returns the rate rule associated with the kinetics of a reaction by parsing the comments.
         Will return the template associated with the matched rate rule.
         Returns a tuple containing (Boolean_Is_Kinetics_From_Training_reaction, Source_Data)
-        
+
         For a training reaction, the Source_Data returns::
 
             [Family_Label, Training_Reaction_Entry, Kinetics_In_Reverse?]
-        
+
         For a reaction from rate rules, the Source_Data is a tuple containing::
 
             [Family_Label, {'template': originalTemplate,
@@ -4486,7 +4511,7 @@ class KineticsFamily(Database):
                                          'but does not match the training reaction {1} from the '
                                          '{2} family.'.format(reaction, training_reaction_index, self.label))
 
-                # Sometimes the matched kinetics could be in the reverse direction..... 
+                # Sometimes the matched kinetics could be in the reverse direction.....
                 if reaction.is_isomorphic(training_entry.item, either_direction=False, save_order=self.save_order):
                     reverse = False
                 else:
@@ -4500,7 +4525,7 @@ class KineticsFamily(Database):
             elif line.startswith('Multiplied by'):
                 degeneracy = float(line.split()[-1])
 
-        # Extract the rate rule information 
+        # Extract the rate rule information
         full_comment_string = reaction.kinetics.comment.replace('\n', ' ')
 
         # The rate rule string is right after the phrase 'for rate rule'
@@ -4685,7 +4710,7 @@ def _child_make_tree_nodes(family, child_conn, template_rxn_map, obj, T, nprocs,
     family.groups.entries[root_label].parent = None
 
     family.make_tree_nodes(template_rxn_map=template_rxn_map, obj=obj, T=T, nprocs=nprocs, depth=depth + 1,
-                           min_splitable_entry_num=min_splitable_entry_num, min_rxns_to_spawn=min_rxns_to_spawn, 
+                           min_splitable_entry_num=min_splitable_entry_num, min_rxns_to_spawn=min_rxns_to_spawn,
                            extension_iter_max=extension_iter_max, extension_iter_item_cap=extension_iter_item_cap)
 
     child_conn.send(list(family.groups.entries.values()))

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -3601,9 +3601,12 @@ class KineticsFamily(Database):
         inds = inds.tolist()
         revinds = [inds.index(x) for x in np.arange(len(inputs))]
 
-        pool = mp.Pool(nprocs)
+        if nprocs > 1:
+            pool = mp.Pool(nprocs)
+            kinetics_list = np.array(pool.map(_make_rule, inputs[inds]))
+        else:
+            kinetics_list = np.array(list(map(_make_rule, inputs[inds])))
 
-        kinetics_list = np.array(pool.map(_make_rule, inputs[inds]))
         kinetics_list = kinetics_list[revinds]  # fix order
 
         for i, kinetics in enumerate(kinetics_list):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4653,3 +4653,80 @@ def _child_make_tree_nodes(family, child_conn, template_rxn_map, obj, T, nprocs,
                            extension_iter_max=extension_iter_max, extension_iter_item_cap=extension_iter_item_cap)
 
     child_conn.send(list(family.groups.entries.values()))
+
+def average_kinetics(kinetics_list):
+    """
+    Based on averaging log k.
+    Hence we average n, Ea, arithmetically, but we
+    average log A (geometric average)
+    """
+    logA = 0.0
+    n = 0.0
+    Ea = 0.0
+    alpha = 0.5
+    electrons = None
+    if isinstance(kinetics_list[0], SurfaceChargeTransfer) or isinstance(kinetics_list[0], ArrheniusChargeTransfer):
+        if electrons is None:
+            electrons = kinetics_list[0].electrons.value_si
+        assert all(np.abs(k.V0.value_si) < 0.0001 for k in kinetics_list), [k.V0.value_si for k in kinetics_list]
+        assert all(np.abs(k.alpha.value_si - 0.5) < 0.001 for k in kinetics_list), [k.alpha for k in kinetics_list]
+    V0 = 0.0
+    count = 0
+    for kinetics in kinetics_list:
+        count += 1
+        logA += np.log10(kinetics.A.value_si)
+        n += kinetics.n.value_si
+        Ea += kinetics.Ea.value_si
+
+    logA /= count
+    n /= count
+    alpha /= count
+    Ea /= count
+    Aunits = kinetics_list[0].A.units
+    if Aunits == 'cm^3/(mol*s)' or Aunits == 'cm^3/(molecule*s)' or Aunits == 'm^3/(molecule*s)':
+        Aunits = 'm^3/(mol*s)'
+    elif Aunits == 'cm^6/(mol^2*s)' or Aunits == 'cm^6/(molecule^2*s)' or Aunits == 'm^6/(molecule^2*s)':
+        Aunits = 'm^6/(mol^2*s)'
+    elif Aunits == 's^-1' or Aunits == 'm^3/(mol*s)' or Aunits == 'm^6/(mol^2*s)':
+        # they were already in SI
+        pass
+    elif Aunits in ['m^2/(mol*s)', 'cm^2/(mol*s)', 'm^2/(molecule*s)', 'cm^2/(molecule*s)']:
+        # surface: bimolecular (Langmuir-Hinshelwood)
+        Aunits = 'm^2/(mol*s)'
+    elif Aunits in ['m^5/(mol^2*s)', 'cm^5/(mol^2*s)', 'm^5/(molecule^2*s)', 'cm^5/(molecule^2*s)']:
+        # surface: dissociative adsorption
+        Aunits = 'm^5/(mol^2*s)'
+    elif Aunits == '':
+        # surface: sticking coefficient
+        pass
+    else:
+        raise Exception('Invalid units {0} for averaging kinetics.'.format(Aunits))
+
+    if type(kinetics) not in [Arrhenius,SurfaceChargeTransfer,ArrheniusChargeTransfer]:
+        raise Exception('Invalid kinetics type {0!r} for {1!r}.'.format(type(kinetics), self))
+
+    if isinstance(kinetics, SurfaceChargeTransfer):
+        averaged_kinetics = SurfaceChargeTransfer(
+            A=(10 ** logA, Aunits),
+            n=n,
+            electrons=electrons,
+            alpha=alpha,
+            V0=(V0,'V'),
+            Ea=(Ea * 0.001, "kJ/mol"),
+            )
+    elif isinstance(kinetics, ArrheniusChargeTransfer):
+        averaged_kinetics = ArrheniusChargeTransfer(
+            A=(10 ** logA, Aunits),
+            n=n,
+            electrons=electrons,
+            alpha=alpha,
+            V0=(V0,'V'),
+            Ea=(Ea * 0.001, "kJ/mol"),
+            )
+    else:
+        averaged_kinetics = Arrhenius(
+            A=(10 ** logA, Aunits),
+            n=n,
+            Ea=(Ea * 0.001, "kJ/mol"),
+        )
+    return averaged_kinetics

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4770,6 +4770,7 @@ def average_kinetics(kinetics_list):
             alpha=alpha,
             V0=(V0,'V'),
             Ea=(Ea * 0.001, "kJ/mol"),
+            comment="Only one reaction or BM with E0 < 0. Averaged from {} reactions.".format(len(kinetics_list)),
             )
     elif isinstance(kinetics, ArrheniusChargeTransfer):
         averaged_kinetics = ArrheniusChargeTransfer(
@@ -4779,11 +4780,13 @@ def average_kinetics(kinetics_list):
             alpha=alpha,
             V0=(V0,'V'),
             Ea=(Ea * 0.001, "kJ/mol"),
+            comment="Only one reaction or BM with E0 < 0. Averaged from {} reactions.".format(len(kinetics_list)),
             )
     else:
         averaged_kinetics = Arrhenius(
             A=(10 ** logA, Aunits),
             n=n,
             Ea=(Ea * 0.001, "kJ/mol"),
+            comment="Only one reaction or BM with E0 < 0. Averaged from {} reactions.".format(len(kinetics_list)),
         )
     return averaged_kinetics

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -3648,7 +3648,7 @@ class KineticsFamily(Database):
 
                 index += 1
 
-    def cross_validate(self, folds=5, template_rxn_map=None, test_rxn_inds=None, T=1000.0, iters=0, random_state=1, ascend=False):
+    def cross_validate(self, folds=5, template_rxn_map=None, test_rxn_inds=None, T=1000.0, iters=0, random_state=1):
         """
         Perform K-fold cross validation on an automatically generated tree at temperature T
         after finding an appropriate node for kinetics estimation it will move up the tree
@@ -3704,47 +3704,43 @@ class KineticsFamily(Database):
                     if entry.parent:
                         entry = entry.parent
 
+                boo = True
+
+                while boo:
+                    if entry.parent is None:
+                        break
+                    kin = self.rules.entries[entry.label][0].data
+                    kinparent = self.rules.entries[entry.parent.label][0].data
+                    err_parent = abs(kinparent.uncertainty.data_mean + kinparent.uncertainty.mu - kin.uncertainty.data_mean) + np.sqrt(2.0*kinparent.uncertainty.var/np.pi)
+                    err_entry = abs(kin.uncertainty.mu) + np.sqrt(2.0*kin.uncertainty.var/np.pi)
+                    if err_entry <= err_parent:
+                        break
+                    else:
+                        entry = entry.parent
+
                 uncertainties[rxn] = self.rules.entries[entry.label][0].data.uncertainty
 
-                if not ascend:
-                    L = list(set(template_rxn_map[entry.label]) - set(rxns_test))
 
-                    if L != []:
-                        if isinstance(L[0].kinetics,Arrhenius):
-                            kinetics = ArrheniusBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
-                            kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(T))
+                L = list(set(template_rxn_map[entry.label]) - set(rxns_test))
+
+                if L != []:
+                    if isinstance(L[0].kinetics, Arrhenius):
+                        kinetics = ArrheniusBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
+                        if kinetics.E0.value_si < 0.0 or len(L) == 1:
+                            kinetics = average_kinetics([r.kinetics for r in L])
                         else:
-                            kinetics = ArrheniusChargeTransferBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
-                            kinetics = kinetics.to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(T))
-                        k = kinetics.get_rate_coefficient(T)
-                        errors[rxn] = np.log(k / krxn)
+                            kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(298.0))
                     else:
-                        raise ValueError('only one piece of kinetics information in the tree?')
-                else:
-                    boo = True
-                    rlist = list(set(template_rxn_map[entry.label]) - set(rxns_test))
-                    kinetics = _make_rule((self.forward_recipe.actions,rlist,T,1.0e3,"",[rxn.rank for rxn in rlist]))
-                    logging.error("determining fold rate")
-                    c = 1
-                    while boo:
-                        parent = entry.parent
-                        if parent is None:
-                            break
-                        rlistparent = list(set(template_rxn_map[parent.label]) - set(rxns_test))
-                        kineticsparent = _make_rule((self.forward_recipe.actions,rlistparent,T,1.0e3,"",[rxn.rank for rxn in rlistparent]))
-                        err_parent = abs(kineticsparent.uncertainty.data_mean + kineticsparent.uncertainty.mu - kinetics.uncertainty.data_mean) + np.sqrt(2.0*kineticsparent.uncertainty.var/np.pi)
-                        err_entry = abs(kinetics.uncertainty.mu) + np.sqrt(2.0*kinetics.uncertainty.var/np.pi)
-                        if err_entry > err_parent:
-                            entry = entry.parent
-                            kinetics = kineticsparent
-                            logging.error("recursing {}".format(c))
-                            c += 1
+                        kinetics = ArrheniusChargeTransferBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
+                        if kinetics.E0.value_si < 0.0 or len(L) == 1:
+                            kinetics = average_kinetics([r.kinetics for r in L])
                         else:
-                            boo = False
+                            kinetics = kinetics.to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(298.0))
 
-                    kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(T))
                     k = kinetics.get_rate_coefficient(T)
                     errors[rxn] = np.log(k / krxn)
+                else:
+                    raise ValueError('only one piece of kinetics information in the tree?')
 
         return errors, uncertainties
 

--- a/rmgpy/kinetics/__init__.py
+++ b/rmgpy/kinetics/__init__.py
@@ -29,7 +29,8 @@
 
 from rmgpy.kinetics.model import KineticsModel, PDepKineticsModel, TunnelingModel, \
                    get_rate_coefficient_units_from_reaction_order, get_reaction_order_from_rate_coefficient_units
-from rmgpy.kinetics.arrhenius import Arrhenius, ArrheniusEP, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, ArrheniusBM
+from rmgpy.kinetics.arrhenius import Arrhenius, ArrheniusEP, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, \
+                   ArrheniusBM, ArrheniusChargeTransfer, ArrheniusChargeTransferBM
 from rmgpy.kinetics.chebyshev import Chebyshev
 from rmgpy.kinetics.falloff import ThirdBody, Lindemann, Troe
 from rmgpy.kinetics.kineticsdata import KineticsData, PDepKineticsData

--- a/rmgpy/kinetics/arrhenius.pxd
+++ b/rmgpy/kinetics/arrhenius.pxd
@@ -157,4 +157,26 @@ cdef class ArrheniusChargeTransfer(KineticsModel):
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2
 
 
+################################################################################
+
+cdef class ArrheniusChargeTransferBM(KineticsModel):
+
+    cdef public ScalarQuantity _A
+    cdef public ScalarQuantity _n
+    cdef public ScalarQuantity _E0
+    cdef public ScalarQuantity _w0
+    cdef public ScalarQuantity _V0
+    cdef public ScalarQuantity _alpha
+    cdef public ScalarQuantity _electrons
+
+    cpdef change_v0(self, double V0)
+
+    cpdef double get_activation_energy(self, double dGrxn) except -1
+
+    cpdef double get_rate_coefficient_from_potential(self, double T, double V, double dGrxn) except -1
+
+    cpdef ArrheniusChargeTransfer to_arrhenius_charge_transfer(self, double dGrxn)
+
+    cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2
+
     cpdef change_rate(self, double factor)

--- a/rmgpy/kinetics/arrhenius.pxd
+++ b/rmgpy/kinetics/arrhenius.pxd
@@ -128,4 +128,33 @@ cdef class MultiPDepArrhenius(PDepKineticsModel):
 
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2
     
+
+    cpdef change_rate(self, double factor)
+
+################################################################################
+cdef class ArrheniusChargeTransfer(KineticsModel):
+
+    cdef public ScalarQuantity _A
+    cdef public ScalarQuantity _n
+    cdef public ScalarQuantity _Ea
+    cdef public ScalarQuantity _T0
+    cdef public ScalarQuantity _V0
+    cdef public ScalarQuantity _alpha
+    cdef public ScalarQuantity _electrons
+
+    cpdef double get_activation_energy_from_potential(self, double V=?, bint non_negative=?)
+
+    cpdef double get_rate_coefficient(self, double T, double V=?) except -1
+
+    cpdef change_rate(self, double factor)
+
+    cpdef change_t0(self, double T0)
+
+    cpdef change_v0(self, double V0)
+
+    cpdef fit_to_data(self, np.ndarray Tlist, np.ndarray klist, str kunits, double T0=?, np.ndarray weights=?, bint three_params=?)
+
+    cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2
+
+
     cpdef change_rate(self, double factor)

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -58,15 +58,16 @@ cdef class Arrhenius(KineticsModel):
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `solute`        Transition state solute data
     `comment`       Information about the model (e.g. its source)
     =============== =============================================================
 
     """
 
     def __init__(self, A=None, n=0.0, Ea=None, T0=(1.0, "K"), Tmin=None, Tmax=None, Pmin=None, Pmax=None,
-                 uncertainty=None, comment=''):
+                 uncertainty=None, solute=None, comment=''):
         KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, uncertainty=uncertainty,
-                               comment=comment)
+                               solute=solute, comment=comment)
         self.A = A
         self.n = n
         self.Ea = Ea
@@ -83,6 +84,7 @@ cdef class Arrhenius(KineticsModel):
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.uncertainty: string += ', uncertainty={0!r}'.format(self.uncertainty)
+        if self.solute: string += ', solute={0!r}'.format(self.solute)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -92,7 +94,7 @@ cdef class Arrhenius(KineticsModel):
         A helper function used when pickling an Arrhenius object.
         """
         return (Arrhenius, (self.A, self.n, self.Ea, self.T0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
-                            self.uncertainty, self.comment))
+                            self.uncertainty, self.solute, self.comment))
 
     property A:
         """The preexponential factor."""
@@ -196,6 +198,7 @@ cdef class Arrhenius(KineticsModel):
         self.T0 = (T0, "K")
         self.Tmin = (np.min(Tlist), "K")
         self.Tmax = (np.max(Tlist), "K")
+        self.solute = None
         self.comment = 'Fitted to {0:d} data points; dA = *|/ {1:g}, dn = +|- {2:g}, dEa = +|- {3:g} kJ/mol'.format(
             len(Tlist),
             exp(sqrt(cov[0, 0])),
@@ -295,6 +298,7 @@ cdef class Arrhenius(KineticsModel):
                           Pmin=self.Pmin,
                           Pmax=self.Pmax,
                           uncertainty=self.uncertainty,
+                          solute=self.solute,
                           comment=self.comment)
         return aep
 ################################################################################
@@ -317,15 +321,16 @@ cdef class ArrheniusEP(KineticsModel):
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `solute`        Transition state solute data
     `comment`       Information about the model (e.g. its source)
     =============== =============================================================
 
     """
 
     def __init__(self, A=None, n=0.0, alpha=0.0, E0=None, Tmin=None, Tmax=None, Pmin=None, Pmax=None, uncertainty=None,
-                 comment=''):
+                 solute=None, comment=''):
         KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, uncertainty=uncertainty,
-                               comment=comment)
+                               solute=solute, comment=comment)
         self.A = A
         self.n = n
         self.alpha = alpha
@@ -342,6 +347,7 @@ cdef class ArrheniusEP(KineticsModel):
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.uncertainty is not None: string += ', uncertainty={0!r}'.format(self.uncertainty)
+        if self.solute is not None: string += ', solute={0!r}'.format(self.solute)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -351,7 +357,7 @@ cdef class ArrheniusEP(KineticsModel):
         A helper function used when pickling an ArrheniusEP object.
         """
         return (ArrheniusEP, (self.A, self.n, self.alpha, self.E0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
-                              self.uncertainty, self.comment))
+                              self.uncertainty, self.solute, self.comment))
 
     property A:
         """The preexponential factor."""
@@ -422,6 +428,7 @@ cdef class ArrheniusEP(KineticsModel):
             Pmin=self.Pmin,
             Pmax=self.Pmax,
             uncertainty=self.uncertainty,
+            solute=self.solute,
             comment=self.comment,
         )
 
@@ -475,15 +482,16 @@ cdef class ArrheniusBM(KineticsModel):
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `solute`        Transition state solute data
     `comment`       Information about the model (e.g. its source)
     =============== =============================================================
 
     """
 
     def __init__(self, A=None, n=0.0, w0=(0.0, 'J/mol'), E0=None, Tmin=None, Tmax=None, Pmin=None, Pmax=None,
-                 uncertainty=None, comment=''):
+                 uncertainty=None, solute=None, comment=''):
         KineticsModel.__init__(self, Tmin=Tmin, Tmax=Tmax, Pmin=Pmin, Pmax=Pmax, uncertainty=uncertainty,
-                               comment=comment)
+                               solute=solute, comment=comment)
         self.A = A
         self.n = n
         self.w0 = w0
@@ -500,6 +508,7 @@ cdef class ArrheniusBM(KineticsModel):
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
         if self.uncertainty is not None: string += ', uncertainty={0!r}'.format(self.uncertainty)
+        if self.solute is not None: string += ', solute={0!r}'.format(self.solute)
         if self.comment != '': string += ', comment="""{0}"""'.format(self.comment)
         string += ')'
         return string
@@ -509,7 +518,7 @@ cdef class ArrheniusBM(KineticsModel):
         A helper function used when pickling an ArrheniusEP object.
         """
         return (ArrheniusBM, (self.A, self.n, self.w0, self.E0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
-                              self.uncertainty, self.comment))
+                              self.uncertainty, self.solute, self.comment))
 
     property A:
         """The preexponential factor."""
@@ -580,6 +589,7 @@ cdef class ArrheniusBM(KineticsModel):
             Tmin=self.Tmin,
             Tmax=self.Tmax,
             uncertainty=self.uncertainty,
+            solute=self.solute,
             comment=self.comment,
         )
 
@@ -617,6 +627,7 @@ cdef class ArrheniusBM(KineticsModel):
 
             self.Tmin = rxn.kinetics.Tmin
             self.Tmax = rxn.kinetics.Tmax
+            self.solute = None
             self.comment = 'Fitted to {0} reaction at temperature: {1} K'.format(len(rxns), T)
         else:
             # define optimization function            
@@ -666,6 +677,7 @@ cdef class ArrheniusBM(KineticsModel):
 
             self.Tmin = (np.min(Ts), "K")
             self.Tmax = (np.max(Ts), "K")
+            self.solute = None
             self.comment = 'Fitted to {0} reactions at temperatures: {1}'.format(len(rxns), Ts)
 
         # fill in parameters

--- a/rmgpy/kinetics/model.pxd
+++ b/rmgpy/kinetics/model.pxd
@@ -29,7 +29,7 @@ cimport numpy as np
 
 from rmgpy.quantity cimport ScalarQuantity, ArrayQuantity
 from rmgpy.kinetics.uncertainties cimport RateUncertainty
-
+from rmgpy.data.solvation import SoluteData
 ################################################################################
 
 cpdef str get_rate_coefficient_units_from_reaction_order(n_gas, n_surf=?)
@@ -43,6 +43,7 @@ cdef class KineticsModel:
     cdef public ScalarQuantity _Tmin, _Tmax
     cdef public ScalarQuantity _Pmin, _Pmax
     cdef public RateUncertainty uncertainty
+    cdef public object solute
 
     cdef public str comment
     

--- a/rmgpy/kinetics/model.pyx
+++ b/rmgpy/kinetics/model.pyx
@@ -117,16 +117,18 @@ cdef class KineticsModel:
     `Tmax`          The maximum temperature at which the model is valid, or zero if unknown or undefined
     `Pmin`          The minimum pressure at which the model is valid, or zero if unknown or undefined
     `Pmax`          The maximum pressure at which the model is valid, or zero if unknown or undefined
+    `solute`        Solute data for the transition state
     `comment`       Information about the model (e.g. its source)
     =============== ============================================================
 
     """
 
-    def __init__(self, Tmin=None, Tmax=None, Pmin=None, Pmax=None, uncertainty=None, comment=''):
+    def __init__(self, Tmin=None, Tmax=None, Pmin=None, Pmax=None, uncertainty=None, solute=None, comment=''):
         self.Tmin = Tmin
         self.Tmax = Tmax
         self.Pmin = Pmin
         self.Pmax = Pmax
+        self.solute = solute
         self.uncertainty = uncertainty
         self.comment = comment
 
@@ -136,13 +138,13 @@ cdef class KineticsModel:
         KineticsModel object.
         """
         return 'KineticsModel(Tmin={0!r}, Tmax={1!r}, Pmin={2!r}, Pmax={3!r}, uncertainty={4!r}, comment="""{5}""")'.format(
-            self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.uncertainty, self.comment)
+            self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.solute, self.uncertainty, self.comment)
 
     def __reduce__(self):
         """
         A helper function used when pickling a KineticsModel object.
         """
-        return (KineticsModel, (self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.uncertainty, self.comment))
+        return (KineticsModel, (self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.solute, self.uncertainty, self.comment))
 
     property Tmin:
         """The minimum temperature at which the model is valid, or ``None`` if not defined."""

--- a/rmgpy/yml.py
+++ b/rmgpy/yml.py
@@ -40,7 +40,7 @@ from rmgpy.species import Species
 from rmgpy.reaction import Reaction
 from rmgpy.thermo.nasa import NASAPolynomial, NASA
 from rmgpy.thermo.wilhoit import Wilhoit
-from rmgpy.kinetics.arrhenius import Arrhenius, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius
+from rmgpy.kinetics.arrhenius import Arrhenius, PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, ArrheniusChargeTransfer
 from rmgpy.kinetics.falloff import Troe, ThirdBody, Lindemann
 from rmgpy.kinetics.chebyshev import Chebyshev
 from rmgpy.data.solvation import SolventData
@@ -136,6 +136,21 @@ def obj_to_dict(obj, spcs, names=None, label="solvent"):
         result_dict["A"] = obj.A.value_si
         result_dict["Ea"] = obj.Ea.value_si
         result_dict["n"] = obj.n.value_si
+    elif isinstance(obj, ArrheniusChargeTransfer):
+        obj.change_t0(1.0)
+        obj.change_v0(0.0)
+        result_dict["type"] = "Arrheniusq"
+        result_dict["A"] = obj.A.value_si
+        result_dict["Ea"] = obj.Ea.value_si
+        result_dict["n"] = obj.n.value_si
+        result_dict["q"] = obj._alpha.value_si*obj._electrons.value_si
+    elif isinstance(obj, SurfaceChargeTransfer):
+        obj.change_v0(0.0)
+        result_dict["type"] = "Arrheniusq"
+        result_dict["A"] = obj.A.value_si
+        result_dict["Ea"] = obj.Ea.value_si
+        result_dict["n"] = obj.n.value_si
+        result_dict["q"] = obj._alpha.value_si*obj._electrons.value_si
     elif isinstance(obj, StickingCoefficient):
         obj.change_t0(1.0)
         result_dict["type"] = "StickingCoefficient"


### PR DESCRIPTION
This has four main changes
1) Enables tree generation for charge transfer families
2) Updates tree generation, if E0 < 0 or n = 1 it simply uses the average instead of the BM rule
3) Improves BM fitting using dH298
4) Adds a SolventData attribute to reactions that can hold transition state solute information
