### PR TITLE
Getting the regression tests to work

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,7 +204,7 @@ jobs:
 
             # Compare the edge and core
             if python-jl scripts/checkModels.py \
-                "$regr_test" \
+                "$regr_test-core" \
                 $REFERENCE/"$regr_test"/chemkin/chem_annotated.inp \
                 $REFERENCE/"$regr_test"/chemkin/species_dictionary.txt \
                 test/regression/"$regr_test"/chemkin/chem_annotated.inp \
@@ -216,7 +216,7 @@ jobs:
               export FAILED=Yes
             fi
             if python-jl scripts/checkModels.py \
-                "$regr_test" \
+                "$regr_test-edge" \
                 $REFERENCE/"$regr_test"/chemkin/chem_edge_annotated.inp \
                 $REFERENCE/"$regr_test"/chemkin/species_edge_dictionary.txt \
                 test/regression/"$regr_test"/chemkin/chem_edge_annotated.inp \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -188,6 +188,7 @@ jobs:
         env:
           REFERENCE: stable_regression_results
         run: |
+          mkdir -p "test/regression-diff"
           for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat;
           do
             echo ""
@@ -213,6 +214,7 @@ jobs:
               echo "$regr_test Passed Core Comparison"
             else
               echo "$regr_test Failed Core Comparison" | tee -a $GITHUB_STEP_SUMMARY
+              cp "$regr_test-core.log" test/regression-diff/
               export FAILED=Yes
             fi
             if python-jl scripts/checkModels.py \
@@ -225,6 +227,7 @@ jobs:
               echo "$regr_test Passed Edge Comparison"
             else
               echo "$regr_test Failed Edge Comparison" | tee -a $GITHUB_STEP_SUMMARY
+              cp "$regr_test-edge.log" test/regression-diff/
               export FAILED=Yes
             fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -190,7 +190,7 @@ jobs:
           REFERENCE: stable_regression_results
         run: |
           mkdir -p "test/regression-diff"
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation;
           do
             echo ""
             echo "## Regression test $regr_test:"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -184,6 +184,7 @@ jobs:
 
       # Regression Testing - Actual Comparisons
       - name: Regression Tests - Compare to Baseline
+        id: regression-comparison
         if: ${{ env.REFERENCE_JOB == 'false' }}
         env:
           REFERENCE: stable_regression_results
@@ -252,7 +253,14 @@ jobs:
             echo "Please download the failed results and run the tests locally or check the above log to see why." | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
-
+      # Upload Regression Results as Failed if above step failed
+      - name: Upload Failed Comparison Results
+        if: ${{ failure() && steps.regression-comparison.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: failed regression comparison results ${{ matrix.os }}
+          path: |
+            test/regression-diff
       # Install and Call codecov only if the tests were successful (permitting failures in the regression comparison tests)
       - name: Code coverage install and run
         if: success() || ( failure() && steps.regression-execution.conclusion == 'success' )

--- a/scripts/checkModels.py
+++ b/scripts/checkModels.py
@@ -285,7 +285,7 @@ def initialize_log(verbose, log_file_name='checkModels.log'):
     logging.basicConfig(
         filename=log_file_name,
         filemode='w',
-        format='%(name)s=%(message)s',
+        format='%(message)s',
         level=verbose
     )
 


### PR DESCRIPTION
### Motivation or Problem
The regression tests are not working.
Pull request #2470  shows the difficulty in getting the RMS_liquidSurface_ch4o2cat test to work.
It'll be easier once #2335 is merged, which enables loading and comparison of heterogeneous catalysis models.
But in the mean time, let's just skip that RMS_liquidSurface_ch4o2cat test.
We'll still run the test case, so we know it doesn't crash, but we won't try
comparing the output for now, because trying to fix it is holding back our testing.
Also, we weren't saving the results of the model comparisons.

### Description of Changes

In this PR we don't try comparing the results of the RMS_liquidSurface_ch4o2cat with the "benchmark" run. We still run it, to check that it doesn't crash, but don't check the results.

This PR also enhances the regression testing by saving the results of the comparison in the cases that differences are found in the models, and uploads them as artifacts for later inspection.


### Testing
Parts of it have been tested on #2470, but let's wait for the CI to run.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
