### PR TITLE
adding resonance for adsorbates

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1640,6 +1640,13 @@ class ThermoDatabase(object):
             add_thermo_data(thermo, adsorption_thermo, group_additivity=True)
 
             resonance_data.append(thermo)
+            # if the molecule had labels, reapply them
+            for label, atom in labeled_atoms.items():
+                if isinstance(atom,list):
+                    for a in atom:
+                        a.label = label
+                else:
+                    atom.label = label
 
         # Get the enthalpy of formation of every adsorbate at 298 K and determine the resonance structure with the lowest enthalpy of formation
         # We assume that the lowest enthalpy of formation is the correct thermodynamic property for the adsorbate
@@ -1655,14 +1662,6 @@ class ThermoDatabase(object):
             thermo.label += 'X' * len(surface_sites)
 
         find_cp0_and_cpinf(species, thermo)
-
-        # if the molecule had labels, reapply them 
-        for label,atom in labeled_atoms.items():
-            if isinstance(atom,list):
-                for a in atom:
-                    a.label = label
-            else:
-                atom.label = label
 
         return thermo
 

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1646,19 +1646,18 @@ class ThermoDatabase(object):
                 else:
                     atom.label = label
 
-            # a tuple of the H298, the ThermoData object, and the molecule
-            resonance_data.append((thermo.get_enthalpy(298), thermo, molecule))
+            # a tuple of molecule and its thermo
+            resonance_data.append((molecule, thermo))
 
         # Get the enthalpy of formation of every adsorbate at 298 K and
         # determine the resonance structure with the lowest enthalpy of formation.
         # We assume that the lowest enthalpy of formation is the correct
-        # thermodynamic property for the adsorbate.
+        # thermodynamic property for the adsorbate, and the preferred representation.
 
-        # first element of each tuple is H298, so sort by that
-        resonance_data = sorted(resonance_data)
+        resonance_data = sorted(resonance_data, key=lambda x: x[1].H298.value_si)
 
         # reorder the resonance structures (molecules) by their H298
-        species.molecule = [mol for h, thermo, mol in resonance_data]
+        species.molecule = [mol for mol, thermo in resonance_data]
 
         thermo = resonance_data[0][1]
 

--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -1240,6 +1240,19 @@ class Fragment(Molecule):
                 return True
         return False
 
+    def is_multidentate(self):
+        """
+        Return ``True`` if the adsorbate contains at least two binding sites,
+        or ``False`` otherwise.
+        """
+        surface_sites = 0
+        for atom in self.vertices:
+            if atom.is_surface_site():
+                surface_sites += 1
+                if surface_sites >= 2:
+                    return True
+        return False
+
     def from_smiles_like_string(self, smiles_like_string):
         smiles = smiles_like_string
 

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -301,6 +301,8 @@ cdef class Molecule(Graph):
 
     cpdef list get_adatoms(self)
 
+    cpdef bint is_multidentate(self)
+
     cpdef list get_desorbed_molecules(self)
 
 cdef atom_id_counter

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2864,6 +2864,16 @@ class Molecule(Graph):
         cython.declare(atom=Atom)
         return [atom for atom in self.atoms if atom.is_surface_site()]
 
+    def is_multidentate(self):
+        """
+        Return ``True`` if the adsorbate contains at least two binding sites,
+        or ``False`` otherwise.
+        """
+        cython.declare(atom=Atom)
+        if len([atom for atom in self.atoms if atom.is_surface_site()])>=2:
+            return True
+        return False
+
     def get_adatoms(self):
         """
         Get a list of adatoms in the molecule.

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -883,6 +883,13 @@ class Bond(Edge):
         """
         return self.is_order(4)
 
