### PR TITLE
restrict newer versions of cclib

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
   - coolprop
   - cantera::cantera=2.6
   - conda-forge::mopac
-  - conda-forge::cclib >=1.6.3,!=1.8.0
+  - conda-forge::cclib >=1.6.3,<1.8.0
   - conda-forge::openbabel >= 3
   - conda-forge::rdkit >=2022.09.1
 


### PR DESCRIPTION
### Motivation or Problem
this is related to #2535, regression tests are failing because we are using a newer version of cclib. the previous statement did not restrict newer versions of cclib, just versions that are !=1.8.0. 1.8.1 was released recently and broke out regressions tests again. 

### Description of Changes
change environment.yaml line for cclib to disallow versions that are equal to or greater than cclib 1.8.0