### PR TITLE
Change method for loading energies from Gaussian log files to regex search to avoid errors 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,7 +230,7 @@ jobs:
         # the stable regression results
           run-id: ${{ env.CI_RUN_ID }}
           repository: ReactionMechanismGenerator/RMG-Py
-          github-token:  ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: stable_regression_results
           path: stable_regression_results
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
         id: regression-execution
         timeout-minutes: 60
         run: |
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment minimal_surface;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment;
           do
             if python-jl rmg.py test/regression/"$regr_test"/input.py; then
               echo "$regr_test" "Executed Successfully"
@@ -243,7 +243,7 @@ jobs:
         run: |
           exec 2> >(tee -a regression.stderr >&2) 1> >(tee -a regression.stdout)
           mkdir -p "test/regression-diff"
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation fragment RMS_constantVIdealGasReactor_fragment minimal_surface;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation fragment RMS_constantVIdealGasReactor_fragment;
           do
             echo ""
             echo "### Regression test $regr_test:"

--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -35,7 +35,7 @@ Used to parse Gaussian output files
 import logging
 import math
 import os.path
-
+import re
 import numpy as np
 
 import rmgpy.constants as constants
@@ -309,9 +309,8 @@ class GaussianLog(ESSAdapter):
         with open(self.path, 'r') as f:
             line = f.readline()
             while line != '':
-
                 if 'SCF Done:' in line:
-                    e_elect = float(line.split()[4]) * constants.E_h * constants.Na
+                    e_elect = float(re.findall(r"SCF Done:  E\(.+\) \=\s+[^\s]+",line)[0].split()[-1])* constants.E_h * constants.Na
                     elect_energy_source = 'SCF'
                 elif ' E2(' in line and ' E(' in line:
                     e_elect = float(line.split()[-1].replace('D', 'E')) * constants.E_h * constants.Na
@@ -351,7 +350,7 @@ class GaussianLog(ESSAdapter):
                     # G4MP2 calculation without opt and freq calculation
                     # Keyword in Gaussian G4MP2(SP), No zero-point or thermal energies are included.
                     e_elect = float(line.split()[2]) * constants.E_h * constants.Na
-
+                
                 # Read the ZPE from the "E(ZPE)=" line, as this is the scaled version.
                 # Gaussian defines the following as
                 # E (0 K) = Elec + E(ZPE),
@@ -376,6 +375,12 @@ class GaussianLog(ESSAdapter):
                             elect_energy_source = 'HF'
                     except ValueError:
                         pass
+                elif 'Energy=' in line:
+                    # for xtb
+                    e_elect = float(line.split()[1]) * constants.E_h * constants.Na
+                elif 'Energy=' in line:
+                    # for xtb
+                    e_elect = float(line.split()[1]) * constants.E_h * constants.Na
                 # Read the next line in the file
                 line = f.readline()
 

--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -375,12 +375,6 @@ class GaussianLog(ESSAdapter):
                             elect_energy_source = 'HF'
                     except ValueError:
                         pass
-                elif 'Energy=' in line:
-                    # for xtb
-                    e_elect = float(line.split()[1]) * constants.E_h * constants.Na
-                elif 'Energy=' in line:
-                    # for xtb
-                    e_elect = float(line.split()[1]) * constants.E_h * constants.Na
                 # Read the next line in the file
                 line = f.readline()
 

--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -310,7 +310,7 @@ class GaussianLog(ESSAdapter):
             line = f.readline()
             while line != '':
                 if 'SCF Done:' in line:
-                    e_elect = float(re.findall(r"SCF Done:  E\(.+\) \=\s+[^\s]+",line)[0].split()[-1])* constants.E_h * constants.Na
+                    e_elect = float(re.findall(r"SCF Done:  E\(.+\) \=\s+[^\s]+", line)[0].split()[-1]) * constants.E_h * constants.Na
                     elect_energy_source = 'SCF'
                 elif ' E2(' in line and ' E(' in line:
                     e_elect = float(line.split()[-1].replace('D', 'E')) * constants.E_h * constants.Na
@@ -350,7 +350,6 @@ class GaussianLog(ESSAdapter):
                     # G4MP2 calculation without opt and freq calculation
                     # Keyword in Gaussian G4MP2(SP), No zero-point or thermal energies are included.
                     e_elect = float(line.split()[2]) * constants.E_h * constants.Na
-                
                 # Read the ZPE from the "E(ZPE)=" line, as this is the scaled version.
                 # Gaussian defines the following as
                 # E (0 K) = Elec + E(ZPE),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Sometimes, in  gaussian log files, the line that contains the energy has extra characters (more than one line printed in the same line) that prevent the load_energy function in arkane/ess/gaussian.py from parsing the energy. (e.g., it will try to use an "=" as the energy)

### Description of Changes
Before: find the line that has "SCF Done:", split it, take the 4th index as the energy

After: find the line that has "SCF Done:", find the substring that matches "SCF Done: E(...) = {energyfloat}, split the substring, and take the last item

the same can be done for E2, MP2, E(CORR), CCSD(T), CBS-QB3 (0 K), E(CBS-QB3)=, CBS-4 (0 K)=, G3(0 K), G3 Energy=,G4(0 K), G4 Energy=, G4MP2(0 K), G4MP2 Energy= in the same function

### Testing
I plan to try the load_energy function on many gaussian log files, some which have extra characters in the line containing the energy

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.

<!--
Checklist before submission: 
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
