### PR TITLE
Save the actual reaction label when creating a reaction library in Arkane

### DIFF
--- a/arkane/output.py
+++ b/arkane/output.py
@@ -269,7 +269,9 @@ def save_kinetics_lib(rxn_list, path, name, lib_long_desc):
                     index=i,
                     item=rxn,
                     data=rxn.kinetics,
-                    label=rxn.label)
+                    label=' <=> '.join([' + '.join([reactant.label for reactant in rxn.reactants]),
+                                        ' + '.join([product.label for product in rxn.products])]),
+                )
                 entries[i+1] = entry
             else:
                 logging.warning(f'Reaction {rxn.label} did not contain any kinetic data and was omitted from the '


### PR DESCRIPTION
When Arkane saves a kinetics library it currently passes `rxn.label` for the reaction label.
However, in an RMG run PDep networks generated automatically have simple labels such as `reaction1` instead of a chemically meaningful label. Then, running such `network_x.py` files through Arkane will generate an ill-formatted RMG library.
Here we fix the reaction label in the RMG libraries generated by an Arkane kinetics job by using a reasonable reaction label.
