### PR TITLE
revise conda recipe and github actions to execute it

### DIFF
--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -23,7 +23,23 @@ fi
 make install
 export PYTHON=$PREFIX/bin/python
 export PYTHONPATH=$SRC_DIR:$PYTHONPATH
+echo "testing rmgpy"
+python -c "from rmgpy.molecule import Molecule"
+
+echo "pythonpath"
+echo $PYTHONPATH 
+echo "python"
+echo $PYTHON
+
+
 python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
+echo "current python"
+which python
+echo "julia python"
+julia -e "using PyCall; println(PyCall.PYTHONHOME)"
+echo "retest rmgpy"
+python -c "from rmgpy.molecule import Molecule"
+
 julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator'
 
 set +x

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -25,3 +25,5 @@ export PYTHON=$PREFIX/bin/python
 export PYTHONPATH=$SRC_DIR:$PYTHONPATH
 python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator'
+
+set +x

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -1,5 +1,9 @@
 set -x
+# as done in the pure-python conda recipe
+make install
+python -c "from rmgpy.molecule import Molecule"
 
+# attempting to run the Julia install
 # from https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2631#issuecomment-1998723914
 #make julia directory
 mkdir -p ${PREFIX}/share/julia/site
@@ -20,7 +24,6 @@ else
         # echo 'sed -i \'/julia.install/d\' $ACTIVATE_ENV' >> $ACTIVATE_ENV
 fi
 
-make install
 export PYTHON=$PREFIX/bin/python
 export PYTHONPATH=$SRC_DIR:$PYTHONPATH
 echo "testing rmgpy"

--- a/.conda/conda_build_config.yaml
+++ b/.conda/conda_build_config.yaml
@@ -2,7 +2,3 @@ python:
   - 3.7
 numpy:
   - 1.15
-
-# Specifically for Travis build. Should change if building locally.
-CONDA_BUILD_SYSROOT:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk # [osx] 

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -11,65 +11,163 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }} # [unix]
+    - {{ compiler('c') }}
   host:
-    - cython >=0.25.2
-    - lpsolve55
-    - numpy
-    - openbabel >=3
-    - pydas >=1.0.2
-    - pydqed >=1.0.1
-    - pyrdl
-    - python
-    - quantities
-    - rdkit >=2018
-    - scipy
-    - setuptools
+    - conda-forge::libxcrypt  # remove after upgrading Python versions
+    - conda-forge::cairo
+    - conda-forge::cairocffi
+    - conda-forge::ffmpeg
+    - conda-forge::xlrd
+    - conda-forge::xlwt
+    - conda-forge::h5py
+    - conda-forge::graphviz
+    - conda-forge::markupsafe
+    - conda-forge::psutil
+    - conda-forge::ncurses
+    - conda-forge::suitesparse
+    - conda-forge::coolprop
+    - cantera::cantera =2.6
+    - conda-forge::mopac
+    - conda-forge::cclib >=1.6.3,!=1.8.0
+    - conda-forge::openbabel >=3
+    - conda-forge::rdkit >=2022.09.1
+    - conda-forge::python >=3.7
+    - conda-forge::coverage
+    - conda-forge::cython >=0.25.2
+    - conda-forge::scikit-learn
+    - conda-forge::scipy <1.11
+    - conda-forge::numpy >=1.10.0
+    - conda-forge::pydot
+    - conda-forge::jinja2
+    - conda-forge::jupyter
+    - conda-forge::pymongo
+    - conda-forge::pyparsing
+    - conda-forge::pyyaml
+    - conda-forge::networkx
+    - conda-forge::pytest
+    - conda-forge::pytest-cov
+    - conda-forge::matplotlib >=1.5
+    - conda-forge::mpmath
+    - conda-forge::pandas
+    - conda-forge::gprof2dot
+    - conda-forge::numdifftools
+    - conda-forge::quantities
+    - rmg::lpsolve55
+    - rmg::muq2
+    - rmg::pydas >=1.0.3
+    - rmg::pydqed >=1.0.3
+    - rmg::pyrdl
+    - rmg::symmetry
+    - rmg::diffeqpy
+    - rmg::pyrms
+    - conda-forge::julia=1.9.1
+    - conda-forge::pyjulia>=0.6
+    - conda-forge::nomkl
   run:
