### PR TITLE
Modified main.py script to include TROE reactions in the violators log

### DIFF
--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -65,6 +65,7 @@ from rmgpy.exceptions import ForbiddenStructureException, DatabaseError, CoreErr
 from rmgpy.kinetics.diffusionLimited import diffusion_limiter
 from rmgpy.data.vaporLiquidMassTransfer import vapor_liquid_mass_transfer
 from rmgpy.kinetics import ThirdBody
+from rmgpy.kinetics import Troe
 from rmgpy.molecule import Molecule
 from rmgpy.qm.main import QMDatabaseWriter
 from rmgpy.reaction import Reaction
@@ -1451,7 +1452,7 @@ class RMG(util.Subject):
                     " rate at the relevant conditions\n\n"
                 )
                 for violator in violators:
-                    if isinstance(violator[0].kinetics, ThirdBody):
+                    if isinstance(violator[0].kinetics, (ThirdBody,Troe)):
                         rxn_string = violator[0].to_chemkin(self.reaction_model.core.species)
                     else:
                         rxn_string = violator[0].to_chemkin()


### PR DESCRIPTION
### Motivation or Problem
Interruption in simulation during the final model check. 

### Description of Changes
Added Troe kinetic (along with thirdbody) to the main.py file of the RMG. 
![image](https://github.com/ReactionMechanismGenerator/RMG-Py/assets/131012151/19f9d482-472e-4219-a720-7d4a1bb29bd4)
The present RMG code checks if violator[0].kinetics is the ThirdBody and, if True, enters into the if condition where self.reaction_model.core.species (species_list) is supplied as an argument to the function to_chemkin. For all the other types of kinetics, the else loop is followed, which does not have any argument. However, Troe kinetics also requires species_list as an argument to identify collider species, which is considered None as per the current code. Therefore, adding Troe to the if statement is essential to include reactions with Troe kinetics in the violators' log.
For more details, refer to the RMG issue #2604.

### Testing
The model generation was completed successfully without any interruption. 
