### PR TITLE
Added Julia into the conda rmg_env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - graphviz
   - h5py
   - jinja2
+  - conda-forge::julia
   - jupyter
   - rmg::lpsolve55
   - markupsafe


### PR DESCRIPTION
### Motivation or Problem
New users installing RMG from source get stuck when executing
`python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"`
since `Julia` isn't present in the `rmg_env`

### Description of Changes
Added Julia into the conda environment

### Reviewer Tips
From my experience this addition is required to run RMG when building a fresh env, I'm surprised that the current tests do pass w/o it, so perhaps I'm wrong. Could use another set of eyes.