### PR TITLE
transport warning for undefined species in load_transport_file

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -896,10 +896,12 @@ def remove_comment_from_line(line):
     return line, comment
 
 
-def load_transport_file(path, species_dict):
+def load_transport_file(path, species_dict, skip_missing_species=False):
     """
     Load a Chemkin transport properties file located at `path` and store the
     properties on the species in `species_dict`.
+    If skip_missing_species=True then species not defined in the species_dict 
+    are just skipped over, with a warning.
     """
     with open(path, 'r') as f:
         for line0 in f:
@@ -909,6 +911,10 @@ def load_transport_file(path, species_dict):
                 # This line contains an entry, so parse it
                 label = line[0:16].strip()
                 data = line[16:].split()
+                if skip_missing_species:
+                    if label not in species_dict:
+                        logging.warning(f"Skipping transport data for unknown species {label}")
+                        continue
                 species = species_dict[label]
                 species.transport_data = TransportData(
                     shapeIndex=int(data[0]),
@@ -999,7 +1005,7 @@ def load_chemkin_file(path, dictionary_path=None, transport_path=None, read_comm
     # If the transport path is given, then read it to obtain the transport
     # properties
     if transport_path:
-        load_transport_file(transport_path, species_dict)
+        load_transport_file(transport_path, species_dict, skip_missing_species=True)
 
     if not use_chemkin_names:
         # Apply species aliases if known


### PR DESCRIPTION

### Motivation or Problem
load_chemkin_file crashes if there is an extra species in the transport file that is not in the model. Some transport files (not generated in RMG) that I've received from other sources will have some extra species in the transport file, so I will have to manually search through the transport file and remove them, which can get annoying. This proposed fix allows the user to "skip" species in the transport file in the load_transport_file function without crashing. 

### Description of Changes
Added a parameter `skip_missing_species` to load_transport_file, and a for loop that catches species in the transport file that are not in the species dictionary and skips them.

### Testing
Tested .load_chemkin_file (which uses .load_transport_file) with two mechanisms: one with an extra species in the transport file, and one with only the appropriate species in the transport file. Warning about undefined species was raised as intended. 


