### PR TITLE
'Fragment' object has no attribute 'is_atom_in_cycle' error

### DIFF
--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -656,6 +656,19 @@ class Fragment(Graph):
         result = Graph.is_subgraph_isomorphic(self.mol_repr, other, new_initial_map)
         return result
 
+    def is_atom_in_cycle(self, atom):
+        """
+        Returns ``True`` if ``atom`` is in one or more cycles in the structure, ``False`` otherwise.
+        """
+        return self.is_vertex_in_cycle(atom)
+
+    def is_bond_in_cycle(self, bond):
+        """
+        Returns ``True`` if the bond between atoms ``atom1`` and ``atom2``
+        is in one or more cycles in the graph, ``False`` otherwise.
+        """
+        return self.is_edge_in_cycle(bond)
+
     def assign_representative_molecule(self):
 
         # create a molecule from fragment.vertices.copy

--- a/rmgpy/molecule/fragment_test.py
+++ b/rmgpy/molecule/fragment_test.py
@@ -1,11 +1,11 @@
 import os
 import unittest
 
-from rmgpy.species import Species
 from rmgpy.molecule import resonance
 from rmgpy.molecule.atomtype import ATOMTYPES
 from rmgpy.molecule.element import get_element
 from rmgpy.molecule.molecule import Atom, Bond, Molecule
+from rmgpy.species import Species
 
 import rmgpy.molecule.fragment
 
@@ -867,3 +867,31 @@ class TestFragment(unittest.TestCase):
         rdmol,_ = fragment.to_rdkit_mol()
 
         self.assertEqual(rdmol.GetNumAtoms(), 8)
+
+    def test_is_in_cycle_ethane(self):
+        """
+        Test the Fragment is_atom_in_cycle() and is_bond_in_cycle() methods with ethane.
+        """
+        frag = rmgpy.molecule.fragment.Fragment(smiles='CC')
+        for atom in frag.atoms:
+            self.assertFalse(frag.is_atom_in_cycle(atom))
+        for atom1 in frag.atoms:
+            for atom2, bond in atom1.bonds.items():
+                self.assertFalse(frag.is_bond_in_cycle(bond))
+
+    def test_is_in_cycle_cyclohexane(self):
+        """
+        Test the Fragment is_atom_in_cycle() and is_bond_in_cycle() methods with ethane.
+        """
+        frag = rmgpy.molecule.fragment.Fragment(smiles='C1CCCCC1')
+        for atom in frag.atoms:
+            if atom.is_hydrogen():
+                self.assertFalse(frag.is_atom_in_cycle(atom))
+            elif atom.is_carbon():
+                self.assertTrue(frag.is_atom_in_cycle(atom))
+        for atom1 in frag.atoms:
+            for atom2, bond in atom1.bonds.items():
+                if atom1.is_carbon() and atom2.is_carbon():
+                    self.assertTrue(frag.is_bond_in_cycle(bond))
+                else:
+                    self.assertFalse(frag.is_bond_in_cycle(bond))

--- a/rmgpy/molecule/fragment_test.py
+++ b/rmgpy/molecule/fragment_test.py
@@ -340,7 +340,7 @@ class TestFragment(unittest.TestCase):
 
         self.assertFalse(fragment.is_subgraph_isomorphic(other, initial_map=initial_map))
 
-    def test_assign_representative_species(self):
+    def test_assign_representative_species_1(self):
 
         smiles_like = 'RCR'
         fragment = rmgpy.molecule.fragment.Fragment().from_smiles_like_string(smiles_like)
@@ -350,6 +350,14 @@ class TestFragment(unittest.TestCase):
         expected_repr_spec = Species().from_smiles('C=CC(C)(CCCCCCCC(C)(C=C)C(C)C(C)C=CC)C(C)C(C)C=CC')
 
         self.assertTrue(expected_repr_spec.is_isomorphic(fragment.species_repr))
+
+    def test_assign_representative_species_2(self):
+
+        fragment = rmgpy.molecule.fragment.Fragment().from_smiles_like_string('CCR')
+        fragment.assign_representative_species()
+
+        self.assertEqual(fragment.species_repr.symmetry_number, 3.0)
+        self.assertEqual(fragment.species_repr.smiles.count('C'), 14+2)
 
     def test_assign_representative_molecule(self):
 
