### PR TITLE
change shebang in update_headers to use python-jl instead of python3

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -310,7 +310,7 @@ def update_headers():
     start of each file, be sure to double-check the results to make sure
     important lines aren't accidentally overwritten.
     """
-    shebang = """#!/usr/bin/env python3
+    shebang = """#!/usr/bin/env python-jl
 
 """
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The script to automatically update the LICENSE header at the top of all files uses python3 instead of python-jl. This script is run when generating new binaries.

### Description of Changes
Changed the shebang in the utilities.py:update_headers function to use python-jl instead of python3

