### PR TITLE
Clean up some code for calculating degeneracy in kinetics codebase

### DIFF
--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -222,9 +222,51 @@ def ensure_independent_atom_ids(input_species, resonance=True):
         for species in input_species:
             species.generate_resonance_structures(keep_isomorphic=True)
 
+def check_for_same_reactants(reactants):
+    """
+    Given a list reactants, check if the reactants are the same.
+    If they refer to the same memory address, then make a deep copy so they can be manipulated independently.
+    
+    Returns the modified reactants list and an integer containing the number of same reactants in the reactants list. 
+    
+    """
+
+    same_reactants = 0
+    if len(reactants) == 2:
+        if reactants[0] is reactants[1]:
+            reactants[1] = reactants[1].copy(deep=True)
+            same_reactants = 2
+        elif reactants[0].is_isomorphic(reactants[1]):
+            same_reactants = 2
+    elif len(reactants) == 3:
+        same_01 = reactants[0] is reactants[1]
+        same_02 = reactants[0] is reactants[2]
+        if same_01 and same_02:
+            same_reactants = 3
+            reactants[1] = reactants[1].copy(deep=True)
+            reactants[2] = reactants[2].copy(deep=True)
+        elif same_01:
+            same_reactants = 2
+            reactants[1] = reactants[1].copy(deep=True)
+        elif same_02:
+            same_reactants = 2
+            reactants[2] = reactants[2].copy(deep=True)
+        elif reactants[1] is reactants[2]:
+            same_reactants = 2
+            reactants[2] = reactants[2].copy(deep=True)
+        else:
+            same_01 = reactants[0].is_isomorphic(reactants[1])
+            same_02 = reactants[0].is_isomorphic(reactants[2])
+            if same_01 and same_02:
+                same_reactants = 3
+            elif same_01 or same_02:
+                same_reactants = 2
+            elif reactants[1].is_isomorphic(reactants[2]):
+                same_reactants = 2
+    return reactants, same_reactants
 
 def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kinetics_database=None,
-                              kinetics_family=None, save_order=False):
+                              kinetics_family=None, save_order=False, resonance=True):
     """
     Given a list of Reaction objects, this method combines degenerate
     reactions and increments the reaction degeneracy value. For multiple
@@ -250,6 +292,7 @@ def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kine
         kinetics_database (KineticsDatabase, optional): provide a KineticsDatabase instance for calculating degeneracy
         kinetics_family (KineticsFamily, optional):     provide a KineticsFamily instance for calculating degeneracy
         save_order (bool, optional):                    reset atom order after performing atom isomorphism
+        resonance (bool, optional):                     whether to consider resonance when computing degeneracy 
 
     Returns:
         Reaction list with degenerate reactions combined with proper degeneracy values
@@ -340,7 +383,7 @@ def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kine
                 from rmgpy.data.rmg import get_db
                 family = get_db('kinetics').families[rxn.family]
             if not family.own_reverse:
-                rxn.degeneracy = family.calculate_degeneracy(rxn)
+                rxn.degeneracy = family.calculate_degeneracy(rxn, resonance=resonance)
 
     return rxn_list
 

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -227,7 +227,7 @@ def check_for_same_reactants(reactants):
     Given a list reactants, check if the reactants are the same.
     If they refer to the same memory address, then make a deep copy so they can be manipulated independently.
     
-    Returns the modified reactants list and an integer containing the number of same reactants in the reactants list. 
+    Returns a tuple containing the modified reactants list, and an integer containing the number of identical reactants in the reactants list. 
     
     """
 

--- a/rmgpy/data/kinetics/common.py
+++ b/rmgpy/data/kinetics/common.py
@@ -263,6 +263,10 @@ def check_for_same_reactants(reactants):
                 same_reactants = 2
             elif reactants[1].is_isomorphic(reactants[2]):
                 same_reactants = 2