+    def is_double_or_triple(self):
+        """
+        Return ``True`` if the bond represents a double or triple bond or ``False``
+        if not.
+        """
+        return self.is_order(2) or self.is_order(3)
+
     def is_benzene(self):
         """
         Return ``True`` if the bond represents a benzene bond or ``False`` if

--- a/rmgpy/molecule/pathfinder.pxd
+++ b/rmgpy/molecule/pathfinder.pxd
@@ -58,3 +58,7 @@ cpdef list find_N5dc_radical_delocalization_paths(Vertex atom1)
 cpdef bint is_atom_able_to_gain_lone_pair(Vertex atom)
 
 cpdef bint is_atom_able_to_lose_lone_pair(Vertex atom)
+
+cpdef list find_adsorbate_delocalization_paths(Vertex atom1)
+
+cpdef list find_adsorbate_conjugate_delocalization_paths(Vertex atom1)

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -480,3 +480,58 @@ def is_atom_able_to_lose_lone_pair(atom):
     return (((atom.is_nitrogen() or atom.is_sulfur()) and atom.lone_pairs in [1, 2, 3])
             or (atom.is_oxygen() and atom.lone_pairs in [2, 3])
             or atom.is_carbon() and atom.lone_pairs == 1)
+
+
+def find_adsorbate_delocalization_paths(atom1):
+    """
+    Find all multidentate adsorbates which have a bonding configuration X-C-C-X.
+    Examples:
+
+    - XCXC, XCHXCH, XCXCH, where X is the surface site. The adsorption site X
+      is always placed on the left-hand side of the adatom and every adatom
+      is bonded to only one surface site X.
+
+    In this transition atom1 and atom4 are surface sites while atom2 and atom3
+    are carbon or nitrogen atoms.
+    """
+    cython.declare(paths=list, atom2=Vertex, atom3=Vertex, atom4=Vertex, bond12=Edge, bond23=Edge, bond34=Edge)
+
+    paths = []
+    if atom1.is_surface_site():
+        for atom2, bond12 in atom1.edges.items():
+            if atom2.is_carbon():
+                for atom3, bond23 in atom2.edges.items():
+                    if atom3.is_carbon():
+                        for atom4, bond34 in atom3.edges.items():
+                            if atom4.is_surface_site():
+                                paths.append([atom1, atom2, atom3, atom4, bond12, bond23, bond34])
+    return paths
+
+
+def find_adsorbate_conjugate_delocalization_paths(atom1):
+    """
+    Find all multidentate adsorbates which have a bonding configuration X-C-C-C-X.
+    Examples:
+
+    - XCHCHXCH/XCHCHXC, where X is the surface site. The adsorption site X
+      is always placed on the left-hand side of the adatom and every adatom
+      is bonded to only one surface site X.
+
+    In this transition atom1 and atom5 are surface sites while atom2, atom3,
+    and atom4 are carbon or nitrogen atoms.
+    """
+
+    cython.declare(paths=list, atom2=Vertex, atom3=Vertex, atom4=Vertex, atom5=Vertex, bond12=Edge, bond23=Edge, bond34=Edge, bond45=Edge)
+
+    paths = []
+    if atom1.is_surface_site():
+        for atom2, bond12 in atom1.edges.items():
+            if atom2.is_carbon():
+                for atom3, bond23 in atom2.edges.items():
+                    if atom3.is_carbon():
+                        for atom4, bond34 in atom3.edges.items():
+                            if atom2 is not atom4 and atom4.is_carbon():
+                                for atom5, bond45 in atom4.edges.items():
+                                    if atom5.is_surface_site():
+                                        paths.append([atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45])
+    return paths

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -499,9 +499,9 @@ def find_adsorbate_delocalization_paths(atom1):
     paths = []
     if atom1.is_surface_site():
         for atom2, bond12 in atom1.edges.items():
-            if atom2.is_carbon():
+            if atom2.is_carbon() or atom2.is_nitrogen():
                 for atom3, bond23 in atom2.edges.items():
-                    if atom3.is_carbon():
+                    if atom3.is_carbon() or atom3.is_nitrogen():
                         for atom4, bond34 in atom3.edges.items():
                             if atom4.is_surface_site():
                                 paths.append([atom1, atom2, atom3, atom4, bond12, bond23, bond34])
@@ -526,11 +526,11 @@ def find_adsorbate_conjugate_delocalization_paths(atom1):
     paths = []
     if atom1.is_surface_site():
         for atom2, bond12 in atom1.edges.items():
-            if atom2.is_carbon():
+            if atom2.is_carbon() or atom2.is_nitrogen():
                 for atom3, bond23 in atom2.edges.items():
-                    if atom3.is_carbon():
+                    if atom3.is_carbon() or atom3.is_nitrogen():
                         for atom4, bond34 in atom3.edges.items():
-                            if atom2 is not atom4 and atom4.is_carbon():
+                            if atom2 is not atom4 and (atom4.is_carbon() or atom4.is_nitrogen()):
                                 for atom5, bond45 in atom4.edges.items():
                                     if atom5.is_surface_site():
                                         paths.append([atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45])

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -63,3 +63,9 @@ cpdef list generate_clar_structures(Graph mol, bint save_order=?)
 cpdef list _clar_optimization(Graph mol, list constraints=?, max_num=?, save_order=?)
 
 cpdef list _clar_transformation(Graph mol, list aromatic_ring)
+
+cpdef list generate_adsorbate_shift_down_resonance_structures(Graph mol)
+
+cpdef list generate_adsorbate_shift_up_resonance_structures(Graph mol)
+
+cpdef list generate_adsorbate_conjugate_resonance_structures(Graph mol)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -1180,20 +1180,21 @@ def generate_adsorbate_shift_up_resonance_structures(mol):
         for atom in mol.vertices:
             paths = pathfinder.find_adsorbate_delocalization_paths(atom)
             for atom1, atom2, atom3, atom4, bond12, bond23, bond34 in paths:
-                if (bond12.is_double() and bond23.is_single() and bond34.is_double()) or (bond23.is_double() and bond12.is_double() and bond34.is_double()) or (bond12.is_triple() and bond23.is_single() and bond34.is_triple()) or (bond12.is_triple() and bond23.is_single() and bond34.is_double()):
-                    bond12.decrement_order()
-                    bond23.increment_order()
-                    bond34.decrement_order()
-                    structure = mol.copy(deep=True)
-                    bond12.increment_order()
-                    bond23.decrement_order()
-                    bond34.increment_order()
-                    try:
-                        structure.update_atomtypes(log_species=False)
-                    except AtomTypeError:
-                        pass
-                    else:
-                        structures.append(structure)
+                if ((bond12.is_double_or_triple() and bond23.is_single() and bond34.is_double_or_triple()) or
+                    (bond12.is_double() and bond23.is_double() and bond34.is_double())):
+                        bond12.decrement_order()
+                        bond23.increment_order()
+                        bond34.decrement_order()
+                        structure = mol.copy(deep=True)
+                        bond12.increment_order()
+                        bond23.decrement_order()
+                        bond34.increment_order()
+                        try:
+                            structure.update_atomtypes(log_species=False)
+                        except AtomTypeError:
+                            pass
+                        else:
+                            structures.append(structure)
     return structures
 
 
@@ -1215,9 +1216,9 @@ def generate_adsorbate_conjugate_resonance_structures(mol):
         for atom in mol.vertices:
             paths = pathfinder.find_adsorbate_conjugate_delocalization_paths(atom)
             for atom1, atom2, atom3, atom4, atom45, bond12, bond23, bond34, bond45 in paths:
-                    if ((bond12.is_double() or bond12.is_triple()) and
+                    if (bond12.is_double_or_triple() and
                         (bond23.is_single() or bond23.is_double()) and
-                        (bond34.is_double() or bond34.is_triple()) and
+                        bond34.is_double_or_triple() and
                         (bond45.is_single() or bond45.is_double())):
                                 bond12.decrement_order()
                                 bond23.increment_order()

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -49,6 +49,10 @@ Currently supported resonance types:
     - ``generate_kekule_structure``: generate a single Kekule structure for an aromatic compound (single/double bond form)
     - ``generate_opposite_kekule_structure``: for monocyclic aromatic species, rotate the double bond assignment
     - ``generate_clar_structures``: generate all structures with the maximum number of pi-sextet assignments
+- Multidentate adsorbates only
+    - ``generate_adsorbate_shift_down_resonance_structures``: shift 2 electrons from a C=/#C bond to the X-C bond
+    - ``generate_adsorbate_shift_up_resonance_structures``: shift 2 electrons from a X=/#C bond to a C-C bond
+    - ``generate_adsorbate_conjugate_resonance_structures``: shift 2 electrons in a conjugate pi system for bridged X-C-C-C-X adsorbates
 """
 
 import logging
