### PR TITLE
Set Keq=inf for irreversible reactions.

### DIFF
--- a/rmgpy/solver/simple.pyx
+++ b/rmgpy/solver/simple.pyx
@@ -268,6 +268,9 @@ cdef class SimpleReactor(ReactionSystem):
             if rxn.reversible:
                 self.Keq[j] = rxn.get_equilibrium_constant(self.T.value_si)
                 self.kb[j] = self.kf[j] / self.Keq[j]
+            else:
+                self.kb[j] = 0.0
+                self.Keq[j] = np.inf
 
     def get_threshold_rate_constants(self, model_settings):
         """


### PR DESCRIPTION
### Motivation or Problem
Third body and pressure dependent reactions with collision efficiencies need to have their rate constants recalculated during the solver step because of the efficiencies, which means their reverse rates are re-evaluated using the Keq. If the Keq was left as zero (as the case prior to this commit) because a reaction was irreversible, then it would crash with a zero division error.

This fix allows irreversible, pressure-dependent reactions, with collision efficiencies.

(Not a common scenario - why would a PDep reaction ever be irreversible? but some published kinetic models have them, and so they have crept in to user's seed mechanisms).

### Description of Changes
When evaluating the equilibrium constant array (that is later reused) set it to `np.inf` for irreversible reactions
rather than leaving it at zero.

### Testing
I ran the unit test suite (locally) and it passed.
Obviously this particular scenario is not covered by an existing test - but at least nothing else broke!

### Reviewer Tips
I suggest @Nora-Khalil tries it on the seed mechanism that was causing her issues (that led to Chris discovering this bug).
Thank you both.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
