### PR TITLE
Surface diff fixup

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1888,7 +1888,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
         for species, cov_params in kinetics.coverage_dependence.items():
             label = get_species_identifier(species)
             string += f'    COV / {label:<41} '
-            string += f"{cov_params['a'].value:<9.3g} {cov_params['m'].value:<9.3g} {cov_params['E'].value_si/4184.:<9.3f} /\n"
+            string += f"{cov_params['a']:<9.3g} {cov_params['m']:<9.3g} {cov_params['E']/4184.:<9.3f} /\n"
 
     if isinstance(kinetics, (_kinetics.ThirdBody, _kinetics.Lindemann, _kinetics.Troe)):
         # Write collider efficiencies

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -467,7 +467,8 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
 
         tokens = case_preserved_tokens[1].split()
         cov_dep_species = species_dict[tokens[0].strip()]
-        k.coverage_dependence[cov_dep_species] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E':(float(tokens[3]), Eunits)}
+        Ea = Quantity(float(tokens[3]), Eunits)
+        k.coverage_dependence[cov_dep_species] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E':Ea}
 
     elif 'LOW' in line:
         # Low-pressure-limit Arrhenius parameters
@@ -1906,7 +1907,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
         for species, cov_params in kinetics.coverage_dependence.items():
             label = get_species_identifier(species)
             string += f'    COV / {label:<41} '
-            string += f"{cov_params['a']:<9.3g} {cov_params['m']:<9.3g} {cov_params['E']/4184.:<9.3f} /\n"
+            string += f"{cov_params['a']:<9.3g} {cov_params['m']:<9.3g} {cov_params['E'].value_si/4184.:<9.3f} /\n"
 
     if isinstance(kinetics, (_kinetics.ThirdBody, _kinetics.Lindemann, _kinetics.Troe)):
         # Write collider efficiencies

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -43,7 +43,8 @@ from rmgpy.data.base import DatabaseError, Database, Entry
 from rmgpy.data.kinetics.common import save_entry
 from rmgpy.data.kinetics.family import TemplateReaction
 from rmgpy.kinetics import Arrhenius, ThirdBody, Lindemann, Troe, \
-                           PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, Chebyshev
+                           PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, Chebyshev 
+from rmgpy.kinetics.surface import StickingCoefficient
 from rmgpy.molecule import Molecule
 from rmgpy.reaction import Reaction
 from rmgpy.species import Species
@@ -206,6 +207,16 @@ class LibraryReaction(Reaction):
                          " it doesn't answer either of the following criteria:\n1. Has a Lindemann or Troe"
                          " kinetics type; 2. Has a PDepArrhenius or Chebyshev kinetics type and has valid"
                          " kinetics at P >= 100 bar.\n".format(self))
+        return False
+
+    def get_sticking_coefficient(self, T):
+        """
+        Helper function to get sticking coefficient
+        """
+        if isinstance(self.kinetics, StickingCoefficient):
+            stick = self.kinetics.get_sticking_coefficient(T)
+            return stick
+            
         return False
 
 

--- a/rmgpy/kinetics/model.pyx
+++ b/rmgpy/kinetics/model.pyx
@@ -38,6 +38,8 @@ from libc.math cimport log10
 
 import rmgpy.quantity as quantity
 from rmgpy.molecule import Molecule
+from rmgpy.kinetics.surface import StickingCoefficient, StickingCoefficientBEP
+
 
 ################################################################################
 
@@ -196,6 +198,7 @@ cdef class KineticsModel:
         """
         raise NotImplementedError('Unexpected call to KineticsModel.get_rate_coefficient(); '
                                   'you should be using a class derived from KineticsModel.')
+    
 
     cpdef to_html(self):
         """
@@ -232,6 +235,9 @@ cdef class KineticsModel:
         cdef double T
 
         if other_kinetics.is_pressure_dependent():
+            return False
+
+        if isinstance(other_kinetics, (StickingCoefficient, StickingCoefficientBEP)):
             return False
 
         for T in [500, 1000, 1500, 2000]:

--- a/rmgpy/kinetics/surface.pxd
+++ b/rmgpy/kinetics/surface.pxd
@@ -47,6 +47,8 @@ cdef class StickingCoefficient(KineticsModel):
 
     cpdef fit_to_data(self, np.ndarray Tlist, np.ndarray klist, str kunits, double T0=?, np.ndarray weights=?, bint three_params=?)
 
+    cpdef bint is_similar_to(self, KineticsModel other_kinetics) except -2
+
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2
     
     cpdef change_rate(self, double factor)
@@ -63,6 +65,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
     cpdef double get_sticking_coefficient(self, double T, double dHrxn=?) except -1
     cpdef double get_activation_energy(self, double dHrxn) except -1
     cpdef StickingCoefficient to_arrhenius(self, double dHrxn)
+    cpdef bint is_similar_to(self, KineticsModel other_kinetics) except -2
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2
     cpdef change_rate(self, double factor)
 

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -522,7 +522,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E']}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -87,7 +87,7 @@ cdef class StickingCoefficient(KineticsModel):
         if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{repr(parameters['a'])}, 'm':{repr(parameters['m'])}, 'E':{repr(parameters['E'])}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -336,7 +336,7 @@ cdef class StickingCoefficientBEP(KineticsModel):
         if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{repr(parameters['a'])}, 'm':{repr(parameters['m'])}, 'E':{repr(parameters['E'])}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -554,7 +554,7 @@ cdef class SurfaceArrhenius(Arrhenius):
         if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E']}}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{repr(parameters['a'])}, 'm':{repr(parameters['m'])}, 'E':{repr(parameters['E'])}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)
@@ -648,7 +648,7 @@ cdef class SurfaceArrheniusBEP(ArrheniusEP):
         if self.coverage_dependence:
             string += ", coverage_dependence={"
             for species, parameters in self.coverage_dependence.items():
-                string += f"{species.to_chemkin()!r}: {{'a':{parameters['a']}, 'm':{parameters['m']}, 'E':({parameters['E'].value}, '{parameters['E'].units}')}},"
+                string += f"{species.to_chemkin()!r}: {{'a':{repr(parameters['a'])}, 'm':{repr(parameters['m'])}, 'E':{repr(parameters['E'])}}},"
             string += "}"
         if self.Pmin is not None: string += ', Pmin={0!r}'.format(self.Pmin)
         if self.Pmax is not None: string += ', Pmax={0!r}'.format(self.Pmax)

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -29,7 +29,7 @@
 
 import numpy as np
 cimport numpy as np
-from libc.math cimport exp, sqrt
+from libc.math cimport exp, sqrt, log10
 
 cimport rmgpy.constants as constants
 import rmgpy.quantity as quantity
@@ -219,6 +219,22 @@ cdef class StickingCoefficient(KineticsModel):
         """
         self._A.value_si /= (self._T0.value_si / T0) ** self._n.value_si
         self._T0.value_si = T0
+
+    cpdef bint is_similar_to(self, KineticsModel other_kinetics) except -2:
+        """
+        Returns ``True`` if rates of reaction at temperatures 500,1000,1500,2000 K
+        and 1 and 10 bar are within +/ .5 for log(k), in other words, within a factor of 3.
+        """
+        cdef double T
+
+        if not isinstance(other_kinetics, StickingCoefficient):
+            return False
+
+        for T in [500, 1000, 1500, 2000]:
+            if abs(log10(self.get_sticking_coefficient(T)) - log10(other_kinetics.get_sticking_coefficient(T))) > 0.5:
+                return False
+
+        return True
 
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2:
         """
@@ -421,6 +437,22 @@ cdef class StickingCoefficientBEP(KineticsModel):
             coverage_dependence=self.coverage_dependence,
             comment=self.comment,
         )
+
+    cpdef bint is_similar_to(self, KineticsModel other_kinetics) except -2:
+        """
+        Returns ``True`` if rates of reaction at temperatures 500,1000,1500,2000 K
+        and 1 and 10 bar are within +/ .5 for log(k), in other words, within a factor of 3.
+        """
+        cdef double T
+
+        if not isinstance(other_kinetics, StickingCoefficientBEP):
+            return False
+
+        for T in [500, 1000, 1500, 2000]:
+            if abs(log10(self.get_sticking_coefficient(T)) - log10(other_kinetics.get_sticking_coefficient(T))) > 0.5:
+                return False
+
+        return True
 
     cpdef bint is_identical_to(self, KineticsModel other_kinetics) except -2:
         """

--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -222,8 +222,8 @@ cdef class StickingCoefficient(KineticsModel):
 
     cpdef bint is_similar_to(self, KineticsModel other_kinetics) except -2:
         """
-        Returns ``True`` if rates of reaction at temperatures 500,1000,1500,2000 K
-        and 1 and 10 bar are within +/ .5 for log(k), in other words, within a factor of 3.
+        Returns ``True`` if the sticking coefficient at temperatures 500,1000,1500,2000 K
+        are within +/ .5 for log(k), in other words, within a factor of 3.
         """
         cdef double T
 
@@ -440,8 +440,8 @@ cdef class StickingCoefficientBEP(KineticsModel):
 
     cpdef bint is_similar_to(self, KineticsModel other_kinetics) except -2:
         """
