### PR TITLE
Enable Metal, Facet, site and terrace specification in Molecule

### DIFF
--- a/documentation/source/reference/molecule/adjlist.rst
+++ b/documentation/source/reference/molecule/adjlist.rst
@@ -34,8 +34,8 @@ alphanumeric characters and the underscore, as if an identifier in many popular
 programming languages. However, strictly speaking any non-space ASCII character
 is allowed.
 
-The subsequent lines may contain keyword-value pairs. Currently there is only
-one keyword, ``multiplicity``.
+The subsequent lines may contain keyword-value pairs. Currently there can be: 
+``multiplicity``, ``metal`` and ``facet``.
 
 For species or molecule declarations, the value after ``multiplicity`` defines 
 the spin multiplicity of the molecule. E.g. ``multiplicity 1`` for most ground state 
@@ -44,7 +44,7 @@ and ``multiplicity 3`` for a triplet biradical.
 If the ``multiplicity`` line is not present then a value of 
 (1 + number of unpaired electrons) is assumed. 
 Thus, it can usually be omitted, but if present can be used to distinguish,
-for example, singlet CH2 from triplet CH2.
+for example, singlet CH2 from triplet CH2. 
 
 If defining a Functional :class:`~rmgpy.molecule.Group`, then the value must be a list,
 which defines the multiplicities that will be matched by the group, eg. 
@@ -52,6 +52,9 @@ which defines the multiplicities that will be matched by the group, eg.
 If a wildcard is desired, the line ``'multiplicity x`` can be used instead to accept
 all multiplicities.  If the multiplicity line is omitted altogether, then a wildcard 
 is assumed.
+
+``metal`` and ``facet`` work similarly and will correspond to lines like ``metal Fe``, 
+``metal [Fe,Cu,Ag]``, ``facet 111``, ``facet [111,211,110]``. 
 
 e.g. the following two group adjlists represent identical groups. ::
 
@@ -69,7 +72,7 @@ each subsequent line describes a single atom and its
 local bond structure. The format of these lines is a whitespace-delimited list
 with tokens ::
 
-    <number> [<label>] <element> u<unpaired> [p<pairs>] [c<charge>] <bondlist>
+    <number> [<label>] <element> u<unpaired> [p<pairs>] [c<charge>] [s<site>] [m<morphology>] <bondlist>
 
 The first item is the number used to identify that atom. Any number may be used,
 though it is recommended to number the atoms sequentially starting from one.
@@ -86,6 +89,8 @@ a sequence of tokens describing the electronic state of the atom:
 * ``p0`` number of lone **pairs** of electrons, common on oxygen and nitrogen.
 * ``c0`` formal **charge** on the atom, e.g. ``c-1`` (negatively charged),
   ``c0``, ``c+1`` (positively charged)
+* ``s`` the site type a site atom is e.g. ``s"fcc"``
+* ``m`` the morphology of a site atom e.g. ``m"terrace"``
 
 For :class:`~rmgpy.molecule.Molecule` definitions:
 The value must be a single integer (and for charge must have a + or - sign if not equal to 0)
@@ -94,7 +99,7 @@ The number of lone pairs and the formal charge are assumed to be zero if omitted
 
 For :class:`~rmgpy.molecule.Group` definitions:
 The value can be an integer or a list of integers (with signs, for charges),
-eg. ``u[0,1,2]`` or ``c[0,+1,+2,+3,+4]``, or may be a wildcard ``x`` 
+eg. ``u[0,1,2]``, ``c[0,+1,+2,+3,+4]``, or ``s["hcp","fcc"] or may be a wildcard ``x`` 
 which matches any valid value, 
 eg. ``px`` is the same as ``p[0,1,2,3,4, ...]`` and ``cx`` is the same as
 ``c[...,-4,-3,-2,-1,0,+1,+2,+3,+4,...]``. Lists must be enclosed is square brackets,
@@ -169,6 +174,12 @@ The allowed element types, radicals, and bonds are listed in the following table
  |                      | T        | Triple bond         |
  |                      +----------+---------------------+
  |                      | B        | Benzene bond        |
+ |                      +--------------------------------+
+ |                      | vdW      | Van der Waals bond  |
+ |                      +--------------------------------+
+ |                      | H        | Hydrogen bond       |
+ |                      +--------------------------------+
+ |                      | R        | Reaction bond       |
  +----------------------+----------+---------------------+
 
 

--- a/rmgpy/molecule/adjlist.py
+++ b/rmgpy/molecule/adjlist.py
@@ -460,7 +460,7 @@ re_old_adjlist = re.compile(r'^\s*(\d*)\s+' +  # atom number digit
                             r'\s*$')  # the end!
 
 
