### PR TITLE
Skip number of products check for ATG tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ RMG_Py.egg-info/*
 
 # RMG configuration file
 rmgpy/rmgrc
+
+scripts/treegen.log
+
+scripts/treegen_backup.log

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1508,20 +1508,22 @@ class KineticsFamily(Database):
             product_num = self.product_num or len(template.products)
 
         # Split product structure into multiple species if necessary
-        product_structures = product_structure.split()
-
-        # Make sure we've made the expected number of products
-        if product_num != len(product_structures):
-            # We have a different number of products than expected by the template.
-            # By definition this means that the template is not a match, so
-            # we return None to indicate that we could not generate the product
-            # structures
-            # We need to think this way in order to distinguish between
-            # intermolecular and intramolecular versions of reaction families,
-            # which will have very different kinetics
-            # Unfortunately this may also squash actual errors with malformed
-            # reaction templates
-            return None
+        if (isinstance(product_structure, Group) and self.auto_generated and self.label in ["Intra_R_Add_Endocyclic","Intra_R_Add_Exocyclic"]):
+            product_structures = [product_structure]
+        else:
+            product_structures = product_structure.split()
+            # Make sure we've made the expected number of products
+            if product_num != len(product_structures):
+                # We have a different number of products than expected by the template.
+                # By definition this means that the template is not a match, so
+                # we return None to indicate that we could not generate the product
+                # structures
+                # We need to think this way in order to distinguish between
+                # intermolecular and intramolecular versions of reaction families,
+                # which will have very different kinetics
+                # Unfortunately this may also squash actual errors with malformed
+                # reaction templates
+                return None
 
         # Remove vdW bonds
         for struct in product_structures:


### PR DESCRIPTION
### Motivation or Problem
Per Bill's request, @kspieks and I are working on fixing the `Intra_R_Add_Endocyclic` and `Intra_R_Add_Exocyclic` trees. During RMG subgroup, we discussed the problem identified in PR https://github.com/ReactionMechanismGenerator/RMG-database/issues/577, where we found that the ATG root nodes for these two families are essentially the same, and we are not able to provide enough information from the ring closing direction to tell a priori that whether the closed ring is endo or exo. We have concluded that defining these two families from the ring opening direction is the right way to go (even though it would not be the exothermic's direction).

During generating tree from the ring opening direction, we've found that the check of number of products equal to the number of product groups failed. We found that for the ring closing direction, the product template would only have one group. But for the ring opening direction, the product template would contain a group for the double bond and a group for the radical, even though they should be on the same product, i.e. number of groups != number of products. For the ATG tree, the groups in the product template are not necessarily connected together, even though they are on the same species (as opposed to the old tree, where we write out the label on the backbones, so the groups on the product template are always connected).

### Description of Changes
I skip the check for ATG generated tree per @mjohnson541's suggestion.

### Testing
After the change, I was able to generate `Intra_R_Add_Endocyclic` tree from the ring opening direction using ATG.
