### PR TITLE
Change Documentation Build Action to use github-actions bot instead of RMG_dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,10 +54,13 @@ jobs:
           cat documentation/errors.log
       - name: Make documentation - to publish
         if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
-        env:
-            GH_TOKEN: ${{ secrets.RMG_DEV_TOKEN }}
         run: |
-          make -C documentation continous_integration_setup clean html
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          cd documentation
+          rm -rf build/html
+          git clone --single-branch --branch gh-pages --origin official git@github.com:ReactionMechanismGenerator/RMG-Py.git build/html
+          make html
       - name: Check documentation links
         continue-on-error: true
         run: |
@@ -65,12 +68,6 @@ jobs:
           sphinx-build -b linkcheck -d build/doctrees/ source/ build/linkcheck | grep -e broken -e redirect | grep -v -e 'redirect  https://doi.org/' -e 'broken    https://doi.org/.* 403 Client Error: Forbidden'
       - name: Publish documentation
         if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
-        env:
-            GH_TOKEN: ${{ secrets.RMG_DEV_TOKEN }}
-            COMMITMESSAGE: "Automatic documentation rebuild"
-            GIT_AUTHOR_NAME: "RMG Bot"
-            GIT_AUTHOR_EMAIL: "rmg_dev@mit.edu"
-            GIT_COMMITTER_NAME: "RMG Bot"
-            GIT_COMMITTER_EMAIL: "rmg_dev@mit.edu"
         run: |
-          make -C documentation publish
+          touch build/html/.nojekyll
+          cd build/html; git add -A .; git commit -m "Automated documentation rebuild"; git push official gh-pages

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -41,20 +41,6 @@ setup_github_pages:
 	rm -rf $(BUILDDIR)/html
 	git clone --single-branch --branch gh-pages --origin official git@github.com:ReactionMechanismGenerator/RMG-Py.git build/html
 
-publish: $(BUILDDIR)/html/.git
-# Commit changes to gh-pages and push to github, to publish the results!
-	touch $(BUILDDIR)/html/.nojekyll
-ifdef COMMITMESSAGE # Use the provided COMMITMESSAGE variable for noninteractive use.
-	cd $(BUILDDIR)/html; git add -A .; git commit -m "$(COMMITMESSAGE)"; git push official gh-pages
-else # Prompt for a commit message
-	cd $(BUILDDIR)/html; git add -A .; git commit; git push official gh-pages
-endif
-
-continous_integration_setup:
-# This target is intended to be used when automatically compiling documentation with Continous Integration
-	@rm -rf $(BUILDDIR)/html
-	@git clone --single-branch --branch gh-pages --origin official https://${GH_TOKEN}@github.com/ReactionMechanismGenerator/RMG-Py.git $(BUILDDIR)/html
-
 clean:
 # set aside the git repository info used to push pages to github
 	mkdir build_temp


### PR DESCRIPTION
GitHub is now requiring 2FA on all accounts - this means our helpful bot RMG_dev, which is used to push documentation to the repo, is 'banished' (or will at least break soon). This PR changes the docs building action to use the GitHub actions bot account to push the changes to the docs instead.

I'm not sure how to test this besides running it on GHA, just to see if it works?