### PR TITLE
adding check for macos in debug statement in reactors.py

### DIFF
--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -36,7 +36,7 @@ import sys
 import logging
 import itertools
 
-if __debug__:
+if __debug__ and sys.platform != 'darwin':
     try:
         from os.path import dirname, abspath, join, exists
         path_rms = dirname(dirname(dirname(abspath(__file__))))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
fix for #2392, mac nosetests fail with segmentation fault

### Description of Changes
added a check in `reactors.py` for mac os. imports julia as before if using a mac. 

### Testing
unit tests and CI tests will not pickup the change because they use ubuntu. ran tests locally and it worked with the added statement. 

### Reviewer Tips
if you have mac or ubuntu, try main branch with this change and see if you still get a segmentation fault. 
