### PR TITLE
use conda-forge ncurses instead of default

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,3 +50,4 @@ dependencies:
   - rmg::symmetry
   - xlrd
   - xlwt
+  - conda-forge::ncurses


### PR DESCRIPTION
the default does not provide version information which raises an annoying warning in the docker image