### PR TITLE
Fix CC smiles

### DIFF
--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -116,6 +116,8 @@ def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True, save_o
         for label, ind_list in label_dict.items():
             for ind in ind_list:
                 Chem.SetSupplementalSmilesLabel(rdkitmol.GetAtomWithIdx(ind), label)
+    [atom.SetNoImplicit(True) for atom in rdkitmol.GetAtoms()
+     if atom.GetAtomicNum() > 1]
     if sanitize:
         Chem.SanitizeMol(rdkitmol)
     if remove_h:

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -116,8 +116,9 @@ def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True, save_o
         for label, ind_list in label_dict.items():
             for ind in ind_list:
                 Chem.SetSupplementalSmilesLabel(rdkitmol.GetAtomWithIdx(ind), label)
-    [atom.SetNoImplicit(True) for atom in rdkitmol.GetAtoms()
-     if atom.GetAtomicNum() > 1]
+    for atom in rdkitmol.GetAtoms():
+        if atom.GetAtomicNum() > 1:
+            atom.SetNoImplicit(True)
     if sanitize:
         Chem.SanitizeMol(rdkitmol)
     if remove_h:

--- a/rmgpy/molecule/inchi.py
+++ b/rmgpy/molecule/inchi.py
@@ -602,12 +602,12 @@ def create_augmented_layers(mol):
     else:
         molcopy = mol.copy(deep=True)
 
+        rdkitmol = to_rdkit_mol(molcopy, remove_h=True)
+        _, auxinfo = Chem.MolToInchiAndAuxInfo(rdkitmol, options='-SNon')  # suppress stereo warnings
+
         hydrogens = [at for at in molcopy.atoms if at.number == 1]
         for h in hydrogens:
             molcopy.remove_atom(h)
-
-        rdkitmol = to_rdkit_mol(molcopy)
-        _, auxinfo = Chem.MolToInchiAndAuxInfo(rdkitmol, options='-SNon')  # suppress stereo warnings
 
         # extract the atom numbers from N-layer of auxiliary info:
         atom_indices = _parse_n_layer(auxinfo)

--- a/test/rmgpy/molecule/converterTest.py
+++ b/test/rmgpy/molecule/converterTest.py
@@ -145,6 +145,7 @@ class ConverterTest:
             Molecule().from_smiles("S"),
             Molecule().from_smiles("[CH2]C"),
             Molecule().from_smiles("[CH]C"),
+            Molecule().from_smiles('[C][C]'),
             Molecule().from_smiles("C=CC=C"),
             Molecule().from_smiles("C#C[CH2]"),
             Molecule().from_smiles("c1ccccc1"),

--- a/test/rmgpy/molecule/translatorTest.py
+++ b/test/rmgpy/molecule/translatorTest.py
@@ -750,6 +750,47 @@ class SMILESGenerationTest:
         smiles = "[C]Br"
         self.compare(adjlist, smiles)
 
+        # Test CC-triplet-1
+        adjlist = '''
+        multiplicity 3
+        1 *3 C u1 p1 c0 {2,S}
+        2 *3 C u1 p1 c0 {1,S}
+        '''
+        smiles = '[C][C]'
+        self.compare(adjlist, smiles)
+
+        # Test CC-triplet-2
+        adjlist = '''
+        multiplicity 3
+        1 *3 C u1 p0 c0 {2,T}
+        2 *3 C u1 p0 c0 {1,T}
+        '''
+        smiles = '[C]#[C]'
+        self.compare(adjlist, smiles)
+
+        # todo: Test CC-singlet-1
+        # We couldn't test the case where C forms quadruple bond with C
+        # because `$ `is not added to rdkit until Jan 2022,
+        # and RMG environment usually has rdkit <= 2022.03
+        # as of Sep 2023.
+        # This test should be added after we update the rdkit dependency.
+
+        # adjlist = '''
+        # 1 *3 C u0 p0 c0 {2,Q}
+        # 2 *3 C u0 p0 c0 {1,Q}
+        # '''
+        # smiles = '[C]$[C]'
+        # self.compare(adjlist, smiles)
+
+        # Test CC-singlet-2
+        # We couldn't test the case where C forms quadruple bond with C
+        adjlist = '''
+        1 *3 C u0 p1 c0 {2,D}
+        2 *3 C u0 p1 c0 {1,D}
+        '''
+        smiles = '[C]=[C]'
+        self.compare(adjlist, smiles)
+
     def test_aromatics(self):
         """Test that different aromatics representations returns different SMILES."""
         mol1 = Molecule().from_adjacency_list(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
This PR tries to fix issue #2536, where the SMILES of bicarbon (CC) is not correctly generated.

### Description of Changes
This PR forces the setting of no implicit Hs when converting the RMG Molecule to an RDKit Mol object. This is viable since all hydrogens in the RMG Molecules are defined explicitly.

### Testing
Add a few unit tests to test the molecule of CC with various multiplicities. I comment out the case with a quadruple bond, as it is very likely the installed RDKit version doesn't have support for output smiles of quadruple bond (which is introduced in sometime 2022)

<del> There is an InChI error raised due to this change, and I am investigating it.
https://github.com/xiaoruiDong/RMG-Py/actions/runs/6238513699/job/16934497099



<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
