### PR TITLE
When loading all reaction libraries, only process "reactions.py" files.

### DIFF
--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -251,8 +251,7 @@ class KineticsDatabase(object):
             self.library_order = []
             for (root, dirs, files) in os.walk(os.path.join(path)):
                 for f in files:
-                    name, ext = os.path.splitext(f)
-                    if ext.lower() == '.py':
+                    if f.lower() == 'reactions.py':
                         library_file = os.path.join(root, f)
                         label = os.path.dirname(library_file)[len(path) + 1:]
                         logging.info(f'Loading kinetics library {label} from {library_file}...')


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
I had a reaction library folder with another python file in it (`renumber.py`)that had been used to renumber the reactions
at some point. RMG was trying to load this as if it were a `reactions.py`, and failing the database tests. 

### Description of Changes

Since named reaction libraries are forced to have the file be called "reactions.py", I think it is OK that the "load all libraries" method makes the same assumption.

So now it only searches for libraries with a file called `reactions.py` (though it is case insensitive).

### Testing
On my computer, `make test-database` now passes (on the new pytest system) whereas it didn't before this.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