-def from_adjacency_list(adjlist, group=False, saturate_h=False):
+def from_adjacency_list(adjlist, group=False, saturate_h=False, check_consistency=True):
     """
     Convert a string adjacency list `adjlist` into a set of :class:`Atom` and
     :class:`Bond` objects.
@@ -772,7 +772,7 @@ def from_adjacency_list(adjlist, group=False, saturate_h=False):
             Saturator.saturate(atoms)
 
     # Consistency checks
-    if not group:
+    if not group and check_consistency:
         # Molecule consistency check
         # Electron and valency consistency check for each atom
         for atom in atoms:
@@ -790,6 +790,12 @@ def from_adjacency_list(adjlist, group=False, saturate_h=False):
         return atoms, multiplicity
     else:
         # Currently no group consistency check
+
+        if not group:
+            if multiplicity is None:
+                n_rad = sum([atom.radical_electrons for atom in atoms])
+                multiplicity = n_rad + 1
+
         return atoms, multiplicity
 
 

--- a/rmgpy/molecule/adjlistTest.py
+++ b/rmgpy/molecule/adjlistTest.py
@@ -171,6 +171,58 @@ class TestGroupAdjLists(unittest.TestCase):
         adjlist2 = group.to_adjacency_list()
 
         self.assertEqual(adjlist.strip(), adjlist2.strip())
+        
+    def test_metal_facet_site_morphology(self):
+        adjlist1 = """metal Cu
+facet 111
+1 *3 X u0 p0 c0 s"atop" m"terrace"  {2,S} {4,S}
+2 *1 O u0 p2 c0 {1,S} {3,R}
+3 *2 H u0 p0 c0 {2,R} {4,R}
+4 *4 X u0 p0 c0 s"hcp" m"terrace" {3,R} {1,S}"""
+        
+        adjlist2 = """multiplicity [1]
+metal [Cu, Fe, CuO2 ]
+facet [111, 211, 1101, 110, ]
+1 *3 X u0 p0 c0 s["atop","fcc"] m"terrace"  {2,S} {4,S}
+2 *1 O u0 p2 c0 {1,S} {3,R}
+3 *2 H u0 p0 c0 {2,R} {4,R}
+4 *4 X u0 p0 c0 s"hcp" m["terrace","sc"] {3,R} {1,S}"""
+        
+        adjlist1test = """metal Cu
+facet 111
+1 *3 X u0 p0 c0 s"atop" m"terrace" {2,S} {4,S}
+2 *1 O u0 p2 c0 {1,S} {3,R}
+3 *2 H u0 p0 c0 {2,R} {4,R}
+4 *4 X u0 p0 c0 s"hcp" m"terrace" {1,S} {3,R}"""
+        
+        adjlist2test = """multiplicity [1]
+metal [Cu,Fe,CuO2]
+facet [111,211,1101,110]
+1 *3 X u0 p0 c0 s["atop","fcc"] m"terrace" {2,S} {4,S}
+2 *1 O u0 p2 c0 {1,S} {3,R}
+3 *2 H u0 p0 c0 {2,R} {4,R}
+4 *4 X u0 p0 c0 s"hcp" m["terrace","sc"] {1,S} {3,R}"""
+        mol = Molecule().from_adjacency_list(adjlist1,check_consistency=False)
+        group = Group().from_adjacency_list(adjlist2)
+        
+        self.assertEqual(mol.metal,"Cu")
+        self.assertEqual(mol.facet,"111")
+        self.assertEqual(group.metal,["Cu","Fe","CuO2"])
+        self.assertEqual(group.facet,["111","211","1101","110"])
+        
+        self.assertEqual(mol.atoms[0].site,"atop")
+        self.assertEqual(mol.atoms[3].site,"hcp")
+        self.assertEqual(mol.atoms[0].morphology, "terrace")
+        self.assertEqual(mol.atoms[3].morphology, "terrace")
+        
+        self.assertEqual(group.atoms[0].site,["atop","fcc"])
+        self.assertEqual(group.atoms[3].site,["hcp"])
+        self.assertEqual(group.atoms[0].morphology, ["terrace"])
+        self.assertEqual(group.atoms[3].morphology,["terrace","sc"])
+        
+        self.assertEqual(mol.to_adjacency_list().strip(),adjlist1test.strip())
+        self.assertEqual(group.to_adjacency_list().strip(), adjlist2test.strip())
+
 
 
 class TestMoleculeAdjLists(unittest.TestCase):

--- a/rmgpy/molecule/atomtype.py
+++ b/rmgpy/molecule/atomtype.py
@@ -249,8 +249,8 @@ ATOMTYPES['Xv']   = AtomType('Xv', generic=['X'], specific=[],
                              benzene=[0], lone_pairs=[0])
 # Occupied surface site:
 ATOMTYPES['Xo']   = AtomType('Xo', generic=['X'], specific=[],
-                             single=[0, 1], all_double=[0, 1], r_double=[], o_double=[], s_double=[], triple=[0, 1],
-                             quadruple=[0, 1], benzene=[0], lone_pairs=[0])
+                             single=[0, 1, 2, 3, 4, 5, 6, 7, 8], all_double=[0, 1, 2, 3, 4, 5, 6, 7, 8], r_double=[], o_double=[], s_double=[], triple=[0, 1, 2, 3, 4, 5, 6, 7, 8],
+                             quadruple=[0, 1, 2, 3, 4, 5, 6, 7, 8], benzene=[0], lone_pairs=[0])
 
 # Non-surface atomTypes, R being the most generic:
 ATOMTYPES['R']    = AtomType(label='R', generic=[], specific=[

--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -28,6 +28,8 @@ class CuttingLabel(Vertex):
         self.isotope = -1
         self.id = id
         self.mass = 0
+        self.site = ''
+        self.morphology = ''
 
     def __str__(self):
         """
