### PR TITLE
updating 'rotconsts' ref to be compatible with cclib v1.8+

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - cantera::cantera=2.6
   - conda-forge::mopac
   # see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2639#issuecomment-2050292972
-  - conda-forge::cclib >=1.6.3,<1.8.0,<2
+  - conda-forge::cclib >=1.6.3,<2
   - conda-forge::openbabel >= 3
   - conda-forge::rdkit >=2022.09.1
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@
 #   made dependency list more explicit (@JacksonBurns).
 # - October 16, 2023 Switched RDKit and descripatastorus to conda-forge,
 #   moved diffeqpy to pip and (temporarily) removed chemprop
+# - April 17, 2024 Limit versions of cclib at advice of maintainers.
 #
 name: rmg_env
 channels:
@@ -44,7 +45,8 @@ dependencies:
   - coolprop
   - cantera::cantera=2.6
   - conda-forge::mopac
-  - conda-forge::cclib >=1.6.3,<1.8.0
+  # see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2639#issuecomment-2050292972
+  - conda-forge::cclib >=1.6.3,<1.8.0,<2
   - conda-forge::openbabel >= 3
   - conda-forge::rdkit >=2022.09.1
 

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -409,18 +409,25 @@ class QMMolecule(object):
         parser.logger.setLevel(
             logging.ERROR
         )  # cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
-        parser.rotcons = (
-            []
-        )  # give it an attribute and it won't delete it, leaving it on the parser object
+
         parser.molmass = None  # give it an attribute and it won't delete it, leaving it on the parser object
         cclib_data = parser.parse()
+
+        # for bacwards compatibility with cclib <1.6
+        if not hasattr(cclib_data, "rotconsts"):
+             # this hack required because rotconsts not part of a default cclib data object
+            parser.rotconsts = (
+                []
+            )  # give it an attribute and it won't delete it, leaving it on the parser object
+
+            cclib_data.rotconsts = (
+                parser.rotconsts
+            ) 
+
         radical_number = self.molecule.get_radical_count()
