### PR TITLE
Getting structure information correctly for fragment

### DIFF
--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -322,15 +322,6 @@ class Fragment(Molecule):
         result = Graph.is_subgraph_isomorphic(self.mol_repr, other, new_initial_map)
         return result
 
-    def get_molecular_weight(self):
-        """
-        Return the fragmental weight of the fragment in kg/mol.
-        """
-        mass = 0
-        for vertex in self.vertices:
-            mass += vertex.element.mass
-        return mass
-
     def calculate_cp0(self):
         """
         Return the value of the heat capacity at zero temperature in J/mol*K.

--- a/rmgpy/rmg/reactors.py
+++ b/rmgpy/rmg/reactors.py
@@ -680,38 +680,20 @@ def to_rms(obj, species_names=None, rms_species_list=None, rmg_species=None):
     elif isinstance(obj, NASA):
         return rms.NASA([to_rms(poly) for poly in obj.polynomials], rms.EmptyThermoUncertainty())
     elif isinstance(obj, Species):
-        atomnums = dict()
-        for atm in obj.molecule[0].atoms:
-            try:
-                if atomnums.get(atm.element.symbol):
-                    atomnums[atm.element.symbol] += 1
-                else:
-                    atomnums[atm.element.symbol] = 1
-            except AttributeError:
-                # means it is fragment's cutting label
-                pass
-        bondnum = len(obj.molecule[0].get_all_edges())
-        
+
         if isinstance(obj.molecule[0], Fragment):
-            th = obj.get_thermo_data()
-            thermo = to_rms(th)
-            return rms.Species(
-                name=obj.label,
-                index=obj.index,
-                inchi="",
-                smiles="",
-                adjlist="",
-                thermo=thermo,
-                atomnums=atomnums,
-                bondnum=bondnum,
-                diffusion=rms.EmptyDiffusivity(),
-                radius=0.0,
-                radicalelectrons=obj.molecule[0].multiplicity - 1,
-                molecularweight=0.0,
-                henrylawconstant=rms.EmptyHenryLawConstant(),
-                liquidvolumetricmasstransfercoefficient=rms.EmptyLiquidVolumetricMassTransferCoefficient(),
-                comment=obj.thermo.comment,
-            )
+            obj.molecule[0].assign_representative_molecule()
+            mol = obj.molecule[0].mol_repr
+        else:
+            mol = obj.molecule[0]
+
+        atomnums = dict()
+        for atm in mol.atoms:
+            if atomnums.get(atm.element.symbol):
+                atomnums[atm.element.symbol] += 1
+            else:
+                atomnums[atm.element.symbol] = 1
+        bondnum = len(mol.get_all_edges())
         
         if not obj.molecule[0].contains_surface_site():
             rad = rms.getspeciesradius(atomnums, bondnum)


### PR DESCRIPTION
### Motivation or Problem
This PR contains changes made to https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2413. See this [comment](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2413#discussion_r1362981840) for details. I put it into a separate PR rather than push commits directly PR as suggested by @JacksonBurns.

### Description of Changes
I use a representative molecule for a fragment to calculate the correct molecular weight, number of atoms, and number of bonds. The number of atoms for the representative molecule is used to estimate radius for a fragment, which is used to estimate the stokes diffusivity. I also pass the kLA and kH into the RMS Species for fragments.
