### PR TITLE
Cleaning up the RMG-Py GitHub with a robot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,9 @@
 name: Stale Issues and Pull Requests
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: "0 8 * * *"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Stale Issues and Pull Requests
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Stale Issues and Pull Requests
+        uses: actions/stale@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is being automatically marked as stale because it has not received any interaction in the last 90 days. Please leave a comment if this is still a relevant issue, otherwise it will automatically be closed in 30 days.'
+          stale-pr-message: 'This pull request is being automatically marked as stale because it has not received any interaction in the last 90 days. Please leave a comment if this is still a relevant pull request, otherwise it will automatically be closed in 30 days.'
+          days-before-stale: 90
+          days-before-close: 30
+          stale-issue-label: stale
+          stale-pr-label: stale
+          operations-per-run: 1000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,3 +24,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           operations-per-run: 1000
+          exempt-issue-labels: bug
+          exempt-pr-labels: bug
+          close-issue-label: abandoned
+          close-pr-label: abandoned


### PR DESCRIPTION
This PR is a followup to some discussion had at the previous RMG developer meeting, and is fodder for the meeting we have today.

### The Problem
RMG-Py's GitHub page is... _busy_. As of writing this, we have 384 open issues and 56 outstanding PRs. Of course, many of these issues are no longer relevant (they have been resolved), and many of these PRs are severely out of date or abandoned.

### The Proposed Solution
This PR proposes adding a bot which will:
 1. Mark any issue or PR that has received _zero_ interaction in the past 90 days as __stale__.
 2. Automatically _close_ any issue or PR which it has previously marked as __stale__ if it does not receive any interaction within 30 days after being marked.

This bot is not a temporary measure - it will first help us resolve our significant backlog, but should also stay into the future.

### The Reason
This is part of a larger effort to keep the GitHub issues and PRs doing what they are meant to do - tracking the __software development__ of RMG. Right now they are being used at TODO lists and archives/discussion boards for scientific issues. We should limit the use of these pages for their intended purpose and move TODOs to project boards, internal documents, etc. and move important discussion to the [Discussions tab](https://github.com/ReactionMechanismGenerator/RMG-Py/discussions).

As it stands, it is _impossible_ for new developers to find an issue to work on or a PR to help out with because there are so many, and so many irrelevant ones. It's cloying for current developers as well (at least for me). I think this is an important move for the sustainability of RMG.

I would like to erassure everyone with outstanding PRs that none of the work will be lost, either. [PRs and branches can be reopened at any point in the future](https://github.com/orgs/community/discussions/23262).

### Call for Input
I am aware that there are some PRs which do just take a _really long time_. My thinking here is that 90 days without _any_ interactions at all (no commits, no comments), is likely either abandoned or severely out of date (and would likely need to be restarted anyway). I welcome feedback on the exact choice of timeline, but reiterate that even if this is seen as too aggressive of a window, no work is lost.