### PR TITLE
Upgrading to Python 3.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,10 @@ env:
 jobs:
   build-osx:
     runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     # skip scheduled runs from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
     defaults:
@@ -62,13 +66,13 @@ jobs:
         uses: actions/checkout@v4
 
       # configures the mamba environment manager and builds the environment
-      - name: Setup Mambaforge Python 3.7
+      - name: Setup Mambaforge Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: environment.yml
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
           activate-environment: rmg_env
           use-mamba: true
 
@@ -99,6 +103,10 @@ jobs:
 
   build-and-test-linux:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     # skip scheduled runs from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
     env: 
@@ -112,13 +120,13 @@ jobs:
         uses: actions/checkout@v4
 
       # configures the mamba environment manager and builds the environment
-      - name: Setup Mambaforge Python 3.7
+      - name: Setup Mambaforge Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: environment.yml
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
           activate-environment: rmg_env
           use-mamba: true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,63 +50,14 @@ env:
 
 
 jobs:
-  build-osx:
-    runs-on: macos-13
+  build-and-test:
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
-    # skip scheduled runs from forks
-    if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - name: Checkout RMG-Py
-        uses: actions/checkout@v4
-
-      # configures the mamba environment manager and builds the environment
-      - name: Setup Mambaforge Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          environment-file: environment.yml
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          python-version: ${{ matrix.python-version }}
-          activate-environment: rmg_env
-          use-mamba: true
-
-      # list the environment for debugging purposes
-      - name: mamba info
-        run: |
-          mamba info
-          mamba list
-
-      # Clone RMG-database
-      - name: Clone RMG-database
-        run: |
-          cd ..
-          git clone -b $RMG_DATABASE_BRANCH https://github.com/ReactionMechanismGenerator/RMG-database.git
-
-      # modify env variables as directed in the RMG installation instructions
-      - name: Set Environment Variables
-        run: |
-          RUNNER_CWD=$(pwd)
-          echo "PYTHONPATH=$RUNNER_CWD/RMG-Py:$PYTHONPATH" >> $GITHUB_ENV
-          echo "$RUNNER_CWD/RMG-Py" >> $GITHUB_PATH
-
-      # RMG build step
-      - name: make RMG
-        run: |
-          make clean
-          make
-
-  build-and-test-linux:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12"]
+        os: [macos-13, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} Build and Test
     # skip scheduled runs from forks
     if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-Py' && github.event_name == 'schedule' ) }}
     env: 
@@ -369,7 +320,7 @@ jobs:
     # who knows ¯\_(ツ)_/¯
     #
     # taken from https://github.com/docker/build-push-action
-    needs: build-and-test-linux
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.repository == 'ReactionMechanismGenerator/RMG-Py'
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -43,9 +43,9 @@ dependencies:
 
 # external software tools for chemistry
   - coolprop
-  - cantera::cantera=2.6
+  - cantera::cantera >=3
   - conda-forge::mopac
-  - conda-forge::cclib >=1.6.3,<1.8.0
+  - conda-forge::cclib >=1.6.3
   - conda-forge::openbabel >= 3
   - conda-forge::rdkit >=2022.09.1
 
@@ -58,7 +58,7 @@ dependencies:
   - coverage
   - cython >=0.25.2
   - scikit-learn
-  - scipy <1.11
+  - scipy
   - numpy >=1.10.0
   - pydot
   - jinja2

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@
 #   made dependency list more explicit (@JacksonBurns).
 # - October 16, 2023 Switched RDKit and descripatastorus to conda-forge,
 #   moved diffeqpy to pip and (temporarily) removed chemprop
+# - March 15, 2024 - started migration to Python 3.11/2
 #
 name: rmg_env
 channels:
@@ -53,7 +54,7 @@ dependencies:
   - conda-forge::pyjulia >=0.6
 
 # Python tools
-  - python >=3.7
+  - python =3.11,3.12
   - coverage
   - cython >=0.25.2
   - scikit-learn
@@ -68,13 +69,7 @@ dependencies:
   - networkx
   - pytest
   - pytest-cov
-  # we use a the pytest-check plugin, which is on Conda and PyPI, but the
-  # version compatible with Python 3.7 is only on PyPI
-  # switch to the conda version after upgrading to 3.11
-  # - conda-forge::pytest-check
-  - pip
-  - pip:
-    - pytest-check
+  - conda-forge::pytest-check
   - matplotlib >=1.5
   - mpmath
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -76,7 +76,6 @@ dependencies:
   - conda-forge::gprof2dot
   - conda-forge::numdifftools
   - conda-forge::quantities
-  - conda-forge::muq
   - conda-forge::lpsolve55
 #   - conda-forge::ringdecomposerlib-python
 

--- a/environment.yml
+++ b/environment.yml
@@ -54,7 +54,7 @@ dependencies:
   - conda-forge::pyjulia >=0.6
 
 # Python tools
-  - python =3.11,3.12
+  - python =3.11
   - coverage
   - cython >=0.25.2
   - scikit-learn
@@ -78,16 +78,16 @@ dependencies:
   - conda-forge::quantities
   - conda-forge::muq
   - conda-forge::lpsolve55
-  - conda-forge::ringdecomposerlib-python
+#   - conda-forge::ringdecomposerlib-python
 
-# packages we maintain
-  - rmg::pydas >=1.0.3
-  - rmg::pydqed >=1.0.3
-  - rmg::pyrms
-  - rmg::symmetry
+# # packages we maintain
+#   - rmg::pydas >=1.0.3
+#   - rmg::pydqed >=1.0.3
+#   - rmg::pyrms
+#   - rmg::symmetry
 
-# packages we would like to stop maintaining (and why)
-  - rmg::diffeqpy
+# # packages we would like to stop maintaining (and why)
+#   - rmg::diffeqpy
   # we should use the official verison https://github.com/SciML/diffeqpy),
   # rather than ours (which is only made so that we can get it from conda)
   # It is only on pip, so we will need to do something like:


### PR DESCRIPTION
This PR will (eventually) move RMG from Python 3.7 to 3.11/2. Python 3.7 is deprecated, which reason enough on its own to move, but doing so will also unblock a number of other improvements.

Opening this now to track the progress of the change and so that I can use the CI to test what packages need to be rebuilt, etc. Will edit this description and clean up the git history when things actually stand a chance of working.