### PR TITLE
Continuous Integration, Documentation Build, and Dockerfile Fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,8 @@ jobs:
         uses: actions/checkout@v3
 
       # configures the mamba environment manager and builds the environment
+      - name: Patch Environment File
+        run: sed -i '' 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.1/' environment.yml
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -112,6 +114,8 @@ jobs:
         uses: actions/checkout@v3
 
       # configures the mamba environment manager and builds the environment
+      - name: Patch Environment File
+        run: sed -i 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.1/' environment.yml
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+      - name: Patch Environment File
+        run: sed -i 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.1/' environment.yml
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -59,8 +61,8 @@ jobs:
       - name: Make documentation - to publish
         if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
           cd documentation
           make html
       - name: Check documentation links
@@ -72,4 +74,4 @@ jobs:
         if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
         run: |
           touch build/html/.nojekyll
-          cd build/html; git add -A .; git commit -m "Automated documentation rebuild"; git push official gh-pages
+          cd build/html; git add -A .; git commit -m "Automated documentation rebuild"; git push origin gh-pages


### PR DESCRIPTION
These changes are unrelated but small, so I have combined them with reckless abandon.

 - The CI has been failing because of an upstream problem with Julia dependencies. To try and resolve this @mjohnson541 suggested pinning the Julia version to 1.8.5 - this PR does that in the CI files with `sed`. (note: ended up using 1.9.1 because 1.8.5 did not work)
 - In a continuing effort to address #2582 (at which #2599 and #2602 were only _partially_ successful) this changes some minor syntax in `git` commands inside the doc building action.
 - Dockerfile would not run properly on windows, a small patch has been added (see commit message for [51924d9](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2608/commits/51924d98ed65bac069cbbde0ab7c894979c567a5))

If the CI passes this should be good to go in.