@@ -87,6 +91,9 @@ def populate_resonance_algorithms(features=None):
             generate_aryne_resonance_structures,
             generate_kekule_structure,
             generate_clar_structures,
+            generate_adsorbate_shift_down_resonance_structures,
+            generate_adsorbate_shift_up_resonance_structures,
+            generate_adsorbate_conjugate_resonance_structures
         ]
     else:
         # If the molecule is aromatic, then radical resonance has already been considered
@@ -110,7 +117,10 @@ def populate_resonance_algorithms(features=None):
                 # solution. A more holistic approach would be to identify these cases in generate_resonance_structures,
                 # and pass a list of forbidden atom ID's to find_lone_pair_multiple_bond_paths.
                 method_list.append(generate_lone_pair_multiple_bond_resonance_structures)
-
+        if features['is_multidentate']:
+            method_list.append(generate_adsorbate_shift_down_resonance_structures)
+            method_list.append(generate_adsorbate_shift_up_resonance_structures)
+            method_list.append(generate_adsorbate_conjugate_resonance_structures)
     return method_list
 
 
@@ -130,6 +140,7 @@ def analyze_molecule(mol, save_order=False):
                 'is_aryl_radical': False,
                 'hasNitrogenVal5': False,
                 'hasLonePairs': False,
+                'is_multidentate': mol.is_multidentate(),
                 }
 
     if features['is_cyclic']:
