### PR TITLE
Deadend radical species selection RMG-RMS Twin PR

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -448,8 +448,6 @@ or :ref:`pruning <pruning>` can be turned on to speed up your simulation at a sl
 - ``toleranceMoveToCore`` indicates how high the edge flux ratio for a species must get to enter the core model. This tolerance is designed for controlling the accuracy of final model.
 - ``toleranceInterruptSimulation`` indicates how high the edge flux ratio must get to interrupt the simulation (before reaching the ``terminationConversion`` or ``terminationTime``).  This value should be set to be equal to ``toleranceMoveToCore`` unless the advanced :ref:`pruning <pruning>` feature is desired.
 
-.. _filterReactions:
-
 Advanced Setting:  Branching Criterion
 ----------------------------------------
 The flux criterion works very well for identifying new species that have high flux
@@ -504,6 +502,8 @@ For example ::
 				toleranceTransitoryDict={"NO":0.2},
 				transitoryStepPeriod=20,
 		)
+
+.. _filterReactions:
 
 Advanced Setting: Speed Up By Filtering Reactions
 -------------------------------------------------

--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -469,6 +469,21 @@ For example ::
 			  branchingRatioMax=1.0,
 		)
 
+Advanced Setting: Deadend Radical Elimination (RMS Reactors only)
+-----------------------------------------------------------------
+When generating mechanisms involving significant molecular growth (such as in polymerization),
+there are many possible radicals, so fast propagation pathways compete with very slow termination and chain transfer reactions.
+These slow reactions individually usually have a negligible impact on the model, and thus will not be picked up by the flux or branching criteria. 
+However, together they can have a very significant impact on the overall radical concentration, and need to be included in the generated mechanism. 
+The deadend radical elimination algorithm identifies important chain transfer and termination reactions in the edge, based on their flux ratio with radical consumption and termination reactions in the core. 
+
+For example ::
+
+		model(
+				toleranceMoveToCore=0.01,
+				toleranceReactionToCoreDeadendRadical=0.01,
+		)
+
 Advanced Setting:  Radical Flux Criterion (RMS Reactors Only)
 --------------------------------------------------------------
 At high radical concentrations important products can accumulate from termination reactions. In these cases

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1143,7 +1143,7 @@ def solvation(solvent):
     rmg.solvent = solvent
 
 
-def model(toleranceMoveToCore=None, toleranceRadMoveToCore=None,
+def model(toleranceMoveToCore=None, toleranceRadMoveToCore=np.inf,
           toleranceMoveEdgeReactionToCore=np.inf, toleranceKeepInEdge=0.0,
           toleranceInterruptSimulation=1.0,
           toleranceMoveEdgeReactionToSurface=np.inf, toleranceMoveSurfaceSpeciesToCore=np.inf,

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1155,7 +1155,8 @@ def model(toleranceMoveToCore=None, toleranceRadMoveToCore=None,
           maxNumSpecies=None, maxNumObjsPerIter=1, terminateAtMaxObjects=False,
           toleranceThermoKeepSpeciesInEdge=np.inf, dynamicsTimeScale=(0.0, 'sec'),
           toleranceBranchReactionToCore=0.0, branchingIndex=0.5, branchingRatioMax=1.0,
-          toleranceTransitoryDict={}, transitoryStepPeriod=20):
+          toleranceTransitoryDict={}, transitoryStepPeriod=20,
+          toleranceReactionToCoreDeadendRadical=0.0):
     """
     How to generate the model. `toleranceMoveToCore` must be specified. 
     toleranceMoveReactionToCore and toleranceReactionInterruptSimulation refers to an additional criterion for forcing an edge reaction to be included in the core
@@ -1199,6 +1200,7 @@ def model(toleranceMoveToCore=None, toleranceRadMoveToCore=None,
             branching_ratio_max=branchingRatioMax,
             transitory_tol_dict=toleranceTransitoryDict,
             transitory_step_period=transitoryStepPeriod,
+            tol_rxn_to_core_deadend_radical=toleranceReactionToCoreDeadendRadical,
         )
     )
 

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -402,7 +402,7 @@ class Reactor:
                                                 model_settings.filter_reactions, model_settings.max_num_objects_per_iter, model_settings.tol_branch_rxn_to_core,
                                                 model_settings.branching_ratio_max, model_settings.branching_index, model_settings.terminate_at_max_objects,
                                                 self.terminations, model_settings.filter_threshold, model_settings.transitory_tol_dict,
-                                                model_settings.transitory_step_period, atol=simulator_settings.atol, rtol=simulator_settings.rtol, solver=de.CVODE_BDF())
+                                                model_settings.transitory_step_period, model_settings.tol_rxn_to_core_deadend_radical, atol=simulator_settings.atol, rtol=simulator_settings.rtol, solver=de.CVODE_BDF())
 
         return terminated, resurrected, invalid_objects, unimolecular_threshold, bimolecular_threshold, trimolecular_threshold, max_edge_species_rate_ratios, t, x
 

--- a/rmgpy/rmg/settings.py
+++ b/rmgpy/rmg/settings.py
@@ -77,7 +77,7 @@ class ModelSettings(object):
                  terminate_at_max_objects=False, thermo_tol_keep_spc_in_edge=np.inf,
                  dynamics_time_scale=Quantity((0.0, 'sec')),
                  tol_branch_rxn_to_core=0.0, branching_index=0.5, branching_ratio_max=1.0,transitory_tol_dict=dict(),
-                 transitory_step_period=20):
+                 transitory_step_period=20, tol_rxn_to_core_deadend_radical=0.0):
 
         self.tol_keep_in_edge = tol_keep_in_edge
         self.tol_move_to_core = tol_move_to_core
@@ -101,6 +101,7 @@ class ModelSettings(object):
         self.branching_ratio_max = branching_ratio_max
         self.transitory_tol_dict = transitory_tol_dict
         self.transitory_step_period = transitory_step_period
+        self.tol_rxn_to_core_deadend_radical = tol_rxn_to_core_deadend_radical
 
         if tol_interrupt_simulation:
             self.tol_interrupt_simulation = tol_interrupt_simulation


### PR DESCRIPTION
### Motivation or Problem
During the generation of oligomerization mechanism, I found that current species selection algorithm often prioritize selecting propagation reaction in each iteration, such that RMG has difficulty recognizing the importance of many chain transfer and chain termination reactions. This causes the generated mechanism to contain many radicals that are only consumed by very slow reverse reaction and accumulate to nonphysical concentrations in the longer time span simulation. The algorithm designs to help RMG recognize these important but low flux chain transfer and chain termination reactions.

### Description of Change
I add tolerance to move reaction to core based on the dead-end radical algorithm. This is a RMG-RMS twin PR.
