### PR TITLE
`CI.yml` and `environment.yml` updates to run CI on MacOS and Ubuntu

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,6 +94,11 @@ jobs:
         with:
           version: "1.8.5"
 
+      - name: Install PyCall on MacOS Global Julia
+        if: runner.os == 'macos'
+        run: |
+          julia -e 'using Pkg; Pkg.add("PyCall"); using PyCall' || true 
+
       # RMS installation and linking to Julia
       # Allow these installs to 'fail' (as they do in RMG-Tests) with the command || True trick
       - name: Install and link Julia dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -235,7 +235,7 @@ jobs:
   # 
   # taken from https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
   ci-report-status:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build-and-test-unix
     if: always()
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,10 +76,12 @@ jobs:
           git clone -b $RMG_DATABASE_BRANCH https://github.com/ReactionMechanismGenerator/RMG-database.git
           
       # modify env variables as directed in the RMG installation instructions
-      - name: Set PYTHONPATH and PATH
+      - name: Set Environment Variables
         run: |
           RUNNER_CWD=$(pwd)
           echo "PYTHONPATH=$RUNNER_CWD/RMG-Py:$PYTHONPATH" >> $GITHUB_ENV
+          echo "JULIA_DEPOT_PATH=/usr/share/miniconda3/envs/rmg_env/share/julia/site" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=/usr/share/miniconda3/envs/rmg_env/lib" >> $GITHUB_ENV
           echo "$RUNNER_CWD/RMG-Py" >> $GITHUB_PATH
 
       # RMG build step

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,6 +88,12 @@ jobs:
           make clean
           make
 
+      - name: Add Global Julia Install on MacOS
+        if: runner.os == 'macos'
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.8.5"
+
       # RMS installation and linking to Julia
       # Allow these installs to 'fail' (as they do in RMG-Tests) with the command || True trick
       - name: Install and link Julia dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,7 @@ jobs:
               export FAILED=Yes
             fi
           done
-          if [[ -v FAILED ]]; then
+          if [[ ${FAILED} ]]; then
             echo "One or more regression tests could not be executed."
             echo "Please download the failed results or check the above log to see why."
             exit 1
@@ -219,7 +219,7 @@ jobs:
               fi
             fi
           done
-          if [[ -v FAILED ]]; then
+          if [[ ${FAILED} ]]; then
             echo "One or more regression tests failed."
             echo "Please download the failed results and run the tests locally or check the above log to see why."
             exit 1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
   build-and-test-linux:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     # skip scheduled runs on main from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
@@ -51,6 +51,12 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Update Xcode on MacOS
+        if: runner.os == 'macos'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       # configures the mamba environment manager and builds the environment
       - name: Setup Mambaforge Python 3.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,8 +80,6 @@ jobs:
         run: |
           RUNNER_CWD=$(pwd)
           echo "PYTHONPATH=$RUNNER_CWD/RMG-Py:$PYTHONPATH" >> $GITHUB_ENV
-          echo "JULIA_DEPOT_PATH=/usr/share/miniconda3/envs/rmg_env/share/julia/site" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/usr/share/miniconda3/envs/rmg_env/lib" >> $GITHUB_ENV
           echo "$RUNNER_CWD/RMG-Py" >> $GITHUB_PATH
 
       # RMG build step

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test-linux:
+  build-and-test-unix:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -231,6 +231,21 @@ jobs:
           mamba install -y -c conda-forge codecov
           codecov
 
+  # This allows us to have a branch protection rule for tests and deploys with matrix
+  # 
+  # taken from https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
+  ci-report-status:
+    runs-on: ubuntu-20.04
+    needs: build-and-test-unix
+    if: always()
+    steps:
+      - name: Successful CI
+        if: ${{ !(contains(needs.build-and-test-unix.result, 'failure')) }}
+        run: exit 0
+      - name: Failing CI
+        if: ${{ contains(needs.build-and-test-unix.result, 'failure') }}
+        run: exit 1          
+
   build-and-push-docker:
     # after testing and on pushes to main, build and push docker image
     # technically we could live without the 'needs' since _in theory_
@@ -238,7 +253,7 @@ jobs:
     # who knows ¯\_(ツ)_/¯
     # 
     # taken from https://github.com/docker/build-push-action
-    needs: build-and-test-linux
+    needs: build-and-test-unix
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.repository == 'ReactionMechanismGenerator/RMG-Py'
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,10 @@ concurrency:
 
 jobs:
   build-and-test-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-11]