@@ -1290,7 +1292,7 @@ class Fragment(Graph):
         """
         from rmgpy.molecule.adjlist import from_adjacency_list
         
-        self.vertices, self.multiplicity = from_adjacency_list(adjlist, group=False, saturate_h=saturate_h)
+        self.vertices, self.multiplicity, self.site, self.morphology = from_adjacency_list(adjlist, group=False, saturate_h=saturate_h)
         self.update_atomtypes(raise_exception=raise_atomtype_exception)
         
         # Check if multiplicity is possible

--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -150,6 +150,8 @@ class Fragment(Graph):
         self.props = props or {}
         self.multiplicity = multiplicity
         self.reactive = reactive
+        self.metal = ''
+        self.facet = ''
 
         if inchi and smiles:
             logging.warning('Both InChI and SMILES provided for Fragment instantiation, '

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -166,7 +166,7 @@ cdef class Group(Graph):
 
     cpdef dict get_element_count(self)
 
-    cpdef from_adjacency_list(self, str adjlist)
+    cpdef from_adjacency_list(self, str adjlist, bint check_consistency=?)
 
     cpdef to_adjacency_list(self, str label=?)
     

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -38,13 +38,16 @@ cdef class GroupAtom(Vertex):
     cdef public list charge
     cdef public str label
     cdef public list lone_pairs
-
+    cdef public list site 
+    cdef public list morphology
     cdef public dict props
 
     cdef public list reg_dim_atm
     cdef public list reg_dim_u
     cdef public list reg_dim_r
-
+    cdef public list reg_dim_site
+    cdef public list reg_dim_morphology
+    
     cpdef Vertex copy(self)
 
     cpdef _change_bond(self, short order)

--- a/rmgpy/molecule/group.pxd
+++ b/rmgpy/molecule/group.pxd
@@ -126,7 +126,8 @@ cdef class Group(Graph):
 
     cdef public dict props
     cdef public list multiplicity
-
+    cdef public list metal 
+    cdef public list facet
     # These read-only attribues act as a "fingerprint" for accelerating
     # subgraph isomorphism checks
     cdef public dict elementCount

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -1744,14 +1744,14 @@ class Group(Graph):
 
         return element_count
 
-    def from_adjacency_list(self, adjlist):
+    def from_adjacency_list(self, adjlist, check_consistency=True):
         """
         Convert a string adjacency list `adjlist` to a molecular structure.
         Skips the first line (assuming it's a label) unless `withLabel` is
         ``False``.
         """
         from rmgpy.molecule.adjlist import from_adjacency_list
-        self.vertices, multiplicity = from_adjacency_list(adjlist, group=True)
+        self.vertices, multiplicity = from_adjacency_list(adjlist, group=True, check_consistency=check_consistency)
         if multiplicity is not None:
             self.multiplicity = multiplicity
         self.update()

--- a/rmgpy/molecule/group.py
+++ b/rmgpy/molecule/group.py
@@ -750,6 +750,8 @@ class GroupBond(Edge):
                 values.append('vdW')
             elif value == 0.1:
                 values.append('H')
+            elif value == 0.05:
+                values.append('R')
             else:
                 raise TypeError('Bond order number {} is not hardcoded as a string'.format(value))
         return values
@@ -775,6 +777,8 @@ class GroupBond(Edge):
                 values.append(1.5)
             elif value == 'H':
                 values.append(0.1)
+            elif value == 'R':
+                values.append(0.05)
             else:
                 # try to see if an float disguised as a string was input by mistake
                 try:
@@ -903,12 +907,28 @@ class GroupBond(Edge):
         """
         if wildcards:
             for order in self.order:
-                if abs(order) <= 1e-9:
+                if abs(order - 0.1) <= 1e-9:
                     return True
             else:
                 return False
         else:
-            return abs(self.order[0]) <= 1e-9 and len(self.order) == 1
+            return abs(self.order[0] - 0.1) <= 1e-9 and len(self.order) == 1
+        
+    def is_reaction_bond(self, wildcards=False):
+        """
+        Return ``True`` if the bond represents a reaction bond or ``False`` if
+        not. If `wildcards` is ``False`` we return False anytime there is more
+        than one bond order, otherwise we return ``True`` if any of the options
+        are reaction bonds.
+        """
+        if wildcards:
+            for order in self.order:
+                if abs(order - 0.05) <= 1e-9:
+                    return True
+            else:
+                return False
+        else:
+            return abs(self.order[0] - 0.05) <= 1e-9 and len(self.order) == 1
 
     def _change_bond(self, order):
         """

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -217,7 +217,7 @@ cdef class Molecule(Graph):
     cpdef from_smiles(self, str smilesstr, backend=?, bint raise_atomtype_exception=?)
 
     cpdef from_adjacency_list(self, str adjlist, bint saturate_h=?, bint raise_atomtype_exception=?,
-                              bint raise_charge_exception=?)
+                              bint raise_charge_exception=?, bint check_consistency=?)
 
     cpdef from_xyz(self, np.ndarray atomic_nums, np.ndarray coordinates, float critical_distance_factor=?, bint raise_atomtype_exception=?)
     

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -45,6 +45,8 @@ cdef class Atom(Vertex):
     cdef public AtomType atomtype
     cdef public np.ndarray coords
     cdef public short lone_pairs
+    cdef public str site 
+    cdef public str morphology
     cdef public int id
     cdef public dict props
     

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -146,6 +146,8 @@ cdef class Molecule(Graph):
     cdef public int multiplicity
     cdef public bint reactive
     cdef public dict props
+    cdef public str metal
+    cdef public str facet
     cdef str _fingerprint
     cdef str _inchi
     cdef str _smiles

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -88,6 +88,8 @@ class Atom(Vertex):
     `mass`               ``int``             atomic mass of element (read only)
     `number`             ``int``             atomic number of element (read only)
     `symbol`             ``str``             atomic symbol of element (read only)
+    `site`               ``str``             type of adsorption site
+    `morphology`         ``str``             morphology of the adsorption site
     ==================== =================== ====================================
 
     Additionally, the ``mass``, ``number``, and ``symbol`` attributes of the
@@ -95,8 +97,8 @@ class Atom(Vertex):
     e.g. ``atom.symbol`` instead of ``atom.element.symbol``.
     """
 
-    def __init__(self, element=None, radical_electrons=0, charge=0, label='', lone_pairs=-100, coords=np.array([]),
-                 id=-1, props=None):
+    def __init__(self, element=None, radical_electrons=0, charge=0, label='', lone_pairs=-100, site='', morphology='', 
+                 coords=np.array([]), id=-1, props=None):
         Vertex.__init__(self)
         if isinstance(element, str):
             self.element = elements.__dict__[element]
@@ -107,6 +109,8 @@ class Atom(Vertex):
         self.label = label
         self.atomtype = None
         self.lone_pairs = lone_pairs
+        self.site = site 
+        self.morphology = morphology
         self.coords = coords
         self.id = id
         self.props = props or {}
@@ -139,6 +143,8 @@ class Atom(Vertex):
             'sorting_label': self.sorting_label,
             'atomtype': self.atomtype.label if self.atomtype else None,
             'lone_pairs': self.lone_pairs,
+            'site': self.site,
+            'morphology': self.morphology,
         }
         if self.element.isotope == -1:
             element2pickle = self.element.symbol
