### PR TITLE
FIx Handling of Initial Species with Seed Mechanisms

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -635,7 +635,10 @@ class CoreEdgeReactionModel:
                     display(new_species)  # if running in IPython --pylab mode, draws the picture!
 
                 # Add new species
-                reactions_moved_from_edge = self.add_species_to_core(new_species)
+                if new_species not in self.core.species:
+                    reactions_moved_from_edge = self.add_species_to_core(new_species)
+                else:
+                    reactions_moved_from_edge = []
 
             elif isinstance(new_object, tuple) and isinstance(new_object[0], PDepNetwork) and self.pressure_dependence:
                 pdep_network, new_species = new_object

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1582,7 +1582,8 @@ class CoreEdgeReactionModel:
 
         self.new_reaction_list = []
         self.new_species_list = []
-
+        edge_species_to_move = []
+        
         num_old_core_species = len(self.core.species)
         num_old_core_reactions = len(self.core.reactions)
 
@@ -1611,6 +1612,9 @@ class CoreEdgeReactionModel:
                     reversible=rxn.reversible,
                 )
             r, isNew = self.make_new_reaction(rxn)  # updates self.new_species_list and self.new_reaction_list
+            for s in rxn.reactants+rxn.products:
+                if s in self.edge.species and s not in edge_species_to_move:
+                    edge_species_to_move.append(s)
             if getattr(r.kinetics, "coverage_dependence", None):
                 self.process_coverage_dependence(r.kinetics)
             if not isNew:
@@ -1661,7 +1665,7 @@ class CoreEdgeReactionModel:
                         " explicitly allow it.".format(spec.label, seed_mechanism.label)
                     )
 
-        for spec in self.new_species_list:
+        for spec in edge_species_to_move+self.new_species_list:
             if spec.reactive:
                 submit(spec, self.solvent_name)
             if vapor_liquid_mass_transfer.enabled:


### PR DESCRIPTION
In #2649 it seems like we are having issues with adding seed mechanism containing a matching initial species while the initial species are in the edge. 

Because of how we process creating the initial core-edge and running estimation we add the initial species to the edge first later add the seed mechanisms and reaction libraries and lastly add the initial species to core and react them. 

In #2649 we run into a problem because the function for adding seed mechanisms searches for "site" and finds it (it is in the edge), since it finds it, it seems to assume it doesn't need to do anything which becomes a problem when it tries to add the associated reaction directly to core since "site" isn't in the core. 

I have modified add_seed_mechanism_to_core to track species that are in the edge and add them to core before adding the reactions. I have modified enlarge to be okay with reacting a species that has already been added to core. 

