### PR TITLE
fix checkout command for docs building action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: build/html
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -58,8 +61,6 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           cd documentation
-          rm -rf build/html
-          git clone --single-branch --branch gh-pages --origin official git@github.com:ReactionMechanismGenerator/RMG-Py.git build/html
           make html
       - name: Check documentation links
         continue-on-error: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,6 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          path: build/html
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -46,6 +43,10 @@ jobs:
           cd RMG-Py
           sed -i '/embedsignature/s/# //g' setup.py
           make
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: build/html
       - name: Make documentation - for testing
         if: ${{  github.event_name != 'push' || github.repository != 'ReactionMechanismGenerator/RMG-Py' }}
         run: |


### PR DESCRIPTION
As luck would have it #2599 did _not_ in fact work, so this PR is attempting (again) to fix it.

Seems like after using the default git checkout github actions step, we can't use other git commands because of some nonsense with the ssh key. Rather than deal with figuring that out, I have just moved all of the weirdness we were doing in the git command to the original checkout command.

I have also removed the `rm -rf build/html` command. That directory does not exist before the clone (I think this was carried over from a previous script, because it doesn't actually break anything).