-    - cairo
-    - cairocffi
-    - cantera >=2.3.0
-    - cclib >=1.6.3
-    - coolprop
-    - coverage
-    - cython >=0.25.2
-    - ffmpeg
-    - gprof2dot
-    - graphviz
-    - h5py
-    - jinja2
-    - jupyter
-    - lpsolve55
-    - markupsafe
-    - matplotlib >=1.5
-    - mopac
-    - mpmath
-    - muq2
-    - networkx
-    - nose
-    - numdifftools
-    - {{ pin_compatible('numpy') }}
-    - openbabel >=3
-    - pandas
-    - psutil
-    - pydas >=1.0.2
-    - pydot
-    - pydqed >=1.0.1
-    - pymongo
-    - pyparsing
-    - pyrdl
-    - python
-    - pyyaml
-    - pyzmq
-    - quantities
-    - rdkit >=2018
-    - rmgdatabase >=3.2.0
-    - scikit-learn
-    - scipy
-    - symmetry
-    - xlrd
-    - xlwt
+    - conda-forge::libxcrypt  # remove after upgrading Python versions
+    - rmg::rmgdatabase
+    - conda-forge::cairo
+    - conda-forge::cairocffi
+    - conda-forge::ffmpeg
+    - conda-forge::xlrd
+    - conda-forge::xlwt
+    - conda-forge::h5py
+    - conda-forge::graphviz
+    - conda-forge::markupsafe
+    - conda-forge::psutil
+    - conda-forge::ncurses
+    - conda-forge::suitesparse
+    - conda-forge::coolprop
+    - cantera::cantera =2.6
+    - conda-forge::mopac
+    - conda-forge::cclib >=1.6.3,!=1.8.0
+    - conda-forge::openbabel >=3
+    - conda-forge::rdkit >=2022.09.1
+    - conda-forge::python >=3.7
+    - conda-forge::coverage
+    - conda-forge::cython >=0.25.2
+    - conda-forge::scikit-learn
+    - conda-forge::scipy <1.11
+    - conda-forge::numpy >=1.10.0
+    - conda-forge::pydot
+    - conda-forge::jinja2
+    - conda-forge::jupyter
+    - conda-forge::pymongo
+    - conda-forge::pyparsing
+    - conda-forge::pyyaml
+    - conda-forge::networkx
+    - conda-forge::pytest
+    - conda-forge::pytest-cov
+    - conda-forge::matplotlib >=1.5
+    - conda-forge::mpmath
+    - conda-forge::pandas
+    - conda-forge::gprof2dot
+    - conda-forge::numdifftools
+    - conda-forge::quantities
+    - rmg::lpsolve55
+    - rmg::muq2
+    - rmg::pydas >=1.0.3
+    - rmg::pydqed >=1.0.3
+    - rmg::pyrdl
+    - rmg::symmetry
+    - rmg::diffeqpy
+    - rmg::pyrms
+    - conda-forge::julia=1.9.1
+    - conda-forge::pyjulia>=0.6
+    - conda-forge::nomkl
 test:
+  requires:
+    - conda-forge::libxcrypt  # remove after upgrading Python versions
+    - rmg::rmgdatabase
+    - conda-forge::cairo
+    - conda-forge::cairocffi
+    - conda-forge::ffmpeg
+    - conda-forge::xlrd
+    - conda-forge::xlwt
+    - conda-forge::h5py
+    - conda-forge::graphviz
+    - conda-forge::markupsafe
+    - conda-forge::psutil
+    - conda-forge::ncurses
+    - conda-forge::suitesparse
+    - conda-forge::coolprop
+    - cantera::cantera =2.6
+    - conda-forge::mopac
+    - conda-forge::cclib >=1.6.3,!=1.8.0
+    - conda-forge::openbabel >=3
+    - conda-forge::rdkit >=2022.09.1
+    - conda-forge::python >=3.7
+    - conda-forge::coverage
+    - conda-forge::cython >=0.25.2
+    - conda-forge::scikit-learn
+    - conda-forge::scipy <1.11
+    - conda-forge::numpy >=1.10.0
+    - conda-forge::pydot
+    - conda-forge::jinja2
+    - conda-forge::jupyter
+    - conda-forge::pymongo
+    - conda-forge::pyparsing
+    - conda-forge::pyyaml
+    - conda-forge::networkx
+    - conda-forge::pytest
+    - conda-forge::pytest-cov
+    - conda-forge::matplotlib >=1.5
+    - conda-forge::mpmath
+    - conda-forge::pandas
+    - conda-forge::gprof2dot
+    - conda-forge::numdifftools
+    - conda-forge::quantities
+    - rmg::lpsolve55
+    - rmg::muq2
+    - rmg::pydas >=1.0.3
+    - rmg::pydqed >=1.0.3
+    - rmg::pyrdl
+    - rmg::symmetry
+    - rmg::diffeqpy
+    - rmg::pyrms
+    - conda-forge::julia=1.9.1
+    - conda-forge::pyjulia>=0.6
+    - conda-forge::nomkl
   source_files:
     - 'examples/rmg/superminimal'
     - 'examples/arkane/networks/n-butanol'
