### PR TITLE
Make chemkin read of transport and thermo files more robust

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -951,7 +951,7 @@ def load_transport_file(path, species_dict, skip_missing_species=False):
                         continue
                 species = species_dict[label]
                 species.transport_data = TransportData(
-                    shapeIndex=int(data[0]),
+                    shapeIndex=int(float(data[0])),
                     sigma=(float(data[2]), 'angstrom'),
                     epsilon=(float(data[1]), 'K'),
                     dipoleMoment=(float(data[3]), 'De'),
@@ -1035,15 +1035,16 @@ def load_chemkin_file(path, dictionary_path=None, transport_path=None, read_comm
     # Read in the thermo data from the thermo file        
     if thermo_path:
         with open(thermo_path, 'r') as f:
-            line0 = f.readline()
+            line0 = None
             while line0 != '':
-                line = remove_comment_from_line(line0)[0]
-                line = line.strip()
+                previous_line = f.tell()
+                line0 = f.readline()
+                line = remove_comment_from_line(line0)[0].strip()
                 if 'THERM' in line.upper():
-                    f.seek(-len(line0), 1)
+                    f.seek(previous_line)
                     read_thermo_block(f, species_dict)
                     break
-                line0 = f.readline()
+                
     # Index the reactions now to have identical numbering as in Chemkin
     index = 0
     for reaction in reaction_list:


### PR DESCRIPTION
Make chemkin read of transport and thermo files more robust

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
I ran into these two issues while importing the Aramco 3.0 mechanism:
1. It couldn't read the separate thermo file because of the relative seek command, which apparently requires reading in binary format and gave this error message: `UnsupportedOperation: can't do nonzero cur-relative seeks`
2. It couldn't read the transport file because the shape_index column had been formatted as a float instead of an int.

### Description of Changes
1. Instead of using a relative f.seek() command, keep track of the previous line and just seek to that. This is how the file is parsed in the rest of chemkin.pyx.
2. Read in the shape_index as a float and then convert it to an int. This works whether the data is formatted as 0 or 0.000
--------------------------------------------------
### Testing
#### Part 1 - separate thermo file
1. For the separate thermo read: here is a mechanism split into [mech.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14804947/mech.txt), [species_dictionary.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14804949/species_dictionary.txt), [tran.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14804959/tran.txt), and [thermo.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14804960/thermo.txt) files.
Try reading it with the following code:
```
import rmgpy.chemkin

mech_file = 'mech.txt'
thermo = 'thermo.txt'
transport = 'tran.txt'
dictionary_path = 'species_dictionary.txt'

species_list, reaction_list = rmgpy.chemkin.load_chemkin_file(mech_file, dictionary_path=dictionary_path, transport_path=transport, thermo_path=thermo)
```

You should get the following error when trying this on main: `UnsupportedOperation: can't do nonzero cur-relative seeks` that is fixed on `readchemkin_robust_transthermo`

--------------------------------------------------
#### Part 2 - float issue
2. For the shape_index issue, you can test out this [full_mech.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14805007/full_mech.txt) [species_dictionary.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14804990/species_dictionary.txt), and
[tran_float.txt](https://github.com/ReactionMechanismGenerator/RMG-Py/files/14804992/tran_float.txt).

```
import rmgpy.chemkin
mech_file = 'full_mech.txt'
transport = 'tran_float.txt'
dictionary_path = 'species_dictionary.txt'
species_list, reaction_list = rmgpy.chemkin.load_chemkin_file(mech_file, dictionary_path=dictionary_path, transport_path=transport)
```

which will give you this error on main: `ValueError: invalid literal for int() with base 10: '0.0' ` that is fixed on `readchemkin_robust_transthermo`

### Reviewer Tips
I modified a .pyx file, so don't forget to rebuild RMG with `make`!

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