+    runs-on: ${{ matrix.os }}
     # skip scheduled runs on main from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
     env: # update this if needed to match a pull request on the RMG-database
@@ -103,10 +106,11 @@ jobs:
 
       # Regression Testing - Test Execution
       - name: Regression Tests - Execution
+        timeout-minutes: 60
         run: |
           for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal;
           do
-            if timeout 600 python-jl rmg.py test/regression/"$regr_test"/input.py; then
+            if python-jl rmg.py test/regression/"$regr_test"/input.py; then
               echo "$regr_test" "Executed Successfully"
             else
               echo "$regr_test" "Failed to Execute"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,7 +135,7 @@ jobs:
       # Upload Regression Results as Stable if Scheduled or Push to Main
       - name: Upload Results as Reference
         # upload the results for scheduled CI (on main) and pushes to main
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && runner.os =='ubuntu'
         uses: actions/upload-artifact@v3
         with:
           name: stable_regression_results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,17 +88,6 @@ jobs:
           make clean
           make
 
-      - name: Add Global Julia Install on MacOS
-        if: runner.os == 'macos'
-        uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.8.5"
-
-      - name: Install PyCall on MacOS Global Julia
-        if: runner.os == 'macos'
-        run: |
-          julia -e 'using Pkg; Pkg.add("PyCall"); using PyCall' || true 
-
       # RMS installation and linking to Julia
       # Allow these installs to 'fail' (as they do in RMG-Tests) with the command || True trick
       - name: Install and link Julia dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,12 +51,6 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      
-      - name: Update Xcode on MacOS
-        if: runner.os == 'macos'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
 
       # configures the mamba environment manager and builds the environment
       - name: Setup Mambaforge Python 3.7

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -102,12 +102,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 #. Activate conda environment ::
 
     conda activate rmg_env
-    
-   Note regarding differences between conda versions: Prior to Anaconda 4.4, the command to activate an environment was
-   ``source activate rmg_env``. It has since been changed to ``conda activate rmg_env`` due to underlying changes to
-   standardize operation across different operating systems. However, a prerequisite to using the new syntax is having
-   run the ``conda init`` setup routine, which can be done at the end of the install procedure if the user requests.
-    
+
 #. Compile RMG-Py after activating the conda environment ::
 
     make

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -18,7 +18,8 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    Note that you should restart your terminal in order for the changes to take effect, as the installer will tell you.
 
 #. There are a few system-level dependencies which are required and should not be installed via Anaconda. These include
-   `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
+   `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, 
+   and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
 
    For Linux users, you can check whether these are already installed by simply calling them via the command line, which
    will let you know if they are missing. To install any missing packages, you should use the appropriate package manager
@@ -68,30 +69,33 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     conda install -n base conda-libmamba-solver
     conda config --set solver libmamba
 
-   Navigate to the RMG-Py directory ::
+#. Navigate to the RMG-Py directory ::
 
     cd RMG-Py
 
-.. warning:: Apple Silicon (M1+) Users
-   Execute the following commands instead of ``conda env create -f environment.yml``: ::
-    
+#. Apple silicon (M1+) users only: execute the following commands
+   **instead of** the following `conda env create -f environment.yml` step.
+   (This will tell conda that we want to the environment to use x86 
+   architecture rather than the native ARM64 architecture) ::
+
     conda create -n rmg_env
     conda activate rmg_env
     conda config --env --set subdir osx-64
     conda env update -f environment.yml
-..
 
-   Now create the conda environment for RMG-Py ::
+#. Create the conda environment for RMG-Py ::
 
     conda env create -f environment.yml
 
-   If either of these commands return an error due to being unable to find the ``conda`` command, try to either close and reopen your terminal to refresh your environment variables or type the following command.
+   If either of these commands return an error due to being unable to find the ``conda`` command,
+   try to either close and reopen your terminal to refresh your environment variables
+   or type the following command.
 
-   If on Linux or pre-Catalina MacOS ::
+   If on Linux or pre-Catalina MacOS (or if you have a bash shell)::
 
     source ~/.bashrc
 
-   If on MacOS Catalina or later ::
+   If on MacOS Catalina or later (or if you have a Z shell)::
 
     source ~/.zshrc
 
@@ -111,10 +115,10 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 #. Modify environment variables. Add RMG-Py to the PYTHONPATH to ensure that you can access RMG modules from any folder.
    Also, add your RMG-Py folder to PATH to launch ``rmg.py`` from any folder.
 
