### PR TITLE
changing forbidden groups documentation 

### DIFF
--- a/documentation/source/users/rmg/database/introduction.rst
+++ b/documentation/source/users/rmg/database/introduction.rst
@@ -296,10 +296,12 @@ alongside normal group entries. The starred atoms in the forbidden group
 ban the specified reaction recipe from occurring in matched products and reactants.
 
 In addition for forbidding groups, there is the option of forbidding specific
-molecules or species. Forbidding a molecule will prevent that exact structure
-from being generated, while forbidding a species will prevent any of its resonance
-structures from being generated. To specify a forbidden molecule or species, simply
-replace the ``group`` keyword with ``molecule`` or ``species``: ::
+molecules or species in ``RMG-database/input/forbiddenStructures.py``. 
+Forbidding a molecule will prevent that exact structure from being generated, 
+while forbidding a species will prevent any of its resonance structures from being
+generated. Note that specific molecules or species can only be forbidden globally
+and should not be specified in the groups.py file. To specify a forbidden molecule
+or species, simply replace the ``group`` keyword with ``molecule`` or ``species``: ::
 
     # This forbids a molecule
     forbidden(


### PR DESCRIPTION
### Motivation or Problem
This is the PR in response to [issue #2493](https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2493). It updates the documentations and makes it clear that you can only specify forbidden molecules or species in the forbiddenStructures.py file and not in groups.py. 


### Description of Changes
Added in two sentences to `introduction.rst` that remind the reader that forbidden molecules/species cannot be specified in groups.py.

### Testing
Checked what the new updates look like in the documentation. looked fine. 


