### PR TITLE
Replace a few packages maintained by us to their conda-forge version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -75,9 +75,9 @@ dependencies:
   - matplotlib >=1.5
   - mpmath
   - pandas
-  - gprof2dot
-  - numdifftools
-  - quantities
+  - conda-forge::gprof2dot
+  - conda-forge::numdifftools
+  - conda-forge::quantities
 
 # packages we maintain
   - rmg::lpsolve55

--- a/environment.yml
+++ b/environment.yml
@@ -75,17 +75,17 @@ dependencies:
   - matplotlib >=1.5
   - mpmath
   - pandas
+  - grof2dot
+  - numdifftools
+  - quantities
 
 # packages we maintain
-  - rmg::gprof2dot
   - rmg::lpsolve55
   - rmg::muq2
-  - rmg::numdifftools
   - rmg::pydas >=1.0.3
   - rmg::pydqed >=1.0.3
   - rmg::pyrdl
   - rmg::pyrms
-  - rmg::quantities
   - rmg::symmetry
 
 # packages we would like to stop maintaining (and why)

--- a/environment.yml
+++ b/environment.yml
@@ -75,7 +75,7 @@ dependencies:
   - matplotlib >=1.5
   - mpmath
   - pandas
-  - grof2dot
+  - gprof2dot
   - numdifftools
   - quantities
 


### PR DESCRIPTION
A draft PR for testing if we can switch `grof2dot`, `numdifftools`, `quantities` to the conda-forge version. 
<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
