### PR TITLE
update developer installation instructions to use the main rms branch

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -119,7 +119,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
      python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
-     julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",version="0.4")); using ReactionMechanismSimulator;'
+     julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
 
    Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
    interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation

--- a/documentation/source/users/rmg/installation/updatingSourceCode.rst
+++ b/documentation/source/users/rmg/installation/updatingSourceCode.rst
@@ -27,6 +27,10 @@ Again, for those (still) using ``https``, the command is instead::
 
     git pull https://github.com/ReactionMechanismGenerator/RMG-database.git main
 
+We also recommend that the RMS julia package is updated::
+
+    julia -e 'using Pkg; Pkg.update("ReactionMechanismSimulator")'
+
 For more information about how to use the Git workflow to make changes to the source code, please
 refer to the handy `Git Tutorial <http://git-scm.com/docs/gittutorial>`_
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
people are having trouble installing rmg because it is using an old rms version, see issue #2290

### Description of Changes
changed the documentation to use the rms main branch instead of v 0.4. 

### Testing
did a clean rmg install and verified that I could regenerate the issue with the old install, and that the issue was resolved with the updated instructions. 

### Reviewer Tips
Just verify that this is a reasonable way to do this. I think the root cause is the specification of "v 0.4" in the install supercedes any configuration we have in the pyrms wrapper config. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
