### PR TITLE
GitHub Actions Maintenance

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout RMG-Py
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # configures the mamba environment manager and builds the environment
       - name: Setup Mambaforge Python 3.7
@@ -109,11 +109,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout RMG-Py
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # configures the mamba environment manager and builds the environment
-      - name: Patch Environment File
-        run: sed -i 's/  - conda-forge::julia>=1.8.5,!=1.9.0/  - conda-forge::julia=1.9.1/' environment.yml
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -132,7 +130,6 @@ jobs:
 
       # Clone RMG-database
       - name: Clone RMG-database
-        if: github.repository != 'ReactionMechanismGenerator/RMG-database'
         run: |
           cd ..
           git clone -b $RMG_DATABASE_BRANCH https://github.com/ReactionMechanismGenerator/RMG-database.git

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,19 +81,13 @@ jobs:
           cd build/html
           touch .nojekyll
           git add -A --force .
-          git commit -m "Automated documentation rebuild"
+          git commit -m "Automated documentation rebuild" || true  # allow this to fail if no changes were made
 
       - name: Check documentation links
         continue-on-error: true
         run: |
           cd documentation
           sphinx-build -b linkcheck -d build/doctrees/ source/ build/linkcheck | grep -e broken -e redirect | grep -v -e 'redirect  https://doi.org/' -e 'broken    https://doi.org/.* 403 Client Error: Forbidden'
-
-      - name: Test Publish Documentation
-        if: ${{  github.event_name != 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}
-        run: |
-          cd documentation/build/html
-          git push --dry-run origin gh-pages
 
       - name: Publish Updated Documentation
         if: ${{  github.event_name == 'push' && github.repository == 'ReactionMechanismGenerator/RMG-Py' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,7 +81,7 @@ jobs:
           cd build/html
           touch .nojekyll
           git add -A --force .
-          git commit -m "Automated documentation rebuild" || true  # allow this to fail if no changes were made
+          git diff --exit-code --quiet || git commit -m "Automated documentation rebuild"  # only commit if changes were made
 
       - name: Check documentation links
         continue-on-error: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,7 +81,7 @@ jobs:
           cd build/html
           touch .nojekyll
           git add -A --force .
-          git diff --exit-code --quiet || git commit -m "Automated documentation rebuild"  # only commit if changes were made
+          git diff --staged --exit-code --quiet || git commit -m "Automated documentation rebuild"  # only commit if changes were made
 
       - name: Check documentation links
         continue-on-error: true


### PR DESCRIPTION
#2621 fixed the docs building but was not tested from forks or with PRs that do not update the docs, and in both cases the action now _looks_ like it fails even though it's fine. This PR removes the test push (which failed from forks) and allow the commit step to fail, which it would do if the PR does not contain docs updates.

#2512 and #2608 left some lint in the CI which this PR removes.

Blocked by #2553 since I accidentally made this branch locally off of that one and am too lazy to rebase + this isn't urgent.