### PR TITLE
Fix Failing CI because of `cclib`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
   - coolprop
   - cantera::cantera=2.6
   - conda-forge::mopac
-  - conda-forge::cclib >=1.6.3
+  - conda-forge::cclib >=1.6.3,!=1.8.0
   - conda-forge::openbabel >= 3
 
 # general-purpose external software tools


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The CI has been failing ([see here](https://github.com/ReactionMechanismGenerator/RMG-Py/actions/runs/6009736707/job/16299748843#step:4:86)) for a couple days because of the latest release of `cclib` (see [here](https://github.com/ReactionMechanismGenerator/RMG-Py/actions/runs/5973597214/job/16206162069#step:4:86) for reference), breaking unrelated PRs such as #2533 

### Description of Changes
Disallows `1.8.0` of `cclib` in the RMG `environment.yml`. This is intended as a temporary patch so PRs can keep working and I can do some work locally to find out why this version of `cclib` is failing, and potentially file a bug report with the maintainers.

### Testing
Just using the CI here. As mentioned above, need to do some local debugging to try and find out _why_ this is failing.

### Reviewer Tips
Should be quick to merge (famous last words).

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
