### PR TITLE
Fix a bug in the CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -347,6 +347,8 @@ jobs:
 
       - name: Prepare Results for PR Comment
         if : ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > summary.txt
           echo "## Regression Testing Results" >> summary.txt

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -41,7 +41,7 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/regression_summary.zip`, Buffer.from(download.data));
 
       - name: Report the github.event.workflow_run as json
-        if: ${{ error() }}
+        if: ${{ failure() }}
         run: echo '${{ toJson(github.event.workflow_run) }}'
 
       - name: 'Unzip artifact'

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - run: echo 'The triggering workflow passed'
       - name: 'Download regression_summary artifact'
+        continue-on-error: true
         uses: actions/github-script@v6
         with:
           script: |
@@ -39,16 +40,22 @@ jobs:
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/regression_summary.zip`, Buffer.from(download.data));
 
+      - name: Report the github.event.workflow_run as json
+        if: ${{ error() }}
+        run: echo '${{ toJson(github.event.workflow_run) }}'
+
       - name: 'Unzip artifact'
         run: unzip regression_summary.zip
+        if : ${{ success() }}
 
       - name: 'Get pull request number'
-        id: pr_number
+        if: ${{ success() }}
         run: |
           echo "PR_NUMBER=$( head -n 1 summary.txt )" >> $GITHUB_ENV
           # remove the first line from the file
           sed -i '1d' summary.txt
       - name: Write summary to pull request as a comment
+        if: ${{ success() }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: summary.txt


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
There are a couple of problems with the new regression test result annotations workflow introduced in #2501
1. I stupidly left out a couple of lines. We need to define the pull request number in an environment variable in the step where we write it to the file. Sorry. (I had done the testing on a much accelerated workflow, and then didn't correctly copy it across to the real workflow).
2. The "Continuous Integration" workflow runs on a push to master (eg merging a PR) and on a cron job, both of which will trigger the Annotation workflow, but neither of which will have uploaded a regression test summary file, so the Annotation workflow will fail. The only problem with this is folks getting emails and notifications about workflow failures. Ideally the workflow just wouldn't run in those cases, but I can't see how to filter a [`workflow_run`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) trigger this way.

### Description of Changes
Fix problem 1.

If someone has ideas about problem 2, contribute them before merging. Else let's just get this in to fix problem 1 - assuming that it does so (let's let the slow tests run this time)

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
