### PR TITLE
Fix resonance save order

### DIFF
--- a/rmgpy/molecule/converter.pxd
+++ b/rmgpy/molecule/converter.pxd
@@ -29,10 +29,10 @@ cimport rmgpy.molecule.molecule as mm
 cimport rmgpy.molecule.element as elements
 
 
-cpdef to_rdkit_mol(mm.Molecule mol, bint remove_h=*, bint return_mapping=*, bint sanitize=*)
+cpdef to_rdkit_mol(mm.Molecule mol, bint remove_h=*, bint return_mapping=*, bint sanitize=*, bint save_order=?)
 
 cpdef mm.Molecule from_rdkit_mol(mm.Molecule mol, object rdkitmol, bint raise_atomtype_exception=?)
 
-cpdef to_ob_mol(mm.Molecule mol, bint return_mapping=*)
+cpdef to_ob_mol(mm.Molecule mol, bint return_mapping=*, bint save_order=?)
 
 cpdef mm.Molecule from_ob_mol(mm.Molecule mol, object obmol, bint raise_atomtype_exception=?)

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -49,7 +49,7 @@ import rmgpy.molecule.molecule as mm
 from rmgpy.exceptions import DependencyError
 
 
-def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True):
+def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True, save_order=False):
     """
     Convert a molecular structure to a RDKit rdmol object. Uses
     `RDKit <http://rdkit.org/>`_ to perform the conversion.
@@ -61,7 +61,8 @@ def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True):
     from rmgpy.molecule.fragment import Fragment
     # Sort the atoms before converting to ensure output is consistent
     # between different runs
-    mol.sort_atoms()
+    if not save_order:
+        mol.sort_atoms()
     atoms = mol.vertices
     rd_atom_indices = {}  # dictionary of RDKit atom indices
     label_dict = {} # store label of atom for Framgent
@@ -227,7 +228,7 @@ def debug_rdkit_mol(rdmol, level=logging.INFO):
     return message
 
 
-def to_ob_mol(mol, return_mapping=False):
+def to_ob_mol(mol, return_mapping=False, save_order=False):
     """
     Convert a molecular structure to an OpenBabel OBMol object. Uses
     `OpenBabel <http://openbabel.org/>`_ to perform the conversion.
@@ -236,7 +237,8 @@ def to_ob_mol(mol, return_mapping=False):
         raise DependencyError('OpenBabel is not installed. Please install or use RDKit.')
 
     # Sort the atoms to ensure consistent output
-    mol.sort_atoms()
+    if not save_order:
+        mol.sort_atoms()
     atoms = mol.vertices
 
     ob_atom_ids = {}  # dictionary of OB atom IDs

--- a/rmgpy/molecule/converterTest.py
+++ b/rmgpy/molecule/converterTest.py
@@ -117,6 +117,18 @@ class RDKitTest(unittest.TestCase):
                     except RuntimeError:
                         self.fail("RDKit failed in finding the bond in the original atom!")
 
+    def test_atom_mapping_3(self):
+        """Test that to_rdkit_mol with save_order=True retains the atom order and create the correct RDKit Molecule"""
+        adjlist = """1  H u0 p0 c0 {2,S}
+2  C u0 p0 c0 {1,S} {3,T}
+3  N u0 p1 c0 {2,T}
+"""
+        mol = Molecule().from_adjacency_list(adjlist)
+        rdkitmol, _ = to_rdkit_mol(mol, remove_h=False, return_mapping=True, save_order=True)
+
+        self.assertSequenceEqual([atom.number for atom in mol.atoms], [1, 6, 7])
+        self.assertSequenceEqual([rdkitmol.GetAtomWithIdx(idx).GetAtomicNum() for idx in range(3)], [1, 6, 7])
+
 
 class ConverterTest(unittest.TestCase):
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -242,16 +242,16 @@ cdef class Molecule(Graph):
     cpdef double calculate_cp0(self) except -1
 
     cpdef double calculate_cpinf(self) except -1