+    elif len(reactants) > 3:
+        raise ValueError('Cannot check for duplicate reactants if provided number of reactants is greater than 3. ' 
+                         'Got: {} reactants'.format(len(reactants))) 
+        
     return reactants, same_reactants
 
 def find_degenerate_reactions(rxn_list, same_reactants=None, template=None, kinetics_database=None,

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -427,7 +427,7 @@ and immediately used in input files without any additional changes.
         if only_families is None:
             reaction_list.extend(self.generate_reactions_from_libraries(reactants, products))
         reaction_list.extend(self.generate_reactions_from_families(reactants, products,
-                                                                   only_families=None, resonance=resonance))
+                                                                   only_families=only_families, resonance=resonance))
         return reaction_list
 
     def generate_reactions_from_libraries(self, reactants, products=None):

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -504,7 +504,8 @@ and immediately used in input files without any additional changes.
                                                       prod_resonance=resonance))
 
         # Calculate reaction degeneracy
-        reaction_list = find_degenerate_reactions(reaction_list, same_reactants, kinetics_database=self)
+        reaction_list = find_degenerate_reactions(reaction_list, same_reactants, kinetics_database=self,
+                                                  resonance=resonance)
         # Add reverse attribute to families with ownReverse
         to_delete = []
         for i, rxn in enumerate(reaction_list):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1741,15 +1741,13 @@ class KineticsFamily(Database):
                 rxn.reverse = reactions[0]
                 return True
 
-    def calculate_degeneracy(self, reaction):
+    def calculate_degeneracy(self, reaction, resonance=True):
         """
         For a `reaction`  with `Molecule` or `Species` objects given in the direction in which
-        the kinetics are defined, compute the reaction-path degeneracy.
+        the kinetics are defined, compute the reaction-path degeneracy. Can specify whether to consider resonance.
 
         This method by default adjusts for double counting of identical reactants. 
-        This should only be adjusted once per reaction. To not adjust for 
-        identical reactants (since you will be reducing them later in the algorithm), add
-        `ignoreSameReactants= True` to this method.
+        This should only be adjusted once per reaction. 
         """
         # Check if the reactants are the same
         # If they refer to the same memory address, then make a deep copy so
@@ -1789,7 +1787,7 @@ class KineticsFamily(Database):
                     same_reactants = 2
 
         # Label reactant atoms for proper degeneracy calculation
-        ensure_independent_atom_ids(reactants, resonance=True)
+        ensure_independent_atom_ids(reactants, resonance=resonance)
         molecule_combos = generate_molecule_combos(reactants)
 
         reactions = []

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1759,7 +1759,7 @@ class KineticsFamily(Database):
         reactions = []
         for combo in molecule_combos:
             reactions.extend(self._generate_reactions(combo, products=reaction.products, forward=True,
-                                                      react_non_reactive=True))
+                                                      prod_resonance=resonance, react_non_reactive=True))
 
         # remove degenerate reactions
         reactions = find_degenerate_reactions(reactions, same_reactants, template=reaction.template,

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1763,7 +1763,7 @@ class KineticsFamily(Database):
 
         # remove degenerate reactions
         reactions = find_degenerate_reactions(reactions, same_reactants, template=reaction.template,
-                                              kinetics_family=self)
+                                              kinetics_family=self, resonance=resonance)
 
         # log issues
         if len(reactions) != 1:


### PR DESCRIPTION
### Motivation or Problem
In #2630 it was observed that `kinetics.database.generate_reactions_from_families` and `kinetics.family.calculate_degeneracy` can be modularized and improved.

### Description of Changes
This PR accomplishes the following:
1. Copies the overlapping code in the above functions and re-implements as a new function `kinetics.common.check_for_same_reactants`, which checks to see whether the provided reactants list has duplicate reactants (or not).
2. Allow `resonance` to propagate in `kinetics.family.calculate_degeneracy`. This way, you can specify `resonance=False` when generating families and it will not consider resonance anymore (which is crucial for some species that have many resonance forms, see #2630).
3. Fix up various typos; for example previously `kinetics.database.generate_reactions` does not allow `only_families` to propagate rendering that argument useless.

### Testing
Verified that both of these functions work in terms of allowing `kinetics.database.generate_reactions_from_families` and setting `resonance=False` (see minimal example in #2630 above).

Need to check if any unit tests fail.