@@ -77,10 +175,8 @@ test:
     - rmgpy
     - arkane
   commands:
-    - rmg.py examples/rmg/superminimal/input.py # [unix]
-    - Arkane.py examples/arkane/networks/n-butanol/input.py # [unix]
-    - python %SCRIPTS%\rmg.py examples\rmg\superminimal\input.py # [win]
-    - python %SCRIPTS\Arkane.py examples\arkane\networks\n-butanol\input.py # [win]
+    - rmg.py examples/rmg/superminimal/input.py
+    - Arkane.py examples/arkane/networks/n-butanol/input.py
 
 about:
   home: https://github.com/ReactionMechanismGenerator/RMG-Py

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -65,7 +65,7 @@ requirements:
     - conda-forge::nomkl
   run:
     - conda-forge::libxcrypt  # remove after upgrading Python versions
-    - rmg::rmgdatabase
+    - jacksonburns::rmgdatabase
     - conda-forge::cairo
     - conda-forge::cairocffi
     - conda-forge::ffmpeg
@@ -118,7 +118,7 @@ requirements:
 test:
   requires:
     - conda-forge::libxcrypt  # remove after upgrading Python versions
-    - rmg::rmgdatabase
+    - jacksonburns::rmgdatabase
     - conda-forge::cairo
     - conda-forge::cairocffi
     - conda-forge::ffmpeg

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -1,58 +1,46 @@
 name: Conda Build
 
 on:
+  pull_request:
   push:
     branches:
       - stable
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          environment-file: environment.yml
-          python-version: 3.7
-          activate-environment: rmg_env
-      - name: Conda info
+          auto-update-conda: false
+          conda-solver: libmamba
+          auto-activate-base: true
+          activate-environment: ""
+      - name: Install Build Tools
+        run: conda install python anaconda-client conda-build
+      - name: Configure Auto-Upload
+        if: github.ref == 'refs/heads/stable'
         run: |
-          conda info
-          conda list
-      - name: Build Binary
-        env: 
-          CONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: |
-          conda install -y conda-build 
-          conda install -y anaconda-client 
-          conda config --add channels rmg
           conda config --set anaconda_upload yes
-          conda build --token $CONDA_TOKEN --user rmg .conda
-  build-osx:
-    runs-on: macos-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          environment-file: environment.yml
-          python-version: 3.7
-          activate-environment: rmg_env
-      - name: Conda info
-        run: |
-          conda info
-          conda list
       - name: Build Binary
         env: 
-          CONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          CONDA_TOKEN: "need_to_add_this_secret"  # ${{ secrets.ANACONDA_TOKEN }}
         run: |
-            conda install -y conda-build 
-            conda install -y anaconda-client 
-            conda config --add channels rmg
-            conda config --set anaconda_upload yes
-            xcrun --show-sdk-path
-            conda build --token $CONDA_TOKEN --user rmg .conda
+          conda config --add channels rmg
+          conda config --add channels cantera
+          conda config --add channels conda-forge
+          conda-build --token $CONDA_TOKEN --user rmg .conda
+      - name: Test Binary Install with RMS
+        run: |
+          conda create --name rmg_test python=3.7*
+          conda activate rmg_test
+          conda install -c local rmg
+          python-jl rmg.py test/regression/RMS_constantVIdealGasReactor_superminimal/input.py

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -37,6 +37,7 @@ jobs:
           conda config --add channels rmg
           conda config --add channels cantera
           conda config --add channels conda-forge
+          conda config --add channels jacksonburns
           conda-build --token $CONDA_TOKEN --user rmg .conda
       - name: Test Binary Install with RMS
         run: |

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ scripts = [
     'scripts/standardizeModelSpeciesNames.py',
     'scripts/thermoEstimator.py',
     'scripts/isotopes.py',
-    'testing/databaseTest.py',
+    'test/database/databaseTest.py',
 ]
 
 modules = []


### PR DESCRIPTION
This PR is a combination of effort from https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2539 to fix the conda recipe and advice recieved on https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2631 in this comment: https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2631#issuecomment-1998723914 which may allow fixing the conda recipe without making RMS an optional installation dependency (which was the solution proposed in #2631).

Prior efforts to do this were unsuccessful for some reasons discussed on #2631 in addition to the limited capacity of the GitHub runners - when the actions runners try to build the recipe they run out of memory. Fortunately in the last year they have upgraded the linux runners, so they might be able to do it now. Failing all else, we will at least have one publicly visible attempt at fixing the recipe so that everyone can run it locally.