-    
+
     cpdef update_atomtypes(self, bint log_species=?, bint raise_exception=?)
-    
+
     cpdef bint is_radical(self) except -2
 
     cpdef bint has_lone_pairs(self) except -2
 
     cpdef bint has_halogen(self) except -2
 
-    cpdef bint is_aryl_radical(self, list aromatic_rings=?) except -2
+    cpdef bint is_aryl_radical(self, list aromatic_rings=?, bint save_order=?) except -2
 
     cpdef float calculate_symmetry_number(self) except -1
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -267,7 +267,7 @@ cdef class Molecule(Graph):
 
     cpdef int count_aromatic_rings(self)
 
-    cpdef tuple get_aromatic_rings(self, list rings=?)
+    cpdef tuple get_aromatic_rings(self, list rings=?, bint save_order=?)
 
     cpdef list get_deterministic_sssr(self)
 

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2140,14 +2140,17 @@ class Molecule(Graph):
                 return True
         return False
 
-    def is_aryl_radical(self, aromatic_rings=None):
+    def is_aryl_radical(self, aromatic_rings=None, save_order=False):
         """
         Return ``True`` if the molecule only contains aryl radicals,
-        ie. radical on an aromatic ring, or ``False`` otherwise.
+        i.e., radical on an aromatic ring, or ``False`` otherwise.
+        If no ``aromatic_rings`` provided, aromatic rings will be searched in-place,
+        and this process may involve atom order change by default. Set ``save_order`` to
+        ``True`` to force the atom order unchanged.
         """
         cython.declare(atom=Atom, total=int, aromatic_atoms=set, aryl=int)
         if aromatic_rings is None:
-            aromatic_rings = self.get_aromatic_rings()[0]
+            aromatic_rings = self.get_aromatic_rings(save_order=save_order)[0]
 
         total = self.get_radical_count()
         aromatic_atoms = set([atom for atom in itertools.chain.from_iterable(aromatic_rings)])
@@ -2228,7 +2231,7 @@ class Molecule(Graph):
 
     def saturate_radicals(self, raise_atomtype_exception=True):
         """
-        Saturate the molecule by replacing all radicals with bonds to hydrogen atoms.  Changes self molecule object.  
+        Saturate the molecule by replacing all radicals with bonds to hydrogen atoms.  Changes self molecule object.
         """
         cython.declare(added=dict, atom=Atom, i=int, H=Atom, bond=Bond)
         added = {}

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2341,7 +2341,7 @@ class Molecule(Graph):
 
         return count
 
-    def get_aromatic_rings(self, rings=None):
+    def get_aromatic_rings(self, rings=None, save_order=False):
         """
         Returns all aromatic rings as a list of atoms and a list of bonds.
 
@@ -2351,6 +2351,9 @@ class Molecule(Graph):
 
         The method currently restricts aromaticity to six-membered carbon-only rings. This is a limitation imposed
         by RMG, and not by RDKit.
+
+        By default, the atom order will be sorted to get consistent results from different runs. The atom order can
+        be saved when dealing with problems that are sensitive to the atom map.
         """
         cython.declare(rd_atom_indices=dict, ob_atom_ids=dict, aromatic_rings=list, aromatic_bonds=list)
         cython.declare(ring0=list, i=cython.int, atom1=Atom, atom2=Atom)
@@ -2365,7 +2368,7 @@ class Molecule(Graph):
             return [], []
 
         try:
-            rdkitmol, rd_atom_indices = converter.to_rdkit_mol(self, remove_h=False, return_mapping=True)
+            rdkitmol, rd_atom_indices = converter.to_rdkit_mol(self, remove_h=False, return_mapping=True, save_order=save_order)
         except ValueError:
             logging.warning('Unable to check aromaticity by converting to RDKit Mol.')
         else:
@@ -2394,7 +2397,7 @@ class Molecule(Graph):
 
         logging.info('Trying to use OpenBabel to check aromaticity.')
         try:
-            obmol, ob_atom_ids = converter.to_ob_mol(self, return_mapping=True)
+            obmol, ob_atom_ids = converter.to_ob_mol(self, return_mapping=True, save_order=save_order)
         except DependencyError:
             logging.warning('Unable to check aromaticity by converting for OB Mol.')
             return [], []

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -2501,6 +2501,30 @@ multiplicity 2
         self.assertEqual(len(aromatic_atoms), 0)
         self.assertEqual(len(aromatic_bonds), 0)
 
+    def test_aromaticity_perception_save_order(self):
+        """Test aromaticity perception via get_aromatic_rings for phenyl radical without changing atom order."""
+        mol = Molecule().from_adjacency_list("""multiplicity 2
+1  C u0 p0 c0 {2,S} {3,S} {7,D}
+2  O u1 p2 c0 {1,S}
+3  C u0 p0 c0 {1,S} {4,D} {8,S}
+4  C u0 p0 c0 {3,D} {5,S} {9,S}
+5  C u0 p0 c0 {4,S} {6,D} {10,S}
+6  C u0 p0 c0 {5,D} {7,S} {11,S}
+7  C u0 p0 c0 {1,D} {6,S} {12,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {7,S}
+"""
+        )
+        aromatic_atoms, aromatic_bonds = mol.get_aromatic_rings(save_order=True)
+        self.assertEqual(len(aromatic_atoms), 1)
+        self.assertEqual(len(aromatic_bonds), 1)
+        # A quick check for non-changed atom order is to check
+        # if the first atom becomes the oxygen atom after calling `get_aromatic_rings`
+        self.assertFalse(mol.atoms[0].is_oxygen())
+
     def test_aryl_radical_true(self):
         """Test aryl radical perception for phenyl radical."""
         mol = Molecule(smiles='[c]1ccccc1')

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -52,14 +52,14 @@ cpdef list generate_isomorphic_resonance_structures(Graph mol, bint saturate_h=?
 
 cpdef list generate_optimal_aromatic_resonance_structures(Graph mol, dict features=?, bint save_order=?)
 
-cpdef list generate_aromatic_resonance_structure(Graph mol, list aromatic_bonds=?, bint copy=?)
+cpdef list generate_aromatic_resonance_structure(Graph mol, list aromatic_bonds=?, bint copy=?, bint save_order=?)
 
 cpdef list generate_aryne_resonance_structures(Graph mol)
 
 cpdef list generate_kekule_structure(Graph mol)
 
-cpdef list generate_clar_structures(Graph mol)
+cpdef list generate_clar_structures(Graph mol, bint save_order=?)
 
-cpdef list _clar_optimization(Graph mol, list constraints=?, max_num=?)
+cpdef list _clar_optimization(Graph mol, list constraints=?, max_num=?, save_order=?)
 
 cpdef list _clar_transformation(Graph mol, list aromatic_ring)

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -30,7 +30,7 @@ from rmgpy.molecule.molecule cimport Atom, Bond, Molecule
 
 cpdef list populate_resonance_algorithms(dict features=?)
 
-cpdef dict analyze_molecule(Graph mol)
+cpdef dict analyze_molecule(Graph mol, bint save_order=?)
 
 cpdef list generate_resonance_structures(Graph mol, bint clar_structures=?, bint keep_isomorphic=?, bint filter_structures=?, bint save_order=?)
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -208,7 +208,7 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
             features['isPolycyclicAromatic'] = False
         else:
             features['is_aromatic'] = True
-            if len(new_mol_list[0].get_aromatic_rings()[0]) > 1:
+            if len(new_mol_list[0].get_aromatic_rings(save_order=save_order)[0]) > 1:
                 features['isPolycyclicAromatic'] = True
             for new_mol in new_mol_list:
                 # Append to structure list if unique
@@ -216,7 +216,7 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
                                                              initial_map=None,
                                                              generate_initial_map=False,
                                                              save_order=save_order):