@@ -1117,3 +1128,110 @@ def _clar_transformation(mol, aromatic_ring):
 
     for bond in bond_list:
         bond.order = 1.5
+
+
+def generate_adsorbate_shift_down_resonance_structures(mol):
+    """
+    Generate all of the resonance structures formed by the shift a pi bond between two C-C atoms to both X-C bonds.
+    Example XCHXCH: [X]C=C[X] <=> [X]=CC=[X]
+    (where '=' denotes a double bond)
+    """
+    cython.declare(structures=list, paths=list, index=cython.int, structure=Graph)
+    cython.declare(atom=Vertex, atom1=Vertex, atom2=Vertex, atom3=Vertex, atom4=Vertex, bond12=Edge, bond23=Edge, bond34=Edge)
+    cython.declare(v1=Vertex, v2=Vertex)
+
+    structures = []
+    if mol.is_multidentate():
+        for atom in mol.vertices:
+            paths = pathfinder.find_adsorbate_delocalization_paths(atom)
+            for atom1, atom2, atom3, atom4, bond12, bond23, bond34 in paths:
+                if bond23.is_single():
+                    continue
+                else:
+                    bond12.increment_order()
+                    bond23.decrement_order()
+                    bond34.increment_order()
+                    structure = mol.copy(deep=True)
+                    bond12.decrement_order()
+                    bond23.increment_order()
+                    bond34.decrement_order()
+                    try:
+                        structure.update_atomtypes(log_species=False)
+                    except AtomTypeError:
+                        pass
+                    else:
+                        structures.append(structure)
+    return structures
+
+
+def generate_adsorbate_shift_up_resonance_structures(mol):
+    """
+    Generate all of the resonance structures formed by the shift of two electrons from X-C bonds to increase the bond
+    order between two C-C atoms by 1.
+    Example XCHXCH: [X]=CC=[X] <=> [X]C=C[X]
+    (where '=' denotes a double bond, '#' denotes a triple bond)
+    """
+    cython.declare(structures=list, paths=list, index=cython.int, structure=Graph)
+    cython.declare(atom=Vertex, atom1=Vertex, atom2=Vertex, atom3=Vertex, atom4=Vertex, bond12=Edge, bond23=Edge, bond34=Edge)
+    cython.declare(v1=Vertex, v2=Vertex)
+
+    structures = []
+    if mol.is_multidentate():
+        for atom in mol.vertices:
+            paths = pathfinder.find_adsorbate_delocalization_paths(atom)
+            for atom1, atom2, atom3, atom4, bond12, bond23, bond34 in paths:
+                if (bond12.is_double() and bond23.is_single() and bond34.is_double()) or (bond23.is_double() and bond12.is_double() and bond34.is_double()) or (bond12.is_triple() and bond23.is_single() and bond34.is_triple()) or (bond12.is_triple() and bond23.is_single() and bond34.is_double()):
+                    bond12.decrement_order()
+                    bond23.increment_order()
+                    bond34.decrement_order()
+                    structure = mol.copy(deep=True)
+                    bond12.increment_order()
+                    bond23.decrement_order()
+                    bond34.increment_order()
+                    try:
+                        structure.update_atomtypes(log_species=False)
+                    except AtomTypeError:
+                        pass
+                    else:
+                        structures.append(structure)
+    return structures
+
+
+def generate_adsorbate_conjugate_resonance_structures(mol):
+    """
+    Generate all of the resonance structures formed by the shift of two
+    electrons in a conjugated pi bond system of a bidentate adsorbate
+    with a bridging atom in between.
+
+    Example XCHCHXC: [X]#CC=C[X] <=> [X]=C=CC=[X]
+    (where '#' denotes a triple bond, '=' denotes a double bond)
+    """
+    cython.declare(structures=list, paths=list, index=cython.int, structure=Graph)
+    cython.declare(atom=Vertex, atom1=Vertex, atom2=Vertex, atom3=Vertex, atom4=Vertex, atom5=Vertex, bond12=Edge, bond23=Edge, bond34=Edge, bond45=Edge)
+    cython.declare(v1=Vertex, v2=Vertex)
+
+    structures = []
+    if mol.is_multidentate():
+        for atom in mol.vertices:
+            paths = pathfinder.find_adsorbate_conjugate_delocalization_paths(atom)
+            for atom1, atom2, atom3, atom4, atom45, bond12, bond23, bond34, bond45 in paths:
+                    if ((bond12.is_double() or bond12.is_triple()) and
+                        (bond23.is_single() or bond23.is_double()) and
+                        (bond34.is_double() or bond34.is_triple()) and
+                        (bond45.is_single() or bond45.is_double())):
+                                bond12.decrement_order()
+                                bond23.increment_order()
+                                bond34.decrement_order()
+                                bond45.increment_order()
+                                structure = mol.copy(deep=True)
+                                bond12.increment_order()
+                                bond23.decrement_order()
+                                bond34.increment_order()
+                                bond45.decrement_order()
+                                try:
+                                    structure.update_atomtypes(log_species=False)
+                                except AtomTypeError:
+                                    pass
+                                else:
+                                    structures.append(structure)
+    return structures

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -2139,6 +2139,26 @@ multiplicity 2
         assert adsorbed.number_of_surface_sites() == 1
         assert bidentate.number_of_surface_sites() == 2
 
