### PR TITLE
[Documentation]: point users to a specific version of RMG rather than latest

### DIFF
--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -16,11 +16,11 @@ RMG is primarily distributed using Docker, a software package for delivering app
 
 #. Download and install `Docker <https://docs.docker.com/get-docker/>`_.
 
-#. Open a terminal, powershell, or command prompt and run ``docker pull reactionmechanismgenerator/rmg:latest``.
+#. Open a terminal, powershell, or command prompt and run ``docker pull reactionmechanismgenerator/rmg:3.1.1``.
 
    This step may take some time as the image is downloaded.
 
-#. Run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it reactionmechanismgenerator/rmg:latest``
+#. Run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it reactionmechanismgenerator/rmg:3.1.1``
 
    This command will make the folder ``C:\Users\rmguser\myrmgfiles`` on your computer accessible from inside the container to easily edit and transfer input and output files.
    Change the path to match your individual computer.


### PR DESCRIPTION
TL;DR: This PR changes a couple lines in the docs to tell users to download RMG v3.1.1, which is a _temporary_ release we decided on in RMG subgroup to point users toward for RMG training (rather than `latest`).

Right now the documentation points users towards the `latest` build, which is the one that is constructed every night and after every merge to main. We should actually point them toward some specific version, which will allow us to actually debug issues since everyone who has problems will be running a version we can try ourselves. The latest build should be used by devs, or in the case that an error has been fixed but a minor or patch release has not yet been published. This should consequently include a more consistent release schedule.

To coincide with this I have pushed a 3.1.1 version of RMG to docker. This is not intended for long term use but is instead a stop-gap solution. We already have a PR open for 3.2 #1852 but that will not be done in time for RMG training. This patch release includes all changes from 3.1.0 to today (which will also be in 3.2, and this patch will be deleted).