### PR TITLE
Fix Incorrect Rendering in RMG-Py Installation Documentation

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -78,10 +78,8 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     conda install -n base conda-libmamba-solver
     conda config --set solver libmamba
-    ..
-        The above step is retrieved from https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community also see https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2323
 
-    Now create the conda environment for RMG-Py ::
+   Now create the conda environment for RMG-Py ::
 
     cd RMG-Py
     conda env create -f environment.yml


### PR DESCRIPTION
The installation instructions are not rendering correctly (see [here](https://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/installation/anacondaDeveloper.html#:~:text=conda%20config%20%2D%2Dset%20solver%20libmamba%0A..%0A%20%20%20%20The%20above%20step%20is%20retrieved%20from%20https%3A//www.anaconda.com/blog/a%2Dfaster%2Dconda%2Dfor%2Da%2Dgrowing%2Dcommunity%20also%20see%20https%3A//github.com/ReactionMechanismGenerator/RMG%2DPy/issues/2323%0A%0ANow%20create%20the)) due to an inline comment and incorrect spacing. This PR removes the comment and fixes the spacing.