### PR TITLE
allow the CI to be called from other repos in the organization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,8 @@ on:
   push:
   # runs on PRs against RMG-Py (and anywhere else, but we add this for RMG-Py)
   pull_request:
+  # allow calling from other repos in the ReactionMechanismGenerator organization
+  workflow_call:
 
 # this prevents one PR from simultaneously running multiple runners, which will clog up the queue
 # and prevent other PRs from running the CI


### PR DESCRIPTION
Since the regression testing updates are (:crossed_fingers: #2470) almost done, we can switch RMG-database over to using the updated CI.

This PR just allows us to re-use the action file in RMG-database, rather than copy-paste it over there.