### PR TITLE
Fixing save_input_file method for surface reactors.

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1478,7 +1478,7 @@ def save_input_file(path, rmg):
     f.write('    thermoLibraries = {0!r},\n'.format(rmg.thermo_libraries))
     f.write('    reactionLibraries = {0!r},\n'.format(rmg.reaction_libraries))
     f.write('    seedMechanisms = {0!r},\n'.format(rmg.seed_mechanisms))
-    f.write('    kinetics_depositories = {0!r},\n'.format(rmg.kinetics_depositories))
+    f.write('    kineticsDepositories = {0!r},\n'.format(rmg.kinetics_depositories))
     f.write('    kineticsFamilies = {0!r},\n'.format(rmg.kinetics_families))
     f.write('    kineticsEstimator = {0!r},\n'.format(rmg.kinetics_estimator))
     f.write(')\n\n')
@@ -1486,9 +1486,9 @@ def save_input_file(path, rmg):
     if rmg.surface_site_density or rmg.binding_energies:
         f.write('catalystProperties(\n')
         if rmg.surface_site_density:
-            f.write('    surface_site_density = {0!r},\n'.format(rmg.surface_site_density))
+            f.write('    surfaceSiteDensity = {0!r},\n'.format(rmg.surface_site_density))
         if rmg.binding_energies:
-            f.write('    binding_energies = {\n')
+            f.write('    bindingEnergies = {\n')
             for elem, be in rmg.binding_energies.items():
                 f.write('     {0!r}:{1!r},\n'.format(elem, be))
             f.write('    },\n')
@@ -1527,19 +1527,24 @@ def save_input_file(path, rmg):
             # Convert the pressure from SI pascal units to bar here
             # Do something more fancy later for converting to user's desired units for both T and P..
             if system.P_initial:
-                f.write('    pressure = ({0:g}, {1!s}),\n'.format(system.P_initial.value, system.P_initial.units))
+                f.write('    initialPressure = ({0:g}, "{1!s}"),\n'.format(system.P_initial.value, system.P_initial.units))
             else:
                 Prange_lo = (system.Prange[0].value, system.Prange[0].units)
                 Prange_hi = (system.Prange[1].value, system.Prange[1].units)
                 f.write('    temperature = [{0}, {1}],\n'.format(Prange_lo, Prange_hi))
 
-
-            f.write('    initialMoleFractions={\n')
+            f.write('    initialGasMoleFractions={\n')
             for spcs, molfrac in system.initial_gas_mole_fractions.items():
                 f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
+            f.write('    },\n')
+
             f.write('    initialSurfaceCoverages={\n')
             for spcs, molfrac in system.initial_surface_coverages.items():
                 f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
+            f.write('    },\n')
+
+            f.write('    surfaceVolumeRatio=({0:g},"{1!s}"),\n'.format(system.surface_volume_ratio.value, system.surface_volume_ratio.units))
+
         else:
             f.write('simpleReactor(\n')
             if system.T:
@@ -1561,10 +1566,7 @@ def save_input_file(path, rmg):
             f.write('    initialMoleFractions={\n')
             for spcs, molfrac in system.initial_gas_mole_fractions.items():
                 f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
-            f.write('    initialSurfaceCoverages={\n')
-            for spcs, molfrac in system.initial_surface_coverages.items():
-                f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
-        f.write('    },\n')
+            f.write('    },\n')
 
         # Termination criteria
         conversions = ''
@@ -1676,8 +1678,18 @@ def save_input_file(path, rmg):
     f.write('    keepIrreversible = {0},\n'.format(rmg.keep_irreversible))
     f.write('    trimolecularProductReversible = {0},\n'.format(rmg.trimolecular_product_reversible))
     f.write('    verboseComments = {0},\n'.format(rmg.verbose_comments))
-    f.write('    wallTime = {0},\n'.format(rmg.walltime))
+    f.write('    wallTime = "{0!s}",\n'.format(rmg.walltime))
     f.write(')\n\n')
