### PR TITLE
Add regression input file for fragment + simple reactor and regression test for fragment + RMS reactor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -168,7 +168,7 @@ jobs:
         id: regression-execution
         timeout-minutes: 60
         run: |
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment;
           do
             if python-jl rmg.py test/regression/"$regr_test"/input.py; then
               echo "$regr_test" "Executed Successfully"

--- a/test/regression/RMS_constantVIdealGasReactor_fragment/input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_fragment/input.py
@@ -86,11 +86,6 @@ model(
 )
 
 options(
-    units="si",
-    saveRestartPeriod=None,
-    generateOutputHTML=False,
-    generatePlots=False,
-    saveSimulationProfiles=False,
-    saveEdgeSpecies=False,
-    verboseComments=False,
+    units='si',
+    saveEdgeSpecies=True,
 )

--- a/test/regression/RMS_constantVIdealGasReactor_fragment/input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_fragment/input.py
@@ -1,0 +1,96 @@
+database(
+    thermoLibraries=["primaryThermoLibrary", "DFT_QCI_thermo"],
+    reactionLibraries=[],
+    seedMechanisms=[],
+    kineticsDepositories=["training"],
+    kineticsFamilies=[
+        "H_Abstraction",
+        "R_Addition_MultipleBond",
+        "R_Recombination",
+        "Disproportionation",
+    ],
+    kineticsEstimator="rate rules",
+)
+
+generatedSpeciesConstraints(
+    maximumRadicalElectrons=1,
+)
+
+species(
+    label="LCCCC",
+    reactive=True,
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  L u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+species(
+    label="RCCCC",
+    reactive=True,
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  R u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+
+constantVIdealGasReactor(
+    temperature=(1600, "K"), 
+    pressure=(40, "bar"),
+    initialMoleFractions={
+        "LCCCC": 1,
+        "RCCCC": 1,
+    },
+    terminationConversion={
+        "RCCCC": 0.99,
+    },
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-08,
+)
+
+model(
+    toleranceMoveToCore=0.01,
+    toleranceInterruptSimulation=0.01,
+    maxNumSpecies=10,
+    filterReactions=True,
+)
+
+options(
+    units="si",
+    saveRestartPeriod=None,
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveSimulationProfiles=False,
+    saveEdgeSpecies=False,
+    verboseComments=False,
+)

--- a/test/regression/RMS_constantVIdealGasReactor_fragment/regression_input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_fragment/regression_input.py
@@ -1,0 +1,59 @@
+
+options(
+    title='RMS_constantVIdealGasReactor_fragment',
+    tolerance=0.1
+)
+
+observable(
+    label="LCCCC",
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  L u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+observable(
+    label="RCCCC",
+    reactive=True,
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  R u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([0.01],'s'),
+    initialMoleFractionsList=[{
+        "LCCCC": 1,
+        "RCCCC": 1,
+    }],
+    temperatures=([1600],'K'),
+    pressures=([40.0],'bar'),
+)

--- a/test/regression/RMS_constantVIdealGasReactor_fragment/regression_input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_fragment/regression_input.py
@@ -25,7 +25,28 @@ observable(
     ),
 )
 
-observable(
+species(
+    label="LCCCC",
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  L u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+species(
     label="RCCCC",
     reactive=True,
     structure=fragment_adj(

--- a/test/regression/fragment/input.py
+++ b/test/regression/fragment/input.py
@@ -84,11 +84,6 @@ model(
 )
 
 options(
-    units="si",
-    saveRestartPeriod=None,
-    generateOutputHTML=False,
-    generatePlots=False,
-    saveSimulationProfiles=False,
-    saveEdgeSpecies=False,
-    verboseComments=False,
+    units='si',
+    saveEdgeSpecies=True,
 )

--- a/test/regression/fragment/regression_input.py
+++ b/test/regression/fragment/regression_input.py
@@ -25,7 +25,28 @@ observable(
     ),
 )
 
-observable(
+species(
+    label="LCCCC",
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  L u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+species(
     label="RCCCC",
     reactive=True,
     structure=fragment_adj(

--- a/test/regression/fragment/regression_input.py
+++ b/test/regression/fragment/regression_input.py
@@ -1,0 +1,59 @@
+
+options(
+    title='fragment',
+    tolerance=0.1
+)
+
+observable(
+    label="LCCCC",
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  L u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+observable(
+    label="RCCCC",
+    reactive=True,
+    structure=fragment_adj(
+        """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  R u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+"""
+    ),
+)
+
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([0.01],'s'),
+    initialMoleFractionsList=[{
+        "LCCCC": 1,
+        "RCCCC": 1,
+    }],
+    temperatures=([1600],'K'),
+    pressures=([40.0],'bar'),
+)


### PR DESCRIPTION
### Motivation or Problem
The current fragment regression test only tests that the mechanism can be generated, but not testing that the results actually stay consistent with previous runs. Additionally, currently we are not testing fragment is compatible with RMS reactor.

### Description of Changes
I add a `regression_input.py` for the fragment + simple reactor regression test. I also add a new regression test for fragment + RMS reactor.