### PR TITLE
Doc surf rxns

### DIFF
--- a/documentation/source/reference/kinetics/index.rst
+++ b/documentation/source/reference/kinetics/index.rst
@@ -57,6 +57,19 @@ Class                   Description
 ======================= ========================================================
 
 
+
+Heterogenous catalysis kinetics models
+======================================
+
+.. currentmodule:: rmgpy.kinetics
+
+============================ ========================================================
+Class                        Description
+============================ ========================================================
+:class:`StickingCoefficient` A kinetics model to give Sticking Coefficients for surface adsorption, following Arrhenius form.
+:class:`SurfaceArrhenius`    A kinetics model based on (modified) Arrhenius for surface reactions.
+============================ ========================================================
+
 .. toctree::
     :hidden:
     
@@ -72,3 +85,5 @@ Class                   Description
     troe
     wigner
     eckart
+    surfacearrhenius
+    stickingcoefficient

--- a/documentation/source/reference/kinetics/stickingcoefficient.rst
+++ b/documentation/source/reference/kinetics/stickingcoefficient.rst
@@ -1,0 +1,22 @@
+**********************************
+rmgpy.kinetics.StickingCoefficient
+**********************************
+
+.. autoclass:: rmgpy.kinetics.StickingCoefficient
+
+    The Sticking coefficient class uses an arrhenius-like expression to determine
+    the sticking coefficient :math:`\gamma` of a species on a surface.
+
+    .. math:: \gamma = A (T/T_0)^{n} \exp\left(-\frac{E_\mathrm{a}}{RT}\right)
+
+    Above, :math:`A` is the preexponential factor, :math:`T_0` is the reference
+    temperature, :math:`n` is the temperature exponent, and :math:`E_\mathrm{a}`
+    is the activation energy.
+
+    The sticking coefficient is then used to calculate the rate coefficient :math:`k`
+    using the following expression:
+
+    .. math:: k = \frac{\gamma}{\Gamma} \sqrt{\frac{RT}{2 \pi W}}
+
+    where :math:`\Gamma` is the surface site density and :math:`W` is the molecular 
+    weight of the gas phase species. 

--- a/documentation/source/reference/kinetics/stickingcoefficient.rst
+++ b/documentation/source/reference/kinetics/stickingcoefficient.rst
@@ -4,7 +4,7 @@ rmgpy.kinetics.StickingCoefficient
 
 .. autoclass:: rmgpy.kinetics.StickingCoefficient
 
-    The Sticking coefficient class uses an arrhenius-like expression to determine
+    The Sticking coefficient class uses an Arrhenius-like expression to determine
     the sticking coefficient :math:`\gamma` of a species on a surface.
 
     .. math:: \gamma = A (T/T_0)^{n} \exp\left(-\frac{E_\mathrm{a}}{RT}\right)

--- a/documentation/source/reference/kinetics/surfacearrhenius.rst
+++ b/documentation/source/reference/kinetics/surfacearrhenius.rst
@@ -1,0 +1,17 @@
+*******************************
+rmgpy.kinetics.SurfaceArrhenius
+*******************************
+
+.. autoclass:: rmgpy.kinetics.SurfaceArrhenius
+
+    The SurfaceArrhenius class uses a rate expression that is identical to the 
+    Arrhenius class:
+
+    .. math:: k(T) = A \left( \frac{T}{T_0} \right)^n \exp \left( -\frac{E_\mathrm{a}}{RT} \right)
+
+    Above, :math:`A` is the preexponential factor, :math:`T_0` is the reference
+    temperature, :math:`n` is the temperature exponent, and :math:`E_\mathrm{a}`
+    is the activation energy.
+
+    The only difference is the units for :math:`A` are in terms of surface concentration 
+    (:math:`\mathrm{mol/m^2}`) instead of volume concentration (:math:`\mathrm{mol/m^3}`).


### PR DESCRIPTION
### Motivation or Problem
Issue #2085, missing documentation for surface kinetics classes in the [api reference](http://reactionmechanismgenerator.github.io/RMG-Py/reference/kinetics/index.html#module-rmgpy.kinetics)

### Description of Changes
added a link for each surface reaction type, and a page for each in the index

### Reviewer discussion
None of the linear free energy reaction types (ArrheniusEP, ArrheniusBM) are listed [here. ](http://reactionmechanismgenerator.github.io/RMG-Py/reference/kinetics/index.html#module-rmgpy.kinetics). Is that intentional or should they be added. 

