### PR TITLE
Add atom props to __reduce__

### DIFF
--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -107,7 +107,7 @@ class GroupAtom(Vertex):
         atomtype = self.atomtype
         if atomtype is not None:
             atomtype = [a.label for a in atomtype]
-        return (GroupAtom, (atomtype, self.radical_electrons, self.charge, self.label, self.lone_pairs), d)
+        return (GroupAtom, (atomtype, self.radical_electrons, self.charge, self.label, self.lone_pairs, self.props), d)
 
     def __setstate__(self, d):
         """


### PR DESCRIPTION
### Motivation or Problem
I ran into this bizarre bug where the node a molecule lands on when descending a tree depends on whether the descending is being run in parallel or not. After some investigation, I realized it's because the ring membership of a group disappears when it's being pickled and unpickled. Here's a minimal working example:

```
group = Group().from_adjacency_list("""
1 * R!H u1 {2,[S,D,T,B,Q]}
2   R!H ux r1 {1,[S,D,T,B,Q]}
""")

print_adj(group)
# 1 * R!H u1 {2,[S,D,T,B,Q]}
# 2   R!H ux r1 {1,[S,D,T,B,Q]}
Parallel(n_jobs=-1, verbose=5, backend='multiprocessing')(delayed(print_adj)(g) for g in [group])
# 1 * R!H u1 {2,[S,D,T,B,Q]}
# 2   R!H ux {1,[S,D,T,B,Q]}
```

### Description of Changes
I add props to `__reduce__`.

### Testing
After the change, the ring membership remains in parallel.