+    def test_is_multidentate(self):
+        """
+        Test that we can identify a multidentate adsorbate
+        """
+        monodentate = Molecule().from_adjacency_list(
+            """
+            1 H u0 p0 c0 {2,S}
+            2 X u0 p0 c0 {1,S}
+            """
+        )
+        adjlist = """
+            1 X u0 p0 c0 {3,S}
+            2 X u0 p0 c0 {4,S}
+            3 C u0 p0 c0 {1,S} {4,T}
+            4 C u0 p0 c0 {2,S} {3,T}
+            """
+        bidentate = Molecule().from_adjacency_list(adjlist)
+        assert not monodentate.is_multidentate()
+        assert bidentate.is_multidentate()
+
     def test_malformed_augmented_inchi(self):
         """Test that augmented inchi without InChI layer raises Exception."""
         malform_aug_inchi = "foo"

--- a/test/rmgpy/molecule/pathfinderTest.py
+++ b/test/rmgpy/molecule/pathfinderTest.py
@@ -41,6 +41,8 @@ from rmgpy.molecule.pathfinder import (
     find_lone_pair_multiple_bond_paths,
     find_N5dc_radical_delocalization_paths,
     find_shortest_path,
+    find_adsorbate_delocalization_paths,
+    find_adsorbate_conjugate_delocalization_paths,
 )
 
 
@@ -458,7 +460,7 @@ class FindLonePairMultipleBondPathsTest:
         assert paths
 
 
-class FindAdjLonePairRadicalDelocalizationPaths:
+class FindAdjLonePairRadicalDelocalizationPathsTest:
     """
     test the find_lone_pair_radical_delocalization_paths method
     """
@@ -490,7 +492,7 @@ class FindAdjLonePairRadicalDelocalizationPaths:
         assert paths
 
 
-class FindAdjLonePairMultipleBondDelocalizationPaths:
+class FindAdjLonePairMultipleBondDelocalizationPathsTest:
     """
     test the find_lone_pair_multiple_bond_delocalization_paths method
     """
@@ -502,7 +504,7 @@ class FindAdjLonePairMultipleBondDelocalizationPaths:
         assert paths
 
 
