### PR TITLE
Modified assertion in thermodata.pyx 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,11 @@ nbproject/*
 .settings/*
 
 # PyCharm project files
+*/.idea/*
 .idea/*
 
 # VS Code settings
+*/.vscode/*
 .vscode/*
 
 # Unit test files

--- a/rmgpy/thermo/thermodata.pyx
+++ b/rmgpy/thermo/thermodata.pyx
@@ -261,7 +261,7 @@ cdef class ThermoData(HeatCapacityModel):
         S = self._S298.value_si
          
         # Correct the entropy from 298 K to the temperature of the lowest heat capacity point
-        assert Tdata[0] > 298
+        assert Tdata[0] >= 298
         Tlow = Tdata[0]; Thigh = Tdata[1]
         Cplow = Cpdata[0]; Cphigh = Cpdata[1]
         slope = (Cphigh - Cplow) / (Thigh - Tlow)


### PR DESCRIPTION
### Motivation or Problem
While trying to create a new thermo library, we got an assertion error since Cp data started in 298K.

### Description of Changes
We modified: `assert Tdata[0] > 298` into `assert  Tdata[0] >= 298`

Also modified gitignore file to consider files of PyCharm and VScode in subfolders

