### PR TITLE
Added a species constraint for the max number of rings fused together

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -1010,6 +1010,7 @@ all of RMG's reaction families. ::
         maximumRadicalElectrons=2,
         maximumSingletCarbenes=1,
         maximumCarbeneRadicals=0,
+        maximumFusedRings=3,
         allowSingletO2 = False,
         speciesCuttingThreshold=20,
     )
@@ -1018,6 +1019,8 @@ An additional flag ``allowed`` can be set to allow species
 from either the input file, seed mechanisms, or reaction libraries to bypass these constraints.
 Note that this should be done with caution, since the constraints will still apply to subsequent
 products that form.
+
+``maximumFusedRings`` is the maximum number of rings in any fused ring system in the species.
 
 By default, the ``allowSingletO2`` flag is set to ``False``.  See :ref:`representing_oxygen` for more information.
 

--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -1010,7 +1010,6 @@ all of RMG's reaction families. ::
         maximumRadicalElectrons=2,
         maximumSingletCarbenes=1,
         maximumCarbeneRadicals=0,
-        maximumIsotopicAtoms=2,
         allowSingletO2 = False,
         speciesCuttingThreshold=20,
     )

--- a/documentation/source/users/rmg/modules/isotopes.rst
+++ b/documentation/source/users/rmg/modules/isotopes.rst
@@ -49,10 +49,6 @@ not match the same depository reactions, leading to inconsistent kinetics. If
 degeneracy errors arise when generating reactions from scratch, try using this
 option to see if it reduces errors in degeneracy.
 
-The arguement ``--maximumIsotopicAtoms [integer]`` limits the number of enriched
-atoms in any isotopologue in the model. This is beneficial for decreasing model 
-size, runtime of model creation and runtime necessary for analysis.
-
 Adding kinetic isotope effects which are described in this paper can be obtained
 through the argument ``--kineticIsotopeEffect simple``. Currently this is the
 only supported method, though this can be extended to other effects.

--- a/examples/rmg/MR_test/input.py
+++ b/examples/rmg/MR_test/input.py
@@ -305,7 +305,5 @@ generatedSpeciesConstraints(
     #If this is false or missing, RMG will throw an error if the more less-stable form of O2 is entered 
     #which doesn't react in the RMG system. normally input O2 as triplet with SMILES [O][O]
     #allowSingletO2=False,
-    # maximum allowed number of non-normal isotope atoms:
-    #maximumIsotopicAtoms=2,
 )
 

--- a/examples/rmg/commented/input.py
+++ b/examples/rmg/commented/input.py
@@ -285,8 +285,6 @@ generatedSpeciesConstraints(
     # If this is false or missing, RMG will throw an error if the more less-stable form of O2 is entered
     # which doesn't react in the RMG system. normally input O2 as triplet with SMILES [O][O]
     # allowSingletO2=False,
-    # maximum allowed number of non-normal isotope atoms:
-    # maximumIsotopicAtoms=2,
 )
 
 # optional block allows thermo to be estimated through quantum calculations

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -31,6 +31,7 @@ import logging
 
 from rmgpy.species import Species
 
+
 def pass_cutting_threshold(species):
     """
     Pass in either a `Species` or `Molecule` object and checks whether it passes 
@@ -57,6 +58,7 @@ def pass_cutting_threshold(species):
         return True
 
     return False
+
 
 def fails_species_constraints(species):
     """

--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -141,4 +141,9 @@ def fails_species_constraints(species):
         if struct.get_singlet_carbene_count() > 0 and struct.get_radical_count() > max_carbene_radicals:
             return True
 
+    max_fused_rings = species_constraints.get('maximumFusedRings', -1)
+    if max_fused_rings != -1 and struct.is_cyclic():
+        if struct.get_ring_count_in_largest_fused_ring_system() > max_fused_rings:
+            return True
+
     return False

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2926,6 +2926,25 @@ class Molecule(Graph):
 
         return desorbed_molecules
 
+    def get_ring_count_in_largest_fused_ring_system(self) -> int:
+        """
+        Get the number of rings in the largest fused ring system in the molecule.
+        """
+        cython.declare(ring_counts=list, rings=list, ring_count=int)
+        polycycles = self.get_polycycles()
+        ring_counts = list()
+        for polycycle in polycycles:
+            rings, ring_count = list(), 0
+            for atom in polycycle:
+                cycles = self.get_all_cycles(atom)
+                for cycle in cycles:
+                    if cycle not in rings:
+                        rings.append(cycle)
+                        ring_count += 1
+            ring_counts.append(ring_count)
+        return max(ring_counts) if len(ring_counts) else 0
+
+
 # this variable is used to name atom IDs so that there are as few conflicts by 
 # using the entire space of integer objects
 atom_id_counter = -2 ** 15

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1379,6 +1379,7 @@ def generated_species_constraints(**kwargs):
         'maximumRadicalElectrons',
         'maximumSingletCarbenes',
         'maximumCarbeneRadicals',
+        'maximumFusedRings',
         'allowSingletO2',
         'speciesCuttingThreshold',
     ]

--- a/scripts/rmg2to3.py
+++ b/scripts/rmg2to3.py
@@ -1796,7 +1796,6 @@ ARGUMENTS2 = {
     # rmgpy.tools.isotopes
     'useOriginalReactions': 'use_original_reactions',
     'kineticIsotopeEffect': 'kinetic_isotope_effect',
-    'maximumIsotopicAtoms': 'maximum_isotopic_atoms',
     # rmgpy.tools.loader
     'generateImages': 'generate_images',
     'useJava': 'use_java',

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -2956,3 +2956,14 @@ multiplicity 2
         assert len(mol.get_all_edges()) == 2
         mol.remove_van_der_waals_bonds()
         assert len(mol.get_all_edges()) == 1
+
+    def test_get_ring_count_in_largest_fused_ring_system(self):
+        """Test that we can count the rings in the largest fused ring system."""
+        mol = Molecule(smiles="CCCC")
+        assert mol.get_ring_count_in_largest_fused_ring_system() == 0
+        mol = Molecule(smiles="c1ccccc1")
+        assert mol.get_ring_count_in_largest_fused_ring_system() == 0
+        mol = Molecule(smiles="c12ccccc1cccc2")
+        assert mol.get_ring_count_in_largest_fused_ring_system() == 2
+        mol = Molecule(smiles="C[C]1C2C(=O)C3CC4C(=O)C=C2CC143")
+        assert mol.get_ring_count_in_largest_fused_ring_system() == 4


### PR DESCRIPTION
### Motivation or Problem
Sometimes users know they are not interested in ring growth in their model, yet RMG spends significant time on suggesting species with complex fused rings. Using the maximum heavy atoms constraints isn't always helpful since other species with the same Mw could be relevant for the model.

### Description of Changes
Added a `maximumFusedRings` key to the constraints dict.
A new method was implemented in Molecule along with a test.

### Testing
A unit test was added.
FWIW, the feature was also tested locally by generating a model that previously gave many fused ring structures and verifying that they are absent now.

### Reviewer Tips
Note that a previously non-implemented constraint was removed from the docs
I saw that this branch fails online due to a Julia installation, I think. Looks unrelated to this feature.