### PR TITLE
Fix documentation View Source links

### DIFF
--- a/documentation/source/_templates/sourcelink.html
+++ b/documentation/source/_templates/sourcelink.html
@@ -12,7 +12,7 @@
     <h3>{{ _('This Page') }}</h3>
         <ul class="this-page-menu">
             <li><a href="https://github.com/ReactionMechanismGenerator/RMG-Py/issues">Report A Bug</a></li>
-            <li><a href="https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/documentation/source/{{ sourcename|replace('.rst.txt','.rst')|e }}"
+            <li><a href="https://github.com/ReactionMechanismGenerator/RMG-Py/blob/main/documentation/source/{{ sourcename|replace('.rst.txt','.rst')|e }}"
                    rel="nofollow">View Source</a></li>
         </ul>
 </div>

--- a/documentation/source/users/arkane/installation.rst
+++ b/documentation/source/users/arkane/installation.rst
@@ -6,7 +6,7 @@ Installing Arkane
 =================
 
 Arkane can be obtained by installing the `RMG-Py <https://rmg.mit.edu/>`_ software, which
-includes all neccesary dependancies.
+includes all neccesary dependencies.
 
 Instructions to install RMG-Py can be found at the :ref:`RMG-Py Installation page <installation>`.
 


### PR DESCRIPTION
### Motivation or Problem
The documentation has links to view (and edit) the source code of the documentation. These pointed to master instead of main.

### Description of Changes
Fix the template.

Also, it seems, I fixed a typo some time ago, and github has mysteriously added it to this pull request. I'm betting that means I'll need to rebase this almost immediately upon creating it.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
