### PR TITLE
Fix docker instruction

### DIFF
--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -26,7 +26,7 @@ RMG is primarily distributed using Docker, a software package for delivering app
    Change the path to match your individual computer.
    If the folder does not exist when the command is run, it will be created.
 
-   If you want to use jupyter notebook inside the docker container, run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it -p 8888:8888 reactionmechanismgenerator/rmg:latest`` instead.
+   If you want to use jupyter notebook inside the docker container, run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it -p 8888:8888 reactionmechanismgenerator/rmg:3.1.1`` instead.
    And you can start the jupyter notebook by running ``jupyter notebook --ip 0.0.0.0 --no-browser --allow-root`` inside the container.
    Then you can access the jupyter notebook from your browser by going to ``http://localhost:8888``.
    You may need to copy and paste the token from the terminal into the browser to access the notebook.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
I notice that we point the users to the latest at one point in the installation instruction, while we specify 3.1.1 in the other parts.

### Description of Changes
I change from latest to 3.1.1.