### PR TITLE
Expand the regression test annotations.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -269,6 +269,7 @@ jobs:
         env:
           REFERENCE: stable_regression_results
         run: |
+          exec 2> >(tee -a regression.stderr >&2) 1> >(tee -a regression.stdout)
           mkdir -p "test/regression-diff"
           for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation;
           do
@@ -284,6 +285,7 @@ jobs:
             echo -n 'Current:   '
             grep "Memory used:" test/regression/"$regr_test"/RMG.log | tail -1
 
+            echo "<details><summary>"
             # Compare the edge and core
             if python-jl scripts/checkModels.py \
                 "$regr_test-core" \
@@ -292,12 +294,15 @@ jobs:
                 test/regression/"$regr_test"/chemkin/chem_annotated.inp \
                 test/regression/"$regr_test"/chemkin/species_dictionary.txt
             then
-              echo "$regr_test Passed Core Comparison"
+              echo "$regr_test Passed Core Comparison ✅"
             else
-              echo "$regr_test Failed Core Comparison" | tee -a $GITHUB_STEP_SUMMARY
+              echo "$regr_test Failed Core Comparison ❌" | tee -a $GITHUB_STEP_SUMMARY
               cp "$regr_test-core.log" test/regression-diff/
               export FAILED=Yes
             fi
+            echo "</summary>"
+            cat "$regr_test-core.log"
+            echo "</details>\n<details><summary>"
             if python-jl scripts/checkModels.py \
                 "$regr_test-edge" \
                 $REFERENCE/"$regr_test"/chemkin/chem_edge_annotated.inp \
@@ -305,59 +310,64 @@ jobs:
                 test/regression/"$regr_test"/chemkin/chem_edge_annotated.inp \
                 test/regression/"$regr_test"/chemkin/species_edge_dictionary.txt
             then
-              echo "$regr_test Passed Edge Comparison"
+              echo "$regr_test Passed Edge Comparison ✅"
             else
-              echo "$regr_test Failed Edge Comparison" | tee -a $GITHUB_STEP_SUMMARY
+              echo "$regr_test Failed Edge Comparison ❌" | tee -a $GITHUB_STEP_SUMMARY
               cp "$regr_test-edge.log" test/regression-diff/
               export FAILED=Yes
             fi
+            echo "</summary>"
+            cat "$regr_test-edge.log"
+            echo "</details>\n"
 
             # Check for Regression between Reference and Dynamic (skip superminimal)
             if [ -f test/regression/"$regr_test"/regression_input.py ];
             then
+              echo "<details>"
               if python-jl rmgpy/tools/regression.py \
                 test/regression/"$regr_test"/regression_input.py \
                 $REFERENCE/"$regr_test"/chemkin \
                 test/regression/"$regr_test"/chemkin
               then
-                echo "$regr_test Passed Observable Testing"
+                echo "<summary>$regr_test Passed Observable Testing ✅</summary>"
               else
-                echo "$regr_test Failed Observable Testing" | tee -a $GITHUB_STEP_SUMMARY
+                echo "<summary>$regr_test Failed Observable Testing ❌</summary>" | tee -a $GITHUB_STEP_SUMMARY
                 export FAILED=Yes
               fi
+              echo "</details>"
             fi
             echo ""
           done
           if [[ ${FAILED} ]]; then
-            echo "One or more regression tests failed." | tee -a $GITHUB_STEP_SUMMARY
-            echo "Please download the failed results and run the tests locally or check the above log to see why." | tee -a $GITHUB_STEP_SUMMARY
+            echo "⚠️ One or more regression tests failed." | tee -a $GITHUB_STEP_SUMMARY >&2
+            echo "Please download the failed results and run the tests locally or check the log to see why." | tee -a $GITHUB_STEP_SUMMARY >&2
           fi
 
       - name: Prepare Results for PR Comment
         if : ${{ github.event_name == 'pull_request' }}
         run: |
