### PR TITLE
Revert `libstdcxx-ng` Patches in CI, Docs, and Dockerfile

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     # skip scheduled runs from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
     env: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,5 @@
 # CI.yml
-# This file contains the script used by GitHub actions to execute the Constant Integration (CI)
+# This file contains the script used by GitHub actions to execute the Continuous Integration (CI)
 # for RMG-Py. This includes building RMG and its dependencies, executing the unit tests,
 # functional tests, database tests, and regression tests.
 # 
@@ -19,6 +19,7 @@
 # 2023-05-12 - added changes to allow running on forks
 # 2023-06-06 - added matrix build for libstdcxx-ng versions 12 and 13 on ubuntu. Only expect 12 to work.
 # 2023-06-07 - updated regression testing. Now fails if significant changes are detected.
+# 2023-06-15 - revert changes from 06-06, both now work
 name: Continuous Integration
 
 on:
@@ -41,16 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        libstdcxx-ng: [null, 12, 13]
-        exclude:
-          - os: macos-latest
-            libstdcxx-ng: 12
-          - os: macos-latest
-            libstdcxx-ng: 13
-          - os: ubuntu-latest
-            libstdcxx-ng: null
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ ( matrix.libstdcxx-ng == 13 || matrix.os == 'macos-latest' ) }} # allow (expect) this to fail
     # skip scheduled runs from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
     env: 
@@ -63,11 +55,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - name: Patch the environment file
-        if: ${{ matrix.libstdcxx-ng }}
-        run: |
-          echo -e "\n  - libstdcxx-ng = ${{ matrix.libstdcxx-ng }}\n" >> environment.yml
-          cat environment.yml
+
       # configures the mamba environment manager and builds the environment
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
@@ -145,7 +133,7 @@ jobs:
         if: ${{ failure() && steps.regression-execution.conclusion == 'failure' }}
         uses: actions/upload-artifact@v3
         with:
-          name: failed regression results ${{ matrix.os }} ${{ matrix.libstdcxx-ng }}
+          name: failed regression results ${{ matrix.os }}
           path: |
             test/regression
 
@@ -164,7 +152,7 @@ jobs:
         if: ${{ env.REFERENCE_JOB == 'false' }}
         uses: actions/upload-artifact@v3
         with:
-          name: dynamic regression results ${{ matrix.os }} ${{ matrix.libstdcxx-ng }}
+          name: dynamic regression results ${{ matrix.os }}
           path: |
             test/regression
 
@@ -254,7 +242,7 @@ jobs:
             echo ""
           done
           if [[ ${FAILED} ]]; then
-            echo "\nOne or more regression tests failed." | tee -a $GITHUB_STEP_SUMMARY
+            echo "One or more regression tests failed." | tee -a $GITHUB_STEP_SUMMARY
             echo "Please download the failed results and run the tests locally or check the above log to see why." | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN git clone -b main https://github.com/ReactionMechanismGenerator/RMG-database
 
 # build the conda environment
 WORKDIR /rmg/RMG-Py
-RUN echo -e "\n  - libstdcxx-ng<13\n" >> environment.yml  # patch for linux
 RUN conda env create --file environment.yml
 
 # This runs all subsequent commands inside the rmg_env conda environment

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -90,16 +90,6 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     conda config --env --set subdir osx-64
     conda env update -f environment.yml
 
-#. Modify the environment file for Linux (eg. Ubuntu). If you are using MacOS, you should skip this step.::
-
-    echo -e "\n  - libstdcxx-ng<13\n" >> environment.yml
-
-   Details: Recently (June 2023) conda-forge have a GNU C++ library version 13,
-   which is incompatible with some of the other binaries in the environment.
-   By specifying that we want a version of the library less than 13, we ensure
-   compatibility. MacOS does not use the conda-forge g++ libraries, so this line 
-   would fail if we included it in the environment.yml file for everyone.
-
 #. Create the conda environment for RMG-Py::
 
     conda env create -f environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - conda-forge::openbabel >= 3
 
 # general-purpose external software tools
-  - conda-forge::julia>=1.8.5
+  - conda-forge::julia>=1.8.5,!=1.9.0
   - conda-forge::pyjulia >=0.6
 
 # Python tools


### PR DESCRIPTION
a new version of Julia has been released that fixes the issue we were facing, so these changes are no longer needed (see issue #2455 and PR #2456).

I have added that version of Julia (1.9.0) to the "do not allow" list for the environment file. We could probably find a way to specifically disallow the problematic _build_ instead, but this is easier.

With this CI update in place, we can look to figure out the issue with regression testing and then finally get the updated CI into RMG-database.
