### PR TITLE
Add to_cantera_kinetics for SurfaceArrhenius and StickingCoefficient kinetics classes

### DIFF
--- a/rmgpy/kinetics/surface.pyx
+++ b/rmgpy/kinetics/surface.pyx
@@ -285,6 +285,36 @@ cdef class StickingCoefficient(KineticsModel):
 
         return string
 
+    def to_cantera_kinetics(self):
+        """
+        Converts the RMG StickingCoefficient object to a cantera StickingArrheniusRate
+        
+        Inputs for both are (A,b,E)  where A is dimensionless, b is dimensionless, and E is in J/kmol
+
+        """
+
+        import cantera as ct
+        import rmgpy.quantity
+
+        assert type(self._A) == rmgpy.quantity.ScalarQuantity, "A factor must be a ScalarQuantity"
+        A = self._A.value_si
+        b = self._n.value_si
+        E = self._Ea.value_si * 1000  # convert from J/mol to J/kmol
+
+        return ct.StickingArrheniusRate(A, b, E)
+
+
+    def set_cantera_kinetics(self, ct_reaction, species_list):
+        """
+        Passes in a cantera Reaction() object and sets its
+        rate to a Cantera ArrheniusRate object.
+        """
+        import cantera as ct
+        assert isinstance(ct_reaction.rate, ct.StickingArrheniusRate), "Must have a Cantera StickingArrheniusRate attribute"
+
+        # Set the rate parameter to a cantera Arrhenius object
+        ct_reaction.rate = self.to_cantera_kinetics()
+
 ################################################################################
 cdef class StickingCoefficientBEP(KineticsModel):
     """
@@ -569,6 +599,54 @@ cdef class SurfaceArrhenius(Arrhenius):
         """
         return (SurfaceArrhenius, (self.A, self.n, self.Ea, self.T0, self.Tmin, self.Tmax, self.Pmin, self.Pmax,
                                    self.coverage_dependence, self.uncertainty, self.comment))
+
+    def to_cantera_kinetics(self):
+        """
+        Converts the RMG SurfaceArrhenius object to a cantera InterfaceArrheniusRate
+        Inputs are (A,b,E)  where A is in units of m^2/kmol/s, b is dimensionless, and E is in J/kmol
+
+        There are no surface falloff reaction types in Cantera, so that isn't implemented here
+        """
+
+        import cantera as ct
+
+        rate_units_dimensionality = {'1/s': 0,
+                                     's^-1': 0,
+                                     'm^2/(mol*s)': 1,
+                                     'm^4/(mol^2*s)': 2,
+                                     'cm^2/(mol*s)': 1,
+                                     'cm^4/(mol^2*s)': 2,
+                                     'm^2/(molecule*s)': 1,
+                                     'm^4/(molecule^2*s)': 2,
+                                     'cm^2/(molecule*s)': 1,
+                                     'cm^4/(molecule^2*s)': 2,
+                                     }
+
+        if self._T0.value_si != 1:
+            A = self._A.value_si / (self._T0.value_si) ** self._n.value_si
+        else:
+            A = self._A.value_si
+
+        try:
+            A *= 1000 ** rate_units_dimensionality[self._A.units]
+        except KeyError:
+            raise Exception('Arrhenius A-factor units {0} not found among accepted units for converting to '
+                            'Cantera Arrhenius object.'.format(self._A.units))
+
+        b = self._n.value_si
+        E = self._Ea.value_si * 1000  # convert from J/mol to J/kmol
+        return ct.InterfaceArrheniusRate(A, b, E)
+
+    def set_cantera_kinetics(self, ct_reaction, species_list):
+        """
+        Passes in a cantera Reaction() object and sets its
+        rate to a Cantera InterfaceArrheniusRate object.
+        """
+        import cantera as ct
+        assert isinstance(ct_reaction.rate, ct.InterfaceArrheniusRate), "Must have a Cantera InterfaceArrheniusRate attribute"
+
+        # Set the rate parameter to a cantera Arrhenius object
+        ct_reaction.rate = self.to_cantera_kinetics()
 
 ################################################################################
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -288,7 +288,10 @@ class Reaction:
         if self.kinetics:
             if isinstance(self.kinetics, Arrhenius):
                 # Create an Elementary Reaction
-                ct_reaction = ct.Reaction(reactants=ct_reactants, products=ct_products, rate=ct.ArrheniusRate())
+                if isinstance(self.kinetics, SurfaceArrhenius):  # SurfaceArrhenius inherits from Arrhenius
+                    ct_reaction = ct.Reaction(reactants=ct_reactants, products=ct_products, rate=ct.InterfaceArrheniusRate())
+                else:
+                    ct_reaction = ct.Reaction(reactants=ct_reactants, products=ct_products, rate=ct.ArrheniusRate())
             elif isinstance(self.kinetics, MultiArrhenius):
                 # Return a list of elementary reactions which are duplicates
                 ct_reaction = [ct.Reaction(reactants=ct_reactants, products=ct_products, rate=ct.ArrheniusRate())
@@ -355,6 +358,9 @@ class Reaction:
                     ct_reaction = ct.FalloffReaction(
                         reactants=ct_reactants, products=ct_products, rate=rate
                     )
+
+            elif isinstance(self.kinetics, StickingCoefficient):
+                ct_reaction = ct.Reaction(reactants=ct_reactants, products=ct_products, rate=ct.StickingArrheniusRate())
 
             else:
                 raise NotImplementedError('Unable to set cantera kinetics for {0}'.format(self.kinetics))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
We want to be able to convert from RMG surface reaction kinetics to Cantera kinetics for simulation purposes. It's faster to do this in memory than through loading a whole file.

### Description of Changes
This PR implements the to_cantera_kinetics functions so RMG reaction objects can be easily converted to Cantera objects

### Testing
COMING SOON: a Jupyter notebook to help compare an example RMG/Cantera surface mechanism

### Reviewer Tips
COMING SOON: a Jupyter notebook to help compare an example RMG/Cantera surface mechanism

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