-        Returns ``True`` if rates of reaction at temperatures 500,1000,1500,2000 K
-        and 1 and 10 bar are within +/ .5 for log(k), in other words, within a factor of 3.
+        Returns ``True`` if sticking coefficient at temperatures 500,1000,1500,2000 K
+        are within +/ .5 for log(k), in other words, within a factor of 3.
         """
         cdef double T
 

--- a/rmgpy/rmg/output.py
+++ b/rmgpy/rmg/output.py
@@ -1183,7 +1183,7 @@ $(document).ready(function() {
 
 <P><b>Fitted Reverse Kinetics:</b>
 {% if not rxn2.kinetics.is_pressure_dependent() %}
-{{rxn2.generate_reverse_rate_coefficient().to_html() }}
+{{rxn2.generate_reverse_rate_coefficient(surface_site_density=2.483e-05).to_html() }}
 {% else %} Pressure dependent
 {% endif %}
 {% endif %}

--- a/rmgpy/tools/data/diffmodels/surf_model/chem_gas1.inp
+++ b/rmgpy/tools/data/diffmodels/surf_model/chem_gas1.inp
@@ -1,0 +1,175 @@
+ELEMENTS
+	H
+	D /2.014/
+	T /3.016/
+	C
+	CI /13.003/
+	O
+	OI /17.999/
+	N
+	Ne
+	Ar
+	He
+	Si
+	S
+	F
+	Cl
+	Br
+	I
+	X /195.083/
+END
+
+SPECIES
+    N2                  ! N2
+    Ne                  ! Ne
+    H2(2)               ! H2(2)
+    CO(3)               ! CO(3)
+    CO2(4)              ! CO2(4)
+    H2O(5)              ! H2O(5)
+    CH2O(6)             ! CH2O(6)
+    HCOOH(7)            ! HCOOH(7)
+    CH3OH(8)            ! CH3OH(8)
+    HCOOCH3(9)          ! HCOOCH3(9)
+    CH4(32)             ! CH4(32)
+END
+
+
+
+THERM ALL
+   300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+N2                      N   2               G   200.000  6000.000 1000.00      1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne  1               G   200.000  6000.000 1000.00      1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H2(2)                   H   2               G   100.000  5000.000 1959.07      1
+ 2.78817514E+00 5.87628848E-04 1.59016078E-07-5.52750390E-11 4.34319267E-15    2
+-5.96149762E+02 1.12677478E-01 3.43536403E+00 2.12711126E-04-2.78626796E-07    3
+ 3.40268542E-10-7.76035403E-14-1.03135984E+03-3.90841698E+00                   4
+
+! Thermo library: primaryThermoLibrary
+CO(3)                   C   1O   1          G   100.000  5000.000 1571.65      1
+ 2.91308532E+00 1.64655185E-03-6.88601689E-07 1.21034554E-10-7.83996529E-15    2
+-1.41808944E+04 6.71034902E+00 3.56837933E+00-8.52119359E-04 2.48916154E-06    3
+-1.56329526E-09 3.13590826E-13-1.42842549E+04 3.57912422E+00                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+CO2(4)                  C   1O   2          G   100.000  5000.000  978.22      1
+ 4.67428652E+00 2.60960766E-03-9.85670949E-07 1.95709378E-10-1.49832521E-14    2
+-4.89512220E+04-2.11084354E+00 3.28084123E+00 2.50189639E-03 8.08177735E-06    3
+-1.20508449E-08 4.66534301E-12-4.84008302E+04 6.00082616E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H2O(5)                  H   2O   1          G   100.000  5000.000 1130.24      1
+ 2.84325062E+00 2.75108520E-03-7.81031348E-07 1.07243608E-10-5.79391987E-15    2
+-2.99586128E+04 5.91041898E+00 4.05763582E+00-7.87935662E-04 2.90877429E-06    3
+-1.47518785E-09 2.12842652E-13-3.02815866E+04-3.11363998E-01                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+CH2O(6)                 C   1H   2O   1     G   100.000  5000.000 1070.44      1
+ 2.21174531E+00 7.94262219E-03-3.34191096E-06 6.28466843E-10-4.40427707E-14    2
+-1.42974547E+04 1.13047802E+01 4.12927419E+00-4.08396883E-03 2.03227836E-05    3
+-1.83522372E-08 5.37967936E-12-1.44294638E+04 3.22419840E+00                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+HCOOH(7)                C   1H   2O   2     G   100.000  5000.000  993.73      1
+ 5.64500944E+00 7.55180879E-03-3.20850721E-06 6.58917337E-10-5.05053801E-14    2
+-4.79890051E+04-5.43108033E+00 3.76240359E+00-9.43830708E-04 3.38777780E-05    3
+-4.04982280E-08 1.43986042E-11-4.68212101E+04 7.63276817E+00                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+CH3OH(8)                C   1H   4O   1     G   100.000  5000.000 1035.74      1
+ 2.79181672E+00 1.15828292E-02-4.51554439E-06 8.21212591E-10-5.67068102E-14    2
+-2.57211561E+04 9.41076413E+00 3.84006767E+00 1.38235488E-03 1.91669449E-05    3
+-2.01571540E-08 6.39114253E-12-2.56083089E+04 5.90976153E+00                   4
+
+! Thermo library: DFT_QCI_thermo
+HCOOCH3(9)              C   2H   4O   2     G   100.000  5000.000 1141.77      1
+ 4.90983526E+00 1.87530628E-02-8.58333645E-06 1.66848491E-09-1.18613015E-13    2
+-4.59009794E+04 2.12518990E-01 3.28124025E+00 1.13179721E-02 1.84480416E-05    3
+-2.41948544E-08 7.75149253E-12-4.46725568E+04 1.20363454E+01                   4
+
+! Thermo library: primaryThermoLibrary
+CH4(32)                 C   1H   4          G   100.000  5000.000 1084.12      1
+ 9.08274117E-01 1.14540720E-02-4.57173047E-06 8.29189859E-10-5.66313411E-14    2
+-9.71997811E+03 1.39930469E+01 4.20541378E+00-5.35555685E-03 2.51122700E-05    3
+-2.13762147E-08 5.97521149E-12-1.01619432E+04-9.21274032E-01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #49
+! Template reaction: 1,2_Insertion_CO
+! Flux pairs: CO(3), CH2O(6); H2(2), CH2O(6); 
+! Matched reaction 2 H2 + CO <=> CH2O in 1,2_Insertion_CO/training
+! This reaction matched rate rule [CO;H2]
+! family: 1,2_Insertion_CO
+H2(2)+CO(3)=CH2O(6)                                 2.890000e+09 1.160     82.100   
+
+! Reaction index: Chemkin #2; RMG #51
+! Template reaction: 1,2_Insertion_CO
+! Flux pairs: CO(3), HCOOH(7); H2O(5), HCOOH(7); 
+! Estimated using an average for rate rule [CO;RO_H]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: 1,2_Insertion_CO
+H2O(5)+CO(3)=HCOOH(7)                               2.540000e-01 3.700     53.360   
+
+! Reaction index: Chemkin #3; RMG #52
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: CO2(4), HCOOH(7); H2(2), HCOOH(7); 
+! Matched reaction 1 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training
+! This reaction matched rate rule [CO2_Od;H2]
+! family: 1,3_Insertion_CO2
+H2(2)+CO2(4)=HCOOH(7)                               1.510000e+09 1.230     73.900   
+DUPLICATE
+
+! Reaction index: Chemkin #4; RMG #61
+! Template reaction: 1,2_Insertion_CO
+! Flux pairs: CO(3), HCOOCH3(9); CH3OH(8), HCOOCH3(9); 
+! Matched reaction 7 CH4O + CO <=> C2H4O2 in 1,2_Insertion_CO/training
+! This reaction matched rate rule [CO;CsO_H]
+! family: 1,2_Insertion_CO
+CO(3)+CH3OH(8)=HCOOCH3(9)                           1.270000e-01 3.700     53.360   
+
+! Reaction index: Chemkin #5; RMG #138
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: H2(2), HCOOH(7); CO2(4), HCOOH(7); 
+! Matched reaction 1 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training
+! This reaction matched rate rule [CO2_Od;H2]
+! family: 1,3_Insertion_CO2
+H2(2)+CO2(4)=HCOOH(7)                               1.510000e+09 1.230     73.900   
+DUPLICATE
+
+! Reaction index: Chemkin #6; RMG #139
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: H2(2), HCOOH(7); CO2(4), HCOOH(7); 
+! Matched reaction 1 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training
+! This reaction matched rate rule [CO2_Cdd;H2]
+! family: 1,3_Insertion_CO2
+H2(2)+CO2(4)=HCOOH(7)                               1.510000e+09 1.230     73.900   
+DUPLICATE
+
+! Reaction index: Chemkin #7; RMG #63
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: CO2(4), HCOOCH3(9); CH4(32), HCOOCH3(9); 
+! Estimated using template [CO2;C_methane] for rate rule [CO2_Od;C_methane]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 8.0
+! family: 1,3_Insertion_CO2
+CO2(4)+CH4(32)=HCOOCH3(9)                           3.624000e+04 2.830     79.200   
+
+END
+

--- a/rmgpy/tools/data/diffmodels/surf_model/chem_gas2.inp
+++ b/rmgpy/tools/data/diffmodels/surf_model/chem_gas2.inp
@@ -1,0 +1,175 @@
+ELEMENTS
+	H
+	D /2.014/
+	T /3.016/
+	C
+	CI /13.003/
+	O
+	OI /17.999/
+	N
+	Ne
+	Ar
+	He
+	Si
+	S
+	F
+	Cl
+	Br
+	I
+	X /195.083/
+END
+
+SPECIES
+    N2                  ! N2
+    Ne                  ! Ne
+    H2(2)               ! H2(2)
+    CO(3)               ! CO(3)
+    CO2(4)              ! CO2(4)
+    H2O(5)              ! H2O(5)
+    CH2O(6)             ! CH2O(6)
+    HCOOH(7)            ! HCOOH(7)
+    CH3OH(8)            ! CH3OH(8)
+    HCOOCH3(9)          ! HCOOCH3(9)
+    CH4(24)             ! CH4(24)
+END
+
+
+
+THERM ALL
+   300.000  1000.000  5000.000
+
+! Thermo library: primaryThermoLibrary
+N2                      N   2               G   200.000  6000.000 1000.00      1
+ 2.95258000E+00 1.39690000E-03-4.92632000E-07 7.86010000E-11-4.60755000E-15    2
+-9.23949000E+02 5.87189000E+00 3.53101000E+00-1.23661000E-04-5.02999000E-07    3
+ 2.43531000E-09-1.40881000E-12-1.04698000E+03 2.96747000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+Ne                      Ne  1               G   200.000  6000.000 1000.00      1
+ 2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
+-7.45375000E+02 3.35532000E+00 2.50000000E+00 0.00000000E+00 0.00000000E+00    3
+ 0.00000000E+00 0.00000000E+00-7.45375000E+02 3.35532000E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H2(2)                   H   2               G   100.000  5000.000 1959.08      1
+ 2.78816619E+00 5.87640475E-04 1.59010635E-07-5.52739465E-11 4.34311304E-15    2
+-5.96144481E+02 1.12730527E-01 3.43536411E+00 2.12710383E-04-2.78625110E-07    3
+ 3.40267219E-10-7.76032129E-14-1.03135984E+03-3.90841731E+00                   4
+
+! Thermo library: primaryThermoLibrary
+CO(3)                   C   1O   1          G   100.000  5000.000 1571.64      1
+ 2.91306987E+00 1.64657389E-03-6.88612820E-07 1.21036930E-10-7.84014743E-15    2
+-1.41808862E+04 6.71043900E+00 3.56837982E+00-8.52124063E-04 2.48917390E-06    3
+-1.56330672E-09 3.13594213E-13-1.42842549E+04 3.57912239E+00                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+CO2(4)                  C   1O   2          G   100.000  5000.000  978.22      1
+ 4.67429780E+00 2.60958835E-03-9.85659769E-07 1.95706729E-10-1.49830320E-14    2
+-4.89512267E+04-2.11090702E+00 3.28083821E+00 2.50193291E-03 8.08164577E-06    3
+-1.20506695E-08 4.66526645E-12-4.84008301E+04 6.00083693E+00                   4
+
+! Thermo library: primaryThermoLibrary
+H2O(5)                  H   2O   1          G   100.000  5000.000 1130.25      1
+ 2.84324104E+00 2.75110073E-03-7.81040007E-07 1.07245603E-10-5.79408217E-15    2
+-2.99586086E+04 5.91047337E+00 4.05763720E+00-7.87951343E-04 2.90882564E-06    3
+-1.47524910E-09 2.12866372E-13-3.02815867E+04-3.11369025E-01                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+CH2O(6)                 C   1H   2O   1     G   100.000  5000.000 1070.44      1
+ 2.21172293E+00 7.94265924E-03-3.34193191E-06 6.28471724E-10-4.40431711E-14    2
+-1.42974450E+04 1.13049069E+01 4.12927829E+00-4.08401633E-03 2.03229448E-05    3
+-1.83524377E-08 5.37976060E-12-1.44294640E+04 3.22418365E+00                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+HCOOH(7)                C   1H   2O   2     G   100.000  5000.000  993.73      1
+ 5.64500305E+00 7.55181966E-03-3.20851348E-06 6.58918818E-10-5.05055029E-14    2
+-4.79890024E+04-5.43104436E+00 3.76240519E+00-9.43849897E-04 3.38778464E-05    3
+-4.04983181E-08 1.43986430E-11-4.68212102E+04 7.63276247E+00                   4
+
+! Thermo library: thermo_DFT_CCSDTF12_BAC
+CH3OH(8)                C   1H   4O   1     G   100.000  5000.000 1035.75      1
+ 2.79184262E+00 1.15827858E-02-4.51551962E-06 8.21206786E-10-5.67063316E-14    2
+-2.57211672E+04 9.41061788E+00 3.84006221E+00 1.38241909E-03 1.91667221E-05    3
+-2.01568699E-08 6.39102422E-12-2.56083087E+04 5.90978110E+00                   4
+
+! Thermo library: DFT_QCI_thermo
+HCOOCH3(9)              C   2H   4O   2     G   100.000  5000.000 1141.76      1
+ 4.90974332E+00 1.87532115E-02-8.58341907E-06 1.66850390E-09-1.18614557E-13    2
+-4.59009381E+04 2.13041707E-01 3.28125302E+00 1.13178286E-02 1.84485081E-05    3
+-2.41954066E-08 7.75170459E-12-4.46725574E+04 1.20362991E+01                   4
+
+! Thermo library: primaryThermoLibrary
+CH4(24)                 C   1H   4          G   100.000  5000.000 1084.15      1
+ 9.08349401E-01 1.14539479E-02-4.57166053E-06 8.29173612E-10-5.66300105E-14    2
+-9.72001110E+03 1.39926204E+01 4.20540072E+00-5.35540640E-03 2.51117636E-05    3
+-2.13755910E-08 5.97496145E-12-1.01619427E+04-9.21226951E-01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #53
+! Template reaction: 1,2_Insertion_CO
+! Flux pairs: CO(3), CH2O(6); H2(2), CH2O(6); 
+! Matched reaction 2 H2 + CO <=> CH2O in 1,2_Insertion_CO/training
+! This reaction matched rate rule [CO;H2]
+! family: 1,2_Insertion_CO
+H2(2)+CO(3)=CH2O(6)                                 2.890000e+09 1.160     82.100   
+
+! Reaction index: Chemkin #2; RMG #55
+! Template reaction: 1,2_Insertion_CO
+! Flux pairs: CO(3), HCOOH(7); H2O(5), HCOOH(7); 
+! Estimated using an average for rate rule [CO;RO_H]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: 1,2_Insertion_CO
+H2O(5)+CO(3)=HCOOH(7)                               2.540000e-01 3.700     53.360   
+
+! Reaction index: Chemkin #3; RMG #56
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: CO2(4), HCOOH(7); H2(2), HCOOH(7); 
+! Matched reaction 1 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training
+! This reaction matched rate rule [CO2_Od;H2]
+! family: 1,3_Insertion_CO2
+H2(2)+CO2(4)=HCOOH(7)                               1.510000e+09 1.230     73.900   
+DUPLICATE
+
+! Reaction index: Chemkin #4; RMG #65
+! Template reaction: 1,2_Insertion_CO
+! Flux pairs: CO(3), HCOOCH3(9); CH3OH(8), HCOOCH3(9); 
+! Matched reaction 7 CH4O + CO <=> C2H4O2 in 1,2_Insertion_CO/training
+! This reaction matched rate rule [CO;CsO_H]
+! family: 1,2_Insertion_CO
+CO(3)+CH3OH(8)=HCOOCH3(9)                           1.270000e-01 3.700     53.360   
+
+! Reaction index: Chemkin #5; RMG #67
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: CO2(4), HCOOCH3(9); CH4(24), HCOOCH3(9); 
+! Estimated using template [CO2;C_methane] for rate rule [CO2_Od;C_methane]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 8.0
+! family: 1,3_Insertion_CO2
+CO2(4)+CH4(24)=HCOOCH3(9)                           3.624000e+04 2.830     79.200   
+
+! Reaction index: Chemkin #6; RMG #134
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: H2(2), HCOOH(7); CO2(4), HCOOH(7); 
+! Matched reaction 1 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training
+! This reaction matched rate rule [CO2_Od;H2]
+! family: 1,3_Insertion_CO2
+H2(2)+CO2(4)=HCOOH(7)                               1.510000e+09 1.230     73.900   
+DUPLICATE
+
+! Reaction index: Chemkin #7; RMG #135
+! Template reaction: 1,3_Insertion_CO2
+! Flux pairs: H2(2), HCOOH(7); CO2(4), HCOOH(7); 
+! Matched reaction 1 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training
+! This reaction matched rate rule [CO2_Cdd;H2]
+! family: 1,3_Insertion_CO2
+H2(2)+CO2(4)=HCOOH(7)                               1.510000e+09 1.230     73.900   
+DUPLICATE
+
+END
+

--- a/rmgpy/tools/data/diffmodels/surf_model/chem_surface1.inp
+++ b/rmgpy/tools/data/diffmodels/surf_model/chem_surface1.inp
@@ -1,0 +1,1452 @@
+SITE   SDEN/2.9430E-09/ ! mol/cm^2
+    X(1)                ! X(1)
+    H*(10)              ! H*(10)
+    O*(11)              ! O*(11)
+    OH*(12)             ! OH*(12)
+    H2O*(13)            ! H2O*(13)
+    CO*(14)             ! CO*(14)
+    CO2*(15)            ! CO2*(15)
+    HCO*(16)            ! HCO*(16)
+    HCOO*(17)           ! HCOO*(17)
+    COOH*(18)           ! COOH*(18)
+    HCOOH*(19)          ! HCOOH*(19)
+    CH2O*(20)           ! CH2O*(20)
+    CH3O*(21)           ! CH3O*(21)
+    CH3O2*(22)          ! CH3O2*(22)
+    CH3OH*(23)          ! CH3OH*(23)
+    CH3X(33)            ! CH3X(33)
+    CH3OX(49)           ! OC[Pt](49)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+X(1)                    X   1               G   100.000  5000.000 1554.83      1
+ 1.60307222E-01-2.52245900E-04 1.14186593E-07-1.21483036E-11 3.85877475E-16    2
+-7.08139224E+01-9.09570138E-01 7.10115128E-03-4.25595874E-05 8.98470419E-08    3
+-7.80135147E-11 2.32448029E-14-8.76089587E-01-3.11202094E-02                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (1.00H) from Pt111
+H*(10)                  H   1X   1          G   100.000  5000.000  952.91      1
+ 2.80339839E+00-5.41050188E-04 4.99509826E-07-7.54968047E-11 3.06776036E-15    2
+-2.34632058E+03-1.59436891E+01-3.80966002E-01 5.47229382E-03 2.60910310E-06    3
+-9.64958626E-09 4.63945257E-12-1.40557038E+03 1.01725745E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (1.00O) from Pt111
+O*(11)                  O   1X   1          G   100.000  5000.000  888.26      1
+ 1.89893631E+00 2.03295404E-03-1.19976562E-06 2.32680628E-10-1.53508256E-14    2
+-2.21111565E+04-9.64104147E+00-7.59013115E-01 1.89868504E-02-3.82473769E-05    3
+ 3.43558429E-08-1.13974388E-11-2.18356104E+04 1.76017413E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50O) from Pt111
+OH*(12)                 H   1O   1X   1     G   100.000  5000.000  914.54      1
+ 2.43541504E+00 4.64599933E-03-2.39987608E-06 4.26351871E-10-2.60607840E-14    2
+-2.17972457E+04-1.03879495E+01-1.29522792E+00 3.36487597E-02-7.07760603E-05    3
+ 6.54375105E-08-2.19437885E-11-2.16453879E+04 4.37657050E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+H2O*(13)                H   2O   1X   1     G   100.000  5000.000  912.85      1
+ 1.12158639E+00 8.16639750E-03-4.02358324E-06 7.20421471E-10-4.51442820E-14    2
+-3.20615224E+04 3.39617196E+00-1.34340039E+00 3.66695415E-02-7.99480251E-05    3
+ 7.74124581E-08-2.68665058E-11-3.23490305E+04 1.10237632E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50C) from Pt111
+CO*(14)                 C   1O   1X   1     G   100.000  5000.000  891.33      1
+ 1.38094041E+00 8.05713036E-03-4.64305420E-06 8.91162171E-10-5.90041183E-14    2
+-2.23513341E+04-4.85336911E+00-1.38215450E+00 3.75307090E-02-8.29764914E-05    3
+ 8.09710767E-08-2.85475175E-11-2.25369943E+04 4.35452365E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+CO2*(15)                C   1O   2X   1     G   100.000  5000.000  882.27      1
+ 1.80887460E+00 9.73001688E-03-5.37608866E-06 1.03587819E-09-6.95102810E-14    2
+-4.74611396E+04 1.52797542E+00-1.54696247E+00 4.08810247E-02-8.54323885E-05    3
+ 8.20020261E-08-2.88134608E-11-4.74892334E+04 1.37825503E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.25C) from Pt111
+HCO*(16)                C   1H   1O   1X   1G   100.000  5000.000  873.23      1
+ 1.83275225E+00 1.00779631E-02-5.28538490E-06 1.01353243E-09-6.85194774E-14    2
+-2.18133044E+04-4.46364400E+00-1.43677423E+00 3.69240780E-02-7.17893681E-05    3
+ 6.73517254E-08-2.35170851E-11-2.16948347E+04 8.27554338E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50O) from Pt111
+HCOO*(17)               C   1H   1O   2X   1G   100.000  5000.000  833.17      1
+ 3.32786844E+00 1.20449095E-02-6.27964490E-06 1.22724372E-09-8.50487462E-14    2
+-4.87978749E+04-1.50585093E+01-1.79153904E+00 4.37078242E-02-7.60394596E-05    3
+ 6.72523533E-08-2.29589602E-11-4.81907161E+04 7.22955055E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.25C) from Pt111
+COOH*(18)               C   1H   1O   2X   1G   100.000  5000.000  816.25      1
+ 3.87906163E+00 9.05726886E-03-4.52242855E-06 8.78583742E-10-6.09444958E-14    2
+-4.71639607E+04-1.26538838E+01-1.63421214E+00 3.88306533E-02-6.43004439E-05    3
+ 5.38381130E-08-1.75481672E-11-4.63557233E+04 1.22627333E+01                   4
+
+! Gas phase thermo for formic_acid from Thermo library: thermo_DFT_CCSDTF12_BAC. Adsorption correction: + Thermo group additivity estimation:
+! adsorptionPt111((CR2CR)*) Binding energy corrected by LSR () from Pt111
+HCOOH*(19)              C   1H   2O   2X   1G   100.000  5000.000  950.51      1
+ 8.66760944E+00 3.45630332E-03-6.94158103E-07 1.78246629E-10-1.93202500E-14    2
+-4.95341783E+04-3.89598805E+01 3.66944203E+00-3.78130643E-03 5.53426538E-05    3
+-7.04170132E-08 2.67788595E-11-4.73069157E+04-8.38230194E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+CH2O*(20)               C   1H   2O   1X   1G   100.000  5000.000  879.32      1
+-8.92903522E-01 1.66196072E-02-8.71593607E-06 1.66816057E-09-1.12503437E-13    2
+-1.95446443E+04 1.78926946E+01-1.46697973E+00 4.13873024E-02-8.87621488E-05    3
+ 9.10118153E-08-3.36610498E-11-2.03002406E+04 1.57178687E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50O) from Pt111
+CH3O*(21)               C   1H   3O   1X   1G   100.000  5000.000  857.63      1
+ 1.14811430E+00 1.71341653E-02-8.39622759E-06 1.59804147E-09-1.08972465E-13    2
+-2.23413522E+04-2.79399018E+00-1.68430314E+00 4.28034059E-02-7.50824214E-05    3
+ 7.03742068E-08-2.50949131E-11-2.23137091E+04 7.76451793E+00                   4
+
+! Gas phase thermo for HOCH2O from Thermo library: DFT_QCI_thermo. Adsorption correction: + Thermo group additivity estimation: adsorptionPt111(O-*R)
+! Binding energy corrected by LSR (0.50O) from Pt111
+CH3O2*(22)              C   1H   3O   2X   1G   100.000  5000.000  932.26      1
+ 1.03101904E+01 3.04304995E-03 9.70278856E-08-3.19150622E-11-2.13569792E-15    2
+-4.99739943E+04-4.60926221E+01 3.21917816E+00 6.71702696E-03 3.72279056E-05    3
+-5.73643906E-08 2.36265626E-11-4.74893817E+04-6.14523883E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+CH3OH*(23)              C   1H   4O   1X   1G   100.000  5000.000  850.42      1
+ 1.01831911E+00 1.82967160E-02-8.58982218E-06 1.62232735E-09-1.10733684E-13    2
+-3.05921685E+04 3.59783126E+00-1.64007440E+00 4.09973323E-02-6.66153238E-05    3
+ 6.12093149E-08-2.17724745E-11-3.05087370E+04 1.38244506E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.25C) from Pt111
+CH3X(33)                C   1H   3X   1     G   100.000  5000.000  848.29      1
+ 1.62291819E+00 1.12987099E-02-5.08315892E-06 9.46831114E-10-6.42883447E-14    2
+-4.45987245E+02-5.42506309E+00-1.21090948E+00 2.92391268E-02-4.49013400E-05    3
+ 3.86013257E-08-1.30362737E-11-1.29918468E+02 6.80941342E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.25C) from Pt111
+CH3OX(49)               C   1H   3O   1X   1G   100.000  5000.000  813.95      1
+ 3.25578694E+00 1.30434899E-02-5.99159283E-06 1.13138564E-09-7.77150824E-14    2
+-2.98846737E+04-1.40488644E+01-1.68231785E+00 3.97248995E-02-5.96105928E-05    3
+ 4.86918513E-08-1.58047953E-11-2.91607667E+04 8.26686793E+00                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #31
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: H2(2), H*(10); X(1), H*(10); X(1), H*(10); 
+X(1)+X(1)+H2(2)=H*(10)+H*(10)                       4.600e-02 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #2; RMG #44
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: OH*(12), O*(11); X(1), H*(10); 
+X(1)+OH*(12)=O*(11)+H*(10)                          7.390000e+19 0.000     18.475   
+
+! Reaction index: Chemkin #3; RMG #34
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: X(1), H2O*(13); H2O(5), H2O*(13); 
+X(1)+H2O(5)=H2O*(13)                                7.500e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #4; RMG #45
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: H2O*(13), OH*(12); X(1), H*(10); 
+X(1)+H2O*(13)=H*(10)+OH*(12)                        1.150000e+19 0.000     24.235   
+
+! Reaction index: Chemkin #5; RMG #46
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: H2O*(13), OH*(12); O*(11), OH*(12); 
+O*(11)+H2O*(13)=OH*(12)+OH*(12)                     1.000000e+20 0.000     21.630   
+
+! Reaction index: Chemkin #6; RMG #37
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CO*(14), X(1); CO*(14), CO(3); 
+CO*(14)=X(1)+CO(3)                                  1.000000e+11 0.000     40.511   
+
+! Reaction index: Chemkin #7; RMG #35
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: X(1), CO2*(15); CO2(4), CO2*(15); 
+X(1)+CO2(4)=CO2*(15)                                5.000e-03 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #8; RMG #39
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CO*(14), CO2*(15); O*(11), X(1); 
+O*(11)+CO*(14)=X(1)+CO2*(15)                        3.700000e+21 0.000     28.107   
+
+! Reaction index: Chemkin #9; RMG #40
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CO*(14), CO2*(15); OH*(12), H*(10); 
+OH*(12)+CO*(14)=H*(10)+CO2*(15)                     1.000000e+19 0.000     9.250    
+
+! Reaction index: Chemkin #10; RMG #74
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), HCOO*(17); CO2(4), HCOO*(17); 
+! Estimated using template [Adsorbate1;Gas] for rate rule [*H;R=R]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CO2(4)=HCOO*(17)                             1.000e-05 0.000     16.410   
+    STICK
+
+! Reaction index: Chemkin #11; RMG #75
+! Template reaction: Surface_Migration
+! Flux pairs: HCOO*(17), COOH*(18); 
+! Exact match found for rate rule [Adsorbate1]
+! Euclidian distance = 0
+! family: Surface_Migration
+HCOO*(17)=COOH*(18)                                 1.000000e+13 0.000     11.950   
+
+! Reaction index: Chemkin #12; RMG #77
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), COOH*(18); CO2(4), COOH*(18); 
+! Estimated using template [Adsorbate1;Gas] for rate rule [*H;R=R]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CO2(4)=COOH*(18)                             1.000e-05 0.000     16.410   
+    STICK
+
+! Reaction index: Chemkin #13; RMG #78
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: HCOOH(7), HCOOH*(19); X(1), HCOOH*(19); 
+! Estimated using template [Adsorbate;VacantSite] for rate rule [O-H;VacantSite]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_vdW
+X(1)+HCOOH(7)=HCOOH*(19)                            1.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #14; RMG #79
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: CH2O(6), CH2O*(20); X(1), CH2O*(20); 
+! Estimated using template [Adsorbate;VacantSite] for rate rule [O;VacantSite]
+! Euclidian distance = 1.0
+! family: Surface_Adsorption_vdW
+X(1)+CH2O(6)=CH2O*(20)                              1.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #15; RMG #81
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), CH3O*(21); CH2O(6), CH3O*(21); 
+! Estimated using template [Adsorbate1;Gas] for rate rule [*H;R=R]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CH2O(6)=CH3O*(21)                            5.000e-06 0.000     16.410   
+    STICK
+
+! Reaction index: Chemkin #16; RMG #84
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: OH*(12), CH3O2*(22); CH2O(6), CH3O2*(22); 
+! Estimated using template [Adsorbate1;Gas] for rate rule [Adsorbate1;R=R]
+! Euclidian distance = 1.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+OH*(12)+CH2O(6)=CH3O2*(22)                          5.000e-06 0.000     16.410   
+    STICK
+
+! Reaction index: Chemkin #17; RMG #85
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), CH3O2*(22); HCOOH(7), CH3O2*(22); 
+! Estimated using template [Adsorbate1;Gas] for rate rule [*H;R=R]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+HCOOH(7)=CH3O2*(22)                          5.000e-06 0.000     16.410   
+    STICK
+
+! Reaction index: Chemkin #18; RMG #88
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: CH3OH(8), CH3OH*(23); X(1), CH3OH*(23); 
+! Estimated using template [Adsorbate;VacantSite] for rate rule [O-H;VacantSite]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_vdW
+X(1)+CH3OH(8)=CH3OH*(23)                            1.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #19; RMG #91
+! Template reaction: Surface_Adsorption_Dissociative_Double
+! Flux pairs: CO2(4), CO*(14); X(1), O*(11); X(1), O*(11); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [CO2;VacantSite1;VacantSite2]
+! Euclidian distance = 2.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Dissociative_Double
+X(1)+X(1)+CO2(4)=O*(11)+CO*(14)                     2.000e-02 0.000     10.000   
+    STICK
+
+! Reaction index: Chemkin #20; RMG #93
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: CH2O(6), HCO*(16); X(1), H*(10); X(1), H*(10); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+CH2O(6)=H*(10)+HCO*(16)                   2.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #21; RMG #96
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOH(7), HCO*(16); X(1), OH*(12); X(1), OH*(12); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOH(7)=OH*(12)+HCO*(16)                 1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #22; RMG #97
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOH(7), HCOO*(17); X(1), H*(10); X(1), H*(10); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOH(7)=H*(10)+HCOO*(17)                 1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #23; RMG #98
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOH(7), COOH*(18); X(1), H*(10); X(1), H*(10); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOH(7)=H*(10)+COOH*(18)                 1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #24; RMG #101
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: CH3OH(8), CH3O*(21); X(1), H*(10); X(1), H*(10); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+CH3OH(8)=H*(10)+CH3O*(21)                 1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #25; RMG #105
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOCH3(9), CH3O*(21); X(1), HCO*(16); X(1), HCO*(16); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOCH3(9)=HCO*(16)+CH3O*(21)             1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #26; RMG #112
+! Template reaction: Surface_Dissociation
+! Flux pairs: HCO*(16), CO*(14); HCO*(16), H*(10); 
+! Exact match found for rate rule [C-H;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation
+X(1)+HCO*(16)=H*(10)+CO*(14)                        3.200000e+21 0.000     15.570   
+
+! Reaction index: Chemkin #27; RMG #114
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CO2*(15), HCOO*(17); H*(10), HCOO*(17); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C=O;H*]
+! Euclidian distance = 3.1622776601683795
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Addition_Single_vdW
+H*(10)+CO2*(15)=X(1)+HCOO*(17)                      6.400000e+21 0.000     5.673    
+
+! Reaction index: Chemkin #28; RMG #115
+! Template reaction: Surface_Dissociation
+! Flux pairs: HCOO*(17), O*(11); HCOO*(17), HCO*(16); 
+! Estimated using template [Combined;VacantSite] for rate rule [O-C;VacantSite]
+! Euclidian distance = 2.0
+! family: Surface_Dissociation
+X(1)+HCOO*(17)=O*(11)+HCO*(16)                      3.200000e+21 0.000     52.326   
+
+! Reaction index: Chemkin #29; RMG #116
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CO2*(15), COOH*(18); H*(10), COOH*(18); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [CO2;H*]
+! Euclidian distance = 4.123105625617661
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Addition_Single_vdW
+H*(10)+CO2*(15)=X(1)+COOH*(18)                      6.400000e+21 0.000     7.407    
+
+! Reaction index: Chemkin #30; RMG #117
+! Template reaction: Surface_Dissociation
+! Flux pairs: COOH*(18), CO*(14); COOH*(18), OH*(12); 
+! Exact match found for rate rule [C-OH;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation
+X(1)+COOH*(18)=OH*(12)+CO*(14)                      3.200000e+21 0.000     31.216   
+
+! Reaction index: Chemkin #31; RMG #120
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), OH*(12); HCOOH*(19), HCO*(16); 
+! Exact match found for rate rule [Combined;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+HCOOH*(19)=OH*(12)+HCO*(16)                    3.200000e+21 0.000     32.670   
+DUPLICATE
+
+! Reaction index: Chemkin #32; RMG #121
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); HCOOH*(19), H*(10); 
+! Exact match found for rate rule [Combined;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+HCOOH*(19)=H*(10)+HCOO*(17)                    3.200000e+21 0.000     25.103   
+
+! Reaction index: Chemkin #33; RMG #122
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), HCO*(16); HCOOH*(19), OH*(12); 
+! Exact match found for rate rule [C-OH;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+HCOOH*(19)=OH*(12)+HCO*(16)                    3.200000e+21 0.000     32.670   
+DUPLICATE
+
+! Reaction index: Chemkin #34; RMG #123
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); HCOOH*(19), H*(10); 
+! Exact match found for rate rule [C-H;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+HCOOH*(19)=H*(10)+COOH*(18)                    3.200000e+21 0.000     17.102   
+
+! Reaction index: Chemkin #35; RMG #126
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH2O*(20), HCO*(16); CH2O*(20), H*(10); 
+! Exact match found for rate rule [C-H;VacantSite]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Dissociation_vdW
+X(1)+CH2O*(20)=H*(10)+HCO*(16)                      6.400000e+21 0.000     14.881   
+
+! Reaction index: Chemkin #36; RMG #128
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); H*(10), CH3O*(21); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;H*]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Addition_Single_vdW
+H*(10)+CH2O*(20)=X(1)+CH3O*(21)                     3.200000e+21 0.000     4.343    
+
+! Reaction index: Chemkin #37; RMG #130
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CH2O*(20), CH3O2*(22); OH*(12), CH3O2*(22); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;HO*]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Addition_Single_vdW
+OH*(12)+CH2O*(20)=X(1)+CH3O2*(22)                   3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #38; RMG #131
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); H*(10), CH3O2*(22); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;H*]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Addition_Single_vdW
+H*(10)+HCOOH*(19)=X(1)+CH3O2*(22)                   3.200000e+21 0.000     6.276    
+
+! Reaction index: Chemkin #39; RMG #134
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); CH3OH*(23), H*(10); 
+! Exact match found for rate rule [Combined;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+CH3OH*(23)=H*(10)+CH3O*(21)                    3.200000e+21 0.000     36.074   
+
+! Reaction index: Chemkin #40; RMG #240
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH2O*(20), HCOO*(17); O*(11), H*(10); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [AdsorbateVdW;*=O]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+! Ea raised from -31.6 to 0.0 kJ/mol.
+O*(11)+CH2O*(20)=H*(10)+HCOO*(17)                   6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #41; RMG #242
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CO*(14), COOH*(18); H2O*(13), H*(10); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [AdsorbateVdW;*=C=R]
+! Euclidian distance = 3.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+! Ea raised from 27.8 to 59.3 kJ/mol to match endothermicity of reaction.
+H2O*(13)+CO*(14)=H*(10)+COOH*(18)                   6.400000e+21 0.000     14.183   
+
+! Reaction index: Chemkin #42; RMG #245
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH2O*(20), HCOOH*(19); OH*(12), H*(10); 
+! Estimated using template [Donating;Abstracting] for rate rule [Donating;*O-H]
+! Euclidian distance = 2.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -28.0 to 0.0 kJ/mol.
+OH*(12)+CH2O*(20)=H*(10)+HCOOH*(19)                 6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #43; RMG #247
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCO*(16); H*(10), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-OH;Abstracting]
+! Euclidian distance = 3.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -22.4 to 0.0 kJ/mol.
+H*(10)+HCOOH*(19)=H2O*(13)+HCO*(16)                 3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #44; RMG #254
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O2*(22); O*(11), H*(10); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [AdsorbateVdW;*=O]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_vdW
+! Ea raised from 16.1 to 28.9 kJ/mol to match endothermicity of reaction.
+O*(11)+CH3OH*(23)=H*(10)+CH3O2*(22)                 9.600000e+21 0.000     6.905    
+
+! Reaction index: Chemkin #45; RMG #257
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: CH2O*(20), CH3O2*(22); H2O*(13), H*(10); 
+! Estimated using template [Adsorbate1;Adsorbate2] for rate rule [O=C;Adsorbate2]
+! Euclidian distance = 2.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Dual_Adsorption_vdW
+! Ea raised from 0.0 to 31.5 kJ/mol to match endothermicity of reaction.
+H2O*(13)+CH2O*(20)=H*(10)+CH3O2*(22)                6.400000e+21 0.000     7.524    
+
+! Reaction index: Chemkin #46; RMG #268
+! Template reaction: Surface_Abstraction
+! Flux pairs: HCO*(16), CO*(14); O*(11), OH*(12); 
+! Estimated using template [O;*C-H] for rate rule [O;*-C-H]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction
+O*(11)+HCO*(16)=OH*(12)+CO*(14)                     3.200000e+21 0.000     30.115   
+
+! Reaction index: Chemkin #47; RMG #269
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), HCOO*(17); OH*(12), O*(11); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C=O;*O-R]
+! Euclidian distance = 3.1622776601683795
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CO2*(15)=O*(11)+HCOO*(17)                   6.400000e+21 0.000     8.815    
+
+! Reaction index: Chemkin #48; RMG #271
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), COOH*(18); OH*(12), O*(11); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [CO2;*O-R]
+! Euclidian distance = 4.123105625617661
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CO2*(15)=O*(11)+COOH*(18)                   6.400000e+21 0.000     10.271   
+
+! Reaction index: Chemkin #49; RMG #272
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-C=R;*=O]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from -3.6 to 0.0 kJ/mol.
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 3.200000e+21 0.000     0.000    
+DUPLICATE
+
+! Reaction index: Chemkin #50; RMG #273
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_vdW
+! Ea raised from -3.6 to 0.0 kJ/mol.
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 3.200000e+21 0.000     0.000    
+DUPLICATE
+
+! Reaction index: Chemkin #51; RMG #275
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_vdW
+! Ea raised from 3.7 to 9.1 kJ/mol to match endothermicity of reaction.
+O*(11)+HCOOH*(19)=OH*(12)+COOH*(18)                 3.200000e+21 0.000     2.167    
+
+! Reaction index: Chemkin #52; RMG #276
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH2O*(20), HCO*(16); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+! Ea raised from -4.3 to 0.0 kJ/mol.
+O*(11)+CH2O*(20)=OH*(12)+HCO*(16)                   6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #53; RMG #277
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); OH*(12), O*(11); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;*O-R]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CH2O*(20)=O*(11)+CH3O*(21)                  3.200000e+21 0.000     7.697    
+
+! Reaction index: Chemkin #54; RMG #280
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); OH*(12), O*(11); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;*O-R]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+HCOOH*(19)=O*(11)+CH3O2*(22)                3.200000e+21 0.000     9.321    
+
+! Reaction index: Chemkin #55; RMG #281
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-C-3R;*=O]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from 36.0 to 69.6 kJ/mol to match endothermicity of reaction.
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 3.200000e+21 0.000     16.629   
+DUPLICATE
+
+! Reaction index: Chemkin #56; RMG #282
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_vdW
+! Ea raised from 36.0 to 69.6 kJ/mol to match endothermicity of reaction.
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 3.200000e+21 0.000     16.629   
+DUPLICATE
+
+! Reaction index: Chemkin #57; RMG #292
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CO*(14), HCO*(16); H2O*(13), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+! Ea raised from 47.9 to 96.0 kJ/mol to match endothermicity of reaction.
+H2O*(13)+CO*(14)=OH*(12)+HCO*(16)                   6.400000e+21 0.000     22.936   
+
+! Reaction index: Chemkin #58; RMG #294
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), HCO*(16); HCOOH*(19), OH*(12); 
+! Exact match found for rate rule [Combined;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+HCOOH*(19)=OH*(12)+HCO*(16)                    3.200000e+21 0.000     32.670   
+DUPLICATE
+
+! Reaction index: Chemkin #59; RMG #295
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), OH*(12); HCOOH*(19), HCO*(16); 
+! Exact match found for rate rule [C-OH;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+HCOOH*(19)=OH*(12)+HCO*(16)                    3.200000e+21 0.000     32.670   
+DUPLICATE
+
+! Reaction index: Chemkin #60; RMG #296
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); OH*(12), H2O*(13); 
+! Exact match found for rate rule [C-H;OH]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+HCOO*(17)=H2O*(13)+CO2*(15)                 3.200000e+21 0.000     11.776   
+
+! Reaction index: Chemkin #61; RMG #297
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-C=R;*=O]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from -3.6 to 0.0 kJ/mol.
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 3.200000e+21 0.000     0.000    
+DUPLICATE
+
+! Reaction index: Chemkin #62; RMG #298
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_vdW
+! Ea raised from -3.6 to 0.0 kJ/mol.
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 3.200000e+21 0.000     0.000    
+DUPLICATE
+
+! Reaction index: Chemkin #63; RMG #300
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); OH*(12), H2O*(13); 
+! Exact match found for rate rule [O-H;OH]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+COOH*(18)=H2O*(13)+CO2*(15)                 3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #64; RMG #302
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*O-H]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -49.7 to 0.0 kJ/mol.
+OH*(12)+HCOOH*(19)=H2O*(13)+HCOO*(17)               3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #65; RMG #304
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O-H]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -42.5 to 0.0 kJ/mol.
+OH*(12)+HCOOH*(19)=H2O*(13)+COOH*(18)               3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #66; RMG #306
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH2O*(20), HCO*(16); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O-H]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -50.4 to 0.0 kJ/mol.
+OH*(12)+CH2O*(20)=H2O*(13)+HCO*(16)                 6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #67; RMG #309
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O*(21), CH2O*(20); OH*(12), H2O*(13); 
+! Exact match found for rate rule [C-H;OH]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+CH3O*(21)=H2O*(13)+CH2O*(20)                9.600000e+21 0.000     13.586   
+
+! Reaction index: Chemkin #68; RMG #310
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-C-3R;*=O]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from 36.0 to 69.6 kJ/mol to match endothermicity of reaction.
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 3.200000e+21 0.000     16.629   
+DUPLICATE
+
+! Reaction index: Chemkin #69; RMG #311
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_vdW
+! Ea raised from 36.0 to 69.6 kJ/mol to match endothermicity of reaction.
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 3.200000e+21 0.000     16.629   
+DUPLICATE
+
+! Reaction index: Chemkin #70; RMG #315
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); OH*(12), H2O*(13); 
+! Exact match found for rate rule [C-H;OH]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+CH3O2*(22)=H2O*(13)+HCOOH*(19)              6.400000e+21 0.000     10.957   
+
+! Reaction index: Chemkin #71; RMG #318
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*O-H]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -10.1 to 0.0 kJ/mol.
+OH*(12)+CH3OH*(23)=H2O*(13)+CH3O*(21)               3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #72; RMG #336
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), HCOO*(17); HCO*(16), CO*(14); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C=O;*C-H]
+! Euclidian distance = 3.605551275463989
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+CO2*(15)+HCO*(16)=CO*(14)+HCOO*(17)                 6.400000e+21 0.000     8.462    
+
+! Reaction index: Chemkin #73; RMG #338
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), COOH*(18); HCO*(16), CO*(14); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [CO2;*C-H]
+! Euclidian distance = 4.47213595499958
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+CO2*(15)+HCO*(16)=CO*(14)+COOH*(18)                 6.400000e+21 0.000     9.919    
+
+! Reaction index: Chemkin #74; RMG #340
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from -1.8 to 0.0 kJ/mol.
+CO*(14)+HCOOH*(19)=HCO*(16)+HCOO*(17)               3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #75; RMG #341
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-OH;*=C=R]
+! Euclidian distance = 4.242640687119285
+! family: Surface_Abstraction_vdW
+! Ea raised from 5.4 to 14.6 kJ/mol to match endothermicity of reaction.
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               3.200000e+21 0.000     3.489    
+DUPLICATE
+
+! Reaction index: Chemkin #76; RMG #342
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from 5.4 to 14.6 kJ/mol to match endothermicity of reaction.
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               3.200000e+21 0.000     3.489    
+DUPLICATE
+
+! Reaction index: Chemkin #77; RMG #343
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH2O*(20), HCO*(16); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+! Ea raised from -2.5 to 0.0 kJ/mol.
+CO*(14)+CH2O*(20)=HCO*(16)+HCO*(16)                 6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #78; RMG #347
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); HCO*(16), CO*(14); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;*C-H]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Adsorption_Abstraction_vdW
+HCO*(16)+CH2O*(20)=CO*(14)+CH3O*(21)                3.200000e+21 0.000     7.345    
+
+! Reaction index: Chemkin #79; RMG #352
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: COOH*(18), CH3O2*(22); CH2O*(20), CO*(14); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;*C-R]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Adsorption_Abstraction_vdW
+COOH*(18)+CH2O*(20)=CO*(14)+CH3O2*(22)              3.200000e+21 0.000     7.376    
+
+! Reaction index: Chemkin #80; RMG #353
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); HCO*(16), CO*(14); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O=C;*C-H]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Adsorption_Abstraction_vdW
+HCO*(16)+HCOOH*(19)=CO*(14)+CH3O2*(22)              3.200000e+21 0.000     8.968    
+
+! Reaction index: Chemkin #81; RMG #355
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [O-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from 37.7 to 75.1 kJ/mol to match endothermicity of reaction.
+CO*(14)+CH3OH*(23)=HCO*(16)+CH3O*(21)               3.200000e+21 0.000     17.950   
+
+! Reaction index: Chemkin #82; RMG #360
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); HCOO*(17), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     27.934   
+
+! Reaction index: Chemkin #83; RMG #361
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     25.576   
+DUPLICATE
+
+! Reaction index: Chemkin #84; RMG #362
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     25.576   
+DUPLICATE
+
+! Reaction index: Chemkin #85; RMG #363
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+COOH*(18)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     23.218   
+
+! Reaction index: Chemkin #86; RMG #364
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+HCOO*(17)=CO2*(15)+CH2O*(20)               3.200000e+21 0.000     28.153   
+
+! Reaction index: Chemkin #87; RMG #365
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+COOH*(18)=CO2*(15)+CH2O*(20)               3.200000e+21 0.000     25.795   
+
+! Reaction index: Chemkin #88; RMG #369
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3O*(21)=CO2*(15)+CH3OH*(23)             3.200000e+21 0.000     15.073   
+
+! Reaction index: Chemkin #89; RMG #372
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3O*(21)=CO2*(15)+CH3OH*(23)             3.200000e+21 0.000     12.715   
+
+! Reaction index: Chemkin #90; RMG #382
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-OH;*=C=R]
+! Euclidian distance = 4.242640687119285
+! family: Surface_Abstraction_vdW
+! Ea raised from 5.4 to 14.6 kJ/mol to match endothermicity of reaction.
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               3.200000e+21 0.000     3.489    
+DUPLICATE
+
+! Reaction index: Chemkin #91; RMG #383
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Abstraction_vdW
+! Ea raised from 5.4 to 14.6 kJ/mol to match endothermicity of reaction.
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               3.200000e+21 0.000     3.489    
+DUPLICATE
+
+! Reaction index: Chemkin #92; RMG #385
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); HCO*(16), CH2O*(20); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*C=R]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from 0.7 to 3.9 kJ/mol to match endothermicity of reaction.
+HCO*(16)+HCOOH*(19)=HCOO*(17)+CH2O*(20)             3.200000e+21 0.000     0.944    
+
+! Reaction index: Chemkin #93; RMG #386
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); HCO*(16), CH2O*(20); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*C=R]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from 7.9 to 19.2 kJ/mol to match endothermicity of reaction.
+HCO*(16)+HCOOH*(19)=COOH*(18)+CH2O*(20)             3.200000e+21 0.000     4.599    
+
+! Reaction index: Chemkin #94; RMG #393
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O*(21), CH2O*(20); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O*(21)=CH2O*(20)+CH2O*(20)              9.600000e+21 0.000     29.963   
+
+! Reaction index: Chemkin #95; RMG #398
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Exact match found for rate rule [Combined;Adsorbate1]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            3.200000e+21 0.000     27.334   
+DUPLICATE
+
+! Reaction index: Chemkin #96; RMG #399
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            6.400000e+21 0.000     27.334   
+DUPLICATE
+
+! Reaction index: Chemkin #97; RMG #403
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); CH2O*(20), HCO*(16); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -40.2 to 0.0 kJ/mol.
+CH2O*(20)+CH3O*(21)=HCO*(16)+CH3OH*(23)             6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #98; RMG #408
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     25.576   
+DUPLICATE
+
+! Reaction index: Chemkin #99; RMG #409
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     25.576   
+DUPLICATE
+
+! Reaction index: Chemkin #100; RMG #410
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOOH*(19); COOH*(18), HCOO*(17); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*C=R]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -7.3 to 0.0 kJ/mol.
+COOH*(18)+HCOOH*(19)=HCOO*(17)+HCOOH*(19)           3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #101; RMG #413
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3O*(21)=CH2O*(20)+HCOOH*(19)            9.600000e+21 0.000     29.743   
+
+! Reaction index: Chemkin #102; RMG #417
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCOO*(17), HCOOH*(19); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3O2*(22)=HCOOH*(19)+HCOOH*(19)          6.400000e+21 0.000     27.115   
+
+! Reaction index: Chemkin #103; RMG #419
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*O]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -39.6 to 0.0 kJ/mol.
+HCOOH*(19)+CH3O*(21)=HCOO*(17)+CH3OH*(23)           3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #104; RMG #423
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3O*(21)=CH2O*(20)+HCOOH*(19)            9.600000e+21 0.000     27.385   
+
+! Reaction index: Chemkin #105; RMG #427
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); COOH*(18), HCOOH*(19); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3O2*(22)=HCOOH*(19)+HCOOH*(19)          6.400000e+21 0.000     24.757   
+
+! Reaction index: Chemkin #106; RMG #429
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -32.3 to 0.0 kJ/mol.
+HCOOH*(19)+CH3O*(21)=COOH*(18)+CH3OH*(23)           3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #107; RMG #433
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            6.400000e+21 0.000     27.334   
+DUPLICATE
+
+! Reaction index: Chemkin #108; RMG #438
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Exact match found for rate rule [Combined;Adsorbate1]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            3.200000e+21 0.000     27.334   
+DUPLICATE
+
+! Reaction index: Chemkin #109; RMG #448
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3O2*(22)=HCOOH*(19)+CH3OH*(23)          6.400000e+21 0.000     14.254   
+
+! Reaction index: Chemkin #110; RMG #465
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3O*(21)=CH2O*(20)+CH3OH*(23)            9.600000e+21 0.000     16.882   
+
+! Reaction index: Chemkin #111; RMG #82
+! Template reaction: Surface_Migration
+! Flux pairs: CH3O*(21), CH3OX(49); 
+! Exact match found for rate rule [Adsorbate1]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Migration
+CH3O*(21)=CH3OX(49)                                 3.000000e+13 0.000     11.950   
+
+! Reaction index: Chemkin #112; RMG #102
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: CH3OH(8), CH3OX(49); X(1), H*(10); X(1), H*(10); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+CH3OH(8)=H*(10)+CH3OX(49)                 3.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #113; RMG #132
+! Template reaction: Surface_Dissociation
+! Flux pairs: CH3O2*(22), O*(11); CH3O2*(22), CH3OX(49); 
+! Estimated using template [Combined;VacantSite] for rate rule [O-C;VacantSite]
+! Euclidian distance = 2.0
+! family: Surface_Dissociation
+X(1)+CH3O2*(22)=O*(11)+CH3OX(49)                    3.200000e+21 0.000     37.857   
+
+! Reaction index: Chemkin #114; RMG #136
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3OH*(23), CH3OX(49); CH3OH*(23), H*(10); 
+! Exact match found for rate rule [C-H;VacantSite]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Dissociation_vdW
+X(1)+CH3OH*(23)=H*(10)+CH3OX(49)                    9.600000e+21 0.000     18.135   
+
+! Reaction index: Chemkin #115; RMG #202
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: CH2O(6), CH3OX(49); H*(10), CH3OX(49); 
+! Estimated using template [Adsorbate1;Gas] for rate rule [*H;R=R]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CH2O(6)=CH3OX(49)                            5.000e-06 0.000     16.410   
+    STICK
+
+! Reaction index: Chemkin #116; RMG #251
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: H*(10), CH3OX(49); CH2O*(20), CH3OX(49); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [2R-C=O;H*]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Addition_Single_vdW
+H*(10)+CH2O*(20)=X(1)+CH3OX(49)                     3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #117; RMG #284
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3OX(49); O*(11), OH*(12); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_vdW
+! Ea raised from 7.4 to 12.6 kJ/mol to match endothermicity of reaction.
+O*(11)+CH3OH*(23)=OH*(12)+CH3OX(49)                 9.600000e+21 0.000     3.016    
+
+! Reaction index: Chemkin #118; RMG #308
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CH2O*(20), CH3OX(49); OH*(12), O*(11); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [2R-C=O;*O-R]
+! Euclidian distance = 3.1622776601683795
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CH2O*(20)=O*(11)+CH3OX(49)                  3.200000e+21 0.000     1.951    
+
+! Reaction index: Chemkin #119; RMG #320
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3OH*(23), CH3OX(49); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O-H]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -38.8 to 0.0 kJ/mol.
+OH*(12)+CH3OH*(23)=H2O*(13)+CH3OX(49)               9.600000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #120; RMG #324
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH2O*(20); OH*(12), H2O*(13); 
+! Exact match found for rate rule [O-H;OH]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+CH3OX(49)=H2O*(13)+CH2O*(20)                3.200000e+21 0.000     0.381    
+
+! Reaction index: Chemkin #121; RMG #357
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3OX(49); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-R;*=C=R]
+! Euclidian distance = 3.1622776601683795
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_vdW
+! Ea raised from 9.1 to 18.1 kJ/mol to match endothermicity of reaction.
+CO*(14)+CH3OH*(23)=HCO*(16)+CH3OX(49)               9.600000e+21 0.000     4.338    
+
+! Reaction index: Chemkin #122; RMG #370
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); CH3OX(49), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3OX(49)=CO2*(15)+CH3OH*(23)             3.200000e+21 0.000     24.377   
+
+! Reaction index: Chemkin #123; RMG #373
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); CH3OX(49), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3OX(49)=CO2*(15)+CH3OH*(23)             3.200000e+21 0.000     22.019   
+
+! Reaction index: Chemkin #124; RMG #391
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CH2O*(20), CH3OX(49); HCO*(16), CO*(14); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [2R-C=O;*C-H]
+! Euclidian distance = 3.605551275463989
+! family: Surface_Adsorption_Abstraction_vdW
+HCO*(16)+CH2O*(20)=CO*(14)+CH3OX(49)                3.200000e+21 0.000     1.598    
+
+! Reaction index: Chemkin #125; RMG #405
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3OX(49), CH3OH*(23); CH2O*(20), HCO*(16); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*C-3R]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -11.6 to 0.0 kJ/mol.
+CH2O*(20)+CH3OX(49)=HCO*(16)+CH3OH*(23)             6.400000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #126; RMG #420
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); CH3OX(49), CH3OH*(23); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*C-3R]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -10.9 to 0.0 kJ/mol.
+HCOOH*(19)+CH3OX(49)=HCOO*(17)+CH3OH*(23)           3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #127; RMG #430
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CH3OX(49), CH3OH*(23); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*C-3R]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -3.7 to 0.0 kJ/mol.
+HCOOH*(19)+CH3OX(49)=COOH*(18)+CH3OH*(23)           3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #128; RMG #437
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); CH3OX(49), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3OX(49)=CH2O*(20)+HCOOH*(19)            3.200000e+21 0.000     39.047   
+
+! Reaction index: Chemkin #129; RMG #440
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); CH3OX(49), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3OX(49)=CH2O*(20)+HCOOH*(19)            3.200000e+21 0.000     36.689   
+
+! Reaction index: Chemkin #130; RMG #449
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); CH3OX(49), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3OX(49)+CH3O2*(22)=HCOOH*(19)+CH3OH*(23)          6.400000e+21 0.000     23.558   
+
+! Reaction index: Chemkin #131; RMG #453
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH2O*(20); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3OX(49)=CH2O*(20)+CH2O*(20)              3.200000e+21 0.000     39.267   
+
+! Reaction index: Chemkin #132; RMG #466
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH3OH*(23); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3OX(49)=CH2O*(20)+CH3OH*(23)            9.600000e+21 0.000     26.186   
+DUPLICATE
+
+! Reaction index: Chemkin #133; RMG #468
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH3OH*(23); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3OX(49)=CH2O*(20)+CH3OH*(23)            3.200000e+21 0.000     26.186   
+DUPLICATE
+
+! Reaction index: Chemkin #134; RMG #469
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH3OH*(23); CH3OX(49), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3OX(49)+CH3OX(49)=CH2O*(20)+CH3OH*(23)            3.200000e+21 0.000     35.490   
+
+! Reaction index: Chemkin #135; RMG #484
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3OH*(23), CH3OH*(23); CH3O*(21), CH3OX(49); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -28.6 to 0.0 kJ/mol.
+CH3O*(21)+CH3OH*(23)=CH3OX(49)+CH3OH*(23)           9.600000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #136; RMG #538
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH3OH*(23); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3OX(49)=CH2O*(20)+CH3OH*(23)            9.600000e+21 0.000     26.186   
+DUPLICATE
+
+! Reaction index: Chemkin #137; RMG #539
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3OX(49), CH3OH*(23); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3OX(49)=CH2O*(20)+CH3OH*(23)            3.200000e+21 0.000     26.186   
+DUPLICATE
+
+! Reaction index: Chemkin #138; RMG #100
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: CH3OH(8), CH3X(33); X(1), OH*(12); X(1), OH*(12); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+CH3OH(8)=OH*(12)+CH3X(33)                 1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #139; RMG #104
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOCH3(9), HCOO*(17); X(1), CH3X(33); X(1), CH3X(33); 
+! Exact match found for rate rule [Adsorbate;VacantSite1;VacantSite2]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOCH3(9)=HCOO*(17)+CH3X(33)             1.000e-02 0.000     9.990    
+    STICK
+
+! Reaction index: Chemkin #140; RMG #129
+! Template reaction: Surface_Dissociation
+! Flux pairs: CH3O*(21), O*(11); CH3O*(21), CH3X(33); 
+! Estimated using template [Combined;VacantSite] for rate rule [O-C;VacantSite]
+! Euclidian distance = 2.0
+! family: Surface_Dissociation
+X(1)+CH3O*(21)=O*(11)+CH3X(33)                      3.200000e+21 0.000     44.971   
+
+! Reaction index: Chemkin #141; RMG #133
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3OH*(23), OH*(12); CH3OH*(23), CH3X(33); 
+! Exact match found for rate rule [Combined;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+CH3OH*(23)=OH*(12)+CH3X(33)                    3.200000e+21 0.000     38.563   
+DUPLICATE
+
+! Reaction index: Chemkin #142; RMG #135
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3OH*(23), CH3X(33); CH3OH*(23), OH*(12); 
+! Exact match found for rate rule [C-OH;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+CH3OH*(23)=OH*(12)+CH3X(33)                    3.200000e+21 0.000     38.563   
+DUPLICATE
+
+! Reaction index: Chemkin #143; RMG #261
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3OH*(23), CH3X(33); H*(10), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-OH;Abstracting]
+! Euclidian distance = 3.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -1.2 to 0.0 kJ/mol.
+H*(10)+CH3OH*(23)=H2O*(13)+CH3X(33)                 3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #144; RMG #356
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), COOH*(18); CO*(14), CH3X(33); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [C-OH;*=C=R]
+! Euclidian distance = 4.242640687119285
+! family: Surface_Abstraction_vdW
+! Ea raised from 26.7 to 54.5 kJ/mol to match endothermicity of reaction.
+CO*(14)+CH3OH*(23)=COOH*(18)+CH3X(33)               3.200000e+21 0.000     13.037   
+
+! Reaction index: Chemkin #145; RMG #404
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), CH3OH*(23); CH3X(33), HCO*(16); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-OH;*C-3R]
+! Euclidian distance = 3.605551275463989
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -21.2 to 0.0 kJ/mol.
+HCOOH*(19)+CH3X(33)=HCO*(16)+CH3OH*(23)             3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #146; RMG #470
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: CH3OH*(23), CH3O2*(22); CH2O*(20), CH3X(33); 
+! Estimated using template [Adsorbate1;Adsorbate2] for rate rule [O=C;C-OH]
+! Euclidian distance = 3.605551275463989
+! family: Surface_Dual_Adsorption_vdW
+! Ea raised from 0.0 to 26.7 kJ/mol to match endothermicity of reaction.
+CH2O*(20)+CH3OH*(23)=CH3X(33)+CH3O2*(22)            3.200000e+21 0.000     6.378    
+
+! Reaction index: Chemkin #147; RMG #569
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3OH*(23), CH3X(33); CH3OH*(23), OH*(12); 
+! Exact match found for rate rule [Combined;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+CH3OH*(23)=OH*(12)+CH3X(33)                    3.200000e+21 0.000     38.563   
+DUPLICATE
+
+! Reaction index: Chemkin #148; RMG #570
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3OH*(23), OH*(12); CH3OH*(23), CH3X(33); 
+! Exact match found for rate rule [C-OH;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Dissociation_vdW
+X(1)+CH3OH*(23)=OH*(12)+CH3X(33)                    3.200000e+21 0.000     38.563   
+DUPLICATE
+
+! Reaction index: Chemkin #149; RMG #32
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CH4(32), CH3X(33); X(1), OH*(12); O*(11), OH*(12); 
+X(1)+O*(11)+CH4(32)=OH*(12)+CH3X(33)                5.000000e+18 0.700     10.038   
+
+! Reaction index: Chemkin #150; RMG #33
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CH4(32), CH3X(33); X(1), H2O*(13); OH*(12), H2O*(13); 
+X(1)+OH*(12)+CH4(32)=H2O*(13)+CH3X(33)              1.000e+00 0.000     2.390    
+    STICK
+
+! Reaction index: Chemkin #151; RMG #48
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CH3X(33), CH4(32); H*(10), X(1); H*(10), X(1); 
+H*(10)+CH3X(33)=X(1)+X(1)+CH4(32)                   3.300000e+21 0.000     11.950   
+
+END
+

--- a/rmgpy/tools/data/diffmodels/surf_model/chem_surface2.inp
+++ b/rmgpy/tools/data/diffmodels/surf_model/chem_surface2.inp
@@ -1,0 +1,1203 @@
+SITE   SDEN/2.9430E-09/ ! mol/cm^2
+    X(1)                ! X(1)
+    H*(10)              ! H*(10)
+    O*(11)              ! O*(11)
+    OH*(12)             ! OH*(12)
+    H2O*(13)            ! H2O*(13)
+    CO*(14)             ! CO*(14)
+    CO2*(15)            ! CO2*(15)
+    HCO*(16)            ! HCO*(16)
+    HCOO*(17)           ! HCOO*(17)
+    COOH*(18)           ! COOH*(18)
+    HCOOH*(19)          ! HCOOH*(19)
+    CH2O*(20)           ! CH2O*(20)
+    CH3O*(21)           ! CH3O*(21)
+    CH3O2*(22)          ! CH3O2*(22)
+    CH3OH*(23)          ! CH3OH*(23)
+    H2X(53)             ! [H][H].[Pt](53)
+END
+
+
+
+THERM ALL
+    300.000  1000.000  5000.000
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+X(1)                    X   1               G   100.000  5000.000 1554.81      1
+ 1.60301287E-01-2.52237396E-04 1.14182282E-07-1.21473809E-11 3.85806589E-16    2
+-7.08108147E+01-9.09535600E-01 7.10134880E-03-4.25615041E-05 8.98521156E-08    3
+-7.80182565E-11 2.32462166E-14-8.76099414E-01-3.11209498E-02                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (1.00H) from Pt111
+H*(10)                  H   1X   1          G   100.000  5000.000  952.91      1
+ 2.80337105E+00-5.41002993E-04 4.99482316E-07-7.54902555E-11 3.06721398E-15    2
+-2.34633659E+03-1.59435356E+01-3.80957846E-01 5.47219393E-03 2.60946928E-06    3
+-9.65008412E-09 4.63967474E-12-1.40559800E+03 1.01722845E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (1.00O) from Pt111
+O*(11)                  O   1X   1          G   100.000  5000.000  888.25      1
+ 1.89894867E+00 2.03293217E-03-1.19975265E-06 2.32677501E-10-1.53505623E-14    2
+-2.21111473E+04-9.64111055E+00-7.59018036E-01 1.89869128E-02-3.82476163E-05    3
+ 3.43561864E-08-1.13976013E-11-2.18355961E+04 1.76019150E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50O) from Pt111
+OH*(12)                 H   1O   1X   1     G   100.000  5000.000  914.54      1
+ 2.43538338E+00 4.64605477E-03-2.39990873E-06 4.26359701E-10-2.60614408E-14    2
+-2.17972259E+04-1.03877722E+01-1.29521674E+00 3.36486200E-02-7.07755341E-05    3
+ 6.54367721E-08-2.19434475E-11-2.16453814E+04 4.37653089E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+H2O*(13)                H   2O   1X   1     G   100.000  5000.000  912.85      1
+ 1.12159987E+00 8.16637387E-03-4.02356932E-06 7.20418131E-10-4.51440018E-14    2
+-3.20615278E+04 3.39609648E+00-1.34340519E+00 3.66696015E-02-7.99482515E-05    3
+ 7.74127762E-08-2.68666529E-11-3.23490303E+04 1.10237802E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50C) from Pt111
+CO*(14)                 C   1O   1X   1     G   100.000  5000.000  891.32      1
+ 1.38101738E+00 8.05699435E-03-4.64297360E-06 8.91142754E-10-5.90024841E-14    2
+-2.23513389E+04-4.85379925E+00-1.38218471E+00 3.75310911E-02-8.29779551E-05    3
+ 8.09731714E-08-2.85485057E-11-2.25369671E+04 4.35463035E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+CO2*(15)                C   1O   2X   1     G   100.000  5000.000  882.20      1
+ 1.80941218E+00 9.72906358E-03-5.37552236E-06 1.03574152E-09-6.94987626E-14    2
+-4.74613533E+04 1.52497318E+00-1.54718249E+00 4.08838213E-02-8.54431738E-05    3
+ 8.20175827E-08-2.88208633E-11-4.74892240E+04 1.37833266E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.25C) from Pt111
+HCO*(16)                C   1H   1O   1X   1G   100.000  5000.000  873.22      1
+ 1.83280289E+00 1.00778729E-02-5.28533123E-06 1.01351946E-09-6.85183825E-14    2
+-2.18133115E+04-4.46392663E+00-1.43679585E+00 3.69243541E-02-7.17904403E-05    3
+ 6.73532841E-08-2.35178331E-11-2.16948208E+04 8.27561958E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50O) from Pt111
+HCOO*(17)               C   1H   1O   2X   1G   100.000  5000.000  833.17      1
+ 3.32787355E+00 1.20449003E-02-6.27963935E-06 1.22724237E-09-8.50486314E-14    2
+-4.87978699E+04-1.50585377E+01-1.79154169E+00 4.37078588E-02-7.60395981E-05    3
+ 6.72525618E-08-2.29590643E-11-4.81907089E+04 7.22955985E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.25C) from Pt111
+COOH*(18)               C   1H   1O   2X   1G   100.000  5000.000  816.24      1
+ 3.87906825E+00 9.05725681E-03-4.52242126E-06 8.78581960E-10-6.09443442E-14    2
+-4.71639503E+04-1.26539206E+01-1.63421584E+00 3.88307021E-02-6.43006419E-05    3
+ 5.38384161E-08-1.75483211E-11-4.63557102E+04 1.22627462E+01                   4
+
+! Gas phase thermo for formic_acid from Thermo library: thermo_DFT_CCSDTF12_BAC. Adsorption correction: + Thermo group additivity estimation:
+! adsorptionPt111((CR2NR)*) Binding energy corrected by LSR () from Pt111
+HCOOH*(19)              C   1H   2O   2X   1G   100.000  5000.000  950.51      1
+ 8.66761161E+00 3.45629958E-03-6.94155921E-07 1.78246109E-10-1.93202067E-14    2
+-5.53463582E+04-3.89598926E+01 3.66944137E+00-3.78129831E-03 5.53426240E-05    3
+-7.04169728E-08 2.67788414E-11-5.31190947E+04-8.38229959E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+CH2O*(20)               C   1H   2O   1X   1G   100.000  5000.000  879.33      1
+-8.93024415E-01 1.66198218E-02-8.71606366E-06 1.66819138E-09-1.12506034E-13    2
+-1.95445963E+04 1.78933696E+01-1.46692959E+00 4.13866641E-02-8.87596815E-05    3
+ 9.10082475E-08-3.36593473E-11-2.03002428E+04 1.57176919E+01                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR (0.50O) from Pt111
+CH3O*(21)               C   1H   3O   1X   1G   100.000  5000.000  857.63      1
+ 1.14809427E+00 1.71342011E-02-8.39624904E-06 1.59804667E-09-1.08972905E-13    2
+-2.23413373E+04-2.79387857E+00-1.68429396E+00 4.28032876E-02-7.50819566E-05    3
+ 7.03735216E-08-2.50945792E-11-2.23137024E+04 7.76448563E+00                   4
+
+! Gas phase thermo for HOCH2O from Thermo library: DFT_QCI_thermo. Adsorption correction: + Thermo group additivity estimation: adsorptionPt111(O-*R)
+! Binding energy corrected by LSR (0.50O) from Pt111
+CH3O2*(22)              C   1H   3O   2X   1G   100.000  5000.000  932.24      1
+ 1.03099669E+01 3.04343871E-03 9.68000311E-08-3.18606028E-11-2.14025476E-15    2
+-4.99738961E+04-4.60913694E+01 3.21925112E+00 6.71612381E-03 3.72312644E-05    3
+-5.73690349E-08 2.36286733E-11-4.74893778E+04-6.14549771E+00                   4
+
+! Thermo library: surfaceThermoPt111 Binding energy corrected by LSR () from Pt111
+CH3OH*(23)              C   1H   4O   1X   1G   100.000  5000.000  850.41      1
+ 1.01837680E+00 1.82966124E-02-8.58976010E-06 1.62231227E-09-1.10732408E-13    2
+-3.05921911E+04 3.59750989E+00-1.64010182E+00 4.09976870E-02-6.66167251E-05    3
+ 6.12113937E-08-2.17734945E-11-3.05087358E+04 1.38245470E+01                   4
+
+! Thermo library: surfaceThermoCu111 Binding energy corrected by LSR () from Cu111
+H2X(53)                 H   2X   1          G   100.000  5000.000  911.32      1
+ 6.45748470E-01 6.69543366E-03-3.82678817E-06 7.04696395E-10-4.41000210E-14    2
+-1.08694554E+03 7.14568126E+00-1.27860902E+00 3.68015330E-02-8.90316729E-05    3
+ 8.91160499E-08-3.14524444E-11-1.63561676E+03 1.13162042E+01                   4
+
+END
+
+
+
+REACTIONS    KCAL/MOLE   MOLES
+
+! Reaction index: Chemkin #1; RMG #31
+! Library reaction: Surface/Methane/Deutschmann_Ni
+! Flux pairs: H2(2), H*(10); X(1), H*(10); X(1), H*(10); 
+X(1)+X(1)+H2(2)=H*(10)+H*(10)                       3.200e-02 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #2; RMG #48
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: OH*(12), O*(11); X(1), H*(10); 
+X(1)+OH*(12)=O*(11)+H*(10)                          7.390000e+19 0.000     18.475   
+    COV / O*(11)                                    0         0         -17.500   /
+
+! Reaction index: Chemkin #3; RMG #41
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: X(1), H2O*(13); H2O(5), H2O*(13); 
+X(1)+H2O(5)=H2O*(13)                                7.500e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #4; RMG #49
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: H2O*(13), OH*(12); X(1), H*(10); 
+X(1)+H2O*(13)=H*(10)+OH*(12)                        1.150000e+19 0.000     24.235   
+    COV / O*(11)                                    0         0         40.000    /
+
+! Reaction index: Chemkin #5; RMG #50
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: H2O*(13), OH*(12); O*(11), OH*(12); 
+O*(11)+H2O*(13)=OH*(12)+OH*(12)                     1.000000e+20 0.000     21.630   
+    COV / O*(11)                                    0         0         -57.500   /
+
+! Reaction index: Chemkin #6; RMG #33
+! Library reaction: Surface/Methane/Deutschmann_Ni
+! Flux pairs: X(1), CO*(14); CO(3), CO*(14); 
+X(1)+CO(3)=CO*(14)                                  5.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #7; RMG #42
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: X(1), CO2*(15); CO2(4), CO2*(15); 
+X(1)+CO2(4)=CO2*(15)                                5.000e-03 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #8; RMG #43
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CO*(14), CO2*(15); O*(11), X(1); 
+O*(11)+CO*(14)=X(1)+CO2*(15)                        3.700000e+21 0.000     28.107   
+    COV / CO*(14)                                   0         0         -7.887    /
+
+! Reaction index: Chemkin #9; RMG #44
+! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
+! Flux pairs: CO*(14), CO2*(15); OH*(12), H*(10); 
+OH*(12)+CO*(14)=H*(10)+CO2*(15)                     1.000000e+19 0.000     9.250    
+    COV / CO*(14)                                   0         0         -7.170    /
+
+! Reaction index: Chemkin #10; RMG #38
+! Library reaction: Surface/Methane/Deutschmann_Ni
+! Flux pairs: HCO*(16), COOH*(18); OH*(12), H*(10); 
+OH*(12)+HCO*(16)=H*(10)+COOH*(18)                   2.280000e+20 0.263     3.800    
+
+! Reaction index: Chemkin #11; RMG #78
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), HCOO*(17); CO2(4), HCOO*(17); 
+! Estimated using template [Adsorbate1;R=R] for rate rule [*H;R=R]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CO2(4)=HCOO*(17)                             1.000e-01 0.000     17.462   
+    STICK
+
+! Reaction index: Chemkin #12; RMG #79
+! Template reaction: Surface_Migration
+! Flux pairs: HCOO*(17), COOH*(18); 
+! Estimated using an average for rate rule [Adsorbate1]
+! Euclidian distance = 0
+! family: Surface_Migration
+HCOO*(17)=COOH*(18)                                 2.500000e+12 0.000     14.465   
+
+! Reaction index: Chemkin #13; RMG #81
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), COOH*(18); CO2(4), COOH*(18); 
+! Estimated using template [Adsorbate1;R=R] for rate rule [*H;R=R]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CO2(4)=COOH*(18)                             1.000e-01 0.000     17.462   
+    STICK
+
+! Reaction index: Chemkin #14; RMG #82
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: HCOOH(7), HCOOH*(19); X(1), HCOOH*(19); 
+! Estimated using an average for rate rule [O-H;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Adsorption_vdW
+X(1)+HCOOH(7)=HCOOH*(19)                            1.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #15; RMG #83
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: CH2O(6), CH2O*(20); X(1), CH2O*(20); 
+! Estimated using an average for rate rule [O;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Adsorption_vdW
+X(1)+CH2O(6)=CH2O*(20)                              1.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #16; RMG #85
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), CH3O*(21); CH2O(6), CH3O*(21); 
+! Estimated using template [Adsorbate1;R=R] for rate rule [*H;R=R]
+! Euclidian distance = 1.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+CH2O(6)=CH3O*(21)                            5.000e-02 0.000     17.462   
+    STICK
+
+! Reaction index: Chemkin #17; RMG #88
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: OH*(12), CH3O2*(22); CH2O(6), CH3O2*(22); 
+! Estimated using an average for rate rule [Adsorbate1;R=R]
+! Euclidian distance = 0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+OH*(12)+CH2O(6)=CH3O2*(22)                          5.000e-02 0.000     17.462   
+    STICK
+
+! Reaction index: Chemkin #18; RMG #89
+! Template reaction: Surface_EleyRideal_Addition_Multiple_Bond
+! Flux pairs: H*(10), CH3O2*(22); HCOOH(7), CH3O2*(22); 
+! Estimated using template [Adsorbate1;R=R] for rate rule [*H;R=R]
+! Euclidian distance = 1.0
+! family: Surface_EleyRideal_Addition_Multiple_Bond
+H*(10)+HCOOH(7)=CH3O2*(22)                          5.000e-02 0.000     17.462   
+    STICK
+
+! Reaction index: Chemkin #19; RMG #92
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: CH3OH(8), CH3OH*(23); X(1), CH3OH*(23); 
+! Estimated using an average for rate rule [O-H;VacantSite]
+! Euclidian distance = 0
+! family: Surface_Adsorption_vdW
+X(1)+CH3OH(8)=CH3OH*(23)                            1.000e-01 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #20; RMG #96
+! Template reaction: Surface_Adsorption_Dissociative_Double
+! Flux pairs: CO2(4), CO*(14); X(1), O*(11); X(1), O*(11); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [CO2;VacantSite1;VacantSite2]
+! Euclidian distance = 2.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Dissociative_Double
+X(1)+X(1)+CO2(4)=O*(11)+CO*(14)                     2.000e-02 0.000     10.000   
+    STICK
+
+! Reaction index: Chemkin #21; RMG #97
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: H2O(5), OH*(12); X(1), H*(10); X(1), H*(10); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [H2O;VacantSite1;VacantSite2]
+! Euclidian distance = 3.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Dissociative
+! Ea raised from 56.3 to 59.6 kJ/mol to match endothermicity of reaction.
+X(1)+X(1)+H2O(5)=H*(10)+OH*(12)                     3.000e-02 0.000     14.250   
+    STICK
+
+! Reaction index: Chemkin #22; RMG #98
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: CH2O(6), HCO*(16); X(1), H*(10); X(1), H*(10); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [C-H;VacantSite1;VacantSite2]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+CH2O(6)=H*(10)+HCO*(16)                   3.000e-02 0.000     1.195    
+    STICK
+
+! Reaction index: Chemkin #23; RMG #100
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOH(7), HCO*(16); X(1), OH*(12); X(1), OH*(12); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [O-C;VacantSite1;VacantSite2]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOH(7)=OH*(12)+HCO*(16)                 1.500e-02 0.000     6.912    
+    STICK
+
+! Reaction index: Chemkin #24; RMG #101
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOH(7), HCOO*(17); X(1), H*(10); X(1), H*(10); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [O-H;VacantSite1;VacantSite2]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOH(7)=H*(10)+HCOO*(17)                 1.500e-02 0.000     1.195    
+    STICK
+
+! Reaction index: Chemkin #25; RMG #102
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOH(7), COOH*(18); X(1), H*(10); X(1), H*(10); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [C-H;VacantSite1;VacantSite2]
+! Euclidian distance = 1.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOH(7)=H*(10)+COOH*(18)                 1.500e-02 0.000     1.195    
+    STICK
+
+! Reaction index: Chemkin #26; RMG #105
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: CH3OH(8), CH3O*(21); X(1), H*(10); X(1), H*(10); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [O-H;VacantSite1;VacantSite2]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_Dissociative
+! Ea raised from 12.9 to 15.2 kJ/mol to match endothermicity of reaction.
+X(1)+X(1)+CH3OH(8)=H*(10)+CH3O*(21)                 1.500e-02 0.000     3.629    
+    STICK
+
+! Reaction index: Chemkin #27; RMG #108
+! Template reaction: Surface_Adsorption_Dissociative
+! Flux pairs: HCOOCH3(9), CH3O*(21); X(1), HCO*(16); X(1), HCO*(16); 
+! Estimated using template [Adsorbate;VacantSite1;VacantSite2] for rate rule [O-C;VacantSite1;VacantSite2]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_Dissociative
+X(1)+X(1)+HCOOCH3(9)=HCO*(16)+CH3O*(21)             1.500e-02 0.000     1.248    
+    STICK
+
+! Reaction index: Chemkin #28; RMG #113
+! Template reaction: Surface_Dissociation
+! Flux pairs: CO*(14), HCO*(16); H*(10), HCO*(16); 
+! Matched reaction 26 OCX_3 + HX_5 <=> CXHO_1 + Ni_4 in Surface_Dissociation/training
+! This reaction matched rate rule [C-H;VacantSite]
+! family: Surface_Dissociation
+! metal: None
+H*(10)+CO*(14)=X(1)+HCO*(16)                        3.140000e+21 0.000     22.830   
+
+! Reaction index: Chemkin #29; RMG #114
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CO2*(15), HCOO*(17); H*(10), HCOO*(17); 
+! Matched reaction 17 CO2* + H* <=> HCOO* + X_5 in Surface_Addition_Single_vdW/training
+! This reaction matched rate rule [O=C=O;H*]
+! family: Surface_Addition_Single_vdW
+! metal: None
+H*(10)+CO2*(15)=X(1)+HCOO*(17)                      1.243000e+22 0.000     20.063   
+
+! Reaction index: Chemkin #30; RMG #115
+! Template reaction: Surface_Dissociation
+! Flux pairs: HCOO*(17), O*(11); HCOO*(17), HCO*(16); 
+! Matched reaction 28 HCOO* + Ni_4 <=> HCO* + OX_3 in Surface_Dissociation/training
+! This reaction matched rate rule [O-C=O;VacantSite]
+! family: Surface_Dissociation
+! metal: None
+X(1)+HCOO*(17)=O*(11)+HCO*(16)                      8.733000e+20 0.000     54.423   
+
+! Reaction index: Chemkin #31; RMG #116
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CO2*(15), COOH*(18); H*(10), COOH*(18); 
+! Matched reaction 45 CO2_2* + H* <=> COOH* + X_5 in Surface_Addition_Single_vdW/training
+! This reaction matched rate rule [CO2;H*]
+! family: Surface_Addition_Single_vdW
+! metal: None
+H*(10)+CO2*(15)=X(1)+COOH*(18)                      6.250000e+24 -0.475    28.011   
+
+! Reaction index: Chemkin #32; RMG #117
+! Template reaction: Surface_Dissociation
+! Flux pairs: CO*(14), COOH*(18); OH*(12), COOH*(18); 
+! Matched reaction 1 OCX_3 + HOX_5 <=> HOCXO_1 + Ni_4 in Surface_Dissociation/training
+! This reaction matched rate rule [C-OH;VacantSite]
+! family: Surface_Dissociation
+! metal: None
+OH*(12)+CO*(14)=X(1)+COOH*(18)                      4.020000e+18 0.000     2.749    
+
+! Reaction index: Chemkin #33; RMG #119
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOOH*(19), OH*(12); HCOOH*(19), HCO*(16); 
+! Matched reaction 34 HCOOH_2* + X_4 <=> HCO* + OH_2* in Surface_Dissociation_vdW/training
+! This reaction matched rate rule [Combined;VacantSite]
+! family: Surface_Dissociation_vdW
+! metal: None
+X(1)+HCOOH*(19)=OH*(12)+HCO*(16)                    1.781000e+21 0.000     37.589   
+
+! Reaction index: Chemkin #34; RMG #120
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); H*(10), HCOOH*(19); 
+! Matched reaction 19 HCOO* + H* <=> HCOOH_1* + X_4 in Surface_Dissociation_vdW/training
+! This reaction matched rate rule [O-H;VacantSite]
+! family: Surface_Dissociation_vdW
+! metal: None
+H*(10)+HCOO*(17)=X(1)+HCOOH*(19)                    4.424000e+22 0.000     20.985   
+
+! Reaction index: Chemkin #35; RMG #121
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); H*(10), HCOOH*(19); 
+! Matched reaction 13 COOH* + H* <=> HCOOH* + X_4 in Surface_Dissociation_vdW/training
+! This reaction matched rate rule [C-H;VacantSite]
+! family: Surface_Dissociation_vdW
+! metal: None
+H*(10)+COOH*(18)=X(1)+HCOOH*(19)                    2.308000e+22 0.000     16.834   
+
+! Reaction index: Chemkin #36; RMG #123
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: HCO*(16), CH2O*(20); H*(10), CH2O*(20); 
+! Matched reaction 30 HCO* + H* <=> CH2O* + X_4 in Surface_Dissociation_vdW/training
+! This reaction matched rate rule [C-H;VacantSite]
+! family: Surface_Dissociation_vdW
+! metal: None
+H*(10)+HCO*(16)=X(1)+CH2O*(20)                      1.932000e+21 0.000     10.838   
+
+! Reaction index: Chemkin #37; RMG #124
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); H*(10), CH3O*(21); 
+! Matched reaction 24 CH2O* + H* <=> CH3O_1* + X_5 in Surface_Addition_Single_vdW/training
+! This reaction matched rate rule [O=C;H*]
+! family: Surface_Addition_Single_vdW
+! metal: None
+H*(10)+CH2O*(20)=X(1)+CH3O*(21)                     6.167000e+21 0.000     5.535    
+
+! Reaction index: Chemkin #38; RMG #126
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: CH2O*(20), CH3O2*(22); OH*(12), CH3O2*(22); 
+! Matched reaction 23 CH2O* + OH* <=> CH3O2* + X_5 in Surface_Addition_Single_vdW/training
+! This reaction matched rate rule [O=C;HO*]
+! family: Surface_Addition_Single_vdW
+! metal: None
+OH*(12)+CH2O*(20)=X(1)+CH3O2*(22)                   3.401000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #39; RMG #127
+! Template reaction: Surface_Addition_Single_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); H*(10), CH3O2*(22); 
+! Matched reaction 20 HCOOH* + H* <=> CH3O2_2* + X_5 in Surface_Addition_Single_vdW/training
+! This reaction matched rate rule [O=C;H*]
+! family: Surface_Addition_Single_vdW
+! metal: None
+H*(10)+HCOOH*(19)=X(1)+CH3O2*(22)                   2.122000e+23 0.000     23.983   
+
+! Reaction index: Chemkin #40; RMG #130
+! Template reaction: Surface_Dissociation_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); H*(10), CH3OH*(23); 
+! Matched reaction 25 CH3O* + H* <=> CH3OH_2* + X_4 in Surface_Dissociation_vdW/training
+! This reaction matched rate rule [O-H;VacantSite]
+! family: Surface_Dissociation_vdW
+! metal: None
+H*(10)+CH3O*(21)=X(1)+CH3OH*(23)                    4.349000e+21 0.000     26.981   
+
+! Reaction index: Chemkin #41; RMG #349
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH2O*(20), HCOO*(17); O*(11), H*(10); 
+! Estimated using an average for rate rule [AdsorbateVdW;*=O]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+O*(11)+CH2O*(20)=H*(10)+HCOO*(17)                   4.782614e+24 -0.188    37.177   
+
+! Reaction index: Chemkin #42; RMG #351
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CO*(14), COOH*(18); H2O*(13), H*(10); 
+! Estimated using an average for rate rule [AdsorbateVdW;*=C=R]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+H2O*(13)+CO*(14)=H*(10)+COOH*(18)                   2.073936e+17 0.937     29.088   
+
+! Reaction index: Chemkin #43; RMG #354
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH2O*(20), HCOOH*(19); OH*(12), H*(10); 
+! Estimated using template [Donating;Abstracting] for rate rule [Donating;*O-H]
+! Euclidian distance = 2.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -52.1 to 0.0 kJ/mol.
+OH*(12)+CH2O*(20)=H*(10)+HCOOH*(19)                 2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #44; RMG #356
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCO*(16); H*(10), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-OH;Abstracting]
+! Euclidian distance = 3.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from 1.7 to 3.6 kJ/mol to match endothermicity of reaction.
+H*(10)+HCOOH*(19)=H2O*(13)+HCO*(16)                 1.000000e+17 0.000     0.856    
+
+! Reaction index: Chemkin #45; RMG #363
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O2*(22); O*(11), H*(10); 
+! Estimated using an average for rate rule [AdsorbateVdW;*=O]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_vdW
+O*(11)+CH3OH*(23)=H*(10)+CH3O2*(22)                 7.173922e+24 -0.188    37.177   
+
+! Reaction index: Chemkin #46; RMG #366
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: CH2O*(20), CH3O2*(22); H2O*(13), H*(10); 
+! Estimated using template [Adsorbate1;Adsorbate2] for rate rule [O=C;Adsorbate2]
+! Euclidian distance = 2.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Dual_Adsorption_vdW
+H2O*(13)+CH2O*(20)=H*(10)+CH3O2*(22)                6.761273e+13 1.181     22.574   
+
+! Reaction index: Chemkin #47; RMG #375
+! Template reaction: Surface_Abstraction
+! Flux pairs: HCO*(16), CO*(14); O*(11), OH*(12); 
+! Matched reaction 39 O* + HCO* <=> OH* + CO* in Surface_Abstraction/training
+! This reaction matched rate rule [O;*-C-H]
+! family: Surface_Abstraction
+! metal: None
+O*(11)+HCO*(16)=OH*(12)+CO*(14)                     3.298000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #48; RMG #376
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), HCOO*(17); OH*(12), O*(11); 
+! Estimated using template [O=C;Adsorbate1] for rate rule [O=C=O;*O-R]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CO2*(15)=O*(11)+HCOO*(17)                   3.628000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #49; RMG #379
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), COOH*(18); OH*(12), O*(11); 
+! Estimated using template [AdsorbateVdW;Adsorbate1] for rate rule [CO2;*O-R]
+! Euclidian distance = 4.123105625617661
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CO2*(15)=O*(11)+COOH*(18)                   3.628000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #50; RMG #381
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! From training reaction 46 used for O-C=R;*=O
+! Exact match found for rate rule [O-C=R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 1.174481e+14 1.215     30.678   
+DUPLICATE
+
+! Reaction index: Chemkin #51; RMG #382
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! From training reaction 34 used for O-R;*=O
+! Exact match found for rate rule [O-R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 4.070000e+24 -0.274    52.199   
+DUPLICATE
+
+! Reaction index: Chemkin #52; RMG #384
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); O*(11), OH*(12); 
+! From training reaction 21 used for C-R;*=O
+! Exact match found for rate rule [C-R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+HCOOH*(19)=OH*(12)+COOH*(18)                 1.405000e+24 -0.101    22.156   
+
+! Reaction index: Chemkin #53; RMG #387
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH2O*(20), HCO*(16); O*(11), OH*(12); 
+! From training reaction 21 used for C-R;*=O
+! Exact match found for rate rule [C-R;*=O]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+O*(11)+CH2O*(20)=OH*(12)+HCO*(16)                   2.810000e+24 -0.101    22.156   
+
+! Reaction index: Chemkin #54; RMG #388
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); OH*(12), O*(11); 
+! Estimated using template [O=C;Adsorbate1] for rate rule [O=C;*O-R]
+! Euclidian distance = 1.0
+! family: Surface_Adsorption_Abstraction_vdW
+OH*(12)+CH2O*(20)=O*(11)+CH3O*(21)                  1.814000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #55; RMG #391
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); OH*(12), O*(11); 
+! Estimated using template [O=C;Adsorbate1] for rate rule [O=C;*O-R]
+! Euclidian distance = 1.0
+! family: Surface_Adsorption_Abstraction_vdW
+! Ea raised from 44.7 to 45.2 kJ/mol to match endothermicity of reaction.
+OH*(12)+HCOOH*(19)=O*(11)+CH3O2*(22)                1.814000e+20 0.000     10.811   
+
+! Reaction index: Chemkin #56; RMG #393
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! Estimated using template [O-C;*=O] for rate rule [O-C-3R;*=O]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_vdW
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 1.174481e+14 1.215     30.678   
+DUPLICATE
+
+! Reaction index: Chemkin #57; RMG #394
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! From training reaction 34 used for O-R;*=O
+! Exact match found for rate rule [O-R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 4.070000e+24 -0.274    52.199   
+DUPLICATE
+
+! Reaction index: Chemkin #58; RMG #406
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCO*(16), CO*(14); OH*(12), H2O*(13); 
+! Matched reaction 40 OH_2* + HCO* <=> H2O* + CO* in Surface_Abstraction_vdW/training
+! This reaction matched rate rule [O-R;*=C=R]
+! family: Surface_Abstraction_vdW
+! metal: None
+OH*(12)+HCO*(16)=H2O*(13)+CO*(14)                   3.261000e+21 0.000     6.918    
+
+! Reaction index: Chemkin #59; RMG #408
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); OH*(12), H2O*(13); 
+! Exact match found for rate rule [C-H;OH]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+HCOO*(17)=H2O*(13)+CO2*(15)                 3.200000e+21 0.000     11.776   
+
+! Reaction index: Chemkin #60; RMG #409
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! From training reaction 46 used for O-C=R;*=O
+! Exact match found for rate rule [O-C=R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 1.174481e+14 1.215     30.678   
+DUPLICATE
+
+! Reaction index: Chemkin #61; RMG #410
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); O*(11), OH*(12); 
+! From training reaction 34 used for O-R;*=O
+! Exact match found for rate rule [O-R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+HCOOH*(19)=OH*(12)+HCOO*(17)                 4.070000e+24 -0.274    52.199   
+DUPLICATE
+
+! Reaction index: Chemkin #62; RMG #414
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); OH*(12), H2O*(13); 
+! Exact match found for rate rule [O-H;OH]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+COOH*(18)=H2O*(13)+CO2*(15)                 3.200000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #63; RMG #419
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*O-H]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -25.5 to 0.0 kJ/mol.
+OH*(12)+HCOOH*(19)=H2O*(13)+HCOO*(17)               1.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #64; RMG #421
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O-H]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -18.3 to 0.0 kJ/mol.
+OH*(12)+HCOOH*(19)=H2O*(13)+COOH*(18)               1.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #65; RMG #427
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH2O*(20), HCO*(16); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O-H]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -50.4 to 0.0 kJ/mol.
+OH*(12)+CH2O*(20)=H2O*(13)+HCO*(16)                 2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #66; RMG #430
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O*(21), CH2O*(20); OH*(12), H2O*(13); 
+! Exact match found for rate rule [C-H;OH]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+CH3O*(21)=H2O*(13)+CH2O*(20)                9.600000e+21 0.000     13.586   
+
+! Reaction index: Chemkin #67; RMG #431
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! Estimated using template [O-C;*=O] for rate rule [O-C-3R;*=O]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_vdW
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 1.174481e+14 1.215     30.678   
+DUPLICATE
+
+! Reaction index: Chemkin #68; RMG #432
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); O*(11), OH*(12); 
+! From training reaction 34 used for O-R;*=O
+! Exact match found for rate rule [O-R;*=O]
+! Euclidian distance = 0
+! family: Surface_Abstraction_vdW
+O*(11)+CH3OH*(23)=OH*(12)+CH3O*(21)                 4.070000e+24 -0.274    52.199   
+DUPLICATE
+
+! Reaction index: Chemkin #69; RMG #436
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); OH*(12), H2O*(13); 
+! Exact match found for rate rule [C-H;OH]
+! Euclidian distance = 0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+OH*(12)+CH3O2*(22)=H2O*(13)+HCOOH*(19)              6.400000e+21 0.000     3.103    
+
+! Reaction index: Chemkin #70; RMG #441
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3OH*(23), CH3O*(21); OH*(12), H2O*(13); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*O-H]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -10.1 to 0.0 kJ/mol.
+OH*(12)+CH3OH*(23)=H2O*(13)+CH3O*(21)               1.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #71; RMG #465
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), HCOO*(17); HCO*(16), CO*(14); 
+! Estimated using template [O=C;*C-H] for rate rule [O=C=O;*C-H]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+CO2*(15)+HCO*(16)=CO*(14)+HCOO*(17)                 3.628000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #72; RMG #469
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CO2*(15), COOH*(18); HCO*(16), CO*(14); 
+! Estimated using template [AdsorbateVdW;*C-H] for rate rule [CO2;*C-H]
+! Euclidian distance = 4.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Adsorption_Abstraction_vdW
+CO2*(15)+HCO*(16)=CO*(14)+COOH*(18)                 3.628000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #73; RMG #473
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); HCO*(16), CO*(14); 
+! Matched reaction 41 HCOO_1* + HCO* <=> HCOOH* + CO* in Surface_Abstraction_vdW/training
+! This reaction matched rate rule [O-R;*=C=R]
+! family: Surface_Abstraction_vdW
+! metal: None
+HCO*(16)+HCOO*(17)=CO*(14)+HCOOH*(19)               7.475000e+22 0.000     13.836   
+
+! Reaction index: Chemkin #74; RMG #474
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;*=C=R] for rate rule [C-OH;*=C=R]
+! Euclidian distance = 3.0
+! family: Surface_Abstraction_vdW
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               1.036968e+17 0.937     29.088   
+DUPLICATE
+
+! Reaction index: Chemkin #75; RMG #475
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;*=C=R] for rate rule [C-R;*=C=R]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_vdW
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               1.036968e+17 0.937     29.088   
+DUPLICATE
+
+! Reaction index: Chemkin #76; RMG #478
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH2O*(20), HCO*(16); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;*=C=R] for rate rule [C-R;*=C=R]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+CO*(14)+CH2O*(20)=HCO*(16)+HCO*(16)                 2.073936e+17 0.937     29.088   
+
+! Reaction index: Chemkin #77; RMG #482
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); HCO*(16), CO*(14); 
+! Matched reaction 44 CH2O* + HCO* <=> CH3O* + CO* in Surface_Adsorption_Abstraction_vdW/training
+! This reaction matched rate rule [O=C;*C-H]
+! family: Surface_Adsorption_Abstraction_vdW
+! metal: None
+HCO*(16)+CH2O*(20)=CO*(14)+CH3O*(21)                3.398000e+21 0.000     0.000    
+
+! Reaction index: Chemkin #78; RMG #487
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: COOH*(18), CH3O2*(22); CH2O*(20), CO*(14); 
+! Estimated using an average for rate rule [O=C;*C-R]
+! Euclidian distance = 0
+! family: Surface_Adsorption_Abstraction_vdW
+COOH*(18)+CH2O*(20)=CO*(14)+CH3O2*(22)              1.814000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #79; RMG #488
+! Template reaction: Surface_Adsorption_Abstraction_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); HCO*(16), CO*(14); 
+! Matched reaction 43 HCOOH* + HCO* <=> CH3O2* + CO* in Surface_Adsorption_Abstraction_vdW/training
+! This reaction matched rate rule [O=C;*C-H]
+! family: Surface_Adsorption_Abstraction_vdW
+! metal: None
+HCO*(16)+HCOOH*(19)=CO*(14)+CH3O2*(22)              1.814000e+20 0.000     9.685    
+
+! Reaction index: Chemkin #80; RMG #492
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); HCO*(16), CO*(14); 
+! Matched reaction 45 CH3O* + HCO* <=> CH3OH* + CO* in Surface_Abstraction_vdW/training
+! This reaction matched rate rule [O-R;*=C=R]
+! family: Surface_Abstraction_vdW
+! metal: None
+HCO*(16)+CH3O*(21)=CO*(14)+CH3OH*(23)               6.572000e+20 0.000     8.763    
+
+! Reaction index: Chemkin #81; RMG #508
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); HCOO*(17), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     20.080   
+
+! Reaction index: Chemkin #82; RMG #510
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     17.722   
+DUPLICATE
+
+! Reaction index: Chemkin #83; RMG #512
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     17.722   
+DUPLICATE
+
+! Reaction index: Chemkin #84; RMG #514
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+COOH*(18)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     15.364   
+
+! Reaction index: Chemkin #85; RMG #519
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+HCOO*(17)=CO2*(15)+CH2O*(20)               3.200000e+21 0.000     28.153   
+
+! Reaction index: Chemkin #86; RMG #520
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+COOH*(18)=CO2*(15)+CH2O*(20)               3.200000e+21 0.000     25.795   
+
+! Reaction index: Chemkin #87; RMG #532
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), CO2*(15); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3O*(21)=CO2*(15)+CH3OH*(23)             3.200000e+21 0.000     15.073   
+
+! Reaction index: Chemkin #88; RMG #536
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), CO2*(15); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3O*(21)=CO2*(15)+CH3OH*(23)             3.200000e+21 0.000     12.715   
+
+! Reaction index: Chemkin #89; RMG #554
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;*=C=R] for rate rule [C-OH;*=C=R]
+! Euclidian distance = 3.0
+! family: Surface_Abstraction_vdW
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               1.036968e+17 0.937     29.088   
+DUPLICATE
+
+! Reaction index: Chemkin #90; RMG #555
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CO*(14), HCO*(16); 
+! Estimated using template [AdsorbateVdW;*=C=R] for rate rule [C-R;*=C=R]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_vdW
+CO*(14)+HCOOH*(19)=HCO*(16)+COOH*(18)               1.036968e+17 0.937     29.088   
+DUPLICATE
+
+! Reaction index: Chemkin #91; RMG #561
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); CH2O*(20), HCO*(16); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -24.8 to 0.0 kJ/mol.
+HCOO*(17)+CH2O*(20)=HCO*(16)+HCOOH*(19)             2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #92; RMG #562
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); CH2O*(20), HCO*(16); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*C=R]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -32.1 to 0.0 kJ/mol.
+COOH*(18)+CH2O*(20)=HCO*(16)+HCOOH*(19)             2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #93; RMG #573
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O*(21), CH2O*(20); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O*(21)=CH2O*(20)+CH2O*(20)              9.600000e+21 0.000     29.963   
+
+! Reaction index: Chemkin #94; RMG #578
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Exact match found for rate rule [Combined;Adsorbate1]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            3.200000e+21 0.000     19.480   
+DUPLICATE
+
+! Reaction index: Chemkin #95; RMG #579
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            6.400000e+21 0.000     19.480   
+DUPLICATE
+
+! Reaction index: Chemkin #96; RMG #586
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); CH2O*(20), HCO*(16); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -40.2 to 0.0 kJ/mol.
+CH2O*(20)+CH3O*(21)=HCO*(16)+CH3OH*(23)             2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #97; RMG #595
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     17.722   
+DUPLICATE
+
+! Reaction index: Chemkin #98; RMG #596
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); COOH*(18), CO2*(15); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [O-H;Adsorbate1]
+! Euclidian distance = 1.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+HCOO*(17)=CO2*(15)+HCOOH*(19)             3.200000e+21 0.000     17.722   
+DUPLICATE
+
+! Reaction index: Chemkin #99; RMG #604
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOOH*(19); COOH*(18), HCOO*(17); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*C=R]
+! Euclidian distance = 2.8284271247461903
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -7.3 to 0.0 kJ/mol.
+COOH*(18)+HCOOH*(19)=HCOO*(17)+HCOOH*(19)           1.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #100; RMG #616
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3O*(21)=CH2O*(20)+HCOOH*(19)            9.600000e+21 0.000     21.889   
+
+! Reaction index: Chemkin #101; RMG #623
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCOO*(17), HCOOH*(19); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCOO*(17)+CH3O2*(22)=HCOOH*(19)+HCOOH*(19)          6.400000e+21 0.000     11.407   
+
+! Reaction index: Chemkin #102; RMG #629
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), HCOO*(17); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Donating;Abstracting] for rate rule [O-H;*O]
+! Euclidian distance = 2.23606797749979
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -15.4 to 0.0 kJ/mol.
+HCOOH*(19)+CH3O*(21)=HCOO*(17)+CH3OH*(23)           1.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #103; RMG #652
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3O*(21)=CH2O*(20)+HCOOH*(19)            9.600000e+21 0.000     19.531   
+
+! Reaction index: Chemkin #104; RMG #661
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); COOH*(18), HCOOH*(19); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+COOH*(18)+CH3O2*(22)=HCOOH*(19)+HCOOH*(19)          6.400000e+21 0.000     9.049    
+
+! Reaction index: Chemkin #105; RMG #668
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOOH*(19), COOH*(18); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;*O]
+! Euclidian distance = 1.4142135623730951
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -8.1 to 0.0 kJ/mol.
+HCOOH*(19)+CH3O*(21)=COOH*(18)+CH3OH*(23)           1.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #106; RMG #683
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            6.400000e+21 0.000     19.480   
+DUPLICATE
+
+! Reaction index: Chemkin #107; RMG #688
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); HCO*(16), CH2O*(20); 
+! Exact match found for rate rule [Combined;Adsorbate1]
+! Euclidian distance = 0
+! family: Surface_Abstraction_Beta_double_vdW
+HCO*(16)+CH3O2*(22)=CH2O*(20)+HCOOH*(19)            3.200000e+21 0.000     19.480   
+DUPLICATE
+
+! Reaction index: Chemkin #108; RMG #716
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O2*(22), HCOOH*(19); CH3O*(21), CH3OH*(23); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3O2*(22)=HCOOH*(19)+CH3OH*(23)          6.400000e+21 0.000     6.400    
+
+! Reaction index: Chemkin #109; RMG #742
+! Template reaction: Surface_Abstraction_Beta_double_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); CH3O*(21), CH2O*(20); 
+! Estimated using template [Combined;Adsorbate1] for rate rule [C-H;Adsorbate1]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 3.0
+! family: Surface_Abstraction_Beta_double_vdW
+CH3O*(21)+CH3O*(21)=CH2O*(20)+CH3OH*(23)            9.600000e+21 0.000     16.882   
+
+! Reaction index: Chemkin #110; RMG #95
+! Template reaction: Surface_Adsorption_vdW
+! Flux pairs: X(1), H2X(53); H2(2), H2X(53); 
+! Estimated using template [Adsorbate;VacantSite] for rate rule [H2;VacantSite]
+! Euclidian distance = 2.0
+! family: Surface_Adsorption_vdW
+X(1)+H2(2)=H2X(53)                                  8.000e-03 0.000     0.000    
+    STICK
+
+! Reaction index: Chemkin #111; RMG #344
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: O*(11), OH*(12); H2X(53), H*(10); 
+! Estimated using template [AdsorbateVdW;*=O] for rate rule [H-H;*=O]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+O*(11)+H2X(53)=H*(10)+OH*(12)                       4.782614e+24 -0.188    37.177   
+
+! Reaction index: Chemkin #112; RMG #345
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: OH*(12), H2O*(13); H2X(53), H*(10); 
+! Estimated using template [Donating;Abstracting] for rate rule [H-H;*O-H]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -45.3 to 0.0 kJ/mol.
+OH*(12)+H2X(53)=H*(10)+H2O*(13)                     2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #113; RMG #347
+! Template reaction: Surface_Abstraction_vdW
+! Flux pairs: CO*(14), HCO*(16); H2X(53), H*(10); 
+! Estimated using template [AdsorbateVdW;*=C=R] for rate rule [H-H;*=C=R]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_vdW
+H2X(53)+CO*(14)=H*(10)+HCO*(16)                     2.073936e+17 0.937     29.088   
+
+! Reaction index: Chemkin #114; RMG #350
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: CO2*(15), HCOO*(17); H2X(53), H*(10); 
+! Estimated using template [Adsorbate1;Adsorbate2] for rate rule [O=C=O;H-H]
+! Euclidian distance = 3.1622776601683795
+! Multiplied by reaction path degeneracy 4.0
+! family: Surface_Dual_Adsorption_vdW
+H2X(53)+CO2*(15)=H*(10)+HCOO*(17)                   1.352255e+14 1.181     22.574   
+
+! Reaction index: Chemkin #115; RMG #353
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: CO2*(15), COOH*(18); H2X(53), H*(10); 
+! Estimated using template [CO2;Adsorbate2] for rate rule [CO2;H-H]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 4.0
+! family: Surface_Dual_Adsorption_vdW
+H2X(53)+CO2*(15)=H*(10)+COOH*(18)                   1.352255e+14 1.181     22.574   
+
+! Reaction index: Chemkin #116; RMG #355
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: HCOO*(17), HCOOH*(19); H2X(53), H*(10); 
+! Estimated using template [Donating;Abstracting] for rate rule [H-H;*O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -19.8 to 0.0 kJ/mol.
+H2X(53)+HCOO*(17)=H*(10)+HCOOH*(19)                 2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #117; RMG #357
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: COOH*(18), HCOOH*(19); H2X(53), H*(10); 
+! Estimated using template [Donating;Abstracting] for rate rule [H-H;*C=R]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -27.0 to 0.0 kJ/mol.
+H2X(53)+COOH*(18)=H*(10)+HCOOH*(19)                 2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #118; RMG #359
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH2O*(20), HCO*(16); H*(10), H2X(53); 
+! Estimated using template [Donating;Abstracting] for rate rule [C-R;Abstracting]
+! Euclidian distance = 1.0
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -5.0 to 0.0 kJ/mol.
+H*(10)+CH2O*(20)=H2X(53)+HCO*(16)                   2.000000e+17 0.000     0.000    
+
+! Reaction index: Chemkin #119; RMG #362
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: CH2O*(20), CH3O*(21); H2X(53), H*(10); 
+! Estimated using template [Adsorbate1;Adsorbate2] for rate rule [O=C;H-H]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Dual_Adsorption_vdW
+H2X(53)+CH2O*(20)=H*(10)+CH3O*(21)                  6.761273e+13 1.181     22.574   
+
+! Reaction index: Chemkin #120; RMG #367
+! Template reaction: Surface_Dual_Adsorption_vdW
+! Flux pairs: HCOOH*(19), CH3O2*(22); H2X(53), H*(10); 
+! Estimated using template [Adsorbate1;Adsorbate2] for rate rule [O=C;H-H]
+! Euclidian distance = 2.23606797749979
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Dual_Adsorption_vdW
+H2X(53)+HCOOH*(19)=H*(10)+CH3O2*(22)                6.761273e+13 1.181     22.574   
+
+! Reaction index: Chemkin #121; RMG #369
+! Template reaction: Surface_Abstraction_Single_vdW
+! Flux pairs: CH3O*(21), CH3OH*(23); H2X(53), H*(10); 
+! Estimated using template [Donating;Abstracting] for rate rule [H-H;*O]
+! Euclidian distance = 1.4142135623730951
+! Multiplied by reaction path degeneracy 2.0
+! family: Surface_Abstraction_Single_vdW
+! Ea raised from -35.2 to 0.0 kJ/mol.
+H2X(53)+CH3O*(21)=H*(10)+CH3OH*(23)                 2.000000e+17 0.000     0.000    
+
+END
+

--- a/rmgpy/tools/data/diffmodels/surf_model/species_dictionary1.txt
+++ b/rmgpy/tools/data/diffmodels/surf_model/species_dictionary1.txt
@@ -1,0 +1,172 @@
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+Ne
+1 Ne u0 p4 c0
+
+X(1)
+1 X u0 p0 c0
+
+H2(2)
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+CO(3)
+1 O u0 p1 c+1 {2,T}
+2 C u0 p1 c-1 {1,T}
+
+CO2(4)
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,D} {2,D}
+
+H2O(5)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CH2O(6)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+
+HCOOH(7)
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+
+CH3OH(8)
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
+
+HCOOCH3(9)
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4 C u0 p0 c0 {1,S} {2,D} {8,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {4,S}
+
+H*(10)
+1 H u0 p0 c0 {2,S}
+2 X u0 p0 c0 {1,S}
+
+O*(11)
+1 O u0 p2 c0 {2,D}
+2 X u0 p0 c0 {1,D}
+
+OH*(12)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 X u0 p0 c0 {1,S}
+
+H2O*(13)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 X u0 p0 c0
+
+CO*(14)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 X u0 p0 c0 {2,D}
+
+CO2*(15)
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,D} {2,D}
+4 X u0 p0 c0
+
+HCO*(16)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 X u0 p0 c0 {2,S}
+
+HCOO*(17)
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 X u0 p0 c0 {1,S}
+
+COOH*(18)
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {5,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {3,S}
+
+HCOOH*(19)
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 X u0 p0 c0
+
+CH2O*(20)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 X u0 p0 c0
+
+CH3O*(21)
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 X u0 p0 c0 {1,S}
+
+CH3O2*(22)
+1 O u0 p2 c0 {3,S} {6,S}
+2 O u0 p2 c0 {3,S} {7,S}
+3 C u0 p0 c0 {1,S} {2,S} {4,S} {5,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {1,S}
+7 X u0 p0 c0 {2,S}
+
+CH3OH*(23)
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
+7 X u0 p0 c0
+
+CH3OX(49)
+1 O u0 p2 c0 {2,S} {5,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {6,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {1,S}
+6 X u0 p0 c0 {2,S}
+
+CH3X(33)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {1,S}
+
+CH4(32)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+

--- a/rmgpy/tools/data/diffmodels/surf_model/species_dictionary2.txt
+++ b/rmgpy/tools/data/diffmodels/surf_model/species_dictionary2.txt
@@ -1,0 +1,162 @@
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+Ne
+1 Ne u0 p4 c0
+
+X(1)
+1 X u0 p0 c0
+
+H2(2)
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+CO(3)
+1 O u0 p1 c+1 {2,T}
+2 C u0 p1 c-1 {1,T}
+
+CO2(4)
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,D} {2,D}
+
+H2O(5)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CH2O(6)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+
+HCOOH(7)
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+
+CH3OH(8)
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
+
+HCOOCH3(9)
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4 C u0 p0 c0 {1,S} {2,D} {8,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {4,S}
+
+H*(10)
+1 H u0 p0 c0 {2,S}
+2 X u0 p0 c0 {1,S}
+
+O*(11)
+1 O u0 p2 c0 {2,D}
+2 X u0 p0 c0 {1,D}
+
+OH*(12)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 X u0 p0 c0 {1,S}
+
+H2O*(13)
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 X u0 p0 c0
+
+CO*(14)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 X u0 p0 c0 {2,D}
+
+CO2*(15)
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,D} {2,D}
+4 X u0 p0 c0
+
+HCO*(16)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 X u0 p0 c0 {2,S}
+
+HCOO*(17)
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 X u0 p0 c0 {1,S}
+
+COOH*(18)
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {5,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {3,S}
+
+HCOOH*(19)
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 X u0 p0 c0
+
+CH2O*(20)
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 X u0 p0 c0
+
+CH3O*(21)
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 X u0 p0 c0 {1,S}
+
+CH3O2*(22)
+1 O u0 p2 c0 {3,S} {6,S}
+2 O u0 p2 c0 {3,S} {7,S}
+3 C u0 p0 c0 {1,S} {2,S} {4,S} {5,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {1,S}
+7 X u0 p0 c0 {2,S}
+
+CH3OH*(23)
+1 O u0 p2 c0 {2,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
+7 X u0 p0 c0
+
+CH4(24)
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+H2X(53)
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+3 X u0 p0 c0
+

--- a/rmgpy/tools/diffmodels.py
+++ b/rmgpy/tools/diffmodels.py
@@ -219,15 +219,29 @@ def compare_model_reactions(model1, model2):
 
 
 def save_compare_html(outputDir, chemkin_path1, species_dict_path1, chemkin_path2, species_dict_path2,
-                      read_comments1=True, read_comments2=True):
+                      read_comments1=True, read_comments2=True, surf_path1 = False, surf_path2=False):
     """
     Saves a model comparison HTML file based on two sets of chemkin and species dictionary
     files.
     """
     model1 = ReactionModel()
-    model1.species, model1.reactions = load_chemkin_file(chemkin_path1, species_dict_path1, read_comments=read_comments1)
     model2 = ReactionModel()
-    model2.species, model2.reactions = load_chemkin_file(chemkin_path2, species_dict_path2, read_comments=read_comments2)
+
+    if surf_path1 and surf_path2:
+        model1.species, model1.reactions = load_chemkin_file(
+            chemkin_path1, species_dict_path1, read_comments=read_comments1,
+            surface_path=surf_path1)
+        model2.species, model2.reactions = load_chemkin_file(
+            chemkin_path2, species_dict_path2, read_comments=read_comments2,
+            surface_path=surf_path2)
+    else: 
+        if not surf_path1 or not surf_path2:
+            logging.error("to compare gas+surface mechanism, both models need a surface chemkin file")
+        model1.species, model1.reactions = load_chemkin_file(
+            chemkin_path1, species_dict_path1, read_comments=read_comments1)
+        model2.species, model2.reactions = load_chemkin_file(
+            chemkin_path2, species_dict_path2, read_comments=read_comments2)
+    
     common_reactions, unique_reactions1, unique_reactions2 = compare_model_reactions(model1, model2)
     common_species, unique_species1, unique_species2 = compare_model_species(model1, model2)
 

--- a/rmgpy/tools/diffmodels.py
+++ b/rmgpy/tools/diffmodels.py
@@ -219,7 +219,7 @@ def compare_model_reactions(model1, model2):
 
 
 def save_compare_html(outputDir, chemkin_path1, species_dict_path1, chemkin_path2, species_dict_path2,
-                      read_comments1=True, read_comments2=True, surf_path1 = False, surf_path2=False):
+                      read_comments1=True, read_comments2=True, surf_path1=False, surf_path2=False):
     """
     Saves a model comparison HTML file based on two sets of chemkin and species dictionary
     files.