-   In general, these commands should be placed in the appropriate shell initialization file. For Linux users using
-   bash (the default on distributions mentioned here), these should be placed in ``~/.bashrc``. For MacOS users using bash (default before MacOS Catalina),
-   these should be placed in ``~/.bash_profile``, which you should create if it doesn't exist. For MacOS users using zsh
-   (default beginning in MacOS Catalina), these should be placed in ``~/.zshrc``. ::
+   In general, these commands should be placed in the appropriate shell initialization file.
+   For Linux users using bash (the default on distributions mentioned here), these should be placed in ``~/.bashrc``.
+   For MacOS users using bash (default before MacOS Catalina), these should be placed in ``~/.bash_profile``, which you should create if it doesn't exist.
+   For MacOS users using zsh (default beginning in MacOS Catalina), these should be placed in ``~/.zshrc``. ::
 
     export PYTHONPATH=YourFolder/RMG-Py/:$PYTHONPATH
     export PATH=YourFolder/RMG-Py/:$PATH

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -108,6 +108,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     make
 
 #. Modify environment variables. Add RMG-Py to the PYTHONPATH to ensure that you can access RMG modules from any folder.
+   *This is important before the next step in which julia dependencies are installed.*
    Also, add your RMG-Py folder to PATH to launch ``rmg.py`` from any folder.
 
    In general, these commands should be placed in the appropriate shell initialization file.

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -68,10 +68,9 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     conda install -n base conda-libmamba-solver
     conda config --set solver libmamba
 
-   Now create the conda environment for RMG-Py ::
+   Navigate to the RMG-Py directory ::
 
     cd RMG-Py
-    conda env create -f environment.yml
 
 .. warning:: Apple Silicon (M1+) Users
    Execute the following commands instead of ``conda env create -f environment.yml``: ::
@@ -81,6 +80,10 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     conda config --env --set subdir osx-64
     conda env update -f environment.yml
 ..
+
+   Now create the conda environment for RMG-Py ::
+
+    conda env create -f environment.yml
 
    If either of these commands return an error due to being unable to find the ``conda`` command, try to either close and reopen your terminal to refresh your environment variables or type the following command.
 
@@ -120,19 +123,11 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
    Be sure to either close and reopen your terminal to refresh your environment variables (``source ~/.bashrc`` or ``source ~/.zshrc``).
 
-#. Install and Link Julia dependencies ::
+#. Install and Link Julia dependencies: ::
+
+     julia -e 'using Pkg; Pkg.add("PyCall");Pkg.build("PyCall");Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
 
      python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
-
-     julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
-
-.. warning:: Apple Silicon (M1+) Users
-   Execute the following commands instead of ``conda env create -f environment.yml``: ::
-    
-    julia -e 'using Pkg; Pk.add("PyCall");Pkg.build("PyCall");Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
-
-    python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
-..
 
    Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
    interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -79,7 +79,6 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     conda create -n rmg_env
     conda activate rmg_env
     conda config --env --set subdir osx-64
-    conda install python=3.7
     conda env update -f environment.yml
 ..
 

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -47,17 +47,6 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    to install this is to simply run one of the commands in the terminal, e.g. ``git``. The terminal will then prompt you on
    whether or not you would like to install the Command Line Tools.
 
-   For MacOS users only, download and install MacOS Julia 1.8 from here: <https://julialang.org/downloads/>. Then add Julia to PATH by running the following command: ::
-
-     echo 'export PATH="/Applications/Julia-1.8.app/Contents/Resources/julia/bin:$PATH"' >> ~/.bash_profile
-
-     export PATH="/Applications/Julia-1.8.app/Contents/Resources/julia/bin:$PATH"
-
-   If using MacOS Catalina or newer your terminal may be using ``zsh`` by default, in which case you should replace ``.bash_profile`` with ``.zshrc``.
-   
-   Note that this Julia install will not respect conda environmental boundaries meaning only one conda environment can be linked to it at a time.
-
-
 #. Install the latest versions of RMG and RMG-database through cloning the source code via Git. Make sure to start in an
    appropriate local directory where you want both RMG-Py and RMG-database folders to exist.
    Github has deprecated password authentication from the command line, so it
@@ -83,6 +72,16 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     cd RMG-Py
     conda env create -f environment.yml
+
+.. warning:: Apple Silicon (M1+) Users
+   Execute the following commands instead of ``conda env create -f environment.yml``: ::
+    
+    conda create -n rmg_env
+    conda activate rmg_env
+    conda config --env --set subdir osx-64
+    conda install python=3.7
+    conda env update -f environment.yml
+..
 
    If either of these commands return an error due to being unable to find the ``conda`` command, try to either close and reopen your terminal to refresh your environment variables or type the following command.
 
