### PR TITLE
Allow RMG to load thermo or kinetic libraries from a file

### DIFF
--- a/examples/rmg/external_library/custom_library/dictionary.txt
+++ b/examples/rmg/external_library/custom_library/dictionary.txt
@@ -1,0 +1,35 @@
+H
+multiplicity 2
+1 H u1 p0 c0
+
+O2
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+O
+multiplicity 3
+1 O u2 p2 c0
+
+OH
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+CH2(T)
+multiplicity 3
+1 C u2 p0 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CH
+multiplicity 2
+1 C u1 p1 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+C2H2
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+

--- a/examples/rmg/external_library/custom_library/reactions.py
+++ b/examples/rmg/external_library/custom_library/reactions.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "custom_library"
+shortDesc = u"dummy external kinetic library"
+longDesc = u"""
+This is a dummy kinetic library,
+showcasing how to use a kinetic library that is external to the RMG-database.
+"""
+
+entry(
+    index = 1,
+    label = "H + O2 <=> O + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (9.841e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (15310, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 2,
+    label = "CH2(T) + CH <=> H + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+

--- a/examples/rmg/external_library/input.py
+++ b/examples/rmg/external_library/input.py
@@ -1,0 +1,65 @@
+# Sometimes it is useful to load an RMG thermo or kinetic library that is not within the RMG-database repository.
+# One use case could be, e.g., running RMG on a server where it is installed in a shared folder to which users have a read-only access.
+# Here we show an example of running RMG with a kinetic library external to its database.
+# THe same approach can be applied for kinetic seed mechanisms and for thermodynamic libraries.
+
+# Data sources
+database(
+	thermoLibraries = ['primaryThermoLibrary'],
+	reactionLibraries = ['custom_library'],  # Specify a FULL PATH if needed. In this case, the library is located in the run folder, and a relative path (just the folder name) is enough.
+	seedMechanisms = [],
+	kineticsDepositories = ['training'], 
+	kineticsFamilies = 'default',
+	kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+	label='CH2',
+	structure=SMILES("[CH2]"),
+)
+species(
+	label='C2H2',
+	structure=SMILES("C#C"),
+)
+species(
+	label='N2',
+	reactive=False,
+	structure=SMILES("N#N"),
+)
+
+# Reaction systems
+simpleReactor(
+	temperature=(1350,'K'),
+	pressure=(1.0,'bar'),
+	initialMoleFractions={
+		"CH2": 0.001,
+		"C2H2": 0.099,
+		"N2": 0.9,
+	},
+	terminationConversion={'C2H2': 0.5},
+	terminationTime=(0.5,'s'),
+)
+model(
+	toleranceKeepInEdge=0,
+	toleranceMoveToCore=0.05,
+	toleranceInterruptSimulation=0.05,
+	maximumEdgeSpecies=100000
+)
+
+simulator(
+	atol=1e-16,
+	rtol=1e-8,
+)
+
+options(
+	units='si',
+	generateOutputHTML=False,
+	generatePlots=False,
+)
+
+generatedSpeciesConstraints(
+    allowed = ['seed mechanisms', 'reaction libraries'],
+    maximumRadicalElectrons = 2,
+)
+

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -236,10 +236,6 @@ class KineticsDatabase(object):
                     library.load(library_file, self.local_context, self.global_context)
                     self.libraries[library.label] = library
                 else:
-                    if library_name == "KlippensteinH2O2":
-                        logging.info("""\n** Note: The KlippensteinH2O2 library was replaced and is no longer available in RMG.
-For H2 combustion chemistry consider using either the BurkeH2inN2 or BurkeH2inArHe
-library instead, depending on the main bath gas (N2 or Ar/He, respectively)\n""")
                     raise IOError("Couldn't find kinetics library {0}".format(library_file))
 
         else:

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -238,12 +238,12 @@ class KineticsDatabase(object):
                     library.load(library_file, self.local_context, self.global_context)
                     self.libraries[library.label] = library
                 elif os.path.exists(library_file):
-                    logging.info('Loading kinetics library {0} from {1}...'.format(library_name, library_file))
+                    logging.info(f'Loading kinetics library {library_name} from {library_file}...')
                     library = KineticsLibrary(label=library_name)
                     library.load(library_file, self.local_context, self.global_context)
                     self.libraries[library.label] = library
                 else:
-                    raise IOError("Couldn't find kinetics library {0}".format(library_file))
+                    raise IOError(f"Couldn't find kinetics library {library_file}")
 
         else:
             # load all the libraries you can find
@@ -255,7 +255,7 @@ class KineticsDatabase(object):
                     if ext.lower() == '.py':
                         library_file = os.path.join(root, f)
                         label = os.path.dirname(library_file)[len(path) + 1:]
-                        logging.info('Loading kinetics library {0} from {1}...'.format(label, library_file))
+                        logging.info(f'Loading kinetics library {label} from {library_file}...')
                         library = KineticsLibrary(label=label)
                         try:
                             library.load(library_file, self.local_context, self.global_context)

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -230,7 +230,14 @@ class KineticsDatabase(object):
         if libraries is not None:
             for library_name in libraries:
                 library_file = os.path.join(path, library_name, 'reactions.py')
-                if os.path.exists(library_file):
+                if os.path.exists(library_name):
+                    library_file = os.path.join(library_name, 'reactions.py')
+                    short_library_name = os.path.split(library_name)[-1]
+                    logging.info(f'Loading kinetics library {short_library_name} from {library_name}...')
+                    library = KineticsLibrary(label=short_library_name)
+                    library.load(library_file, self.local_context, self.global_context)
+                    self.libraries[library.label] = library
+                elif os.path.exists(library_file):
                     logging.info('Loading kinetics library {0} from {1}...'.format(library_name, library_file))
                     library = KineticsLibrary(label=library_name)
                     library.load(library_file, self.local_context, self.global_context)

--- a/rmgpy/data/kinetics/libraryTest.py
+++ b/rmgpy/data/kinetics/libraryTest.py
@@ -32,6 +32,7 @@ import os.path
 import shutil
 import unittest
 
+import rmgpy
 from rmgpy import settings
 from rmgpy.data.kinetics.database import KineticsDatabase
 from rmgpy.data.kinetics.family import TemplateReaction
@@ -73,7 +74,7 @@ class TestLibrary(unittest.TestCase):
 
     def test_save_library(self):
         """
-        This tests the the library.save method by writing a new temporary file and
+        This tests the library.save method by writing a new temporary file and
         loading it and comparing the original and copied reactions
         """
         for library_name in ['ethane-oxidation', 'surface-example']:
@@ -98,6 +99,18 @@ class TestLibrary(unittest.TestCase):
                     # eg. is the metal attribute saved for surface reactions?
             finally:
                 shutil.rmtree(copy_path)
+
+    def test_loading_external_kinetic_library(self):
+        """This tests loading a kinetic library which is not in the RMG-database repo"""
+        kinetic_lib_in_db_path = os.path.join(settings['database.directory'], 'kinetics', 'libraries', 'NOx2018')
+        kinetic_lib_in_test_dir_path = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data', 'copied_kinetic_lib')
+        os.makedirs(kinetic_lib_in_test_dir_path)
+        for file_name in ['reactions.py', 'dictionary.txt']:
+            shutil.copyfile(src=os.path.join(kinetic_lib_in_db_path, file_name),
+                            dst=os.path.join(kinetic_lib_in_test_dir_path, file_name))
+        self.database.load_libraries(path='', libraries=[kinetic_lib_in_test_dir_path])
+        self.assertIn('copied_kinetic_lib', list(self.database.libraries.keys()))
+        shutil.rmtree(kinetic_lib_in_test_dir_path, ignore_errors=True)
 
     def test_generate_high_p_limit_kinetics(self):
         """

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -956,10 +956,6 @@ class ThermoDatabase(object):
                     self.libraries[library.label] = library
                     self.library_order.append(library.label)
                 else:
-                    if libraryName == "KlippensteinH2O2":
-                        logging.info(
-                            '\n** Note: The thermo library KlippensteinH2O2 was replaced and is no longer available '
-                            'in RMG. For H2 combustion chemistry consider using the BurkeH2O2 library instead\n')
                     raise DatabaseError('Library {} not found in {}... Please check if your library is '
                                         'correctly placed'.format(libraryName, path))
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -940,7 +940,7 @@ class ThermoDatabase(object):
 
         else:
             for libraryName in libraries:
-                f = libraryName + '.py'
+                f = f'{libraryName}.py'
                 if os.path.isfile(libraryName):
                     logging.info(f'Loading thermodynamics library from an external location: {libraryName}..')
                     library = ThermoLibrary()
@@ -949,7 +949,7 @@ class ThermoDatabase(object):
                     self.libraries[library.label] = library
                     self.library_order.append(library.label)
                 elif os.path.exists(os.path.join(path, f)):
-                    logging.info('Loading thermodynamics library from {0} in {1}...'.format(f, path))
+                    logging.info(f'Loading thermodynamics library from {f} in {path}...')
                     library = ThermoLibrary()
                     library.load(os.path.join(path, f), self.local_context, self.global_context)
                     library.label = os.path.splitext(f)[0]

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -941,7 +941,14 @@ class ThermoDatabase(object):
         else:
             for libraryName in libraries:
                 f = libraryName + '.py'
-                if os.path.exists(os.path.join(path, f)):
+                if os.path.isfile(libraryName):
+                    logging.info(f'Loading thermodynamics library from an external location: {libraryName}..')
+                    library = ThermoLibrary()
+                    library.load(libraryName, self.local_context, self.global_context)
+                    library.label = os.path.splitext(os.path.split(libraryName)[-1])[0]
+                    self.libraries[library.label] = library
+                    self.library_order.append(library.label)
+                elif os.path.exists(os.path.join(path, f)):
                     logging.info('Loading thermodynamics library from {0} in {1}...'.format(f, path))
                     library = ThermoLibrary()
                     library.load(os.path.join(path, f), self.local_context, self.global_context)

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -29,6 +29,7 @@
 
 import math
 import os
+import shutil
 import unittest
 
 import rmgpy
@@ -76,6 +77,16 @@ class TestThermoDatabaseLoading(unittest.TestCase):
 
         with self.assertRaises(Exception):
             database.load_libraries(os.path.join(path, 'libraries'), libraries)
+
+    def test_loading_external_thermo_library(self):
+        """This tests loading a thermo library which is not in the RMG-database repo"""
+        thermo_lib_in_db_path = os.path.join(settings['database.directory'], 'thermo', 'libraries', 'primaryNS.py')
+        thermo_lib_in_test_dir_path = os.path.join(os.path.dirname(rmgpy.__file__), 'test_data', 'copied_thermo_lib.py')
+        shutil.copyfile(src=thermo_lib_in_db_path, dst=thermo_lib_in_test_dir_path)
+        database = ThermoDatabase()
+        database.load_libraries(path='', libraries=[thermo_lib_in_test_dir_path])
+        self.assertEqual(list(database.libraries.keys()), ['copied_thermo_lib'])
+        os.remove(thermo_lib_in_test_dir_path)
 
 
 class TestThermoDatabase(unittest.TestCase):


### PR DESCRIPTION
### Motivation or Problem
Users who execute RMG on a server where it is installed in a read-only partition cannot add new libraries for their runs.

### Description of Changes
Added functionality to load thermo and kinetic libraries from a user specified location
Tests added