### PR TITLE
#2602 part 2, Electric Boogaloo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Make documentation - to publish
         if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
           cd documentation
           make html
       - name: Check documentation links


### PR DESCRIPTION
_Still_ trying to fix the docs building action. This time, it seems like omitting `--global` from the git sign in has meant that, for some reason, it just didn't work. See:
https://github.com/ReactionMechanismGenerator/RMG-Py/actions/runs/7873601921/job/21481327559#step:12:38