-class FindAdjLonePairRadicalMultipleBondDelocalizationPaths:
+class FindAdjLonePairRadicalMultipleBondDelocalizationPathsTest:
     """
     test the find_lone_pair_radical_multiple_bond_delocalization_paths method
     """
@@ -520,7 +522,7 @@ class FindAdjLonePairRadicalMultipleBondDelocalizationPaths:
         assert paths
 
 
-class FindN5dcRadicalDelocalizationPaths:
+class FindN5dcRadicalDelocalizationPathsTest:
     """
     test the find_N5dc_radical_delocalization_paths method
     """
@@ -529,4 +531,42 @@ class FindN5dcRadicalDelocalizationPaths:
         smiles = "N=[N+]([O])([O-])"
         mol = Molecule().from_smiles(smiles)
         paths = find_N5dc_radical_delocalization_paths(mol.atoms[1])
+        assert paths
+
+class FindAdsorbateDelocalizationPathsTest:
+    """
+    test the find_adsorbate_delocalization_paths method
+    """
+
+    def test_cch(self):
+        adjlist = """
+1 X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {4,S}
+3 C u0 p0 c0 {1,D} {4,D}
+4 C u0 p0 c0 {2,S} {3,D} {5,S}
+5 H u0 p0 c0 {4,S}  
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+        paths = find_adsorbate_delocalization_paths(mol.atoms[0])
+        assert paths
+
+class FindAdsorbateConjugateDelocalizationPathsTest:
+    """
+    test the find_adsorbate_conjugate_delocalization_paths
+    """
+
+    def test_chchc(self):
+        adjlist = """
+1 X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {5,S}
+3 C u0 p0 c0 {1,T} {4,S}
+4 C u0 p0 c0 {3,S} {5,D} {6,S}
+5 C u0 p0 c0 {2,S} {4,D} {7,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+        paths = find_adsorbate_conjugate_delocalization_paths(mol.atoms[0])
         assert paths

--- a/test/rmgpy/molecule/pathfinderTest.py
+++ b/test/rmgpy/molecule/pathfinderTest.py
@@ -538,7 +538,7 @@ class FindAdsorbateDelocalizationPathsTest:
     test the find_adsorbate_delocalization_paths method
     """
 
-    def test_cch(self):
+    def test_xcxch(self):
         adjlist = """
 1 X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {4,S}
@@ -549,14 +549,33 @@ class FindAdsorbateDelocalizationPathsTest:
 
         mol = Molecule().from_adjacency_list(adjlist)
         paths = find_adsorbate_delocalization_paths(mol.atoms[0])
+        no_surface_sites = sum(atom.is_surface_site() for atom in paths[0][:4])
         assert paths
+        assert no_surface_sites == 2
+
+    def test_xcxch2(self):
+        adjlist = """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,T}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {1,S}
+6 X u0 p0 c0 {2,T}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+        paths = find_adsorbate_delocalization_paths(mol.atoms[0])
+        assert len(paths) == 0
+
+
+
 
 class FindAdsorbateConjugateDelocalizationPathsTest:
     """
     test the find_adsorbate_conjugate_delocalization_paths
     """
 
-    def test_chchc(self):
+    def test_xchchxc(self):
         adjlist = """
 1 X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,S}
@@ -569,4 +588,24 @@ class FindAdsorbateConjugateDelocalizationPathsTest:
 
         mol = Molecule().from_adjacency_list(adjlist)
         paths = find_adsorbate_conjugate_delocalization_paths(mol.atoms[0])
+        no_surface_sites = sum(atom.is_surface_site() for atom in paths[0][:5])
         assert paths
