### PR TITLE
More github workflow improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -346,9 +346,9 @@ jobs:
           fi
 
       - name: Prepare Results for PR Comment
-        if : ${{ github.event_name == 'pull_request' }}
+        if: ${{ env.REFERENCE_JOB == 'false' }}
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.number || github.event.after || github.event_name }}
         run: |
           echo $PR_NUMBER > summary.txt
           echo "## Regression Testing Results" >> summary.txt

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - run: echo 'The triggering workflow passed'
       - name: 'Download regression_summary artifact'
-        continue-on-error: true
         uses: actions/github-script@v6
         with:
           script: |
@@ -40,26 +39,23 @@ jobs:
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/regression_summary.zip`, Buffer.from(download.data));
 
-      - name: Report the github.event.workflow_run as json
-        if: ${{ failure() }}
-        run: echo '${{ toJson(github.event.workflow_run) }}'
-
       - name: 'Unzip artifact'
         run: unzip regression_summary.zip
-        if : ${{ success() }}
 
       - name: 'Get pull request number'
-        if: ${{ success() }}
         run: |
           echo "PR_NUMBER=$( head -n 1 summary.txt )" >> $GITHUB_ENV
           # remove the first line from the file
           sed -i '1d' summary.txt
       - name: Write summary to pull request as a comment
-        if: ${{ success() }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: summary.txt
           pr_number: ${{ env.PR_NUMBER }}
+
+      - name: Report the github.event.workflow_run as json
+        if: ${{ failure() }}
+        run: echo '${{ toJson(github.event.workflow_run) }}'
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   on-success:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     steps:
       - run: echo 'The triggering workflow passed'
       - name: 'Download regression_summary artifact'
@@ -47,6 +47,7 @@ jobs:
           echo "PR_NUMBER=$( head -n 1 summary.txt )" >> $GITHUB_ENV
           # remove the first line from the file
           sed -i '1d' summary.txt
+
       - name: Write summary to pull request as a comment
         uses: thollander/actions-comment-pull-request@v2
         with:
@@ -55,11 +56,13 @@ jobs:
 
       - name: Report the github.event.workflow_run as json
         if: ${{ failure() }}
-        run: echo '${{ toJson(github.event.workflow_run) }}'
+        run: echo $JSON
+        env:
+          JSON: ${{ toJson(github.event.workflow_run) }}
 
   on-failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure'  && github.event.workflow_run.event == 'pull_request' }}
     steps:
       - run: echo 'The triggering workflow failed'
 

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -61,10 +61,3 @@ jobs:
         run: echo $JSON
         env:
           JSON: ${{ toJson(github.event.workflow_run) }}
-
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure'  && github.event.workflow_run.event == 'pull_request' }}
-    steps:
-      - run: echo 'The triggering workflow failed'
-

--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -12,6 +12,8 @@ on:
     types:
       - completed
 
+run-name: Annotate PR ${{ github.event.workflow_run.event.display_title }}.
+
 jobs:
   on-success:
     runs-on: ubuntu-latest


### PR DESCRIPTION

### Motivation or Problem
More improvements to the new github workflows

### Description of Changes
* the regression summary is prepared and added to the workflow job summary for everything but the reference job (the push to main and nightly build).
* the annotation workflow is only run for pull requests, not for pushes and scheduled runs.
* if the annotation job fails for some reason, it reports the event that triggered it, for debugging..

### Testing
I ran things on my main branch. I think they're working - but this workflow stuff has been remarkably hard to get right first time.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