+
+    if rmg.forbidden_structures:
+        for struct in rmg.forbidden_structures:
+            f.write('forbidden(\n')
+            f.write('    label="{0!s}",\n'.format(struct.label))
+            f.write('    structure=adjacencyList(\n')
+            f.write('"""\n')
+            f.write(struct.item.to_adjacency_list())
+            f.write('"""),\n')
+            f.write(')\n\n')
 
     f.close()
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1513,12 +1513,51 @@ def save_input_file(path, rmg):
             f.write('    initialConcentrations={\n')
             for spcs, conc in system.initial_concentrations.items():
                 f.write('        "{0!s}": ({1:g},"{2!s}"),\n'.format(spcs.label, conc.value, conc.units))
-        else:
-            f.write('simpleReactor(\n')
-            f.write('    temperature = ({0:g},"{1!s}"),\n'.format(system.T.value, system.T.units))
+
+        elif isinstance(system, SurfaceReactor):
+            f.write('surfaceReactor(\n')
+            # determine if it is a ranged reactor
+            if system.T:
+                f.write('    temperature = ({0:g}, {1!s}),\n'.format(system.T.value, system.T.units))
+            else: 
+                Trange_lo = (system.Trange[0].value, system.Trange[0].units)
+                Trange_hi = (system.Trange[1].value, system.Trange[1].units)
+                f.write('    temperature = [{0}, {1}],\n'.format(Trange_lo, Trange_hi))
+
             # Convert the pressure from SI pascal units to bar here
             # Do something more fancy later for converting to user's desired units for both T and P..
-            f.write('    pressure = ({0:g},"{1!s}"),\n'.format(system.P_initial.value, system.P_initial.units))
+            if system.P_initial:
+                f.write('    pressure = ({0:g}, {1!s}),\n'.format(system.P_initial.value, system.P_initial.units))
+            else:
+                Prange_lo = (system.Prange[0].value, system.Prange[0].units)
+                Prange_hi = (system.Prange[1].value, system.Prange[1].units)
+                f.write('    temperature = [{0}, {1}],\n'.format(Prange_lo, Prange_hi))
+
+
+            f.write('    initialMoleFractions={\n')
+            for spcs, molfrac in system.initial_gas_mole_fractions.items():
+                f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
+            f.write('    initialSurfaceCoverages={\n')
+            for spcs, molfrac in system.initial_surface_coverages.items():
+                f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
+        else:
+            f.write('simpleReactor(\n')
+            if system.T:
+                f.write('    temperature = ({0:g}, {1!s}),\n'.format(system.T.value, system.T.units))
+            else: 
+                Trange_lo = (system.Trange[0].value, system.Trange[0].units)
+                Trange_hi = (system.Trange[1].value, system.Trange[1].units)
+                f.write('    temperature = [{0}, {1}],\n'.format(Trange_lo, Trange_hi))
+
+            # Convert the pressure from SI pascal units to bar here
+            # Do something more fancy later for converting to user's desired units for both T and P..
+            if system.P_initial:
+                f.write('    pressure = ({0:g}, {1!s}),\n'.format(system.P_initial.value, system.P_initial.units))
+            else:
+                Prange_lo = (system.Prange[0].value, system.Prange[0].units)
+                Prange_hi = (system.Prange[1].value, system.Prange[1].units)
+                f.write('    temperature = [{0}, {1}],\n'.format(Prange_lo, Prange_hi))
+            
             f.write('    initialMoleFractions={\n')
             for spcs, molfrac in system.initial_gas_mole_fractions.items():
                 f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1486,9 +1486,12 @@ def save_input_file(path, rmg):
     if rmg.surface_site_density or rmg.binding_energies:
         f.write('catalystProperties(\n')
         if rmg.surface_site_density:
-            f.write('    surface_site_density = {0!r},'.format(rmg.surface_site_density))
+            f.write('    surface_site_density = {0!r},\n'.format(rmg.surface_site_density))
         if rmg.binding_energies:
-            f.write('    binding_energies = {0!r},'.format(rmg.binding_energies))
+            f.write('    binding_energies = {\n')
+            for elem, be in rmg.binding_energies.items():
+                f.write('     {0!r}:{1!r},\n'.format(elem, be))
+            f.write('    },\n')
         f.write(')\n\n')
 
     # Species

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1483,7 +1483,7 @@ def save_input_file(path, rmg):
     f.write('    kineticsEstimator = {0!r},\n'.format(rmg.kinetics_estimator))
     f.write(')\n\n')
 
