### PR TITLE
Better debugging messages for database errors.

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -236,13 +236,17 @@ class Database(object):
             local_context[key] = value
 
         # Process the file
-        f = open(path, 'r')
+        with open(path, 'r') as f:
+            content = f.read()
         try:
-            exec(f.read(), global_context, local_context)
-        except Exception:
-            logging.error('Error while reading database {0!r}.'.format(path))
+            exec(content, global_context, local_context)
+        except Exception as e:
+            logging.exception(f'Error while reading database file {path}.')
+            line_number = e.__traceback__.tb_next.tb_lineno
+            logging.error(f'Error occurred at or near line {line_number} of {path}.')
+            lines = content.splitlines()
+            logging.error(f'Line: {lines[line_number - 1]}')
             raise
-        f.close()
 
         # Extract the database metadata
         self.name = local_context['name']


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
When there are issues in a database file, such as nan values like `uncertainty=RateUncertainty(mu=nan, var=nan,` in a `rules.py` file (which may be due to a bug in the tree fitting), it was very hard to  find the cause of the error because the stack trace wouldn't tell you where the actual error was in the file, and the file handle had been read by the time you caught the exception, making it misleading in a debugger.

### Description of Changes
With this change, we first read the file to a variable, then try executing it, and catch and report any exceptions properly, finding the line within the database file that caused the problem.

### Testing
I got this working and it helped debug something, providing this error message:

```
ERROR:root:Error while reading database /Users/rwest/Code/RMG-database/input/kinetics/families/Intra_R_Add_Endocyclic/rules.py.
Traceback (most recent call last):
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/base.py", line 242, in load
    exec(content, global_context, local_context)
  File "<string>", line 3732, in <module>
TypeError: 'NoneType' object is not subscriptable
ERROR:root:Error occurred at line 3732 of /Users/rwest/Code/RMG-database/input/kinetics/families/Intra_R_Add_Endocyclic/rules.py.
ERROR:root:Line:     kinetics = ArrheniusBM(A=(1.17041e-45,'s^-1'), n=16.4585, w0=(289.5,'kJ/mol'), E0=(7.90103,'kJ/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=nan, var=nan, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R-inRing_N-3R->O_Ext-3CS-R_N-Sp-4R!H=3CCSS_Ext-3CS-R_Ext-5R!H-R_N-Sp-6R!H=5R!H_3CS-inRing_N-Sp-2R=1R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R-inRing_N-3R->O_Ext-3CS-R_N-Sp-4R!H=3CCSS_Ext-3CS-R_Ext-5R!H-R_N-Sp-6R!H=5R!H_3CS-inRing_N-Sp-2R=1R
```
before continuing with the rest of the stack trace
```
ERROR:root:Error when loading reaction family '/Users/rwest/Code/RMG-database/input/kinetics/families/Intra_R_Add_Endocyclic'
Traceback (most recent call last):
  File "/Users/rwest/miniconda3/envs/rmg_env7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/rwest/miniconda3/envs/rmg_env7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/rwest/.vscode/extensions/ms-python.debugpy-2024.6.0-darwin-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/Users/rwest/.vscode/extensions/ms-python.debugpy-2024.6.0-darwin-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/Users/rwest/.vscode/extensions/ms-python.debugpy-2024.6.0-darwin-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/Users/rwest/.vscode/extensions/ms-python.debugpy-2024.6.0-darwin-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 322, in run_path
    pkg_name=pkg_name, script_name=fname)
  File "/Users/rwest/.vscode/extensions/ms-python.debugpy-2024.6.0-darwin-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 136, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/Users/rwest/.vscode/extensions/ms-python.debugpy-2024.6.0-darwin-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/Users/rwest/Code/blahblahblah.py", line 54, in <module>
    depository = False,
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/rmg.py", line 103, in load
    kinetics_depositories
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/rmg.py", line 172, in load_kinetics
    depositories=kinetics_depositories
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/kinetics/database.py", line 111, in load
    self.load_recommended_families(os.path.join(path, 'families', 'recommended.py')),
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/kinetics/database.py", line 215, in load_families
    try:
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/kinetics/family.py", line 761, in load
    index += 1
  File "/Users/rwest/Code/RMG-Py/rmgpy/data/base.py", line 242, in load
    exec(content, global_context, local_context)
  File "<string>", line 3732, in <module>
TypeError: 'NoneType' object is not subscriptable
```

Before, it would just point you to `  File "/Users/rwest/Code/RMG-Py/rmgpy/data/base.py", line 242, in load` which is the `exec(content, global_context, local_context)` line, and not very informative.

### Reviewer Tips
Not much to check here.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
