### PR TITLE
Fix Documentation Build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,14 @@ jobs:
           cd RMG-Py
           sed -i '/embedsignature/s/# //g' setup.py
           make
-      - name: Make documentation
+      - name: Make documentation - CI
+        if: ${{  github.event_name != 'push' || github.repository != 'ReactionMechanismGenerator/RMG-Py' }}
+        run: |
+          make -C documentation continous_integration_setup clean html
+      - name: Make documentation - Publish
+        if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
+        env:
+            GH_TOKEN: ${{ secrets.RMG_DEV_TOKEN }}
         run: |
           make -C documentation continous_integration_setup clean html
       - name: Check documentation links


### PR DESCRIPTION
Previously I made a needed change to allow docs build and test to run on forks (#2431), but it broke the actual publish step (see https://github.com/ReactionMechanismGenerator/RMG-Py/actions/runs/4975775636/attempts/1). this commit adds an additional step to the docs build that will build the documentation with a dev token on pushes to main, or just build it for testing without one on forks/dev branches. Needs to be merged ASAP so the docs can be updated for RMG training.