### PR TITLE
Update list of developers

### DIFF
--- a/documentation/source/users/rmg/credits.rst
+++ b/documentation/source/users/rmg/credits.rst
@@ -23,6 +23,9 @@ Current Developers: (rmg_dev@mit.edu)
 - Jonathan Zheng
 - Jackson Burns
 - Nathan Morgan
+- Prof. C. Franklin Goldsmith
+- Dr. Katrin Blondal
+- Dr. Bjarne Kreitz
 
 Previous Developers: 
 

--- a/documentation/source/users/rmg/credits.rst
+++ b/documentation/source/users/rmg/credits.rst
@@ -4,7 +4,9 @@
 Credits
 *******
  
-RMG is based upon work supported by the Department of Energy, Office of Basic Energy Sciences through grant DE-FG02-98ER14914 and by the National Science Foundation under Grants No. 0312359 and 0535604.
+RMG is based upon work supported by the Department of Energy, Office of Basic Energy Sciences through grant DE-FG02-98ER14914 and  as part of the Computational Chemical Sciences Program. 
+and by the National Science Foundation under Grants No. 0312359, 0535604, and 1751720.
+Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation or the Department of Energy.
 
 Project Supervisors:
 

--- a/documentation/source/users/rmg/credits.rst
+++ b/documentation/source/users/rmg/credits.rst
@@ -26,16 +26,20 @@ Current Developers: (rmg_dev@mit.edu)
 - Prof. C. Franklin Goldsmith
 - Dr. Katrin Blondal
 - Dr. Bjarne Kreitz
+- Chris Blais
+- Sevy Harris
+- Nora Khalil
 
 Previous Developers: 
 
 - Dr. Joshua W. Allen
 - Dr. Yunsie Chung
+- Dr. David Farina
 - Dr. Mark Goldman
 - Dr. Colin Grambow
 - Dr. Mengjie Liu
 - Dr. Mark Payne
-- Jacob Barlow
+- Dr. Jacob Barlow
 - Dr. Pierre L. Bhoorasingh
 - Dr. Beat A. Buesser
 - Dr. Caleb A. Class
@@ -43,7 +47,10 @@ Previous Developers:
 - Dr. Kehang Han
 - Dr. Fariba S. Khanshan
 - Victor Lambert
+- Dr. Emily Mazeau
 - Dr. Shamel S. Merchant
+- Priyanka Satpute
+- Dr. Sai Krishna Sirumalla
 - Dr. Belinda Slakman
 - Sean Troiano
 - Dr. Aaron Vandeputte

--- a/documentation/source/users/rmg/credits.rst
+++ b/documentation/source/users/rmg/credits.rst
@@ -15,10 +15,19 @@ Current Developers: (rmg_dev@mit.edu)
 
 - Dr. Alon Grinberg Dana
 - Dr. Matt Johnson
+- Yen-Ting Wang
+- Xiaorui Dong
+- Hao-Wei Pang
+- Oscar Wu
+- Kevin Spiekermann
+- Jonathan Zheng
+- Jackson Burns
+- Nathan Morgan
 
 Previous Developers: 
 
 - Dr. Joshua W. Allen
+- Dr. Yunsie Chung
 - Dr. Mark Goldman
 - Dr. Colin Grambow
 - Dr. Mengjie Liu

--- a/documentation/source/users/rmg/credits.rst
+++ b/documentation/source/users/rmg/credits.rst
@@ -4,8 +4,9 @@
 Credits
 *******
  
-RMG is based upon work supported by the Department of Energy, Office of Basic Energy Sciences through grant DE-FG02-98ER14914 and  as part of the Computational Chemical Sciences Program. 
-and by the National Science Foundation under Grants No. 0312359, 0535604, and 1751720.
+RMG is based upon work supported by the U.S. Department of Energy, Office of Basic Energy Sciences 
+(through grant DE-FG02-98ER14914 and as part of the Computational Chemical Sciences Program),
+and by the National Science Foundation (under Grants No. 0312359, 0535604, and 1751720).
 Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation or the Department of Energy.
 
 Project Supervisors:


### PR DESCRIPTION
This PR updates the list of current developers on RMG website: http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/credits.html#how-to-cite

I added all current members that do work related to RMG. I apologize in advance if I missed anyone. 

@sevyharris could you please add people from Professor West's group to help us update the list?