### PR TITLE
Fix a logical short circuit in a test expression

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -2445,7 +2445,7 @@ class ThermoDatabase(object):
             entry = ring_database.descend_tree(molecule, atoms)
             matched_ring_entries.append(entry)
 
-        if matched_ring_entries is []:
+        if matched_ring_entries == []:
             raise KeyError('Node not found in database.')
         # Decide which group to keep
         is_partial_match = True


### PR DESCRIPTION
In file: thermo.py, method: `_add_ring_correction_thermo_data_from_tree`, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity an match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

The following binary operation

     `matched_ring_entries is []`

compares a newly created object with the identity operator which will always evaluate to False.

I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.