### PR TITLE
update docker usage instructions to point to v3.2.0

### DIFF
--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -16,17 +16,17 @@ RMG is primarily distributed using Docker, a software package for delivering app
 
 #. Download and install `Docker <https://docs.docker.com/get-docker/>`_.
 
-#. Open a terminal, powershell, or command prompt and run ``docker pull reactionmechanismgenerator/rmg:3.1.1``.
+#. Open a terminal, powershell, or command prompt and run ``docker pull reactionmechanismgenerator/rmg:3.2.0``.
 
    This step may take some time as the image is downloaded.
 
-#. Run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it reactionmechanismgenerator/rmg:3.1.1``
+#. Run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it reactionmechanismgenerator/rmg:3.2.0``
 
    This command will make the folder ``C:\Users\rmguser\myrmgfiles`` on your computer accessible from inside the container to easily edit and transfer input and output files.
    Change the path to match your individual computer.
    If the folder does not exist when the command is run, it will be created.
 
-   If you want to use jupyter notebook inside the docker container, run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it -p 8888:8888 reactionmechanismgenerator/rmg:3.1.1`` instead.
+   If you want to use jupyter notebook inside the docker container, run ``docker run --name rmgcontainer -v "C:\Users\rmguser\myrmgfiles:/rmg/RMG-Py/myrmgfiles" -it -p 8888:8888 reactionmechanismgenerator/rmg:3.2.0`` instead.
    And you can start the jupyter notebook by running ``jupyter notebook --ip 0.0.0.0 --no-browser --allow-root`` inside the container.
    Then you can access the jupyter notebook from your browser by going to ``http://localhost:8888``.
    You may need to copy and paste the token from the terminal into the browser to access the notebook.


### PR DESCRIPTION
### Motivation or Problem
RMG-Py version 3.2 is out (1df107f) :tada:! This PR updates the docs to point users towards that docker image, which I have already built and uploaded to docker hub on the reactionmechanismgenerator/rmg repository.

Resolves #2467 - the required code for the issue mentioned is now in the Docker image.

Let's allow #2516 to go in before this just to save that PR having to rebase (again).