@@ -127,6 +126,14 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
      python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
      julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
+
+.. warning:: Apple Silicon (M1+) Users
+   Execute the following commands instead of ``conda env create -f environment.yml``: ::
+    
+    julia -e 'using Pkg; Pk.add("PyCall");Pkg.build("PyCall");Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
+
+    python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
+..
 
    Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
    interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -129,18 +129,12 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
      python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
-   Note that this links your python to python-jl enabling calls to Julia through pyjulia. Occasionally programs will
-   interact with python-jl differently than the default python. If this occurs for you we recommend doing that operation
-   in a different conda environment. However, if convenient you can undo this linking by replacing python-jl with
-   python3 in the second command above. Just make sure to rerun the linking command once you are done.
 
 #. Finally, you can run RMG from any location by typing the following (given that you have prepared the input file as ``input.py`` in the current folder). ::
 
     python-jl replace/with/path/to/rmg.py input.py
 
 You may now use RMG-Py, Arkane, as well as any of the :ref:`Standalone Modules <modules>` included in the RMG-Py package.
-
-
 
 
 Test Suite

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -103,6 +103,10 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     conda activate rmg_env
 
+#. Switch the conda solver to libmamba again, to accelerate any changes you might make to this conda environment in the future::
+
+    conda config --set solver libmamba
+
 #. Compile RMG-Py after activating the conda environment ::
 
     make

--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,6 @@ dependencies:
 
 # general-purpose external software tools
   - conda-forge::julia>=1.8.5
-  - conda-forge::pyjulia
 
 # Python tools
   - python >=3.7
@@ -92,6 +91,14 @@ dependencies:
   - rmg::rdkit >=2020.03.3.0
   # We should use the official channel, not sure how difficult this
   # change will be.
+
+  - rmg::pyjulia
+  # This is identical to the conda-forge package, except that we run
+  # a hard to decipher sed command during the build process:
+  # https://github.com/ReactionMechanismGenerator/conda-recipes/blob/rmg-deps/pyjulia/build.sh#LL15C69-L15C69
+  #
+  # We should either remove the need to use this command or add this
+  # to the installation steps
 
 # conda mutex metapackage
   - nomkl

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - rmg::pydas >=1.0.3
   - pydot
   - rmg::pydqed >=1.0.3
-  - rmg::pyjulia
+  - conda-forge::julia=1.8.5
   - pymongo
   - pyparsing
   - rmg::pyrdl

--- a/environment.yml
+++ b/environment.yml
@@ -33,6 +33,8 @@ dependencies:
   - graphviz
   - markupsafe
   - psutil
+  # conda-forge not default, since default has a version information bug
+  # (see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2421)
   - conda-forge::ncurses
   - conda-forge::suitesparse
 
@@ -99,6 +101,18 @@ dependencies:
   #
   # We should either remove the need to use this command or add this
   # to the installation steps
+  # 
+  # Both pyrms and diffeqpy depend on this package.
 
 # conda mutex metapackage
   - nomkl
+
+# additional packages that are required, but not specified here (and why)
+  # pydqed, pydas, mopac, and likely others require a fortran compiler (specifically gfortran)
+  # in the environment. Normally we would add this to the environment file with
+  # - libgfortran-ng >= 10
+  # but this exact package is only maintained for Linux, meaning that if we were to add
+  # it here the environment creation would fail on Mac. The way it ends up working behind
+  # the scenes is that conda will find a different package for Mac that provides gfortran,
+  # but because we cannot specify per-platform requirements in this file we simply leave
+  # it out.

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,20 @@
+# environment.yml - conda environment specification file for RMG-Py
+#
+# Usage: conda env create --file environment.yml
+#
+# This file contains all of the software packages needed to run RMG-Py.
+# There is a mixture of the following
+# - packlages would could be installed at OS level, but we install here
+#   for better version control
+# - python tools
+# - external software tools specific to chemistry
+# - other software we maintain which RMG depends on
+# + some other categories (see below)
+#
+# Changelog:
+# - May 15, 2023 Added this changelog, added inline documentation,
+#   made depdency list more explicit (@JacksonBurns).
+#
 name: rmg_env
 channels:
   - defaults
@@ -5,51 +22,76 @@ channels:
   - conda-forge
   - cantera
 dependencies:
+# System-level dependencies - we could install these at the OS level
+# but by installing them in the conda environment we get better control
   - cairo
   - cairocffi
