### PR TITLE
Allow disabling of RMS yaml writer for speedup

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -956,6 +956,7 @@ Miscellaneous options::
         saveSeedToDatabase=True,
         units='si',
         generateOutputHTML=True,
+        generateRMSEachIter=True,
         generatePlots=False,
         saveSimulationProfiles=True,
         verboseComments=False,
@@ -975,6 +976,8 @@ The ``units`` field is set to ``si``.  Currently there are no other unit options
 
 Setting ``generateOutputHTML`` to ``True`` will let RMG know that you want to save 2-D images (png files in the local ``species`` folder) of all species in the generated core model.  It will save a visualized
 HTML file for your model containing all the species and reactions.  Turning this feature off by setting it to ``False`` may save memory if running large jobs.
+
+Setting ``generateRMSEachIter`` to ``True`` will have rmg generate an output yaml file containing the core mechanism for the current iteration, with the number of core species appended to the name of the file (e.g. for 28 core species, the file will be named ``chem28.rms``). If it is ``False`` then only one file will be generated at the end of the run. A value of ``False`` may result in a faster run, as this feature can take up a lot of cpu time. 
 
 Setting ``generatePlots`` to ``True`` will generate a number of plots describing the statistics of the RMG job, including the reaction model core and edge size and memory use versus  execution time. These will be placed in the output directory in the plot/ folder.
 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1337,8 +1337,8 @@ def pressure_dependence(
 
 def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=False, units='si', saveRestartPeriod=None,
             generateOutputHTML=False, generatePlots=False, saveSimulationProfiles=False, verboseComments=False,
-            saveEdgeSpecies=False, keepIrreversible=False, trimolecularProductReversible=True, wallTime='00:00:00:00',
-            saveSeedModulus=-1):
+            saveEdgeSpecies=False, keepIrreversible=False, trimolecularProductReversible=True, generateRMSEachIter=True, 
+            wallTime='00:00:00:00', saveSeedModulus=-1):
     if saveRestartPeriod:
         logging.warning("`saveRestartPeriod` flag was set in the input file, but this feature has been removed. Please "
                         "remove this line from the input file. This will throw an error after RMG-Py 3.1. For "
@@ -1352,6 +1352,7 @@ def options(name='Seed', generateSeedEachIteration=True, saveSeedToDatabase=Fals
     if generateOutputHTML:
         logging.warning('Generate Output HTML option was turned on. Note that this will slow down model generation.')
     rmg.generate_output_html = generateOutputHTML
+    rmg.generate_rms_each_iter = generateRMSEachIter
     rmg.generate_plots = generatePlots
     rmg.save_simulation_profiles = saveSimulationProfiles
     rmg.verbose_comments = verboseComments
@@ -1800,6 +1801,7 @@ def save_input_file(path, rmg):
     f.write('options(\n')
     f.write('    units = "{0}",\n'.format(rmg.units))
     f.write('    generateOutputHTML = {0},\n'.format(rmg.generate_output_html))
+    f.write('    generateRMSEachIter = {0},\n'.format(rmg.generate_rms_each_iter))
     f.write('    generatePlots = {0},\n'.format(rmg.generate_plots))
     f.write('    saveSimulationProfiles = {0},\n'.format(rmg.save_simulation_profiles))
     f.write('    saveEdgeSpecies = {0},\n'.format(rmg.save_edge_species))

--- a/rmgpy/yml.py
+++ b/rmgpy/yml.py
@@ -99,7 +99,7 @@ def get_mech_dict(spcs, rxns, solvent='solvent', solvent_data=None):
 
 
 def get_radicals(spc):
-    if spc.molecule[0].to_smiles() == "[O][O]":  # treat oxygen as stable to improve radical analysis
+    if spc.molecule[0].smiles == "[O][O]":  # treat oxygen as stable to improve radical analysis
         return 0
     else:
         return spc.molecule[0].multiplicity-1
@@ -112,7 +112,7 @@ def obj_to_dict(obj, spcs, names=None, label="solvent"):
         result_dict["type"] = "Species"
         if obj.contains_surface_site():
             result_dict["adjlist"] = obj.molecule[0].to_adjacency_list()
-        result_dict["smiles"] = obj.molecule[0].to_smiles()
+        result_dict["smiles"] = obj.molecule[0].smiles
         result_dict["thermo"] = obj_to_dict(obj.thermo, spcs)
         result_dict["radicalelectrons"] = get_radicals(obj)
         if obj.liquid_volumetric_mass_transfer_coefficient_data:

--- a/test/regression/RMS_CSTR_liquid_oxidation/input.py
+++ b/test/regression/RMS_CSTR_liquid_oxidation/input.py
@@ -62,5 +62,6 @@ model(
 )
 
 options(
+    generateRMSEachIter=False,
     saveEdgeSpecies=True,
 )

--- a/test/regression/RMS_constantVIdealGasReactor_superminimal/input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_superminimal/input.py
@@ -47,4 +47,5 @@ model(
 options(
     units='si',
     saveEdgeSpecies=True,
+    generateRMSEachIter=False,
 )

--- a/test/regression/RMS_liquidSurface_ch4o2cat/input.py
+++ b/test/regression/RMS_liquidSurface_ch4o2cat/input.py
@@ -85,4 +85,5 @@ model(
 options(
     units="si",
     saveEdgeSpecies=True,
+    generateRMSEachIter=False,
 )

--- a/test/regression/aromatics/input.py
+++ b/test/regression/aromatics/input.py
@@ -57,5 +57,6 @@ options(
     saveSimulationProfiles = False,
     saveEdgeSpecies = True,
     verboseComments = False,
+    generateRMSEachIter=False,
 )
 

--- a/test/regression/liquid_oxidation/input.py
+++ b/test/regression/liquid_oxidation/input.py
@@ -63,4 +63,5 @@ model(
 
 options(
     saveEdgeSpecies=True,
+    generateRMSEachIter=False,
 )

--- a/test/regression/nitrogen/input.py
+++ b/test/regression/nitrogen/input.py
@@ -57,6 +57,7 @@ model(
 options(
     units='si',
     saveEdgeSpecies=True,
+    generateRMSEachIter=False,
 )
 
 generatedSpeciesConstraints(

--- a/test/regression/oxidation/input.py
+++ b/test/regression/oxidation/input.py
@@ -74,6 +74,7 @@ options(
     generatePlots=False,
     saveEdgeSpecies=True,
     saveSimulationProfiles=False,
+    generateRMSEachIter=False,
 )
 
 generatedSpeciesConstraints(

--- a/test/regression/sulfur/input.py
+++ b/test/regression/sulfur/input.py
@@ -64,6 +64,7 @@ model(
 
 options(
     generateOutputHTML=False,
+    generateRMSEachIter=False,
     generatePlots=False,
     saveEdgeSpecies=True,
     saveSimulationProfiles=False,

--- a/test/regression/superminimal/input.py
+++ b/test/regression/superminimal/input.py
@@ -56,6 +56,7 @@ options(
     units='si',
     saveRestartPeriod=None,
     generateOutputHTML=True,
+    generateRMSEachIter=False,
     generatePlots=True,
     saveEdgeSpecies=True,
     saveSimulationProfiles=True,

--- a/test/rmgpy/rmg/mainTest.py
+++ b/test/rmgpy/rmg/mainTest.py
@@ -87,6 +87,12 @@ class TestMain:
         assert isinstance(self.rmg.database, RMGDatabase)
         assert self.rmg.done
 
+    def test_disable_rms_yaml_writer(self):
+        """
+        generateRMSEachIter = False in input should set the corresponding property in RMG instance
+        """
+        self.assertFalse(self.rmg.generate_rms_each_iter)
+
     def test_rmg_increases_reactions(self):
         """Test that RMG.execute increases reactions and species."""
         assert len(self.rmg.reaction_model.core.reactions) > 0

--- a/test/rmgpy/test_data/mainTest/input.py
+++ b/test/rmgpy/test_data/mainTest/input.py
@@ -73,6 +73,7 @@ options(
     name='testSeed',
     units='si',
     generateSeedEachIteration=True,
+    generateRMSEachIter=False,
     saveSeedToDatabase=True,
     generateOutputHTML=False,
     generatePlots=False,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
See issue #2499, profiling and rmg execution showed that we spend a significant amount of time writing rms yaml output files. this pr adds an option that allows the user to generate a rms yaml file each iteration (like we do with chemkin files), or just one yaml file at the end of the run (like cantera)

### Description of Changes
Added `generateRMSEachIter` input file arg for the `options` block. `True` makes an rms input file every iter as before. `False` generates only one. The default is `False`. 

### Testing
Ran the Minimal example with `True` set and `False` set. They performed as expected, and the final output files were identical. I think in #2499 we decided that this would be a temporary fix, so I am not sure what level of additional unit testing is appropriate. There do not seem to be existing tests that test some of these miscellaneous options (although I could be looking in the wrong places). 

### Reviewer Tips
I'd like a second opinion on what built in unit testing/functional testing might be required. I couldn't find one that seemed appropriate in `inputTest.py` or `mainTest.py`. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
