### PR TITLE
Don't replace PDep kinetics of a library reaction

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -864,9 +864,9 @@ class CoreEdgeReactionModel:
                 # Since PDepReactions are created as irreversible, not doing so
                 # would cause you to miss the reverse reactions!
                 self.add_reaction_to_unimolecular_networks(rxn, new_species=new_species, network=pdep_network)
-                if isinstance(rxn, LibraryReaction):
-                    # If reaction came from a reaction library, omit it from the core and edge so that it does
-                    # not get double-counted with the pdep network
+                if isinstance(rxn, LibraryReaction) and not rxn.kinetics.is_pressure_dependent():
+                    # If the reaction came from a library, and it does not have PDep kinetics,
+                    # omit it from the core and edge so that it does not get double-counted with the pdep network
                     if rxn in self.core.reactions:
                         self.core.reactions.remove(rxn)
                     if rxn in self.edge.reactions:

--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -898,7 +898,7 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         reactants=configurations[j],
                         products=configurations[i],
                         network=self,
-                        kinetics=None
+                        kinetics=None,
                     )
                     net_reaction = reaction_model.make_new_pdep_reaction(net_reaction)
                     self.net_reactions.append(net_reaction)
@@ -911,10 +911,10 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         for rxn in reaction_model.core.reactions:
                             if isinstance(rxn, LibraryReaction) \
                                     and rxn.is_isomorphic(net_reaction, either_direction=True) \
-                                    and not rxn.allow_pdep_route and not rxn.elementary_high_p:
-                                logging.info('Network reaction {0} matched an existing core reaction {1}'
-                                             ' from the {2} library, and was not added to the model'.format(
-                                    str(net_reaction), str(rxn), rxn.library))
+                                    and not rxn.allow_pdep_route \
+                                    and (rxn.kinetics.is_pressure_dependent() or not rxn.elementary_high_p):
+                                logging.info(f'Network reaction {net_reaction} matched an existing core reaction {rxn} '
+                                             f'from the {rxn.library} library, and was not added to the model')
                                 break
                         else:
                             reaction_model.add_reaction_to_core(net_reaction)
@@ -923,10 +923,10 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                         for rxn in reaction_model.edge.reactions:
                             if isinstance(rxn, LibraryReaction) \
                                     and rxn.is_isomorphic(net_reaction, either_direction=True) \
-                                    and not rxn.allow_pdep_route and not rxn.elementary_high_p:
-                                logging.info('Network reaction {0} matched an existing edge reaction {1}'
-                                             ' from the {2} library, and was not added to the model'.format(
-                                    str(net_reaction), str(rxn), rxn.library))
+                                    and not rxn.allow_pdep_route \
+                                    and (rxn.kinetics.is_pressure_dependent() or not rxn.elementary_high_p):
+                                logging.info(f'Network reaction {net_reaction} matched an existing edge reaction {rxn} '
+                                             f'from the {rxn.library} library, and was not added to the model')
                                 break
                         else:
                             reaction_model.add_reaction_to_edge(net_reaction)


### PR DESCRIPTION
### Motivation or Problem
Library reactions marked with an ``elementary_high_p`` flag set to ``True`` can either have PDep kinetics or Arrhenius kinetics. The high-pressure-limit kinetics is used in PDep networks to improve them instead of using RMG's estimations. However, if the original library reaction already has PDep kinetics, then this library rate should end up in the model rather than a PDep estimation. Of course, if the library reaction only has Arrhenius (non-PDep) kinetics, and the reaction is pressure-dependent, the kinetics must be replaced with the PDep estimation.

### Description of Changes
Only omit a library reaction from the core if an isomorphic  PDep reaction was created and if the library reaction has no PDep kinetics (changes done to model.py).
Also, and complementary, don't add a network reaction to the core if the core already has an isomorphic library reaction with PDep kinetics marked as `elementary_high_p = True`.