### PR TITLE
Send P in SI units to Chebyshev.fit_to_data() when reversing a rate

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1030,15 +1030,15 @@ class Reaction:
             return self.reverse_arrhenius_rate(kf, kunits)
 
         elif isinstance(kf, Chebyshev):
-            Tlist = 1.0 / np.linspace(1.0 / kf.Tmax.value, 1.0 / kf.Tmin.value, 50)
-            Plist = np.linspace(kf.Pmin.value, kf.Pmax.value, 20)
+            Tlist = 1.0 / np.linspace(1.0 / kf.Tmax.value_si, 1.0 / kf.Tmin.value_si, 50)
+            Plist = np.linspace(kf.Pmin.value_si, kf.Pmax.value_si, 20)
             K = np.zeros((len(Tlist), len(Plist)), float)
             for Tindex, T in enumerate(Tlist):
                 for Pindex, P in enumerate(Plist):
                     K[Tindex, Pindex] = kf.get_rate_coefficient(T, P) / self.get_equilibrium_constant(T)
             kr = Chebyshev()
-            kr.fit_to_data(Tlist, Plist, K, kunits, kf.degreeT, kf.degreeP, kf.Tmin.value, kf.Tmax.value, kf.Pmin.value,
-                         kf.Pmax.value)
+            kr.fit_to_data(Tlist, Plist, K, kunits, kf.degreeT, kf.degreeP, kf.Tmin.value, kf.Tmax.value,
+                           kf.Pmin.value_si, kf.Pmax.value_si)
             return kr
 
         elif isinstance(kf, PDepArrhenius):


### PR DESCRIPTION
The Chebyshev.fit_to_data() method treats the Pmin and Pmax args as SI (Pa units), see here for example: `self.Pmin = (Pmin * 1e-5, "bar")`. Make sure we transmit the arguments in SI units and not in the arbitrary units they were defined in.