### PR TITLE
Allow auxilary keywords in an Arkane species YAML file

### DIFF
--- a/rmgpy/rmgobject.pyx
+++ b/rmgpy/rmgobject.pyx
@@ -75,6 +75,9 @@ cdef class RMGObject(object):
             None
         """
         kwargs = recursive_make_object(data, class_dict, make_final_object=False)
+        for key in ['aux', 'mol']:
+            if key in kwargs.keys():
+                del kwargs[key]
         self.__init__(**kwargs)
 
 cpdef expand_to_dict(obj):

--- a/rmgpy/rmgobject.pyx
+++ b/rmgpy/rmgobject.pyx
@@ -129,15 +129,14 @@ cpdef recursive_make_object(obj, class_dictionary, make_final_object=True):
     return the recreated final object.
 
     Args:
-        obj (Any): dictionary representation of an object to be recreated
-        class_dictionary (dict): a dictionary mapping of class strings to classes
+        obj (Any): A dictionary representation of an object to be recreated
+        class_dictionary (dict): A dictionary mapping of class strings to classes
         make_final_object (bool): If True (default) the topmost object will be created and returned. Else, all nested
                                   objects will be recreated but only the keyword arguments needed to recreate the
                                   topmost object will be returned.
 
     Returns: 
         Any: recreated object (default) or dictionary of keyword arguments to recreate the final (topmost) object
-
     """
     if isinstance(obj, dict):
 

--- a/rmgpy/rmgobjectTest.py
+++ b/rmgpy/rmgobjectTest.py
@@ -256,6 +256,23 @@ class TestRMGObject(unittest.TestCase):
         self.assertEqual(obj.a[1].c, 5.0)
         self.assertEqual(obj.b, [])
 
+    def test_ignore_aux_and_mol(self):
+        """Test ignoring specific keys"""
+        data = {'a': [{'class': 'PseudoRMGObject', 'b': 'foobar'},
+                      {'class': 'PseudoRMGObject', 'c': 5.0}],
+                'mol': 7.0,
+                'aux': 2.5}
+        obj = PseudoRMGObject()
+        obj.make_object(data, class_dict={'PseudoRMGObject': PseudoRMGObject})
+        self.assertIsInstance(obj.a, list)
+
+        with self.assertRaises(TypeError):
+            data = {'a': [{'class': 'PseudoRMGObject', 'b': 'foobar'},
+                          {'class': 'PseudoRMGObject', 'c': 5.0}],
+                    'new_key': 2.5}
+            obj = PseudoRMGObject()
+            obj.make_object(data, class_dict={'PseudoRMGObject': PseudoRMGObject})
+
 
 class TestExpandAndMakeFromDictionaries(unittest.TestCase):
     """


### PR DESCRIPTION
### Motivation or Problem
Different use cases require additional information to be stored in an Arkane YAML file that is generated using the `RMGObject`. Thy may include atom order in a molecule.

### Description of Changes
Allow RMG to read Arkane YAML files through the `RMGObject` while ignoring ` mol` and `aux` keywords to store molecular and auxiliary information.

### Testing
A test was added
