### PR TITLE
Change variables from cpdef to cdef in cython.

### DIFF
--- a/rmgpy/molecule/translator.pxd
+++ b/rmgpy/molecule/translator.pxd
@@ -28,12 +28,12 @@
 cimport rmgpy.molecule.molecule as mm
 
 
-cpdef list BACKENDS
-cpdef dict INCHI_LOOKUPS
-cpdef dict SMILES_LOOKUPS
+cdef list BACKENDS
+cdef dict INCHI_LOOKUPS
+cdef dict SMILES_LOOKUPS
 
-cpdef dict MOLECULE_LOOKUPS
-cpdef dict RADICAL_LOOKUPS
+cdef dict MOLECULE_LOOKUPS
+cdef dict RADICAL_LOOKUPS
 
 cpdef str to_inchi(mm.Molecule mol, str backend=?, int aug_level=?)
 

--- a/rmgpy/molecule/vf2.pxd
+++ b/rmgpy/molecule/vf2.pxd
@@ -31,7 +31,7 @@ cdef class VF2:
 
     cdef Graph graph1, graph2
 
-    cpdef Graph graphA, graphB
+    cdef Graph graphA, graphB
     
     cdef dict initial_mapping
     cdef bint subgraph

--- a/rmgpy/quantity.pxd
+++ b/rmgpy/quantity.pxd
@@ -30,7 +30,7 @@ cimport numpy as np
 from rmgpy.rmgobject cimport RMGObject
 
 
-cpdef list NOT_IMPLEMENTED_UNITS
+cdef list NOT_IMPLEMENTED_UNITS
 
 ################################################################################
 


### PR DESCRIPTION

### Motivation or Problem
We were getting warnings
> warning: rmgpy/quantity.pxd:33:6: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables" because for variables (or constants) there is no difference between cpdef and cdef. A future version of cython will turn these warnings into errors.


### Description of Changes
I found the few instances where we tried to cpdef a variable (as opposed to a function or class) and changed them to cdef.

### Testing
I will let the test suite run.

### Reviewer Tips
See https://github.com/cython/cython/pull/3963 for context.
The CI tests should reveal any problems.
<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
