### PR TITLE
Increase allowed length of species labels for chemkin output. 

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1732,7 +1732,7 @@ def write_reaction_string(reaction, java_library=False):
 
     if kinetics is None:
         reaction_string = ' + '.join([get_species_identifier(reactant) for reactant in reaction.reactants])
-        reaction_string += ' => ' if not reaction.reversible else ' = '
+        reaction_string += ' <=> ' if reaction.reversible else ' => '
         reaction_string += ' + '.join([get_species_identifier(product) for product in reaction.products])
         return reaction_string
 
@@ -1777,7 +1777,7 @@ def write_reaction_string(reaction, java_library=False):
 
         reaction_string = '+'.join([get_species_identifier(reactant) for reactant in reaction.reactants])
         reaction_string += third_body
-        reaction_string += '=' if reaction.reversible else '=>'
+        reaction_string += '<=>' if reaction.reversible else '=>'
         reaction_string += '+'.join([get_species_identifier(product) for product in reaction.products])
         reaction_string += third_body
 

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1779,7 +1779,7 @@ def write_reaction_string(reaction, java_library=False):
         reaction_string += third_body
 
     if len(reaction_string) > 52:
-        logging.warning("Chemkin reaction string {0!r} is too long for Chemkin 2!".format(reaction_string))
+        logging.debug("Chemkin reaction string '%s' is too long for Chemkin 2!", reaction_string)
     return reaction_string
 
 ################################################################################

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -1559,13 +1559,10 @@ def get_species_identifier(species):
         # No index present -- probably not in RMG job
         # In this case just return the label (if the right size)
         if len(label) > 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#.:\[\]]+', label):
-            if len(label) <= 10:
-                return label
-            elif len(label) <= 15:
-                #logging.warning('Species label {0} is longer than 10 characters and may exceed chemkin string limit'.format(label))
+            if len(label) <= 16:
                 return label
             else:
-                logging.warning('Species label is longer than 15 characters and will break CHEMKIN 2.0')
+                logging.warning('Species label is longer than 16 characters and will break CHEMKIN 2.0')
                 return label
         else:
             # try the chemical formula if the species label is not present
@@ -1581,14 +1578,14 @@ def get_species_identifier(species):
         # The label can only contain alphanumeric characters, and -()*#_,.:[]
         if len(label) > 0 and species.index >= 0 and not re.search(r'[^A-Za-z0-9\-_,\(\)\*#.:\[\]]+', label):
             name = '{0}({1:d})'.format(label, species.index)
-            if len(name) <= 10:
+            if len(name) <= 16:
                 return name
 
         # Next try the chemical formula
         if len(species.molecule) > 0:
             # Try the chemical formula
             name = '{0}({1:d})'.format(species.molecule[0].get_formula(), species.index)
-            if len(name) <= 10:
+            if len(name) <= 16:
                 if 'obs' in label:
                     # For MBSampledReactor, keep observed species tag
                     return name + '_obs'
@@ -1602,7 +1599,7 @@ def get_species_identifier(species):
                 name = 'SX({0:d})'.format(species.index)
             else:
                 name = 'S({0:d})'.format(species.index)
-            if len(name) <= 10:
+            if len(name) <= 16:
                 if 'obs' in label:
                     # For MBSampledReactor, keep observed species tag
                     return name + '_obs'

--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -351,13 +351,14 @@ def _read_kinetics_reaction(line, species_dict, Aunits, Aunits_surf, Eunits):
 
     # Split the reaction equation into reactants and products
     reversible = True
-    reactants, products = reaction.split('=')
     if '<=>' in reaction:
-        reactants = reactants[:-1]
-        products = products[1:]
+        reactants, products = reaction.split('<=>')
     elif '=>' in reaction:
-        products = products[1:]
+        reactants, products = reaction.split('=>')
         reversible = False
+    else:
+        reactants, products = reaction.split('=')
+
     specific_collider = None
     # search for a third body collider, e.g., '(+M)', '(+m)', or a specific species like '(+N2)',
     #     matching `(+anything_other_than_ending_parenthesis)`:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Anyone who uses RMG likely has encountered the frustrating `S(14567)` species label.

### Description of Changes
This has a few commits by @goldmanm cherry-picked from https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1648 which was recently closed as abandoned.

He wrote:
> In RMG it expands the species length from 10 characters to 16 characters, almost entirely eliminating the dreaded S label.
> This PR is compatible with the cantera and modern versions of chemkin. Unmodified versions of chemkin 2 will not be able to run some models because of a limitation on the length of reaction. chemkin 2, however, can be modified by the users to be compatible with the more widely used chemkin specifications.

I skipped the commits that alter Arkane.

There's also a commit that changes the default chemkin output style for a reaction from 
`A+B=C+D` to `A+B<=>C+D` (notice the arrowheads).
This change I'm not so sure about, because it's not strictly necessary and some folks may have downstream scripts that search for or parse reactions in a certain way.  Anyone have opinions?



