### PR TITLE
Add libxrender1 as a system-level dependency in Unix-based installation instructions

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -26,7 +26,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
       Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
 
 #. There are a few system-level dependencies which are required and should not be installed via Conda. These include
-   `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
+   `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG. For WSL users, `libxrender1 <https://packages.debian.org/sid/libxrender1>`_ may also need to be installed.
 
    For Linux users, you can check whether these are already installed by simply calling them via the command line, which
    will let you know if they are missing. To install any missing packages, you should use the appropriate package manager
@@ -34,21 +34,21 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
    a. On Ubuntu and Debian the package manager is ``apt`` ::
 
-       sudo apt install git gcc g++ make
+       sudo apt install git gcc g++ make libxrender1
 
    b. On Fedora and Red Hat derivatives (RHEL 8+) the package manager is ``dnf`` ::
 
-       sudo dnf install git gcc gcc-c++ make
+       sudo dnf install git gcc gcc-c++ make libxrender1
 
    c. For Red Hat 7 and lower, replace ``dnf`` with ``yum`` in the preceding.
 
    d. On openSUSE the package manager is ``zypper``::
 
-       sudo zypper install git gcc gcc-c++ make
+       sudo zypper install git gcc gcc-c++ make libxrender1
 
    e. On Manjaro or Arch Linux the package manager is ``pacman`` ::
 
-       sudo pacman -S git gcc make
+       sudo pacman -S git gcc make libxrender1
 
    f. For MacOS users, the above packages can be easily obtained by installing the XCode Command Line Tools.
       These are a set of packages relevant for software development which have been bundled together by Apple.

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -38,17 +38,17 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
    b. On Fedora and Red Hat derivatives (RHEL 8+) the package manager is ``dnf`` ::
 
-       sudo dnf install git gcc gcc-c++ make libxrender1
+       sudo dnf install git gcc gcc-c++ make
 
    c. For Red Hat 7 and lower, replace ``dnf`` with ``yum`` in the preceding.
 
    d. On openSUSE the package manager is ``zypper``::
 
-       sudo zypper install git gcc gcc-c++ make libxrender1
+       sudo zypper install git gcc gcc-c++ make
 
    e. On Manjaro or Arch Linux the package manager is ``pacman`` ::
 
-       sudo pacman -S git gcc make libxrender1
+       sudo pacman -S git gcc make
 
    f. For MacOS users, the above packages can be easily obtained by installing the XCode Command Line Tools.
       These are a set of packages relevant for software development which have been bundled together by Apple.


### PR DESCRIPTION
### Motivation or Problem
The "Installation by Source Using Anaconda Environment for Unix-based Systems" page does not mention the system-level dependency of libxrender1, which is not installed by default on systems not intended to render images such as Windows Subsystem for Linux.

### Description of Changes
Added a sentence stating that libxrender1 is a system-level dependency next to the other listed system level dependencies. Also modified the installation commands to include libxrender1. 

### Testing
N/A

### Reviewer Tips
I'm not sure if modifying the installation commands is necessary, and it may be more concise/sufficient to just have the single sentence noting the dependency. However, for future WSL users, mentioning this dependency would save hours of debugging as it is not immediately obvious that libxrender1 is the cause of the issues when it's missing.
