### PR TITLE
Adapt change in RMS to use keyword variables

### DIFF
--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -596,11 +596,11 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
                 kLA = rms.TemperatureDependentLiquidVolumetricMassTransferCoefficient(Ts=obj.liquid_volumetric_mass_transfer_coefficient_data.Ts,kLAs=obj.liquid_volumetric_mass_transfer_coefficient_data.kLAs)
             else:
                 kLA = rms.EmptyLiquidVolumetricMassTransferCoefficient()
-            return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, diff, rad, obj.molecule[0].multiplicity-1, obj.molecular_weight.value_si, kH, kLA, obj.thermo.comment)
+            return rms.Species(label=obj.label, index=obj.index, inchi="", smiles="", adjlist="", thermo=thermo, atomnums=atomnums, bondnum=bondnum, diffusion=diff, radius=rad, radicalelectrons=obj.molecule[0].multiplicity-1, molecularweight=obj.molecular_weight.value_si, henrylawconstant=kH, liquidvolumetricmasstransfercoefficient=kLA, comment=obj.thermo.comment)
         else:
             th = obj.get_thermo_data()
             thermo = to_rms(th)
-            return rms.Species(obj.label, obj.index, "", "", "", thermo, atomnums, bondnum, rms.EmptyDiffusivity(), 0.0, obj.molecule[0].multiplicity-1, 0.0, rms.EmptyHenryLawConstant(), rms.EmptyLiquidVolumetricMassTransferCoefficient(), obj.thermo.comment)
+            return rms.Species(label=obj.label, index=obj.index, inchi="", smiles="", adjlist="", thermo=thermo, atomnums=atomnums, bonnum=bondnum, diffusion=rms.EmptyDiffusivity(), radius=0.0, radicalelectrons=obj.molecule[0].multiplicity-1, molecularweight=0.0, henrylawconstant=rms.EmptyHenryLawConstant(), liquidvolumetricmasstransfercoefficient=rms.EmptyLiquidVolumetricMassTransferCoefficient(), comment=obj.thermo.comment)
     elif isinstance(obj, Reaction):
         reactantinds = [species_names.index(spc.label) for spc in obj.reactants]
         productinds = [species_names.index(spc.label) for spc in obj.products]
@@ -609,7 +609,7 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
         kinetics = to_rms(obj.kinetics, species_names=species_names, rms_species_list=rms_species_list, rmg_species=rmg_species)
         radchange = sum([spc.molecule[0].multiplicity-1 for spc in obj.products]) - sum([spc.molecule[0].multiplicity-1 for spc in obj.reactants])
         electronchange = 0 #for now
-        return rms.ElementaryReaction(obj.index, reactants, reactantinds, products, productinds, kinetics, electronchange, radchange, obj.reversible, [], obj.kinetics.comment)
+        return rms.ElementaryReaction(index=obj.index, reactants=reactants, reactantinds=reactantinds, products=products, productinds=productinds, kinetics=kinetics, electronchange=electronchange, radicalchange=radchange, reversible=obj.reversible, pairs=[], comment=obj.kinetics.comment)
     elif isinstance(obj, SolventData):
         return rms.Solvent("solvent", rms.RiedelViscosity(float(obj.A), float(obj.B), float(obj.C), float(obj.D), float(obj.E)))
     elif isinstance(obj, TerminationTime):


### PR DESCRIPTION
### Motivation or Problem
Currently, the default values in the rms.Species and rms.ElementaryReaction struct wouldn't kick in, which results in RMG-Py needing a Twin PR whenever RMS changes its struct, even when it's not relevant to RMG. This is not ideal.

### Description of Changes
I made a constructor for rms.Species and rms.ElementaryReaction in RMS (https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/pull/210). This will make sure the default variable to kick in for rms.Species and rms.ElementaryReaction. This also allow for keyword variable input.

### Testing
I add a new commit at the end and it should launch test on the https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/pull/210 branch.

### Reviewer Tips
Remember to drop the last commit when merging the PR.

Edit: https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/pull/210 is merged, so I dropped the last commit.