### PR TITLE
CI: don't make destination directory for reference results when generating reference results

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,6 +149,7 @@ jobs:
             test/regression
 
       - name: mkdir stable_regression_results
+        if: github.ref != 'refs/heads/main'
         run: mkdir stable_regression_results
 
       # Retrieve Stable Results for reference


### PR DESCRIPTION
This PR adds a line to the CI that will cause it to skip the `mkdir stable_regression_results` step when it is running on a schedule or a push to main. Under such circumstances, the run _is_ the stable result and will therefore never download anything to this folder making it not needed.