### PR TITLE
Compatibility of `regression.py` with fragment

### DIFF
--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -75,9 +75,9 @@ def read_input_file(path):
         'True': True,
         'False': False,
         'observable': observable,
-        'SMILES': SMILES,
+        'SMILES': smiles,
         'species': species,
-        'adjacencyList': adjacencyList,
+        'adjacencyList': adjacency_list,
         'reactorSetups': reactorSetups,
         'options': options,
     }

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -76,6 +76,8 @@ def read_input_file(path):
         'False': False,
         'observable': observable,
         'SMILES': smiles,
+        'fragment_adj': fragment_adj,
+        'fragment_SMILES': fragment_smiles,
         'species': species,
         'adjacencyList': adjacency_list,
         'reactorSetups': reactorSetups,

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -40,6 +40,7 @@ import sys
 from rmgpy.molecule import Molecule
 from rmgpy.quantity import Quantity
 from rmgpy.species import Species
+from rmgpy.rmg.input import fragment_adj, fragment_smiles, smiles, adjacency_list
 from rmgpy.tools.canteramodel import CanteraCondition
 from rmgpy.tools.observablesregression import ObservablesTestCase
 

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -122,14 +122,6 @@ def reactorSetups(reactorTypes, temperatures, pressures, initialMoleFractionsLis
     setups = [reactorTypes, temperatures, pressures, initialMoleFractionsList, terminationTimes]
 
 
-def SMILES(string):
-    return Molecule().from_smiles(string)
-
-
-def adjacencyList(string):
-    return Molecule().from_adjacency_list(string)
-
-
 def options(title='', tolerance=0.05):
     global casetitle, tol
     casetitle = title

--- a/test/regression/RMS_constantVIdealGasReactor_fragment/regression_input.py
+++ b/test/regression/RMS_constantVIdealGasReactor_fragment/regression_input.py
@@ -48,7 +48,6 @@ species(
 
 species(
     label="RCCCC",
-    reactive=True,
     structure=fragment_adj(
         """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
 2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}

--- a/test/regression/fragment/regression_input.py
+++ b/test/regression/fragment/regression_input.py
@@ -48,7 +48,6 @@ species(
 
 species(
     label="RCCCC",
-    reactive=True,
     structure=fragment_adj(
         """1  C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
 2  C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}


### PR DESCRIPTION
### Motivation or Problem
We merged in the fragment regression tests in https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2571. We thought the failed test was because there was no stable version for comparison. However, it was actually caused by current code not able to read regression input for fragments.

### Description of Changes
I modified the `regression.py` to read fragment structures by importing necessary functions from `rmgpy.rmg.input`. I also replaced some duplicate functions.

### Testing
Let's see if the regression test for fragment works in the CI.