### PR TITLE
Add regression test for RMS reactor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Regression Tests - Execution
         timeout-minutes: 60
         run: |
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat;
           do
             if python-jl rmg.py test/regression/"$regr_test"/input.py; then
               echo "$regr_test" "Executed Successfully"
@@ -190,7 +190,7 @@ jobs:
         env:
           REFERENCE: stable_regression_results
         run: |
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat;
           do
             # Memory Usage and Execution Time
             echo 'Execution time for Reference:'

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -836,7 +836,7 @@ def constant_T_V_liquid_reactor(temperature,
     termination = []
     if terminationConversion is not None:
         for spec, conv in terminationConversion.items():
-            termination.append(TerminationConversion(species_dict[spec], conv))
+            termination.append((species_dict[spec], conv))
     if terminationTime is not None:
         termination.append(TerminationTime(Quantity(terminationTime)))
     if terminationRateRatio is not None:

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -441,8 +441,8 @@ class ConstantTLiquidSurfaceReactor(Reactor):
             inter,pinter = rms.ReactiveInternalInterfaceConstantTPhi(domainliq,domaincat,Main.eval("using ReactionMechanismSimulator; Vector{ElementaryReaction}()"),self.initial_conditions["liquid"]["T"],self.initial_conditions["surface"]["A"])
         else:
             inter,pinter = rms.ReactiveInternalInterfaceConstantTPhi(domainliq,domaincat,interface.reactions,self.initial_conditions["liquid"]["T"],self.initial_conditions["surface"]["A"])
-        react,y0,p = rms.Reactor((domainliq,domaincat), (y0liq,y0cat), (0.0, self.tf), [inter], p=(pliq,pcat,pinter))
-        return react, (domainliq,domaincat), [inter], p
+        react,y0,p = rms.Reactor((domainliq,domaincat), (y0liq,y0cat), (0.0, self.tf), (inter,), (pliq,pcat,pinter))
+        return react, (domainliq,domaincat), (inter,), p
 
 class ConstantTVLiquidReactor(Reactor):
     def __init__(self, core_phase_system, edge_phase_system, initial_conditions, terminations, constant_species=[],

--- a/test/regression/RMS_CSTR_liquid_oxidation/input.py
+++ b/test/regression/RMS_CSTR_liquid_oxidation/input.py
@@ -1,0 +1,66 @@
+# Test liquid-phase simulation with reaction filtering and flux pruning
+# Also test adding multiple species in each iteration and imposing species constraints.
+
+database(
+    thermoLibraries=['primaryThermoLibrary'],
+    reactionLibraries=[],
+    seedMechanisms=[],
+    kineticsDepositories='default',
+    kineticsFamilies=['default', 'liquid_peroxide'],
+    kineticsEstimator='rate rules',
+)
+
+generatedSpeciesConstraints(
+    allowed=['input species'],
+    maximumRadicalElectrons=1,
+    maximumCarbonAtoms=5,
+    maximumOxygenAtoms=4,
+)
+
+species(
+    label='oxygen',
+    reactive=True,
+    structure=SMILES('[O][O]')
+)
+
+species(
+    label='pentane',
+    reactive=True,
+    structure=SMILES('CCCCC'),
+)
+
+constantTVLiquidReactor(
+    temperature=(600, 'K'),
+    initialConcentrations={
+        'pentane': (3.0e-3, 'mol/cm^3'),
+        'oxygen': (1.0e-4, 'mol/cm^3'),
+    },
+    residenceTime=(20, 's'),
+    terminationConversion={'pentane': 0.3},
+    terminationTime=(1000, 's'),
+)
+
+solvation(
+    solvent='pentane'
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceMoveToCore=0.01,
+    toleranceKeepInEdge=0.001,
+    toleranceInterruptSimulation=1e8,
+    maximumEdgeSpecies=10000,
+    minCoreSizeForPrune=10,
+    minSpeciesExistIterationsForPrune=2,
+    maxNumObjsPerIter=3,
+    filterReactions=True,
+    maxNumSpecies=35,
+)
+
+options(
+    saveEdgeSpecies=True,
+)

--- a/test/regression/RMS_CSTR_liquid_oxidation/regression_input.py
+++ b/test/regression/RMS_CSTR_liquid_oxidation/regression_input.py
@@ -1,0 +1,25 @@
+options(
+    title='RMS_CSTR_liquid_oxidation',
+    tolerance=0.1
+)
+
+observable(
+    label='pentane',
+    structure=SMILES('CCCCC')
+)
+
+species(
+    label='oxygen',
+    structure=SMILES('[O][O]'),
+)
+
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([1e3], 's'),
+    initialMoleFractionsList=[{
+        'pentane': 0.9,
+        'oxygen': 0.1,
+    }],
+    temperatures=([600], 'K'),
+    pressures=([1.0], 'bar'),
+)

--- a/test/regression/RMS_constantVIdealGasReactor_superminimal/input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_superminimal/input.py
@@ -1,0 +1,50 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = ['H_Abstraction','Disproportionation','R_Recombination',
+                        'Birad_recombination', 'Birad_R_Recombination'],
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='H2',
+    reactive=True,
+    structure=SMILES("[H][H]"),
+)
+species(
+   label='O2',
+   reactive=True,
+   structure=SMILES("[O][O]"),
+)
+
+# Reaction systems
+constantVIdealGasReactor(
+    temperature=(1000,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        'H2':.67, 'O2':.33,
+    },
+    terminationConversion={
+        'H2': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceMoveToCore=0.01,
+    toleranceInterruptSimulation=0.01,
+)
+
+options(
+    units='si',
+    saveEdgeSpecies=True,
+)

--- a/test/regression/RMS_constantVIdealGasReactor_superminimal/regression_input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_superminimal/regression_input.py
@@ -1,0 +1,26 @@
+
+options(
+    title='RMS_constantVIdealGasReactor_superminimal',
+    tolerance=0.1
+)
+
+observable(
+    label='H2',
+    structure=SMILES("[H][H]"),
+)
+
+observable(
+   label='O2',
+   structure=SMILES("[O][O]"),
+)
+
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([0.01],'s'),
+    initialMoleFractionsList=[{
+        'H2':.67,
+        'O2':.33,
+    }],
+    temperatures=([1000],'K'),
+    pressures=([1.0],'bar'),
+)