@@ -852,14 +860,6 @@ class TestFragment(unittest.TestCase):
         ethane = Molecule().from_smiles('CC')
 
         self.assertTrue(mol_repr.is_isomorphic(ethane))
-
-    def test_assign_representative_species(self):
-
-        fragment = rmgpy.molecule.fragment.Fragment().from_smiles_like_string('CCR')
-        fragment.assign_representative_species()
-
-        self.assertEqual(fragment.species_repr.symmetry_number, 3.0)
-        self.assertEqual(fragment.species_repr.smiles.count('C'), 14+2)
 
     def test_to_rdkit_mol(self):
 

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1420,7 +1420,7 @@ multiplicity 2
 
     def test_is_in_cycle_ethane(self):
         """
-        Test the Molecule.isInCycle() method with ethane.
+        Test the Molecule is_atom_in_cycle() and is_bond_in_cycle() methods with ethane.
         """
         molecule = Molecule().from_smiles('CC')
         for atom in molecule.atoms:
@@ -1431,7 +1431,7 @@ multiplicity 2
 
     def test_is_in_cycle_cyclohexane(self):
         """
-        Test the Molecule.isInCycle() method with ethane.
+        Test the Molecule is_atom_in_cycle() and is_bond_in_cycle() methods with cyclohexane.
         """
         molecule = Molecule().from_inchi('InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2')
         for atom in molecule.atoms:


### PR DESCRIPTION
Related to #2395

Another issue with the `Fragment` class was encountered. It takes time for these errors to pop (in my experience, only in an advanced stage of an RMG run after a few hundred species were added into the core).

I got the following trace:
```
Traceback (most recent call last):
  File "/home/alongd/Code/RMG-Py/rmg.py", line 112, in main
    rmg.execute(**kwargs)
  File "/home/alongd/Code/RMG-Py/rmgpy/rmg/main.py", line 944, in execute
    self.reaction_model.enlarge(objectToEnlarge)
  File "/home/alongd/Code/RMG-Py/rmgpy/rmg/model.py", line 709, in enlarge
    self.update_unimolecular_reaction_networks()
  File "/home/alongd/Code/RMG-Py/rmgpy/rmg/model.py", line 1918, in update_unimolecular_reaction_networks
    network.update(self, self.pressure_dependence)
  File "/home/alongd/Code/RMG-Py/rmgpy/rmg/pdep.py", line 808, in update
    spec.generate_statmech()
  File "rmgpy/species.py", line 821, in rmgpy.species.Species.generate_statmech
  File "/home/alongd/Code/RMG-Py/rmgpy/data/statmech.py", line 679, in get_statmech_data
    statmech_model = self.get_statmech_data_from_groups(molecule, thermo_model)
  File "/home/alongd/Code/RMG-Py/rmgpy/data/statmech.py", line 713, in get_statmech_data_from_groups
    return self.groups['groups'].get_statmech_data(molecule, thermo_model)
  File "/home/alongd/Code/RMG-Py/rmgpy/data/statmech.py", line 388, in get_statmech_data
    group_count = self.get_frequency_groups(molecule)
  File "/home/alongd/Code/RMG-Py/rmgpy/data/statmech.py", line 342, in get_frequency_groups
    if molecule.is_atom_in_cycle(atom):
AttributeError: 'Fragment' object has no attribute 'is_atom_in_cycle'
```

I'm not fluent in the purpose of the `Fragment` object, and one of the questions to be asked is whether the behavior that we see (here and in the previous PR) that a call inside statmech.py of `molecule.is_atom_in_cycle(atom)` is treating a `Fragment` instance instead of a `Molecule` instance is desired. Perhaps `Fragment` objects are not supposed to be processed by statmech at all? If so, then we need a more fundamental fix rather than these patches.
(I didn't specifically asked in the input file to use fragments)

This patch PR addresses the specific error in the above trace. We may encounter additional similar instances in the future since the `Fragment` class by design does not implement all the methods of the `Molecule` object. Perhaps a possible solution would be to inherit from `Molecule` instead of from `Graph`? E.g., `class Fragment(Molecule)`? I don't feel I have a thorough understanding of the `Fragment` object though to go ahead and implement this.