-  - cantera::cantera=2.6
-  - conda-forge::cclib >=1.6.3
-  - rmg::chemprop
-  - coolprop
-  - coverage
-  - cython >=0.25.2
-  - rmg::diffeqpy
   - ffmpeg
-  - rmg::gprof2dot
-  - graphviz
-  - h5py
-  - jinja2
-  - jupyter
-  - rmg::lpsolve55
-  - markupsafe
-  - matplotlib >=1.5
-  - conda-forge::mopac
-  - mpmath
-  - rmg::muq2
-  - networkx
-  - nomkl
-  - nose
-  - rmg::numdifftools
-  - numpy >=1.10.0
-  - conda-forge::openbabel >= 3
-  - pandas
-  - psutil
-  - rmg::pydas >=1.0.3
-  - pydot
-  - conda-forge::julia=1.8.5
-  - conda-forge::suitesparse
-  - rmg::pydqed >=1.0.3
-  - pymongo
-  - pyparsing
-  - rmg::pyrdl
-  - rmg::pyrms
-  - python >=3.7
-  - pyyaml
-  - rmg::quantities
-  - rmg::rdkit >=2020.03.3.0
-  - scikit-learn
-  - scipy
-  - rmg::symmetry
   - xlrd
   - xlwt
+  - h5py
+  - graphviz
+  - markupsafe
+  - psutil
   - conda-forge::ncurses
+  - conda-forge::suitesparse
+
+# external software tools for chemistry
+  - coolprop
+  - cantera::cantera=2.6
+  - conda-forge::mopac
+  - conda-forge::cclib >=1.6.3
+  - conda-forge::openbabel >= 3
+
+# general-purpose external software tools
+  - conda-forge::julia=1.8.5
+
+# Python tools
+  - python >=3.7
+  - coverage
+  - cython >=0.25.2
+  - scikit-learn
+  - scipy
+  - numpy >=1.10.0
+  - pydot
+  - jinja2
+  - jupyter
+  - pymongo
+  - pyparsing
+  - pyyaml
+  - networkx
+  - nose
+  - matplotlib >=1.5
+  - mpmath
+  - pandas
+
+# packages we maintain
+  - rmg::gprof2dot
+  - rmg::lpsolve55
+  - rmg::muq2
+  - rmg::numdifftools
+  - rmg::pydas >=1.0.3
+  - rmg::pydqed >=1.0.3
+  - rmg::pyrdl
+  - rmg::pyrms
+  - rmg::quantities
+  - rmg::symmetry
+  - rmg::pyjulia
+
+# packages we would like to stop maintaining (and why)
+  - rmg::diffeqpy
+  # we should use the official verison https://github.com/SciML/diffeqpy),
+  # rather than ours (which is only made so that we can get it from conda)
+  # It is only on pip, so we will need to do something like:
+  # https://stackoverflow.com/a/35245610
+
+  - rmg::chemprop
+  # Our build of this is version 0.0.1 (!!) and we are using parts
+  # of the API that are now gone. Need a serious PR to fix this.
+
+  - rmg::rdkit >=2020.03.3.0
+  # We should use the official channel, not sure how difficult this
+  # change will be.
+
+# conda mutex metapackage
+  - nomkl

--- a/environment.yml
+++ b/environment.yml
@@ -36,8 +36,9 @@ dependencies:
   - psutil
   - rmg::pydas >=1.0.3
   - pydot
-  - rmg::pydqed >=1.0.3
   - conda-forge::julia=1.8.5
+  - conda-forge::suitesparse
+  - rmg::pydqed >=1.0.3
   - pymongo
   - pyparsing
   - rmg::pyrdl

--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,8 @@ dependencies:
   - conda-forge::openbabel >= 3
 
 # general-purpose external software tools
-  - conda-forge::julia=1.8.5
+  - conda-forge::julia>=1.8.5
+  - conda-forge::pyjulia
 
 # Python tools
   - python >=3.7
@@ -76,7 +77,6 @@ dependencies:
   - rmg::pyrms
   - rmg::quantities
   - rmg::symmetry
-  - rmg::pyjulia
 
 # packages we would like to stop maintaining (and why)
   - rmg::diffeqpy


### PR DESCRIPTION
This PR runs the Continuous Integration on a mac runner in addition to the Ubuntu runner, the idea being that we can catch issues that might crop up on the mac platform independently of debian linux. The results from the ubuntu runner are still considered to be the "baseline" for regression testing.

See #2355 and #2392 for issues related to running on Macs