### PR TITLE
Added Arkane citation info

### DIFF
--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -1,27 +1,5 @@
-@article{doi:10.1021/acs.jcim.2c00965,
-author = {Johnson, Matthew S. and Dong, Xiaorui and Grinberg Dana, Alon and Chung, Yunsie and Farina, David Jr. and Gillis, Ryan J. and Liu, Mengjie and Yee, Nathan W. and Blondal, Katrin and Mazeau, Emily and Grambow, Colin A. and Payne, A. Mark and Spiekermann, Kevin A. and Pang, Hao-Wei and Goldsmith, C. Franklin and West, Richard H. and Green, William H.},
-title = {RMG Database for Chemical Property Prediction},
-journal = {Journal of Chemical Information and Modeling},
-volume = {62},
-number = {20},
-pages = {4906-4915},
-year = {2022},
-doi = {10.1021/acs.jcim.2c00965},
-    note ={PMID: 36222558},
-
-URL = { 
-        https://doi.org/10.1021/acs.jcim.2c00965
-    
-},
-eprint = { 
-        https://doi.org/10.1021/acs.jcim.2c00965
-    
-}
-
-}
-
-@article{GAO2016212,
-title = {Reaction Mechanism Generator: Automatic construction of chemical kinetic mechanisms},
+@article{RMG,
+title = {{Reaction Mechanism Generator: Automatic construction of chemical kinetic mechanisms}},
 journal = {Computer Physics Communications},
 volume = {203},
 pages = {212-225},
@@ -30,30 +8,37 @@ issn = {0010-4655},
 doi = {https://doi.org/10.1016/j.cpc.2016.02.013},
 url = {https://www.sciencedirect.com/science/article/pii/S0010465516300285},
 author = {Connie W. Gao and Joshua W. Allen and William H. Green and Richard H. West},
-keywords = {Chemical kinetics, Combustion, Automatic reaction mechanism generation, Rate-based algorithm},
-abstract = {Reaction Mechanism Generator (RMG) constructs kinetic models composed of elementary chemical reaction steps using a general understanding of how molecules react. Species thermochemistry is estimated through Benson group additivity and reaction rate coefficients are estimated using a database of known rate rules and reaction templates. At its core, RMG relies on two fundamental data structures: graphs and trees. Graphs are used to represent chemical structures, and trees are used to represent thermodynamic and kinetic data. Models are generated using a rate-based algorithm which excludes species from the model based on reaction fluxes. RMG can generate reaction mechanisms for species involving carbon, hydrogen, oxygen, sulfur, and nitrogen. It also has capabilities for estimating transport and solvation properties, and it automatically computes pressure-dependent rate coefficients and identifies chemically-activated reaction paths. RMG is an object-oriented program written in Python, which provides a stable, robust programming architecture for developing an extensible and modular code base with a large suite of unit tests. Computationally intensive functions are cythonized for speed improvements.
-Program summary
-Program title: RMG Catalogue identifier: AEZW_v1_0 Program summary URL:http://cpc.cs.qub.ac.uk/summaries/AEZW_v1_0.html Program obtainable from: CPC Program Library, Queen’s University, Belfast, N. Ireland Licensing provisions: MIT/X11 License No. of lines in distributed program, including test data, etc.: 958681 No. of bytes in distributed program, including test data, etc.: 9495441 Distribution format: tar.gz Programming language: Python. Computer: Windows, Ubuntu, and Mac OS computers with relevant compilers. Operating system: Unix/Linux/Windows. RAM: 1 GB minimum, 16 GB or more for larger simulations Classification: 16.12. External routines: RDKit, Open Babel, DASSL, DASPK, DQED, NumPy, SciPy Nature of problem: Automatic generation of chemical kinetic mechanisms for molecules containing C, H, O, S, and N. Solution method: Rate-based algorithm adds most important species and reactions to a model, with rate constants derived from rate rules and other parameters estimated via group additivity methods. Additional comments: The RMG software package also includes CanTherm, a tool for computing the thermodynamic properties of chemical species and both high-pressure-limit and pressure-dependent rate coefficients for chemical reactions using results from quantum chemical calculations. CanTherm is compatible with a variety of ab initio quantum chemistry software programs, including but not limited to Gaussian, MOPAC, QChem, and MOLPRO. Running time: From 30 s for the simplest molecules, to up to several weeks, depending on the size of the molecule and the conditions of the reaction system chosen.}
 }
 
-@article{doi:10.1021/acs.jcim.0c01480,
+@article{RMG3,
 author = {Liu, Mengjie and Grinberg Dana, Alon and Johnson, Matthew S. and Goldman, Mark J. and Jocher, Agnes and Payne, A. Mark and Grambow, Colin A. and Han, Kehang and Yee, Nathan W. and Mazeau, Emily J. and Blondal, Katrin and West, Richard H. and Goldsmith, C. Franklin and Green, William H.},
-title = {Reaction Mechanism Generator v3.0: Advances in Automatic Mechanism Generation},
+title = {{Reaction Mechanism Generator v3.0: Advances in Automatic Mechanism Generation}},
 journal = {Journal of Chemical Information and Modeling},
 volume = {61},
 number = {6},
 pages = {2686-2696},
 year = {2021},
 doi = {10.1021/acs.jcim.0c01480},
-    note ={PMID: 34048230},
-
-URL = { 
-        https://doi.org/10.1021/acs.jcim.0c01480
-    
-},
-eprint = { 
-        https://doi.org/10.1021/acs.jcim.0c01480
-    
 }
 
+@article{RMG_Database,
+author = {Johnson, Matthew S. and Dong, Xiaorui and Grinberg Dana, Alon and Chung, Yunsie and Farina, David Jr. and Gillis, Ryan J. and Liu, Mengjie and Yee, Nathan W. and Blondal, Katrin and Mazeau, Emily and Grambow, Colin A. and Payne, A. Mark and Spiekermann, Kevin A. and Pang, Hao-Wei and Goldsmith, C. Franklin and West, Richard H. and Green, William H.},
+title = {RMG Database for Chemical Property Prediction},
+journal = {Journal of Chemical Information and Modeling},
+volume = {62},
+number = {20},
+pages = {4906-4915},
+year = {2022},
+doi = {10.1021/acs.jcim.2c00965},
+}
+
+@article{Arkane,
+author = {Dana, Alon Grinberg and Johnson, Matthew S. and Allen, Joshua W. and Sharma, Sandeep and Raman, Sumathy and Liu, Mengjie and Gao, Connie W. and Grambow, Colin A. and Goldman, Mark J. and Ranasinghe, Duminda S. and Gillis, Ryan J. and Payne, A. Mark and Li, Yi-Pei and Dong, Xiaorui and Spiekermann, Kevin A. and Wu, Haoyang and Dames, Enoch E. and Buras, Zachary J. and Vandewiele, Nick M. and Yee, Nathan W. and Merchant, Shamel S. and Buesser, Beat and Class, Caleb A. and Goldsmith, Franklin and West, Richard H. and Green, William H.},
+title = {{Automated reaction kinetics and network exploration (Arkane): A statistical mechanics, thermodynamics, transition state theory, and master equation software}},
+journal = {International Journal of Chemical Kinetics},
+volume = {55},
+number = {6},
+pages = {300-323},
+doi = {https://doi.org/10.1002/kin.21637},
+year = {2023}
 }

--- a/arkane/README.md
+++ b/arkane/README.md
@@ -21,6 +21,16 @@ for RMG-Py.
 - [Arkane Documentation](http://ReactionMechanismGenerator.github.io/RMG-Py/users/arkane/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/main/documentation/RMG-Py_and_Arkane_Documentation.pdf))
 - [RMG API Reference](http://reactionmechanismgenerator.github.io/RMG-Py/reference/index.html) ([PDF version](https://github.com/ReactionMechanismGenerator/RMG-Py/raw/main/documentation/RMG-Py_API_Reference.pdf))
 
+## How to cite
+A. Grinberg Dana, M.S. Johnson, J.W. Allen, S. Sharma, S. Raman, M. Liu, C.W. Gao, C.A. Grambow, M.J. Goldman,
+D.S. Ranasinghe, R.J. Gillis, A.M. Payne, Y.-P. Li, X. Dong, K.A. Spiekermann, H. Wu, E.E. Dames, Z.J. Buras,
+N.M. Vandewiele, N.W. Yee, S.S. Merchant, B. Buesser, C.A. Class, C.F. Goldsmith, R.H. West, W.H. Green,
+"Automated reaction kinetics and network exploration (Arkane):
+A statistical mechanics, thermodynamics, transition state theory, and master equation software",
+*International Journal of Chemical Kinetics* 2023, 55(6), 300-323.
+
+DOI: [10.1002/kin.21637](https://doi.org/10.1002/kin.21637)
+
 ## How to Contribute
 Please see the [Contributor Guidelines](https://github.com/ReactionMechanismGenerator/RMG-Py/wiki/RMG-Contributor-Guidelines)
 for details on how to contribute to RMG-Py or RMG-database.

--- a/documentation/source/users/arkane/credits.rst
+++ b/documentation/source/users/arkane/credits.rst
@@ -1,13 +1,51 @@
+.. _credits:
+
 *******
 Credits
 *******
 
-**Author:** Joshua W. Allen (joshua.w.allen@gmail.com)
+Project Supervisors:
 
-**P.I.:** Prof. William H. Green (whgreen@mit.edu)
+- Prof. William H. Green (whgreen@mit.edu)
+- Prof. Richard H. West (r.west@northeastern.edu)
+- Prof. C. Franklin Goldsmith (franklin_Goldsmith@brown.edu)
+- Asst. Prof. Alon Grinberg Dana (alon@technion.ac.il)
 
-The author acknowledges the Green group for helping put the software through its
-paces and providing suggestions for its improvement.
+Developers: (rmg_dev@mit.edu)
 
-Arkane is based upon work supported by the `King Abdullah University of Science
-and Technology <http://www.kaust.edu.sa/>`_.
+- Dr. M.S. Johnson
+- Dr. J.W. Allen
+- Dr. S. Sharma
+- Dr. S. Raman
+- Dr. M. Liu
+- Dr. C.W. Gao
+- Dr. C.A. Grambow
+- Dr. M.J. Goldman
+- Dr. D.S. Ranasinghe
+- Dr. R.J. Gillis
+- Dr. A.M. Payne
+- Asst. Prof. Y.-P. Li
+- X. Dong
+- K.A. Spiekermann
+- H. Wu
+- Dr. E.E. Dames
+- Dr. Z.J. Buras,
+- Dr. N.M. Vandewiele
+- Dr. N.W. Yee
+- Dr. S.S. Merchant
+- Dr. B. Buesser
+- Dr. C.A. Class
+
+
+***********
+How to Cite
+***********
+
+A. Grinberg Dana, M.S. Johnson, J.W. Allen, S. Sharma, S. Raman, M. Liu, C.W. Gao, C.A. Grambow, M.J. Goldman,
+D.S. Ranasinghe, R.J. Gillis, A.M. Payne, Y.-P. Li, X. Dong, K.A. Spiekermann, H. Wu, E.E. Dames, Z.J. Buras,
+N.M. Vandewiele, N.W. Yee, S.S. Merchant, B. Buesser, C.A. Class, C.F. Goldsmith, R.H. West, W.H. Green,
+"Automated reaction kinetics and network exploration (Arkane):
+A statistical mechanics, thermodynamics, transition state theory, and master equation software",
+*International Journal of Chemical Kinetics* 2023, 55(6), 300-323.
+
+DOI: `10.1002/kin.21637 <https://doi.org/10.1002/kin.21637>`_

--- a/documentation/source/users/rmg/credits.rst
+++ b/documentation/source/users/rmg/credits.rst
@@ -13,16 +13,16 @@ Project Supervisors:
  
 Current Developers: (rmg_dev@mit.edu)
 
-- Dr. Alon G. Dana
-- Mark Goldman
-- Colin Grambow
-- Matt Johnson
-- Mengjie Liu
-- Mark Payne
+- Dr. Alon Grinberg Dana
+- Dr. Matt Johnson
 
 Previous Developers: 
 
 - Dr. Joshua W. Allen
+- Dr. Mark Goldman
+- Dr. Colin Grambow
+- Dr. Mengjie Liu
+- Dr. Mark Payne
 - Jacob Barlow
 - Dr. Pierre L. Bhoorasingh
 - Dr. Beat A. Buesser
@@ -44,5 +44,25 @@ Previous Developers:
 How to Cite
 ***********
 
-Connie W. Gao, Joshua W. Allen, William H. Green, Richard H. West, "Reaction Mechanism Generator: Automatic 
-construction of chemical kinetic mechanisms." *Computer Physics Communications* 203 (2016) 212-225. https://doi.org/10.1016/j.cpc.2016.02.013
+C.W. Gao, J.W. Allen, W.H. Green, R.H. West,
+"Reaction Mechanism Generator: Automatic construction of chemical kinetic mechanisms",
+*Computer Physics Communications* 2016, 203, 212-225.
+
+DOI: `10.1016/j.cpc.2016.02.013 <https://doi.org/10.1016/j.cpc.2016.02.013>`_
+
+
+M. Liu, A. Grinberg Dana, M.S. Johnson, M.J. Goldman, A. Jocher, A.M. Payne, C.A. Grambow, K. Han, N.W. Yee,
+E.J. Mazeau, K. Blondal, R.H. West, C.F. Goldsmith, W.H. Green,
+"Reaction Mechanism Generator v3.0: Advances in Automatic Mechanism Generation",
+*Journal of Chemical Information and Modeling* 2021, 61(6), 2686–2696.
+
+DOI: `10.1021/acs.jcim.0c01480 <https://doi.org/10.1021/acs.jcim.0c01480>`_
+
+
+
+M.S. Johnson, X. Dong, A. Grinberg Dana, Y. Chung, D. Farina, R.J. Gillis, M. Liu, N.W. Yee, K. Blondal,
+E. Mazeau, C.A. Grambow, A.M. Payne, K.A. Spiekermann, H.-W. Pang, C.F. Goldsmith, R.H. West, W.H. Green,
+"The RMG Database for Chemical Property Prediction",
+*Chemical Information* 2022, 62(20), 4906–4915.
+
+DOI: `10.1021/acs.jcim.2c00965 <https://doi.org/10.1021/acs.jcim.2c00965>`_


### PR DESCRIPTION
Added the citation info for Arkane into the docs and the module README

Also updated RMG's citations list.

Note that RMG's credits docs page has "developers" and "previous developers" lists. The current developers list is outdated, perhaps someone from Green Group and West group can complete it? Alternatively, we can just have one list of credits to avoid the need to update it every couple of years.

(docs were built locally and seem OK)