### PR TITLE
Add surface combustion example for regression testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
         id: regression-execution
         timeout-minutes: 60
         run: |
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment minimal_surface;
           do
             if python-jl rmg.py test/regression/"$regr_test"/input.py; then
               echo "$regr_test" "Executed Successfully"
@@ -242,7 +242,7 @@ jobs:
         run: |
           exec 2> >(tee -a regression.stderr >&2) 1> >(tee -a regression.stdout)
           mkdir -p "test/regression-diff"
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation fragment RMS_constantVIdealGasReactor_fragment;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation fragment RMS_constantVIdealGasReactor_fragment minimal_surface;
           do
             echo ""
             echo "### Regression test $regr_test:"

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -101,6 +101,15 @@ def read_input_file(path):
         new_imfs.append(new_dict)
     setups[3] = new_imfs
 
+    # convert keys of the initial surface mole fraction dictionaries (ismfs) from labels into Species objects.
+    if setups[5][0]:
+        ismfs = setups[5]
+        new_ismfs = []
+        for ismf in ismfs:
+            new_dict = convert(ismf, initialSpecies)
+            new_ismfs.append(new_dict)
+        setups[5] = new_ismfs
+
     return casetitle, observables, setups, tol
 
 
@@ -115,14 +124,17 @@ def species(label, structure):
     return spc
 
 
-def reactorSetups(reactorTypes, temperatures, pressures, initialMoleFractionsList, terminationTimes):
+def reactorSetups(reactorTypes, temperatures, pressures, initialMoleFractionsList, terminationTimes, initialSurfaceMoleFractionsList=None):
     global setups
+
+    if initialSurfaceMoleFractionsList is None:
+        initialSurfaceMoleFractionsList = [None]
 
     terminationTimes = Quantity(terminationTimes)
     temperatures = Quantity(temperatures)
     pressures = Quantity(pressures)
 
-    setups = [reactorTypes, temperatures, pressures, initialMoleFractionsList, terminationTimes]
+    setups = [reactorTypes, temperatures, pressures, initialMoleFractionsList, terminationTimes, initialSurfaceMoleFractionsList]
 
 
 def options(title='', tolerance=0.05):
@@ -154,11 +166,12 @@ def run(benchmarkDir, testDir, title, observables, setups, tol):
         ck2cti=False,
     )
 
-    reactor_types, temperatures, pressures, initial_mole_fractions_list, termination_times = setups
+    reactor_types, temperatures, pressures, initial_mole_fractions_list, termination_times, initial_surface_mole_fractions_list = setups
     case.generate_conditions(
         reactor_type_list=reactor_types,
         reaction_time_list=termination_times,
         mol_frac_list=initial_mole_fractions_list,
+        surface_mol_frac_list=initial_surface_mole_fractions_list,
         Tlist=temperatures,
         Plist=pressures
     )

--- a/test/regression/minimal_surface/input.py
+++ b/test/regression/minimal_surface/input.py
@@ -92,7 +92,7 @@ surfaceReactor(
         "X": 1.0,
     },
     surfaceVolumeRatio=(1.e5, 'm^-1'),
-    terminationConversion = { "CH4": 0.95,},
+    terminationConversion={"CH4": 0.95,},
     terminationTime=(0.1, 's'),
     terminationRateRatio=0.01,
 )

--- a/test/regression/minimal_surface/regression_input.py
+++ b/test/regression/minimal_surface/regression_input.py
@@ -1,0 +1,67 @@
+options(
+    title = 'minimal_surface',
+    tolerance = 0.5,
+)
+
+# observables
+observable(
+	label = 'CH4',
+    structure=SMILES('C'),
+)
+
+observable(
+	label = 'O2',
+    structure=SMILES('[O][O]'),
+)
+
+observable(
+	label = 'X',
+    structure=adjacencyList(
+        """
+1 X u0 p0 c0
+"""),
+)
+
+
+# List of species
+species(
+    label='CH4',
+    structure=SMILES("[CH4]"),
+)
+species(
+   label='O2',
+   structure=adjacencyList(
+       """
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+"""),
+)
+species(
+    label='N2',
+    structure=SMILES("N#N"),
+)
+species(
+	label='X',
+    structure=adjacencyList(
+        """
+1 X u0 p0 c0
+"""),
+)
+
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([1.0], 's'),
+    initialMoleFractionsList=[{
+        'CH4': 0.15,
+        'O2': 0.15,
+        'N2': 0.7,
+    }],
+    initialSurfaceMoleFractionsList=[{
+        'X': 1.0,
+    }],
+
+    temperatures=([1000.0], 'K'),
+    pressures=([1.0], 'bar'),
+)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->
moved over from https://github.com/ReactionMechanismGenerator/RMG-tests/pull/85

### Motivation or Problem
We want to make sure in our testing that surface examples work. 

### Description of Changes
Adding a surface test input file.

This also adds functionality to rmgpy.tools.canteramodel.py to load, simulate, and compare surface mechanisms. Then it also adds hooks in the upstream callers, rmgpy.tools.regression.py and rmgpy.tools.observablesregression.py to pass the surface-specific information into the cantera model

### Testing
I ran the regression test on an example surface file and then also on the superminimal and nitrogen examples.

### Reviewer Tips
This PR can be broken down into two parts: adding the surface functionality to the regression tool, and then adding the surface testing files to the CI workflow.