@@ -234,9 +234,9 @@ def save_compare_html(outputDir, chemkin_path1, species_dict_path1, chemkin_path
         model2.species, model2.reactions = load_chemkin_file(
             chemkin_path2, species_dict_path2, read_comments=read_comments2,
             surface_path=surf_path2)
-    else: 
-        if not surf_path1 or not surf_path2:
-            logging.error("to compare gas+surface mechanism, both models need a surface chemkin file")
+    else:
+        if surf_path1 or surf_path2:
+            logging.error("To compare gas+surface mechanism, both models need a surface chemkin file")
         model1.species, model1.reactions = load_chemkin_file(
             chemkin_path1, species_dict_path1, read_comments=read_comments1)
         model2.species, model2.reactions = load_chemkin_file(

--- a/rmgpy/tools/diffmodelsTest.py
+++ b/rmgpy/tools/diffmodelsTest.py
@@ -54,3 +54,27 @@ class DiffModelsTest(unittest.TestCase):
         shutil.rmtree(os.path.join(folder, 'species1'))
         shutil.rmtree(os.path.join(folder, 'species2'))
         os.remove(os.path.join(folder, 'diff.html'))
+
+    def test_surface_models(self):
+        folder = os.path.join(os.getcwd(), 'rmgpy/tools/data/diffmodels/surf_model')
+
+        chemkin_gas1 = os.path.join(folder, 'chem_gas1.inp')
+        chemkin_surf1 = os.path.join(folder, 'chem_surface1.inp')
+        species_dict1 = os.path.join(folder, 'species_dictionary1.txt')
+
+        chemkin_gas2 = os.path.join(folder, 'chem_gas2.inp')
+        chemkin_surf2 = os.path.join(folder, 'chem_surface2.inp')
+        species_dict2 = os.path.join(folder, 'species_dictionary2.txt')
+
+        kwargs = {
+            'wd': folder,
+            'surface_path1': chemkin_surf1,
+            'surface_path2': chemkin_surf2,
+        }
+
+        execute(chemkin_gas1, species_dict1, None,
+                chemkin_gas2, species_dict2, None, **kwargs)
+
+        shutil.rmtree(os.path.join(folder, 'species1'))
+        shutil.rmtree(os.path.join(folder, 'species2'))
+        os.remove(os.path.join(folder, 'diff.html'))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
currently RMG cannot use the "diffmodels" tool to compare surface+gas chemkin files. This means that we can't use a surface model in the CI tests, which is a big problem. This PR is a step towards fixing that. 

### Description of Changes
This PR combines fixes for several issues:
-  interpreting surface input files
-  combining chemkin gas+surface output files
-  comparing surface species/reactions. 


### Testing
Currently have tested by creating a diff.html file for a combined gas+surface model as shown in this [minimal example](https://github.com/ReactionMechanismGenerator/RMG-Py/files/9588247/min_example_for_pr.zip) 

### Reviewer Tips
Until we add in the a surface mechanism to our functional/CI tests, this will not be used regularly, so try it with a surface mechanism and make sure the output is captured as we expect. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
