### PR TITLE
Instruct Docker, Github Actions, and users to use 'for_rmg' branch of RMS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,7 +154,7 @@ jobs:
         timeout-minutes: 120 # this usually takes 20-45 minutes (or hangs for 6+ hours).
         run: |
           python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()" || true
-          julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator' || true 
+          julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="for_rmg")); using ReactionMechanismSimulator' || true 
 
       # non-regression testing
       - name: Unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV PATH="$RUNNER_CWD/RMG-Py:$PATH"
 # 1. Build RMG
 # 2. Install and link Julia dependencies for RMS
 RUN make && \
-    julia -e 'using Pkg; Pkg.add(PackageSpec(name="PyCall",rev="master")); Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator' && \
+    julia -e 'using Pkg; Pkg.add(PackageSpec(name="PyCall",rev="master")); Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="for_rmg")); using ReactionMechanismSimulator' && \
     python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()" 
 
 # RMG-Py should now be installed and ready - trigger precompilation and test run

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -136,7 +136,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
 #. Install and Link Julia dependencies: ::
 
-     julia -e 'using Pkg; Pkg.add("PyCall");Pkg.build("PyCall");Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator;'
+     julia -e 'using Pkg; Pkg.add("PyCall");Pkg.build("PyCall");Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="for_rmg")); using ReactionMechanismSimulator;'
 
      python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The "main" branch of ReactionMechanismSimulator.jl is temporarily incompatible with RMG, causing all builds to fail.

### Description of Changes
For now, there is a dedicated "for_rmg" branch, which we can use, which is currently where main was just before the most recent breaking PR was merged.  Hopefully things can be resolved and a main branch will work for both.

### Testing
I plan to let the CI run its course.


### Other context

The failure looks like this in the CI logs:

```
Wed, 09 Aug 2023 15:50:00 GMT   ....installing Julia stuff...
Wed, 09 Aug 2023 16:20:00 GMT
└  
Wed, 09 Aug 2023 16:21:43 GMT
[ Info: Installing molecule.molecule via the Conda rmgmolecule package...
Wed, 09 Aug 2023 16:21:44 GMT
[ Info: Running `conda config --add channels hwpang --file /usr/share/miniconda3/envs/rmg_env/condarc-julia.yml --force` in root environment
Wed, 09 Aug 2023 16:21:44 GMT
[ Info: Running `conda install -q -y rmgmolecule` in root environment
Wed, 09 Aug 2023 16:22:13 GMT
Collecting package metadata (current_repodata.json): ...working... done
Wed, 09 Aug 2023 16:26:58 GMT
Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
Wed, 09 Aug 2023 16:32:06 GMT
Solving environment: ...working... failed with repodata from current_repodata.json, will retry with next repodata source.
Wed, 09 Aug 2023 16:33:57 GMT
Collecting package metadata (repodata.json): ...working... done
Wed, 09 Aug 2023 17:11:31 GMT
Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
Wed, 09 Aug 2023 17:50:35 GMT
Error: The action has timed out.
```


@mjohnson541 writes in Slack " One of the major improvements was switching RMS’s dependency from rmg to molecule…which is great for RMS, but it is probably causing RMG to automatically install molecule when RMS tries to import it…the simplest solution is probably to try importing rmgpy first and import from there if it finds it…I’m trying to think if that will cause confusion…sorry I’m at a conference right now…"

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