@@ -157,6 +163,8 @@ class Atom(Vertex):
         self.sorting_label = d['sorting_label']
         self.atomtype = ATOMTYPES[d['atomtype']] if d['atomtype'] else None
         self.lone_pairs = d['lone_pairs']
+        self.site = d['site']
+        self.morphology = d['morphology']
 
     def __hash__(self):
         """
@@ -250,6 +258,16 @@ class Atom(Vertex):
                     if self.charge == charge: break
                 else:
                     return False
+            if ap.site:
+                for site in ap.site:
+                    if self.site == site: break
+                else:
+                    return False
+            if ap.morphology:
+                for morphology in ap.morphology:
+                    if self.morphology == morphology: break
+                else:
+                    return False
             if 'inRing' in self.props and 'inRing' in ap.props:
                 if self.props['inRing'] != ap.props['inRing']:
                     return False
@@ -293,6 +311,16 @@ class Atom(Vertex):
                         break
                 else:
                     return False
+            if atom.site:
+                for site in atom.site:
+                    if self.site == site: break
+                else:
+                    return False
+            if atom.morphology:
+                for morphology in atom.morphology:
+                    if self.morphology == morphology: break
+                else:
+                    return False
             if 'inRing' in self.props and 'inRing' in atom.props:
                 if self.props['inRing'] != atom.props['inRing']:
                     return False
@@ -316,6 +344,8 @@ class Atom(Vertex):
         a.label = self.label
         a.atomtype = self.atomtype
         a.lone_pairs = self.lone_pairs
+        a.site = self.site
+        a.morphology = self.morphology
         a.coords = self.coords[:]
         a.id = self.id
         a.props = deepcopy(self.props)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -701,6 +701,8 @@ class Bond(Edge):
             return 'vdW'
         elif self.is_hydrogen_bond():
             return 'H'
+        elif self.is_reaction_bond():
+            return 'R'
         else:
             raise ValueError("Bond order {} does not have string representation.".format(self.order))
 
@@ -722,6 +724,8 @@ class Bond(Edge):
             self.order = 0
         elif new_order == 'H':
             self.order = 0.1
+        elif new_order == 'R':
+            self.order = 0.05
         else:
             # try to see if an float disguised as a string was input by mistake
             try:
@@ -815,6 +819,13 @@ class Bond(Edge):
         """
         return self.is_order(0.1)
 
