### PR TITLE
fix typo in reactors.py

### DIFF
--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -600,7 +600,7 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
         else:
             th = obj.get_thermo_data()
             thermo = to_rms(th)
-            return rms.Species(name=obj.label, index=obj.index, inchi="", smiles="", adjlist="", thermo=thermo, atomnums=atomnums, bonnum=bondnum, diffusion=rms.EmptyDiffusivity(), radius=0.0, radicalelectrons=obj.molecule[0].multiplicity-1, molecularweight=0.0, henrylawconstant=rms.EmptyHenryLawConstant(), liquidvolumetricmasstransfercoefficient=rms.EmptyLiquidVolumetricMassTransferCoefficient(), comment=obj.thermo.comment)
+            return rms.Species(name=obj.label, index=obj.index, inchi="", smiles="", adjlist="", thermo=thermo, atomnums=atomnums, bondnum=bondnum, diffusion=rms.EmptyDiffusivity(), radius=0.0, radicalelectrons=obj.molecule[0].multiplicity-1, molecularweight=0.0, henrylawconstant=rms.EmptyHenryLawConstant(), liquidvolumetricmasstransfercoefficient=rms.EmptyLiquidVolumetricMassTransferCoefficient(), comment=obj.thermo.comment)
     elif isinstance(obj, Reaction):
         reactantinds = [species_names.index(spc.label) for spc in obj.reactants]
         productinds = [species_names.index(spc.label) for spc in obj.products]


### PR DESCRIPTION
This typo prevents RMG from running if a surface species is in the mechanism. 