### PR TITLE
Improve kH estimation code

### DIFF
--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -383,7 +383,7 @@ class TestSoluteDatabase(TestCase):
         solute_data = self.database.get_solute_data(species)
         solvent_data = self.database.get_solvent_data('benzene')
         T = 500 # in K
-        delG, Kfactor = self.database.get_T_dep_solvation_energy_from_LSER_298(solute_data, solvent_data, T)
+        delG, Kfactor, kH = self.database.get_T_dep_solvation_energy_from_LSER_298(solute_data, solvent_data, T)
         self.assertAlmostEqual(Kfactor, 0.403, 3)
         self.assertAlmostEqual(delG/1000, -13.59, 2) # delG is in J/mol
         # For temperature greater than or equal to the critical temperature of the solvent,
@@ -398,7 +398,7 @@ class TestSoluteDatabase(TestCase):
         delS298 = (delH298 - delG298) / 298 # in J/mol/K
         solvent_name = 'benzene'
         T = 500  # in K
-        delG, Kfactor = self.database.get_T_dep_solvation_energy_from_input_298(delG298, delH298, delS298, solvent_name, T)
+        delG, Kfactor, kH = self.database.get_T_dep_solvation_energy_from_input_298(delG298, delH298, delS298, solvent_name, T)
         self.assertAlmostEqual(Kfactor, 0.567, 3)
         self.assertAlmostEqual(delG / 1000, -12.18, 2)  # delG is in J/mol
         # test that it raises InputError for T above the critical temperature

--- a/rmgpy/data/vaporLiquidMassTransfer.py
+++ b/rmgpy/data/vaporLiquidMassTransfer.py
@@ -88,9 +88,8 @@ class VaporLiquidMassTransfer(RMGObject):
             Tcrit = solvent_data.get_solvent_coolprop_Tcrit()
             Ts = [float(T) for T in np.linspace(Tmin, Tcrit-0.01, 50)]
 
-        # The function `get_T_dep_solvation_energy_from_LSER_298`` returns (delG, Kfactor(T,Psat)), the henry's constant kH and the Kfactor = y/x
-        # can be related by kH(T,P) = lim_{x -> 0} P y/x = lim_{x -> 0} P Kfactor(T,P), and thus kH(T,Psat) = lim_{x -> 0} Psat Kfactor(T,Psat)
-        kHs = [self.database.get_T_dep_solvation_energy_from_LSER_298(solute_data, solvent_data, T)[1]* solvent_data.get_solvent_saturation_pressure(T) for T in Ts]
+        # The function `get_T_dep_solvation_energy_from_LSER_298`` returns (delG, Kfactor(T,Psat), kH(T))
+        kHs = [self.database.get_T_dep_solvation_energy_from_LSER_298(solute_data, solvent_data, T)[2] for T in Ts]
 
         return HenryLawConstantData(Ts=Ts,kHs=kHs)
 


### PR DESCRIPTION
### Motivation or Problem
kH as the ratio of pressure of a solute over concentration of a solute is easier to work with on the simulation side. `get_T_dep_solvation_energy_from_input_298` also already contains `rho_l` needed to convert Kfactor to kH (as Psat_solute,g/Csat_solute,l).

### Description of Changes
I moved the calculation of kH into `get_T_dep_solvation_energy_from_input_298` and calculates kH as Psat_solute,g/Csat_solute,l.
