### PR TITLE
Remove `chemprop`-dependent Code

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,8 @@
 # - May 15, 2023 Added this changelog, added inline documentation,
 #   made depdency list more explicit (@JacksonBurns).
 #
+# - May 31, 2023 Switch chemprop to official builds
+#
 name: rmg_env
 channels:
   - defaults
@@ -40,6 +42,7 @@ dependencies:
 
 # external software tools for chemistry
   - coolprop
+  - conda-forge::chemprop
   - cantera::cantera=2.6
   - conda-forge::mopac
   - conda-forge::cclib >=1.6.3
@@ -86,10 +89,6 @@ dependencies:
   # rather than ours (which is only made so that we can get it from conda)
   # It is only on pip, so we will need to do something like:
   # https://stackoverflow.com/a/35245610
-
-  - rmg::chemprop
-  # Our build of this is version 0.0.1 (!!) and we are using parts
-  # of the API that are now gone. Need a serious PR to fix this.
 
   - rmg::rdkit >=2020.03.3.0
   # We should use the official channel, not sure how difficult this


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
As discussed in #2445 our build of `chemprop` is very old and does not support Python 3.11, which will prevent us from doing so as well.

### Description of Changes
Right now the only change is to switch the channel in `environment.yml` from `rmg` to `conda-forge` for `chemprop`. This will likely break other code in `RMG-Py` and require additional changes afterward.

### Testing
I have done a `--dry-run` of resolving this environment file so that at least _works_, but there will be other things to fix as revealed by the CI. 

#### Notes
This PR will later need to be followed by an `upgrade` PR (as part of #2445) to move to chemprop v2, which will support Python 3.11

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
