### PR TITLE
exempt announcements from being closed as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           operations-per-run: 1000
-          exempt-issue-labels: bug
+          exempt-issue-labels: bug,Announcement
           exempt-pr-labels: bug
           close-issue-label: abandoned
           close-pr-label: abandoned


### PR DESCRIPTION
Stale label action currently closes old issues and PRs if they have had no interaction in 90 days, _except_ when they are labeled with `bug`. This PR also excepts those labeled with `Announcement`, especially meant for #2559 which will be open for a while but is not a bug.