### PR TITLE
correcting bidentate adsorption rate constant

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -794,6 +794,11 @@ class Reaction:
 
             # Multidentate adsorption requires multiplication of the sticking coefficient
             # with the number of binding sites**stoichiometric coefficients (it is 1 for monodentates)
+            for r in self.reactants:
+                sites = r.number_of_surface_sites()
+                if sites > 1:
+                    rate_coefficient /= sites
+                    
             for p in self.products:
                 sites = p.number_of_surface_sites()
                 if sites > 1:

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -792,7 +792,15 @@ class Reaction:
             # molecular_weight_kg in kg per molecule
             rate_coefficient *= math.sqrt(constants.kB * T / (2 * math.pi * molecular_weight_kg))
 
-            # ToDo: missing the sigma terms for bidentate species. only works for single site adsorption
+            # Multidentate adsorption requires multiplication of the sticking coefficient
+            # with the number of binding sites**stoichiometric coefficient of the product (it is 1 for monodentates)
+
+            for p in self.products:
+                if p.contains_surface_site():
+                    sigma_nu = len(p.molecule[0].get_surface_sites())**self.get_stoichiometric_coefficient(p)
+
+            rate_coefficient *= sigma_nu
+
             return rate_coefficient
 
         if isinstance(self.kinetics, SurfaceArrhenius):

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -793,13 +793,11 @@ class Reaction:
             rate_coefficient *= math.sqrt(constants.kB * T / (2 * math.pi * molecular_weight_kg))
 
             # Multidentate adsorption requires multiplication of the sticking coefficient
-            # with the number of binding sites**stoichiometric coefficient of the product (it is 1 for monodentates)
-
+            # with the number of binding sites**stoichiometric coefficients (it is 1 for monodentates)
             for p in self.products:
-                if p.contains_surface_site():
-                    sigma_nu = len(p.molecule[0].get_surface_sites())**self.get_stoichiometric_coefficient(p)
-
-            rate_coefficient *= sigma_nu
+                sites = p.number_of_surface_sites()
+                if sites > 1:
+                    rate_coefficient *= sites
 
             return rate_coefficient
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -777,6 +777,9 @@ class Reaction:
             for r in self.reactants:
                 if r.contains_surface_site():
                     rate_coefficient /= surface_site_density
+                    sites = r.number_of_surface_sites()
+                    if sites > 1:
+                        rate_coefficient /= sites
                 else:
                     if adsorbate is None:
                         adsorbate = r
@@ -794,11 +797,7 @@ class Reaction:
 
             # Multidentate adsorption requires multiplication of the sticking coefficient
             # with the number of binding sites**stoichiometric coefficients (it is 1 for monodentates)
-            for r in self.reactants:
-                sites = r.number_of_surface_sites()
-                if sites > 1:
-                    rate_coefficient /= sites
-                    
+            # Integrated in the loop above for reactants
             for p in self.products:
                 sites = p.number_of_surface_sites()
                 if sites > 1:


### PR DESCRIPTION
### Motivation or Problem
The calculation of the rate constant from the sticking coefficients for adsorption of a gas-phase species as a multidentate adsorbate is currently wrong by a small factor (typically 2).  

Currently, the equation we use to derive the rate constant from the sticking coefficient is

$$k_f=\frac{\gamma}{\Gamma^m}\sqrt{\frac{RT}{2\pi W}} $$

For species adsorbing as a multidentate, this changes to 

$$k_f=\frac{\gamma \prod_{j=1} \sigma_j ^{\nu_j}}{\Gamma^m}\sqrt{\frac{RT}{2\pi W}} $$

according to the Chemkin manual, where \$\nu\$ is the stoichiometric coefficient and \$\sigma\$ the site occupancy of number of species \$j\$. It is only necessary to use the term \$\sigma_j ^{\nu_j}\$ for the multidentate adsorbate since the terms for the surface site are always unity. 

### Description of Changes
I modified the `reaction.py` and the `get_surface_rate_coefficient` function. I provided a check to see if a product species contains a surface site and then computed the amount of surface sites using the existing `get_surface_sites()` command from the `Molecule` class. This new equation is applied for all adsorption reactions since it is 1 for mono dentate species. 

### Testing
I tested the change version to compute the rate constant for the adsorption of CHCH

$$ CHCH + 2 ^* = {^*C}H{^*C}H$$

and the `rate_coefficient` was correctly multiplied by a factor of 2. 

### Reviewer Tips
Next to simply running RMG, I think this can best be tested by setting up an adsorption reaction in  a Jupyter notebook to evaluate if the correct factor is applied. I can provide my example if necessary. 
Can you think of cases, where it is necessary to actually have the product over all surface species in the equation instead of just the multidentate adsorbate? 