### PR TITLE
Make 'test' a phony target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-.PHONY : all minimal main solver check pycheck arkane clean install decython documentation mopac_travis
+.PHONY : all minimal main solver check pycheck arkane clean install decython documentation mopac_travis test
 
 all: pycheck main solver check
 


### PR DESCRIPTION



<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Now that there's a folder called 'test' the target with the same name doesn't work properly in make, i.e.
if you do `make test` it just checks that the 'test' folder is up to date. 

### Description of Changes
My making it a "phony" target it doesn't do this, and it  once again works as intended.

### Testing
Ran `make test` on my computer.

Also using this opportunity to check running the CI from a pull request coming from a fork, rather than just a branch in the official repo.

### Reviewer Tips
If you want, learn about phony targets at https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