-                    # Note: `initial_map` and `generagenerate_initial_map` is using default values.
+                    # Note: `initial_map` and `generate_initial_map` is using default values.
                     # They are required in compilation before assigning `save_order`.
                     continue
                 elif keep_isomorphic and mol.is_identical(new_mol):
@@ -306,7 +306,7 @@ def _generate_resonance_structures(mol_list, method_list, keep_isomorphic=False,
                                                              initial_map=None,
                                                              generate_initial_map=False,
                                                              save_order=save_order):
-                    # Note: `initial_map` and `generagenerate_initial_map` is using default values.
+                    # Note: `initial_map` and `generate_initial_map` is using default values.
                     # They are required in compilation before assigning `save_order`.
                     break
                 elif keep_isomorphic and mol.is_identical(new_mol):
@@ -650,7 +650,7 @@ def generate_optimal_aromatic_resonance_structures(mol, features=None, save_orde
         # Generate the aromatic resonance structure(s)
         for mol0, aromatic_bonds in mol_list:
             # Aromatize the molecule in place
-            result = generate_aromatic_resonance_structure(mol0, aromatic_bonds, copy=False)
+            result = generate_aromatic_resonance_structure(mol0, aromatic_bonds, copy=False, save_order=save_order)
             if not result:
                 # We failed to aromatize this molecule
                 # This could be due to incorrect aromaticity perception by RDKit
@@ -672,7 +672,7 @@ def generate_optimal_aromatic_resonance_structures(mol, features=None, save_orde
     return new_mol_list
 
 
-def generate_aromatic_resonance_structure(mol, aromatic_bonds=None, copy=True):
+def generate_aromatic_resonance_structure(mol, aromatic_bonds=None, copy=True, save_order=False):
     """
     Generate the aromatic form of the molecule in place without considering other resonance.
 
@@ -690,7 +690,7 @@ def generate_aromatic_resonance_structure(mol, aromatic_bonds=None, copy=True):
         molecule = mol
 
     if aromatic_bonds is None:
-        aromatic_bonds = molecule.get_aromatic_rings()[1]
+        aromatic_bonds = molecule.get_aromatic_rings(save_order=save_order)[1]
     if len(aromatic_bonds) == 0:
         return []
 
@@ -898,7 +898,7 @@ def generate_isomorphic_resonance_structures(mol, saturate_h=False):
     return isomorphic_isomers
 
 
-def generate_clar_structures(mol):
+def generate_clar_structures(mol, save_order=False):
     """
     Generate Clar structures for a given molecule.
 
@@ -915,7 +915,7 @@ def generate_clar_structures(mol):
         mol.assign_atom_ids()
 
     try:
-        output = _clar_optimization(mol)
+        output = _clar_optimization(mol, save_order=save_order)
     except ILPSolutionError:
         # The optimization algorithm did not work on the first iteration
         return []
@@ -954,7 +954,7 @@ def generate_clar_structures(mol):
     return mol_list
 
 
-def _clar_optimization(mol, constraints=None, max_num=None):
+def _clar_optimization(mol, constraints=None, max_num=None, save_order=False):
     """
     Implements linear programming algorithm for finding Clar structures. This algorithm maximizes the number
     of Clar sextets within the constraints of molecular geometry and atom valency.
@@ -980,7 +980,7 @@ def _clar_optimization(mol, constraints=None, max_num=None):
     # Make a copy of the molecule so we don't destroy the original
     molecule = mol.copy(deep=True)
 
-    aromatic_rings = molecule.get_aromatic_rings()[0]
+    aromatic_rings = molecule.get_aromatic_rings(save_order=save_order)[0]
     aromatic_rings.sort(key=lambda x: sum([atom.id for atom in x]))
 
     if not aromatic_rings:
@@ -1088,7 +1088,7 @@ def _clar_optimization(mol, constraints=None, max_num=None):
 
     # Run optimization with additional constraints
     try:
-        inner_solutions = _clar_optimization(mol, constraints=constraints, max_num=max_num)
+        inner_solutions = _clar_optimization(mol, constraints=constraints, max_num=max_num, save_order=save_order)
     except ILPSolutionError:
         inner_solutions = []
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -637,7 +637,7 @@ def generate_optimal_aromatic_resonance_structures(mol, features=None, save_orde
     # Sort all of the generated structures by number of perceived aromatic rings
     mol_dict = {}
     for mol0 in kekule_list:
-        aromatic_bonds = mol0.get_aromatic_rings()[1]
+        aromatic_bonds = mol0.get_aromatic_rings(save_order=save_order)[1]
         num_aromatic = len(aromatic_bonds)
         mol_dict.setdefault(num_aromatic, []).append((mol0, aromatic_bonds))
 

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -113,9 +113,10 @@ def populate_resonance_algorithms(features=None):
     return method_list
 
 
-def analyze_molecule(mol):
+def analyze_molecule(mol, save_order=False):
     """
     Identify key features of molecule important for resonance structure generation.
+    `save_order` is used to maintain the atom order, when analyzing the molecule, defaults to False.
 
     Returns a dictionary of features.
     """
@@ -131,7 +132,7 @@ def analyze_molecule(mol):
                 }
 
     if features['is_cyclic']:
-        aromatic_rings = mol.get_aromatic_rings()[0]
+        aromatic_rings = mol.get_aromatic_rings(save_order=save_order)[0]
         if len(aromatic_rings) > 0:
             features['is_aromatic'] = True
         if len(aromatic_rings) > 1:
@@ -196,7 +197,7 @@ def generate_resonance_structures(mol, clar_structures=True, keep_isomorphic=Fal
     mol_list = [mol]
 
     # Analyze molecule
-    features = analyze_molecule(mol)
+    features = analyze_molecule(mol, save_order=save_order)
 
     # Use generate_optimal_aromatic_resonance_structures to check for false positives and negatives
     if features['is_aromatic'] or (features['is_cyclic'] and features['is_radical'] and not features['is_aryl_radical']):
@@ -612,7 +613,7 @@ def generate_optimal_aromatic_resonance_structures(mol, features=None, save_orde
                    i=cython.int, counter=cython.int)
 
     if features is None:
-        features = analyze_molecule(mol)
+        features = analyze_molecule(mol, save_order=save_order)
 
     if not features['is_cyclic']:
         return []


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
In my previous PR (#2229), I was trying to fix cases where atom map changes even when setting `save_order=True` when generating resonance structures. The PR fixes most of the cases except for aromatic molecules that I recently ran into. The atom map is changed whenever RMG tries to analyze the aromaticity and find out potential aromatic rings; Inside `get_aromatic_rings`, RMG will sort the atom order of the molecule and then convert it to an RDKit Mol and do the analysis based on the RDKit Mol. There is a comment inside `to_rdkit_mol` and `to_ob_mol` saying `# sort the atoms before converting to ensure output is consistent between different runs`, this can be useful in the case not sensitive to atom map and unnecessary to the case where the input molecule atom map is critical and need to be preserved. 

### Description of Changes
I naively add `save_order` argument to the following functions:
- `molecule.molecule.Molecule.get_aromatic_rings`
- `molecule.molecule.Molecule.get_aryl_radicals`
- `molecule.converter.to_rdkit_mol`
- `molecule.converter.to_ob_mol`
- `molecule.resonance.analyze_mol`
- `molecule.resonance.generate_aromatic_resonance_structure`
- `molecule.resonance.generate_clar_structures`
- `molecule.resonance._clar_optimization`
- `molecule.fragment.Fragment.get_aromatic_rings`
- `molecule.fragment.Fragment.get_aryl_radicals`
- `molecule.fragment.Fragment.to_rdkit_mol`

I set the default value of all `save_order` to `False`, so the default behavior shouldn't be changed. 

### Testing
Unit tests are added for to_rdkit_mol, get_aromatic_rings, and generate_resonance_structures
