### PR TITLE
fix typo in updated docker installation docs

### DIFF
--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -36,7 +36,7 @@ For users unfamiliar with bash or Linux, we recommend looking at
 
 
 Alternative Install: Binary Installation Using Anaconda
-===================================================
+===========================================================
 
 If you are accustomed to using the Anaconda package manager or cannot tolerate the storage overhead of Docker, installation from conda is also available.
 This is recommended for users who want to use RMG out of the box and are not interested in changing the RMG code or making many additions to RMG's thermodynamic and kinetics databases.


### PR DESCRIPTION
missing some equal signs, causes a warning to be rendered: https://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/installation/index.html#alternative-install-binary-installation-using-anaconda
