### PR TITLE
Julia restriction

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,8 +62,6 @@ jobs:
         uses: actions/checkout@v3
 
       # configures the mamba environment manager and builds the environment
-      - name: Patch Environment File
-        run: sed -i '' 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.1/' environment.yml
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,6 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
-      - name: Patch Environment File
-        run: sed -i 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.1/' environment.yml
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN ln -snf /bin/bash /bin/sh
 #  - libxrender1 required by RDKit
 RUN apt-get update && \
     apt-get install -y \
-    make \ 
+    make \
     gcc \
     wget \
     git \
@@ -43,8 +43,6 @@ RUN git clone --single-branch --branch main --depth 1 https://github.com/Reactio
     git clone --single-branch --branch main --depth 1 https://github.com/ReactionMechanismGenerator/RMG-database.git
 
 WORKDIR /rmg/RMG-Py
-# patch the env file to a specific version of Julia that we know to be working on all platforms
-RUN sed -i 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.4/' environment.yml
 # build the conda environment
 RUN conda env create --file environment.yml && \
     conda clean --all --yes
@@ -67,7 +65,7 @@ ENV PATH="$RUNNER_CWD/RMG-Py:$PATH"
 ENV JULIA_CPU_TARGET="x86-64,haswell,skylake,broadwell,znver1,znver2,znver3,cascadelake,icelake-client,cooperlake,generic"
 RUN make && \
     julia -e 'using Pkg; Pkg.add(PackageSpec(name="PyCall",rev="master")); Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator' && \
-    python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()" 
+    python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
 # RMG-Py should now be installed and ready - trigger precompilation and test run
 RUN python-jl rmg.py examples/rmg/minimal/input.py

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - conda-forge::openbabel >= 3
 
 # general-purpose external software tools
-  - conda-forge::julia>=1.8.5,!=1.9.0
+  - conda-forge::julia=1.9.1
   - conda-forge::pyjulia >=0.6
 
 # Python tools


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Julia has been updated to 1.10.0 on Conda-Forge and therefore RMS does not install. https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2608 rectified this issue by patching in a version restriction on Julia to 1.9.1. This PR attempts to restrict the version in the environment.yml file so that we will not need to maintain the patches in the CI/Dockerfile/Doc

### Description of Changes
Restricted Julia to 1.9.1 in the environment.yml file

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