--- a/test/regression/RMS_liquidSurface_ch4o2cat/input.py
+++ b/test/regression/RMS_liquidSurface_ch4o2cat/input.py
@@ -1,0 +1,88 @@
+# Data sources
+database(
+    thermoLibraries=[
+        "surfaceThermoPt111",
+        "primaryThermoLibrary",
+        "thermo_DFT_CCSDTF12_BAC",
+        "DFT_QCI_thermo",
+    ],  # 'surfaceThermoPt' is the default. Thermo data is derived using bindingEnergies for other metals
+    reactionLibraries=[
+        ("Surface/CPOX_Pt/Deutschmann2006_adjusted", False)
+    ],  # when Ni is used change the library to Surface/Deutschmann_Ni
+    seedMechanisms=[],
+    kineticsDepositories=["training"],
+    kineticsFamilies=["surface", "default"],
+    kineticsEstimator="rate rules",
+)
+
+catalystProperties(metal="Pt111")
+
+species(
+    label="CH4",
+    reactive=True,
+    structure=SMILES("[CH4]"),
+)
+
+species(
+    label="O2",
+    reactive=True,
+    structure=adjacencyList(
+        """
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+"""
+    ),
+)
+
+species(
+    label="pentane",
+    reactive=False,
+    structure=SMILES("CCCCC"),
+)
+
+species(
+    label="vacantX",
+    reactive=True,
+    structure=adjacencyList("1 X u0"),
+)
+
+# Reaction systems
+liquidSurfaceReactor(
+    temperature=(600, "K"),
+    initialConcentrations={
+        "CH4": (1.0e-4, "mol/cm^3"),
+        "O2": (1.0e-4, "mol/cm^3"),
+        "pentane": (3.0e-3, "mol/cm^3"),
+    },
+    initialSurfaceCoverages={
+        "vacantX": 1.0,
+    },
+    surfaceVolumeRatio=(1.0e5, "m^-1"),
+    terminationConversion={
+        "CH4": 0.99,
+    },
+    terminationTime=(0.1, "s"),
+)
+
+solvation(solvent="pentane")
+
+simulator(
+    atol=1e-18,
+    rtol=1e-12,
+)
+
+model(
+    toleranceMoveToCore=0.01,
+    toleranceKeepInEdge=0.001,
+    toleranceInterruptSimulation=1e8,
+    maximumEdgeSpecies=10000,
+    minCoreSizeForPrune=10,
+    minSpeciesExistIterationsForPrune=2,
+    maxNumObjsPerIter=3,
+    maxNumSpecies=35,
+)
+
+options(
+    units="si",
+    saveEdgeSpecies=True,
+)

--- a/test/regression/RMS_liquidSurface_ch4o2cat/regression_input.py
+++ b/test/regression/RMS_liquidSurface_ch4o2cat/regression_input.py
@@ -1,0 +1,39 @@
+
+options(
+    title='RMS_liquidSurface_ch4o2cat',
+    tolerance=0.1
+)
+
+
+observable(
+    label='CH4',
+    structure=SMILES("[CH4]"),
+)
+
+observable(
+   label='O2',
+   structure=adjacencyList(
+       """
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+"""),
+)
+
+species(
+    label='vacantX',
+    reactive=True,
+    structure=adjacencyList("1 X u0"),
+)
+
+
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([0.01],'s'),
+    initialMoleFractionsList=[{
+        "CH4": 0.1,
+        "O2": 0.2,
+        "vacantX": 1.0,
+    }],
+    temperatures=([600],'K'),
+    pressures=([1.0],'bar'),
+)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Currently we don't have any regression test for RMS based reactors. See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2442.

### Description of Changes
I add `input.py` and `regression_input.py` to test RMS's Constant V Ideal Gas Reactor and RMS's CSTR. Once this regression runs normally on CI, I will add more for other RMS reactors.