+        assert no_surface_sites == 2
+
+    def test_xchch2xch2(self):
+        adjlist = """
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {9,S}
+3 C u0 p0 c0 {1,S} {8,S} {10,D}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {3,S}
+9 X u0 p0 c0 {2,S}
+10 X u0 p0 c0 {3,D}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+        paths = find_adsorbate_conjugate_delocalization_paths(mol.atoms[0])
+        assert len(paths) == 0

--- a/test/rmgpy/molecule/resonanceTest.py
+++ b/test/rmgpy/molecule/resonanceTest.py
@@ -1363,6 +1363,64 @@ multiplicity 2
                 atom2_nb = {nb.id for nb in list(atom2.bonds.keys())}
                 assert atom1_nb == atom2_nb
 
+    def test_adsorbate_resonance_cc1(self):
+        """Test if all three resonance structures for X#CC#X are generated"""
+        adjlist = """
+1 X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {4,T}
+3 C u0 p0 c0 {1,T} {4,S}
+4 C u0 p0 c0 {2,T} {3,S}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+
+        mol_list = generate_resonance_structures(mol)
+        assert len(mol_list) == 3
+
+    def test_adsorbate_resonance_cc2(self):
+        """Test if all three resonance structures for X=C=C=X are generated"""
+        adjlist = """
+1 X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {4,D}
+3 C u0 p0 c0 {1,D} {4,D}
+4 C u0 p0 c0 {2,D} {3,D}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+
+        mol_list = generate_resonance_structures(mol)
+        assert len(mol_list) == 3
+
+    def test_adsorbate_resonance_cc3(self):
+        """Test if all three resonance structures for XC#CX are generated"""
+        adjlist = """
+1 X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {4,S}
+3 C u0 p0 c0 {1,S} {4,T}
+4 C u0 p0 c0 {2,S} {3,T}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+
+        mol_list = generate_resonance_structures(mol)
+        assert len(mol_list) == 3
+
+    def test_adsorbate_resonance_chchc(self):
+        """Test if both resonance structures for XCHCHXC are generated"""
+        adjlist = """
+1 X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {5,S}
+3 C u0 p0 c0 {1,T} {4,S}
+4 C u0 p0 c0 {3,S} {5,D} {6,S}
+5 C u0 p0 c0 {2,S} {4,D} {7,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+        """
+
+        mol = Molecule().from_adjacency_list(adjlist)
+
+        mol_list = generate_resonance_structures(mol)
+        assert len(mol_list) == 2
 
 class ClarTest:
     """


### PR DESCRIPTION
### Motivation or Problem
Adsorbate molecules can exhibit resonance similar to gas-phase molecules. For example, the bidentate adsorbate XCXC (where X is a surface site) has the following three configurations:
[X]C#C[X] <-> [X]#CC#[X] <-> [X]=C=C=[X]
Currently, RMG cannot identify resonance structures for adsorbates. 
In this pull request, I made the first step and added functions for the generation of resonance structures for adsorbates. 

### Description of Changes
Resonance occurs only for adsorbates that have at least two binding sites, also known as bidentate adsorbates. 
Therefore, a function was added to molecule.py to check if an adsorbate has two binding sites. 
The pathfinder.py was updated with functions to find the structures of adsorbates which can eventually have resonance structures. The structures that are searched for in the adsorbates are X-C-C-X and X-C-C-C-X. 
Five types of resonance for adsorbates were added to resonance.py. The identified and implemented resonance types are as follows:

- Shift 2 electrons from a C=/#C bond to the X-C bond (generate_adsorbate_shift_down_resonance_structures)
- Shift 2 electrons from a X=/#C bond to a C-C bond (generate_adsorbate_shift_up_resonance_structures)
- Shift 4 electrons from a C#C bond to a X-C bond (generate_adsorbate_double_shift_down_resonance_structures)
- Shift 4 electrons from a X#C bond to a C-C bond (generate_adsorbate_double_shift_up_resonance_structures)
- Shift 2 electrons in a conjugate pi system for bridged X-C-C-C-X adsorbates (generate_adsorbate_conjugate_resonance_structures)

Apologies for the funky names of the resonance types. Resonance has not really been discussed in catalysis yet. 
This pull request is work in progress and requires more changes to the source code. This is meant to start the discussion on resonance for adsorbates. 

### Testing
I have tested the functionalities of the added resonance functions by providing various adsorbates with and without resonance and confirmed that the functions work properly. 
An RMG run for an catalytic system completed also without any errors. 

### Reviewer Tips
Use the functions in a standalone Jupyter notebook and see if RMG can identify the resonance structures correctly. A selection of bidentate adsorbates with resonance is: "XCXC, XCHXCH, XCXCH, XCXCCH2, XCHXCCH2, XCHXCXC, XCHXCXCH, XCHCXC, XCHCHXC, XCHCHXCH" where X is a surface atom. 

### Open Tasks

A function is required to generate the resonance structures for bidentate format (XOC(H)XO) and bicarbonate (XOC(OH)XO). Adding resonance generation for the formate case requires more changes to RMG to handle 'van der Waals' bonds. These changes are going to be part of another pull request. 
