### PR TITLE
add check for all zeros in thermo comparison

### DIFF
--- a/rmgpy/thermo/model.pyx
+++ b/rmgpy/thermo/model.pyx
@@ -163,13 +163,18 @@ cdef class HeatCapacityModel(RMGObject):
         
         Tdata = [300,400,500,600,800,1000,1500,2000]
         for T in Tdata:
-            if not (0.8 < self.get_heat_capacity(T) / other.get_heat_capacity(T) < 1.25):
+            # Do exact comparison in addition to relative in case both are zero (surface site)
+            if self.get_heat_capacity(T) != other.get_heat_capacity(T) and \
+                not (0.8 < self.get_heat_capacity(T) / other.get_heat_capacity(T) < 1.25):
                 return False
-            elif not (0.8 < self.get_enthalpy(T) / other.get_enthalpy(T) < 1.25):
+            elif self.get_enthalpy(T) != other.get_enthalpy(T) and \
+                not (0.8 < self.get_enthalpy(T) / other.get_enthalpy(T) < 1.25):
                 return False
-            elif not (0.8 < self.get_entropy(T) / other.get_entropy(T) < 1.25):
+            elif self.get_entropy(T) != other.get_entropy(T) and \
+                not (0.8 < self.get_entropy(T) / other.get_entropy(T) < 1.25):
                 return False
-            elif not (0.8 < self.get_free_energy(T) / other.get_free_energy(T) < 1.25):
+            elif self.get_free_energy(T) != other.get_free_energy(T) and \
+                not (0.8 < self.get_free_energy(T) / other.get_free_energy(T) < 1.25):
                 return False
 
         return True
@@ -185,13 +190,18 @@ cdef class HeatCapacityModel(RMGObject):
         
         Tdata = [300,400,500,600,800,1000,1500,2000]
         for T in Tdata:
-            if not (0.95 < self.get_heat_capacity(T) / other.get_heat_capacity(T) < 1.05):
+            # Do exact comparison in addition to relative in case both are zero (surface site)
+            if self.get_heat_capacity(T) != other.get_heat_capacity(T) and \
+                not (0.95 < self.get_heat_capacity(T) / other.get_heat_capacity(T) < 1.05):
                 return False
-            elif not (0.95 < self.get_enthalpy(T) / other.get_enthalpy(T) < 1.05):
+            elif self.get_enthalpy(T) != other.get_enthalpy(T) and \
+                not (0.95 < self.get_enthalpy(T) / other.get_enthalpy(T) < 1.05):
                 return False
-            elif not (0.95 < self.get_entropy(T) / other.get_entropy(T) < 1.05):
+            elif self.get_entropy(T) != other.get_entropy(T) and \
+                not (0.95 < self.get_entropy(T) / other.get_entropy(T) < 1.05):
                 return False
-            elif not (0.95 < self.get_free_energy(T) / other.get_free_energy(T) < 1.05):
+            elif self.get_free_energy(T) != other.get_free_energy(T) and \
+                not (0.95 < self.get_free_energy(T) / other.get_free_energy(T) < 1.05):
                 return False
 
         return True


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Bug fix for https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2657:

RMG returns false when you call thermo.is_identical_to() on identical vacant sites (all zeros for thermo)

### Description of Changes
This adds an exact check of the Tdata values at each temperature, in addition to the relative check which fails if both values are zero (divide by zero results in nan)

### Testing
Here's the script I used to demonstrate the problem/whether it's fixed:

```
import os
import rmgpy.data.thermo
import rmgpy

library_path = os.path.join(rmgpy.settings['database.directory'], 'thermo')
database = rmgpy.data.thermo.ThermoDatabase()
database.load(
    library_path,
    libraries = ['surfaceThermoPt111']
)

X_thermo_data = database.libraries['surfaceThermoPt111'].entries['vacant'].data
print(X_thermo_data)
print(X_thermo_data.is_identical_to(X_thermo_data))
print(X_thermo_data.is_similar_to(X_thermo_data))

database.libraries['surfaceThermoPt111'].entries['vacant'].data.is_identical_to(
    database.libraries['surfaceThermoPt111'].entries['vacant'].data  # <-- change values here to test on different entries
)
```

### Reviewer Tips
This is a .pyx file so remember to remake RMG
