### PR TITLE
Calculate x only when semiclassical corrections are needed

### DIFF
--- a/rmgpy/statmech/torsion.pyx
+++ b/rmgpy/statmech/torsion.pyx
@@ -328,9 +328,6 @@ cdef class HinderedRotor(Torsion):
         cdef double beta = 1. / (constants.R * T), V, phi, dphi
         cdef int k
 
-        frequency = self.get_frequency() * constants.c * 100
-        x = constants.h * frequency / (constants.kB * T)
-
         if self.quantum:
             if self.energies is None: self.solve_schrodinger_equation()
             return np.sum(np.exp(-self.energies / constants.R / T)) / self.symmetry
@@ -353,6 +350,7 @@ cdef class HinderedRotor(Torsion):
 
         # Semiclassical correction
         if self.semiclassical:
+            x = constants.h * self.get_frequency() * constants.c * 100 / (constants.kB * T)
             Q *= x / (1 - exp(-x))
 
         return Q


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
`frequency` and `x` in get_partition_function are only needed in the end of the function if semiclassical correction is needed. I suggest moving them to the end of the function, after checking `self.semiclassical`

### Description of Changes
Moved `frequency` and `x` to the end of the function.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