+    def is_reaction_bond(self):
+        """
+        Return ``True`` if the bond represents a reaction bond or ``False`` if
+        not.
+        """
+        return self.is_order(0.05)
+    
     def increment_order(self):
         """
         Update the bond as a result of applying a CHANGE_BOND action to
@@ -873,7 +884,7 @@ class Bond(Edge):
         the atom labels in alphabetical order (i.e. 'C-H' is possible but not 'H-C')
         :return: str
         """
-        bond_symbol_mapping = {0.1: '~', 1: '-', 1.5: ':', 2: '=', 3: '#'}
+        bond_symbol_mapping = {0.05: '~', 0.1: '~', 1: '-', 1.5: ':', 2: '=', 3: '#'}
         atom_labels = [self.atom1.symbol, self.atom2.symbol]
         atom_labels.sort()
         try:

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1718,7 +1718,7 @@ class Molecule(Graph):
         return self
 
     def from_adjacency_list(self, adjlist, saturate_h=False, raise_atomtype_exception=True,
-                            raise_charge_exception=True):
+                            raise_charge_exception=True, check_consistency=True):
         """
         Convert a string adjacency list `adjlist` to a molecular structure.
         Skips the first line (assuming it's a label) unless `withLabel` is
@@ -1726,7 +1726,8 @@ class Molecule(Graph):
         """
         from rmgpy.molecule.adjlist import from_adjacency_list
 
-        self.vertices, self.multiplicity = from_adjacency_list(adjlist, group=False, saturate_h=saturate_h)
+        self.vertices, self.multiplicity = from_adjacency_list(adjlist, group=False, saturate_h=saturate_h,
+                                                               check_consistency=check_consistency)
         self.update_atomtypes(raise_exception=raise_atomtype_exception)
         self.identify_ring_membership()
 


### PR DESCRIPTION
Also adds a "Reaction" bond order for creating bonds between atoms participating in a reaction so the structure can be considered as a whole without specific labels and enables sites to be bonded to each other. 

This enables creation of molecules from adjacency lists such as: 
```
    multiplicity 1
    metal Cu
    facet 111
    1 *3 X u0 p0 c0 s"atop" m"terrace"  {2,S} {4,S}
    2 *1 O u0 p2 c0 {1,S} {3,R}
    3 *2 H u0 p0 c0 {2,R} {4,R}
    4 *4 X u0 p0 c0 s"hcp" m"terrace" {3,R} {1,S}
```
