### PR TITLE
Testing PythonCall compatibility with RMG

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,7 +152,7 @@ jobs:
         timeout-minutes: 120 # this usually takes 20-45 minutes (or hangs for 6+ hours).
         run: |
           python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
-          julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator'
+          julia -e 'using Pkg; Pkg.add(PackageSpec(name="ReactionMechanismSimulator", rev="fix_installation")); using ReactionMechanismSimulator'
 
       - name: Install Q2DTor
         run: echo "" | make q2dtor


### PR DESCRIPTION
### Motivation or Problem
I put togehter a RMS PR at https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/pull/256 to switch to use PythonCall.jl, CondaPkg.jl, and PythonPlot.jl from their old versions PyCall.jl, Conda.jl, and PyPlot.jl. I'm opening this PR to see if they are comtability with RMG.

### Description of Changes
A clear and concise description of what what you've changed or added.

### Testing
A clear and concise description of testing that you've done or plan to do.

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.