-          echo "<details>" > summary.txt
-          echo "<summary>Regression Testing Results</summary>" >> summary.txt
-          echo "" >> summary.txt
-          tail -n +1 test/regression-diff/* >> summary.txt
-          echo ""
+          echo "## Regression Testing Results" > summary.txt
+          cat regression.stderr >> summary.txt
+          echo "<details>" >> summary.txt
+          echo "<summary>Detailed regression test results.</summary>" >> summary.txt
+          cat regression.stdout >> summary.txt
           echo "</details>" >> summary.txt
           echo "" >> summary.txt
-          echo "_beep boop this action was performed by a bot_ :robot:" >> summary.txt
+          echo "_beep boop this comment was written by a bot_ :robot:" >> summary.txt
 
       - name: Write Results to PR
         uses: thollander/actions-comment-pull-request@v2
         if : ${{ github.event_name == 'pull_request' }}
         with:
           filePath: summary.txt
-      
+
       - name: Upload Comparison Results
         uses: actions/upload-artifact@v3
         with:
           name: regression_test_comparison_results
           path: |
             test/regression-diff
-      
+
       # Install and Call codecov only if the tests were successful (permitting failures in the regression comparison tests)
       - name: Code coverage install and run
         if: success() || ( failure() && steps.regression-execution.conclusion == 'success' )
@@ -370,7 +380,7 @@ jobs:
     # technically we could live without the 'needs' since _in theory_
     # nothing will ever be merged into main that fails the tests, but
     # who knows ¯\_(ツ)_/¯
-    # 
+    #
     # taken from https://github.com/docker/build-push-action
     needs: build-and-test-linux
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -296,7 +296,7 @@ jobs:
             then
               echo "$regr_test Passed Core Comparison ✅"
             else
-              echo "$regr_test Failed Core Comparison ❌" | tee -a $GITHUB_STEP_SUMMARY
+              echo "$regr_test Failed Core Comparison ❌"
               cp "$regr_test-core.log" test/regression-diff/
               export FAILED=Yes
             fi
@@ -312,7 +312,7 @@ jobs:
             then
               echo "$regr_test Passed Edge Comparison ✅"
             else
-              echo "$regr_test Failed Edge Comparison ❌" | tee -a $GITHUB_STEP_SUMMARY
+              echo "$regr_test Failed Edge Comparison ❌"
               cp "$regr_test-edge.log" test/regression-diff/
               export FAILED=Yes
             fi
@@ -331,7 +331,7 @@ jobs:
               then
                 echo "<summary>$regr_test Passed Observable Testing ✅</summary>"
               else
-                echo "<summary>$regr_test Failed Observable Testing ❌</summary>" | tee -a $GITHUB_STEP_SUMMARY
+                echo "<summary>$regr_test Failed Observable Testing ❌</summary>"
                 export FAILED=Yes
               fi
               echo "</details>"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -354,6 +354,7 @@ jobs:
           echo "</details>" >> summary.txt
           echo "" >> summary.txt
           echo "_beep boop this comment was written by a bot_ :robot:" >> summary.txt
+          cat summary.txt > $GITHUB_STEP_SUMMARY
 
       - name: Write Results to PR
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -357,6 +357,13 @@ jobs:
           echo "_beep boop this comment was written by a bot_ :robot:" >> summary.txt
           cat summary.txt > $GITHUB_STEP_SUMMARY
 
+      - name: Upload regression summary artifact
+        uses: actions/upload-artifact@v3
+        if : ${{ github.event_name == 'pull_request' }}
+        with:
+          name: regression_summary
+          path: summary.txt
+
       - name: Write Results to PR
         uses: thollander/actions-comment-pull-request@v2
         if : ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -274,7 +274,7 @@ jobs:
           for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation;
           do
             echo ""
-            echo "## Regression test $regr_test:"
+            echo "### Regression test $regr_test:"
             # Memory Usage and Execution Time
             echo -n 'Reference: '
             grep "Execution time" $REFERENCE/"$regr_test"/RMG.log | tail -1
@@ -285,7 +285,7 @@ jobs:
             echo -n 'Current:   '
             grep "Memory used:" test/regression/"$regr_test"/RMG.log | tail -1
 
-            echo "<details><summary>"
+            echo "<details>"
             # Compare the edge and core
             if python-jl scripts/checkModels.py \
                 "$regr_test-core" \
@@ -294,15 +294,16 @@ jobs:
                 test/regression/"$regr_test"/chemkin/chem_annotated.inp \
                 test/regression/"$regr_test"/chemkin/species_dictionary.txt
             then
-              echo "$regr_test Passed Core Comparison ✅"
+              echo "<summary>$regr_test Passed Core Comparison ✅</summary>"
             else
-              echo "$regr_test Failed Core Comparison ❌"
+              echo "<summary>$regr_test Failed Core Comparison ❌</summary>"
               cp "$regr_test-core.log" test/regression-diff/
               export FAILED=Yes
             fi
-            echo "</summary>"
+            echo "" # blank line so next block is interpreted as markdown
             cat "$regr_test-core.log"
-            echo "</details>\n<details><summary>"
+            echo "</details>"
+            echo "<details>"
             if python-jl scripts/checkModels.py \
                 "$regr_test-edge" \
                 $REFERENCE/"$regr_test"/chemkin/chem_edge_annotated.inp \
@@ -310,15 +311,15 @@ jobs:
                 test/regression/"$regr_test"/chemkin/chem_edge_annotated.inp \
                 test/regression/"$regr_test"/chemkin/species_edge_dictionary.txt
             then
-              echo "$regr_test Passed Edge Comparison ✅"
+              echo "<summary>$regr_test Passed Edge Comparison ✅</summary>"
             else
-              echo "$regr_test Failed Edge Comparison ❌"
+              echo "<summary>$regr_test Failed Edge Comparison ❌</summary>"
               cp "$regr_test-edge.log" test/regression-diff/
               export FAILED=Yes
             fi
-            echo "</summary>"
+            echo "" # blank line so next block is interpreted as markdown
             cat "$regr_test-edge.log"
-            echo "</details>\n"
+            echo "</details>"
 
             # Check for Regression between Reference and Dynamic (skip superminimal)
             if [ -f test/regression/"$regr_test"/regression_input.py ];

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@
 # 2023-06-15 - revert changes from 06-06, both now work
 # 2023-06-27 - add option to run from RMG-database with GitHub resuable workflows
 # 2023-07-17 - made it pass by default
+# 2023-07-21 - upload the regression results summary as artifact (for use as a comment on PRs)
 name: Continuous Integration
 
 on:
@@ -347,7 +348,8 @@ jobs:
       - name: Prepare Results for PR Comment
         if : ${{ github.event_name == 'pull_request' }}
         run: |
-          echo "## Regression Testing Results" > summary.txt
+          echo $PR_NUMBER > summary.txt
+          echo "## Regression Testing Results" >> summary.txt
           cat regression.stderr >> summary.txt
           echo "<details>" >> summary.txt
           echo "<summary>Detailed regression test results.</summary>" >> summary.txt
@@ -358,17 +360,12 @@ jobs:
           cat summary.txt > $GITHUB_STEP_SUMMARY
 
       - name: Upload regression summary artifact
+       # the annotate workflow uses this artifact to add a comment to the PR
         uses: actions/upload-artifact@v3
         if : ${{ github.event_name == 'pull_request' }}
         with:
           name: regression_summary
           path: summary.txt
-
-      - name: Write Results to PR
-        uses: thollander/actions-comment-pull-request@v2
-        if : ${{ github.event_name == 'pull_request' }}
-        with:
-          filePath: summary.txt
 
       - name: Upload Comparison Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -41,30 +41,11 @@ jobs:
 
       - name: 'Get pull request number'
         id: pr_number
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            let fs = require('fs');
-            let readline = require('readline');
-            let issue_number = 0;
-            const fileStream = fs.createReadStream('summary.txt');
-            const rl = readline.createInterface({
-              input: fileStream,
-              crlfDelay: Infinity
-            });
-            rl.on('line', (line) => {
-              console.log('First line:', line);
-              issue_number = Number(line);
-              rl.close();
-              fileStream.close();
-              return issue_number;
-            });
-
+        run: |
+          echo "PR_NUMBER=$( head summary.txt )" >> $GITHUB_ENV
+      - run: env
       - name: Write Results to PR
         uses: thollander/actions-comment-pull-request@v2
-        env:
-          PR_NUMBER: ${{ steps.pr_number.outputs.result }}
         with:
           filePath: summary.txt
           pr_number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -14,17 +14,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - run: echo 'The triggering workflow passed'
-      - name: 'Get triggering pull request number'
-        id: pr_number
-        uses: actions/github-script@v6
-        with:
-          script: |
-            console.log(JSON.stringify(context.payload.workflow_run, undefined, 2));
-            return context.payload.workflow_run.pull_requests[0];
-      - name: 'Report environment variables'
-        env:
-          PR_NUMBER: ${{ steps.pr_number.outputs.result }}
-        run: env
       # based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: 'Download regression_summary artifact'
         uses: actions/github-script@v6
@@ -50,6 +39,28 @@ jobs:
       - name: 'Unzip artifact'
         run: unzip regression_summary.zip
 
+      - name: 'Get pull request number'
+        id: pr_number
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let readline = require('readline');
+            let issue_number = 0;
+            const fileStream = fs.createReadStream('summary.txt');
+            const rl = readline.createInterface({
+              input: fileStream,
+              crlfDelay: Infinity
+            });
+            rl.on('line', (line) => {
+              console.log('First line:', line);
+              issue_number = Number(line);
+              rl.close();
+              fileStream.close();
+              return issue_number;
+            });
+
       - name: Write Results to PR
         uses: thollander/actions-comment-pull-request@v2
         env:
@@ -57,11 +68,6 @@ jobs:
         with:
           filePath: summary.txt
           pr_number: ${{ env.PR_NUMBER }}
-
-      # For debugging
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -1,4 +1,9 @@
-name: Annotate pull requests with regression summaries
+name: Annotate pull request with regression summaries
+# Takes a regression summary from a workflow run and annotates the pull request with it
+# The pull request number is taken from the first line of the summary.txt file.
+# The summary file is in an artifact called regression_summary associated
+# with the workflow run that triggered this workflow.
+# based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
 
 on:
   workflow_run:
@@ -14,7 +19,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - run: echo 'The triggering workflow passed'
-      # based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: 'Download regression_summary artifact'
         uses: actions/github-script@v6
         with:
@@ -42,9 +46,10 @@ jobs:
       - name: 'Get pull request number'
         id: pr_number
         run: |
-          echo "PR_NUMBER=$( head summary.txt )" >> $GITHUB_ENV
-      - run: env
-      - name: Write Results to PR
+          echo "PR_NUMBER=$( head -n 1 summary.txt )" >> $GITHUB_ENV
+          # remove the first line from the file
+          sed -i '1d' summary.txt
+      - name: Write summary to pull request as a comment
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: summary.txt

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -9,7 +9,6 @@ on:
   workflow_run:
     workflows:
       - Continuous Integration
-      - Testing
     types:
       - completed
 

--- a/scripts/checkModels.py
+++ b/scripts/checkModels.py
@@ -111,16 +111,16 @@ def checkModel(commonSpecies, uniqueSpeciesTest, uniqueSpeciesOrig, commonReacti
     orig_model_species = len(commonSpecies) + len(uniqueSpeciesOrig)
 
     logger.error(f"Original model has {orig_model_species} species.")
-    logger.error(f"Test model has {test_model_species} species." +
-                 '✅' if test_model_species == orig_model_species else '❌')
+    logger.error(f"Test model has {test_model_species} species. " +
+                 ('✅' if test_model_species == orig_model_species else '❌'))
 
 
     test_model_rxns = len(commonReactions) + len(uniqueReactionsTest)
     orig_model_rxns = len(commonReactions) + len(uniqueReactionsOrig)
 
     logger.error(f"Original model has {orig_model_rxns} reactions.")
-    logger.error(f"Test model has {test_model_rxns} reactions." +
-                    '✅' if test_model_rxns == orig_model_rxns else '❌')
+    logger.error(f"Test model has {test_model_rxns} reactions. " +
+                 ('✅' if test_model_rxns == orig_model_rxns else '❌'))
 
 
     return (test_model_species != orig_model_species) or (test_model_rxns != orig_model_rxns)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->
### Motivation or Problem
The results of the regression tests were largely buried in the logs of the continuous integration action workflow, rather than being nicely summarized on the annotation to the pull request.

### Description of Changes
The summaries and comparisons that are generated by the CI running the regression tests are captured, and used to make the annotation.
The summary is stored as a text file, with the pull request number stored on the first line. This is then uploaded as an artifact. A new workflow runs whenever the CI workflow completes, then downloads the artifact, extracts the summary, and posts a comment. This complicated runaround is needed because workflows run by pull requests from forks do not have permission to write comments directly.

### Testing
For the markdown formatting, I have run it a bunch, and checked things render correctly. (See some of the run logs, where things are duplicated into the workflow summary). 
For the artifact and annotation scripts, I debugged and tested it on my own fork. It'll only function properly once the annotation.yml workflow ends up on the main branch - but I tested it there :)

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