-        cclib_data.rotcons = (
-            parser.rotcons
-        )  # this hack required because rotcons not part of a default cclib data object
         cclib_data.molmass = (
             parser.molmass
-        )  # this hack required because rotcons not part of a default cclib data object
+        )  # this hack required because molmass is not part of a default cclib data object
         qm_data = parse_cclib_data(
             cclib_data, radical_number + 1
         )  # Should `radical_number+1` be `self.molecule.multiplicity` in the next line of code? It's the electronic ground state degeneracy.

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -408,7 +408,7 @@ class QMMolecule(object):
         parser = self.get_parser(self.output_file_path)
         parser.logger.setLevel(
             logging.ERROR
-        )  # cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
+        )  # cf. https://cclib.github.io/index.html#how-to-use-cclib
         parser.molmass = None # give it an attribute and it won't delete it, leaving it on the parser object
         parser.rotcons = (  # for cclib < 1.8.0
             []

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -409,7 +409,23 @@ class QMMolecule(object):
         parser.logger.setLevel(
             logging.ERROR
         )  # cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
-
+parser.molmass = None # give it an attribute and it won't delete it, leaving it on the parser object
+parser.rotcons = (  # for cclib < 1.8.0
+    []
+)
+parser.rotconsts = (  # for cclib >= 1.8.0
+    []
+)
+cclib_data = parser.parse()  # fills in either parser.rotcons or parser.rotconsts but not both
+assert bool(parser.rotconsts) != bool(parser.rotcons)
+if parser.rotcons:  # for cclib < 1.8.0
+    cclib_data.rotcons = (
+        parser.rotcons
+    )
+else:  # for cclib >= 1.8.0
+    cclib_data.rotconsts = (
+        parser.rotconsts
+    )
         parser.molmass = None  # give it an attribute and it won't delete it, leaving it on the parser object
         cclib_data = parser.parse()
 

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -409,23 +409,23 @@ class QMMolecule(object):
         parser.logger.setLevel(
             logging.ERROR
         )  # cf. http://cclib.sourceforge.net/wiki/index.php/Using_cclib#Additional_information
-parser.molmass = None # give it an attribute and it won't delete it, leaving it on the parser object
-parser.rotcons = (  # for cclib < 1.8.0
-    []
-)
-parser.rotconsts = (  # for cclib >= 1.8.0
-    []
-)
-cclib_data = parser.parse()  # fills in either parser.rotcons or parser.rotconsts but not both
-assert bool(parser.rotconsts) != bool(parser.rotcons)
-if parser.rotcons:  # for cclib < 1.8.0
-    cclib_data.rotcons = (
-        parser.rotcons
-    )
-else:  # for cclib >= 1.8.0
-    cclib_data.rotconsts = (
-        parser.rotconsts
-    )
+        parser.molmass = None # give it an attribute and it won't delete it, leaving it on the parser object
+        parser.rotcons = (  # for cclib < 1.8.0
+            []
+        )
+        parser.rotconsts = (  # for cclib >= 1.8.0
+            []
+        )
+        cclib_data = parser.parse()  # fills in either parser.rotcons or parser.rotconsts but not both
+        assert bool(parser.rotconsts) != bool(parser.rotcons)
+        if parser.rotcons:  # for cclib < 1.8.0
+            cclib_data.rotcons = (
+                parser.rotcons
+            )
+        else:  # for cclib >= 1.8.0
+            cclib_data.rotconsts = (
+                parser.rotconsts
+            )
         radical_number = self.molecule.get_radical_count()
         cclib_data.molmass = (
             parser.molmass

--- a/rmgpy/qm/molecule.py
+++ b/rmgpy/qm/molecule.py
@@ -426,20 +426,6 @@ else:  # for cclib >= 1.8.0
     cclib_data.rotconsts = (
         parser.rotconsts
     )
-        parser.molmass = None  # give it an attribute and it won't delete it, leaving it on the parser object
-        cclib_data = parser.parse()
-
-        # for bacwards compatibility with cclib <1.6
-        if not hasattr(cclib_data, "rotconsts"):
-             # this hack required because rotconsts not part of a default cclib data object
-            parser.rotconsts = (
-                []
-            )  # give it an attribute and it won't delete it, leaving it on the parser object
-
-            cclib_data.rotconsts = (
-                parser.rotconsts
-            ) 
-
         radical_number = self.molecule.get_radical_count()
         cclib_data.molmass = (
             parser.molmass

--- a/rmgpy/qm/qmdata.py
+++ b/rmgpy/qm/qmdata.py
@@ -98,7 +98,11 @@ def parse_cclib_data(cclib_data, ground_state_degeneracy):
             molecular_mass = None
         energy = (cclib_data.scfenergies[-1], 'eV/molecule')
         atomic_numbers = cclib_data.atomnos
-        rotational_constants = (cclib_data.rotcons[-1], 'cm^-1')
+        if hasattr(cclib_data, 'rotconsts'):
+            rotational_constants = (cclib_data.rotconsts[-1], 'cm^-1')
+        else:
+            rotational_constants = (cclib_data.rotcons[-1], 'cm^-1')
+        
         atom_coords = (cclib_data.atomcoords[-1], 'angstrom')
         frequencies = (cclib_data.vibfreqs, 'cm^-1')
 


### PR DESCRIPTION
### Motivation or Problem
regression tests fail with the superminimal example, because it uses mopac for qm calcs. the root cause is the parser has since been updated, and the variable name for rotational constants has been changed from "rotcons" to "rotconsts" (see [this](https://github.com/cclib/cclib/commit/ebff98a7d0dadc92b1c6c23a91210586ab2470aa) commit on the cclib repo). 

additionally, in more recent versions, it looks like the "rotconsts" is part of a default cclib parser object for MOPAC output files, so there the workaround we use is not necessary. I have left the "old way" of adding rotational constants in for backwards compatibility. 

### Description of Changes
I added checks for whether the cclib_data object has "rotconsts" specified, and assigns the appropriate values to the qm object. 

### Testing
unit tests and functional tests. If the superminimal passes with both 1.8 and <1.8 then it should be fine I think. 
