### PR TITLE
Correct ATG rate rules initialization

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -124,9 +124,7 @@ def database(thermoLibraries=None, transportLibraries=None, reactionLibraries=No
     for family in rmg_database.kinetics.families.values():  # load training
         if not family.auto_generated:
             family.add_rules_from_training(thermo_database=rmg_database.thermo)
-
-    for family in rmg_database.kinetics.families.values():
-        family.fill_rules_by_averaging_up(verbose=True)
+            family.fill_rules_by_averaging_up(verbose=True)
 
 
 def species(label, *args, **kwargs):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1167,6 +1167,13 @@ class KineticsFamily(Database):
         For each reaction involving real reactants and products in the training
         set, add a rate rule for that reaction.
         """
+        if self.auto_generated:
+            warnings.warn(f'add_rules_from_training should be only called for non-ATG families, '
+                          f'but {self.label} is an ATG family. Skip this function call. '
+                          f'Calling add_rules_from_training on ATG families may be deprecated in RMG-Py 3.2',
+                          DeprecationWarning)
+            return
+
         try:
             depository = self.get_training_depository()
         except:
@@ -1354,7 +1361,12 @@ class KineticsFamily(Database):
         Fill in gaps in the kinetics rate rules by averaging child nodes
         recursively starting from the top level root template.
         """
-
+        if self.auto_generated:
+            warnings.warn(f'fill_rules_by_averaging_up should be only called for non-ATG families, '
+                          f'but {self.label} is an ATG family. Skip this function call. '
+                          f'Calling fill_rules_by_averaging_up on ATG families may be deprecated in RMG-Py 3.2',
+                          DeprecationWarning)
+            return
         self.rules.fill_rules_by_averaging_up(self.get_root_template(), {}, verbose)
 
     def apply_recipe(self, reactant_structures, forward=True, unique=True, relabel_atoms=True):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1957,7 +1957,7 @@ class KineticsFamily(Database):
         will return an empty list. Each item in the list of reactants should
         be a list of :class:`Molecule` objects, each representing a resonance
         structure of the species of interest.
-        
+
         This method returns all reactions, and degenerate reactions can then be
         found using `rmgpy.data.kinetics.common.find_degenerate_reactions`.
 

--- a/rmgpy/data/kinetics/kineticsTest.py
+++ b/rmgpy/data/kinetics/kineticsTest.py
@@ -74,8 +74,9 @@ def setUpModule():
 
     # Prepare the database by loading training reactions and averaging the rate rules
     for family in database.kinetics.families.values():
-        family.add_rules_from_training(thermo_database=database.thermo)
-        family.fill_rules_by_averaging_up(verbose=True)
+        if not family.auto_generated:
+            family.add_rules_from_training(thermo_database=database.thermo)
+            family.fill_rules_by_averaging_up(verbose=True)
 
 
 def tearDownModule():

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -1200,8 +1200,9 @@ class RMG(util.Subject):
                 # Temporarily remove species constraints for the training reactions
                 self.species_constraints, speciesConstraintsCopy = {}, self.species_constraints
                 for family in self.database.kinetics.families.values():
-                    family.add_rules_from_training(thermo_database=self.database.thermo)
-                    family.fill_rules_by_averaging_up(verbose=True)
+                    if not family.auto_generated:
+                        family.add_rules_from_training(thermo_database=self.database.thermo)
+                        family.fill_rules_by_averaging_up(verbose=True)
                 self.species_constraints = speciesConstraintsCopy
 
             for correlated in correlation:

--- a/rmgpy/tools/isotopesTest.py
+++ b/rmgpy/tools/isotopesTest.py
@@ -65,8 +65,9 @@ def setUpModule():
 
     # Prepare the database by loading training reactions and averaging the rate rules
     for family in database.kinetics.families.values():
-        family.add_rules_from_training(thermo_database=database.thermo)
-        family.fill_rules_by_averaging_up(verbose=True)
+        if not family.auto_generated:
+            family.add_rules_from_training(thermo_database=database.thermo)
+            family.fill_rules_by_averaging_up(verbose=True)
 
 
 def tearDownModule():

--- a/rmgpy/tools/uncertainty.py
+++ b/rmgpy/tools/uncertainty.py
@@ -315,8 +315,9 @@ class Uncertainty(object):
 
         # Prepare the database by loading training reactions but not averaging the rate rules
         for familyLabel, family in self.database.kinetics.families.items():
-            family.add_rules_from_training(thermo_database=self.database.thermo)
-            family.fill_rules_by_averaging_up(verbose=True)
+            if not family.auto_generated:
+                family.add_rules_from_training(thermo_database=self.database.thermo)
+                family.fill_rules_by_averaging_up(verbose=True)
 
     def load_model(self, chemkin_path, dictionary_path, transport_path=None):
         """

--- a/rmgpy/tools/uncertaintyTest.py
+++ b/rmgpy/tools/uncertaintyTest.py
@@ -66,8 +66,9 @@ class TestUncertainty(unittest.TestCase):
 
         # Prepare the database by loading training reactions and averaging the rate rules verbosely
         for family in cls.uncertainty.database.kinetics.families.values():
-            family.add_rules_from_training(thermo_database=cls.uncertainty.database.thermo)
-            family.fill_rules_by_averaging_up(verbose=True)
+            if not family.auto_generated:
+                family.add_rules_from_training(thermo_database=cls.uncertainty.database.thermo)
+                family.fill_rules_by_averaging_up(verbose=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -395,8 +395,9 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
     # These are the actual tests, that don't start with a "test_" name:
     def kinetics_check_surface_training_reactions_can_be_used(self, family_name):
         """Test that surface training reactions can be averaged and used for generating rate rules"""
-        family = self.database.kinetics.families[family_name]
-        family.add_rules_from_training(thermo_database=self.database.thermo)
+            family = self.database.kinetics.families[family_name]
+            if not family.auto_generated:
+                family.add_rules_from_training(thermo_database=self.database.thermo)
 
     def general_check_metal_database_has_catalyst_properties(self, library):
         """Test that each entry has catalyst properties"""

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -398,6 +398,7 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
         family = self.database.kinetics.families[family_name]
         if not family.auto_generated:
             family.add_rules_from_training(thermo_database=self.database.thermo)
+            family.fill_rules_by_averaging_up(verbose=True)
 
     def general_check_metal_database_has_catalyst_properties(self, library):
         """Test that each entry has catalyst properties"""

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -395,9 +395,9 @@ class TestDatabase(object):  # cannot inherit from unittest.TestCase if we want 
     # These are the actual tests, that don't start with a "test_" name:
     def kinetics_check_surface_training_reactions_can_be_used(self, family_name):
         """Test that surface training reactions can be averaged and used for generating rate rules"""
-            family = self.database.kinetics.families[family_name]
-            if not family.auto_generated:
-                family.add_rules_from_training(thermo_database=self.database.thermo)
+        family = self.database.kinetics.families[family_name]
+        if not family.auto_generated:
+            family.add_rules_from_training(thermo_database=self.database.thermo)
 
     def general_check_metal_database_has_catalyst_properties(self, library):
         """Test that each entry has catalyst properties"""


### PR DESCRIPTION
`add_rules_from_training` and `fill_rules_by_averaging_up` should be only called for non-ATG rate rules when initiating the RMG database rate rule estimator.
1. A full keyword search is done using these two function names. Wherever they are called, `if not autogenerated:` is made sure to be added before the block.
2. Bypass the calls of these two methods on ATG families inside these functions. Currently, there is no error raised to avoid breaking up user's private scripts and workflow. But this will be deprecated in the future version, and an error will be raised.