### PR TITLE
Added 'r' at the start of regex pattern strings where it was missing

### DIFF
--- a/arkane/encorr/bac.py
+++ b/arkane/encorr/bac.py
@@ -409,7 +409,7 @@ class BAC:
             if symbol in self.bacs:
                 bac += count * self.bacs[symbol]
             else:
-                symbol_flipped = ''.join(re.findall('[a-zA-Z]+|[^a-zA-Z]+', symbol)[::-1])  # Check reversed symbol
+                symbol_flipped = ''.join(re.findall(r'[a-zA-Z]+|[^a-zA-Z]+', symbol)[::-1])  # Check reversed symbol
                 if symbol_flipped in self.bacs:
                     bac += count * self.bacs[symbol_flipped]
                 else:

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -475,7 +475,7 @@ class Database(object):
                 record = self.entries[label].item
                 lines = record.splitlines()
                 # If record is a logical node, make it into one.
-                if re.match("(?i)\s*(NOT\s)?\s*(OR|AND|UNION)\s*(\{.*\})", lines[1]):
+                if re.match(r"(?i)\s*(NOT\s)?\s*(OR|AND|UNION)\s*(\{.*\})", lines[1]):
                     self.entries[label].item = make_logic_node(' '.join(lines[1:]))
                 # Otherwise convert adjacency list to molecule or pattern
                 elif pattern:
@@ -497,7 +497,7 @@ class Database(object):
             raise DatabaseError("Load the dictionary before you load the tree.")
 
         # should match '  L3 : foo_bar '  and 'L3:foo_bar'
-        parser = re.compile('^\s*L(?P<level>\d+)\s*:\s*(?P<label>\S+)')
+        parser = re.compile(r'^\s*L(?P<level>\d+)\s*:\s*(?P<label>\S+)')
 
         parents = [None]
         for line in tree.splitlines():
@@ -1120,7 +1120,7 @@ class LogicNode(object):
     def __init__(self, items, invert):
         self.components = []
         for item in items:
-            if re.match("(?i)\s*(NOT\s)?\s*(OR|AND|UNION)\s*(\{.*\})", item):
+            if re.match(r"(?i)\s*(NOT\s)?\s*(OR|AND|UNION)\s*(\{.*\})", item):
                 component = make_logic_node(item)
             else:
                 component = item

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -265,7 +265,7 @@ class KineticsRules(Database):
                       " removed in version 2.3.", DeprecationWarning)
         index = 'General'  # mops up comments before the first rate ID
 
-        re_underline = re.compile('^\-+')
+        re_underline = re.compile(r'^\-+')
 
         comments = {}
         comments[index] = ''
@@ -352,7 +352,7 @@ class KineticsRules(Database):
             if len(line) > 48:  # make long lines line up in 10-space columns
                 flib.write(' ' * (10 - len(line) % 10))
             if entry.data.Tmax is None:
-                if re.match('\d+\-\d+', str(entry.data.Tmin).strip()):
+                if re.match(r'\d+\-\d+', str(entry.data.Tmin).strip()):
                     # Tmin contains string of Trange
                     Trange = '{0} '.format(entry.data.Tmin)
                 elif isinstance(entry.data.Tmin, ScalarQuantity):

--- a/rmgpy/data/surface.py
+++ b/rmgpy/data/surface.py
@@ -240,7 +240,7 @@ class MetalDatabase(object):
             raise DatabaseError("Cannot search for nothing.")
         assert isinstance(metal, str)
 
-        facet = re.search('\d+', metal)
+        facet = re.search(r'\d+', metal)
 
         if facet is not None:
             try:

--- a/rmgpy/molecule/draw.py
+++ b/rmgpy/molecule/draw.py
@@ -1229,7 +1229,7 @@ class MoleculeDrawer(object):
             heavy_atom = symbol[0]
 
             # Split label by atoms
-            labels = re.findall('[A-Z][a-z]*[0-9]*', symbol)
+            labels = re.findall(r'[A-Z][a-z]*[0-9]*', symbol)
             if not heavy_first:
                 labels.reverse()
             if 'C' not in symbol and 'O' not in symbol and len(atoms) == 1:

--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -1431,7 +1431,7 @@ class Fragment(Graph):
         mol_repr.update()
         smiles_after = mol_repr.to_smiles()
         import re
-        smiles = re.sub('\[Si-3\]', '', smiles_after)
+        smiles = re.sub(r'\[Si-3\]', '', smiles_after)
 
         return smiles
 

--- a/rmgpy/molecule/util.py
+++ b/rmgpy/molecule/util.py
@@ -41,7 +41,7 @@ def get_element_count(obj):
     if isinstance(obj, str):
         assert 'InChI=1' in obj
         mf = obj.split('/')[1]
-        pieces = re.findall('[A-Z][^A-Z]*', mf)  # split on capital letters
+        pieces = re.findall(r'[A-Z][^A-Z]*', mf)  # split on capital letters
 
         for piece in pieces:
             match = re.match(r"([a-z]+)([0-9]*)", piece, re.I)

--- a/rmgpy/qm/gaussian.py
+++ b/rmgpy/qm/gaussian.py
@@ -214,7 +214,7 @@ class GaussianMol(QMMolecule, Gaussian):
         for the `attempt`.
         """
         molfile = self.get_mol_file_path_for_calculation(attempt)
-        atomline = re.compile('\s*([\- ][0-9.]+\s+[\-0-9.]+\s+[\-0-9.]+)\s+([A-Za-z]+)')
+        atomline = re.compile(r'\s*([\- ][0-9.]+\s+[\-0-9.]+\s+[\-0-9.]+)\s+([A-Za-z]+)')
 
         output = ['', self.geometry.unique_id_long, '']
         output.append("{charge}   {mult}".format(charge=0, mult=(self.molecule.get_radical_count() + 1)))

--- a/rmgpy/qm/mopac.py
+++ b/rmgpy/qm/mopac.py
@@ -257,7 +257,7 @@ class MopacMol(QMMolecule, Mopac):
         """
 
         molfile = self.get_mol_file_path_for_calculation(attempt)
-        atomline = re.compile('\s*([\- ][0-9.]+)\s+([\- ][0-9.]+)+\s+([\- ][0-9.]+)\s+([A-Za-z]+)')
+        atomline = re.compile(r'\s*([\- ][0-9.]+)\s+([\- ][0-9.]+)+\s+([\- ][0-9.]+)\s+([A-Za-z]+)')
 
         output = [self.geometry.unique_id_long, '']
 


### PR DESCRIPTION
Added the `r` char at the start of regex pattern strings where it was missing. It designates a python "raw" string which passes through backslashes without change. It's recommend to always write Python regex pattern strings with the `r` char. (see [here](https://developers.google.com/edu/python/regular-expressions))

Practically, it causes many warning messages when debugging (I think Python can do without it, but it rightfully complaints)