-    if rmg.surfaceSiteDenisty or rmg.binding_energies:
+    if rmg.surface_site_density or rmg.binding_energies:
         f.write('catalystProperties(\n')
         if rmg.surfaceSiteDenisty:
             f.write('    surface_site_density = {0!r},'.format(rmg.surface_site_density))

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1485,7 +1485,7 @@ def save_input_file(path, rmg):
 
     if rmg.surface_site_density or rmg.binding_energies:
         f.write('catalystProperties(\n')
-        if rmg.surfaceSiteDenisty:
+        if rmg.surface_site_density:
             f.write('    surface_site_density = {0!r},'.format(rmg.surface_site_density))
         if rmg.binding_energies:
             f.write('    binding_energies = {0!r},'.format(rmg.binding_energies))
@@ -1515,9 +1515,9 @@ def save_input_file(path, rmg):
             f.write('    temperature = ({0:g},"{1!s}"),\n'.format(system.T.value, system.T.units))
             # Convert the pressure from SI pascal units to bar here
             # Do something more fancy later for converting to user's desired units for both T and P..
-            f.write('    pressure = ({0:g},"{1!s}"),\n'.format(system.P.value, system.P.units))
+            f.write('    pressure = ({0:g},"{1!s}"),\n'.format(system.P_initial.value, system.P_initial.units))
             f.write('    initialMoleFractions={\n')
-            for spcs, molfrac in system.initial_mole_fractions.items():
+            for spcs, molfrac in system.initial_gas_mole_fractions.items():
                 f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
         f.write('    },\n')
 
@@ -1527,8 +1527,12 @@ def save_input_file(path, rmg):
             if isinstance(term, TerminationTime):
                 f.write('    terminationTime = ({0:g},"{1!s}"),\n'.format(term.time.value, term.time.units))
 
-            else:
+            elif isinstance(term,TerminationConversion):
                 conversions += '        "{0:s}": {1:g},\n'.format(term.species.label, term.conversion)
+
+            elif isinstance(term, TerminationRateRatio):
+                f.write('    terminationRateRatio = {0:g},\n'.format(term.ratio))
+
         if conversions:
             f.write('    terminationConversion = {\n')
             f.write(conversions)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1492,6 +1492,8 @@ def save_input_file(path, rmg):
             for elem, be in rmg.binding_energies.items():
                 f.write('     {0!r}:{1!r},\n'.format(elem, be))
             f.write('    },\n')
+        if rmg.coverage_dependence:
+            f.write('    coverageDependence = {0},\n'.format(rmg.coverage_dependence))
         f.write(')\n\n')
 
     # Species

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1664,7 +1664,7 @@ def save_input_file(path, rmg):
     if rmg.species_constraints:
         f.write('generatedSpeciesConstraints(\n')
         for constraint, value in sorted(list(rmg.species_constraints.items()), key=lambda constraint: constraint[0]):
-            if value is not None:
+            if value is not None and constraint is not "explicitlyAllowedMolecules":
                 f.write('    {0} = {1},\n'.format(constraint, value))
         f.write(')\n\n')
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1519,6 +1519,9 @@ def save_input_file(path, rmg):
             f.write('    initialMoleFractions={\n')
             for spcs, molfrac in system.initial_gas_mole_fractions.items():
                 f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
+            f.write('    initialSurfaceCoverages={\n')
+            for spcs, molfrac in system.initial_surface_coverages.items():
+                f.write('        "{0!s}": {1:g},\n'.format(spcs.label, molfrac))
         f.write('    },\n')
 
         # Termination criteria


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG doesn't properly use "save_input_file" for surfaces. this PR fixes that

### Description of Changes
several typos in surface reactor objects were fixed, and initial_surface_coverages was also added

### Testing
generated a output file and compared it to the original

### Reviewer Tips
review changes If you find that any additional surface specific input file data were missed, please comment so I can add. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
