### PR TITLE
Add initial species in core before seed mechanism 

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -614,6 +614,25 @@ class RMG(util.Subject):
 
         # Initialize reaction model
 
+        # Also always add in a few bath gases (since RMG-Java does)
+        for label, smiles in [('Ar', '[Ar]'), ('He', '[He]'), ('Ne', '[Ne]'), ('N2', 'N#N')]:
+            molecule = Molecule().from_smiles(smiles)
+            spec, is_new = self.reaction_model.make_new_species(molecule, label=label, reactive=False)
+            if is_new:
+                self.initial_species.append(spec)
+
+        for spec in self.initial_species:
+            submit(spec, self.solvent)
+
+        # Add nonreactive species (e.g. bath gases) to core first
+        # This is necessary so that the PDep algorithm can identify the bath gas
+        for spec in self.initial_species:
+            if not spec.reactive:
+                self.reaction_model.enlarge(spec)
+        for spec in self.initial_species:
+            if spec.reactive:
+                self.reaction_model.enlarge(spec)
+
         # Seed mechanisms: add species and reactions from seed mechanism
         # DON'T generate any more reactions for the seed species at this time
         for seed_mechanism in self.seed_mechanisms:
@@ -623,13 +642,6 @@ class RMG(util.Subject):
         # that RMG can find them if their rates are large enough
         for library, option in self.reaction_libraries:
             self.reaction_model.add_reaction_library_to_edge(library)
-
-        # Also always add in a few bath gases (since RMG-Java does)
-        for label, smiles in [("Ar", "[Ar]"), ("He", "[He]"), ("Ne", "[Ne]"), ("N2", "N#N")]:
-            molecule = Molecule().from_smiles(smiles)
-            spec, is_new = self.reaction_model.make_new_species(molecule, label=label, reactive=False)
-            if is_new:
-                self.initial_species.append(spec)
 
         # Perform species constraints and forbidden species checks on input species
         for spec in self.initial_species:
@@ -689,15 +701,6 @@ class RMG(util.Subject):
             if vapor_liquid_mass_transfer.enabled:
                 spec.get_liquid_volumetric_mass_transfer_coefficient_data()
                 spec.get_henry_law_constant_data()
-
-        # Add nonreactive species (e.g. bath gases) to core first
-        # This is necessary so that the PDep algorithm can identify the bath gas
-        for spec in self.initial_species:
-            if not spec.reactive:
-                self.reaction_model.enlarge(spec)
-        for spec in self.initial_species:
-            if spec.reactive:
-                self.reaction_model.enlarge(spec)
 
         # chatelak: store constant SPC indices in the reactor attributes if any constant SPC provided in the input file
         # advantages to write it here: this is run only once (as species indexes does not change over the generation)

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -614,6 +614,11 @@ class RMG(util.Subject):
 
         # Initialize reaction model
 
+        # Reaction libraries: add species and reactions from reaction library to the edge so
+        # that RMG can find them if their rates are large enough
+        for library, option in self.reaction_libraries:
+            self.reaction_model.add_reaction_library_to_edge(library)
+
         # Also always add in a few bath gases (since RMG-Java does)
         for label, smiles in [('Ar', '[Ar]'), ('He', '[He]'), ('Ne', '[Ne]'), ('N2', 'N#N')]:
             molecule = Molecule().from_smiles(smiles)
@@ -637,11 +642,6 @@ class RMG(util.Subject):
         # DON'T generate any more reactions for the seed species at this time
         for seed_mechanism in self.seed_mechanisms:
             self.reaction_model.add_seed_mechanism_to_core(seed_mechanism, react=False)
-
-        # Reaction libraries: add species and reactions from reaction library to the edge so
-        # that RMG can find them if their rates are large enough
-        for library, option in self.reaction_libraries:
-            self.reaction_model.add_reaction_library_to_edge(library)
 
         # Perform species constraints and forbidden species checks on input species
         for spec in self.initial_species:


### PR DESCRIPTION
### Motivation or Problem
The current initialization would fail if one uses a pyrms-based reactor with seed mechanism and the seed mechanism contains species that are the initial species. It would fail with an error related to the initial species not in the `phase.names`.

### Description of Changes
I moved the code block for initializing the bath gases and the initial species in front of the seed mechanism code block.
