### PR TITLE
remove check for adsorbate getting adsorbed again

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2168,7 +2168,7 @@ class KineticsFamily(Database):
             This could be a surface reaction
                 A + X + X <=> BX + CX    (dissociative adsorption)
                 A + X + X <=> AXX        (bidentate adsorption)
-                ABX + X + X <=> AXX + BX (bidentate dissociation)
+                ABX + X + X <=> AXX + BX (dissociation to bidentate)
             or a termolecular gas phase reaction
                 A + B + C <=> stuff
             We check the two scenarios in that order.

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -2133,10 +2133,6 @@ class KineticsFamily(Database):
                     # No reaction with these reactants in this template
                     return []
 
-                if adsorbate_molecules[0].contains_surface_site():
-                    # An adsorbed molecule can't adsorb again
-                    return []
-
                 for r in template_reactants:
                     if not r.is_surface_site():
                         template_adsorbate = r
@@ -2170,8 +2166,9 @@ class KineticsFamily(Database):
         elif len(reactants) == 3 and len(template_reactants) == 3:
             """
             This could be a surface reaction
-                A + X + X <=> BX + CX  (dissociative adsorption)
-                A + X + X <=> AXX      (bidentate adsorption)
+                A + X + X <=> BX + CX    (dissociative adsorption)
+                A + X + X <=> AXX        (bidentate adsorption)
+                ABX + X + X <=> AXX + BX (bidentate dissociation)
             or a termolecular gas phase reaction
                 A + B + C <=> stuff
             We check the two scenarios in that order.
@@ -2199,10 +2196,6 @@ class KineticsFamily(Database):
                     adsorbate_molecules = reactants[0]
                 else:
                     # Three reactants not containing two surface sites
-                    return []
-
-                if adsorbate_molecules[0].contains_surface_site():
-                    # An adsorbed molecule can't adsorb again
                     return []
 
                 for r in template_reactants:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Removes a check in reaction generation routine. If a species is already adsorbed, currently it cannot form a new bond. One of the upcoming bidentate families that @kblondal  is working on requires this:
```
 *1--*2--*3                   *1--*2    *3 
  |                   ---->    |   |     |
~*4~ + ~*5~ + ~*6            ~*4~~*5 + ~*6~~ 
```
### Description of Changes
Removed the checks specified above. they are no longer required. The original problem this was addressing was the mis-identification of an empty surface site as an adsorbed molecule. the routine ```_match_group_to_template``` does this check now, so it is no longer required.

### Testing
check with a surface mechanism and ensure it remains unchanged. 