### PR TITLE
Load a kinetic library not in the RMG database

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -49,7 +49,7 @@ by Benson's method.
 
 For example, if you wish to use the GRI-Mech 3.0 mechanism [GRIMech3.0]_ as a ThermoLibrary in your model, the syntax will be::
 
-	thermoLibraries = ['primaryThermoLibrary','GRI-Mech3.0']
+	thermoLibraries = ['primaryThermoLibrary', 'GRI-Mech3.0']
 
 .. [GRIMech3.0] Gregory P. Smith, David M. Golden, Michael Frenklach, Nigel W. Moriarty, Boris Eiteneer, Mikhail Goldenberg, C. Thomas Bowman, Ronald K. Hanson, Soonho Song, William C. Gardiner, Jr., Vitali V. Lissianski, and Zhiwei Qin http://combustion.berkeley.edu/gri-mech/
 
@@ -78,7 +78,7 @@ In the following example, the user has created
 a reaction library with a few additional reactions specific to n-butane, and these reactions
 are to be used in addition to the Glarborg C3 library::
 
-	reactionLibraries = [('Glarborg/C3',False)],
+	reactionLibraries = [('Glarborg/C3', False)],
 
 The keyword False/True permits user to append all unused reactions (= kept in the edge) from this library to the chemkin file.
 True means those reactions will be appended. Using just the string inputs would lead to
@@ -103,6 +103,23 @@ given in each mechanism, the different mechanisms can have different units.
 	RMG will not handle irreversible reactions correctly, if supplied in a Reaction
 	Library.
 
+
+.. _externallib:
+
+External Libraries
+------------------
+Users may direct RMG to use thermo and/or kinetic libraries which are not included in the RMG database,
+e.g., a library a user created that was intentionally saved to a path different than the conventional
+RMG-database location. In such cases, the user can specify the full path to the library in the input file::
+
+    thermoLibraries = ['path/to/your/thermo/library/file.py']
+
+or::
+
+    reactionLibraries = [(path/to/your/kinetic/library/folder/']
+
+Combinations in any order of RMG's legacy libraries and users' external libraries are allowed,
+and the order in which the libraries are specified is the order in which they are loaded and given priority.
 
 .. _seedmechanism:
 

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -234,7 +234,7 @@ class KineticsDatabase(object):
                 library_file = os.path.join(path, library_name, 'reactions.py')
                 if os.path.exists(library_name):
                     library_file = os.path.join(library_name, 'reactions.py')
-                    short_library_name = os.path.split(library_name)[-1]
+                    short_library_name = os.path.basename(library_name.rstrip(os.path.sep))
                     logging.info(f'Loading kinetics library {short_library_name} from {library_name}...')
                     library = KineticsLibrary(label=short_library_name)
                     library.load(library_file, self.local_context, self.global_context)

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -62,6 +62,7 @@ class KineticsDatabase(object):
         self.recommended_families = {}
         self.families = {}
         self.libraries = {}
+        self.external_library_labels = {}
         self.library_order = []  # a list of tuples in the format ('library_label', LibraryType),
                                  # where LibraryType is set to either 'Reaction Library' or 'Seed'.
         self.local_context = {
@@ -227,7 +228,7 @@ class KineticsDatabase(object):
         The `path` points to the folder of kinetics libraries in the database,
         and the libraries should be in files like :file:`<path>/<library>.py`.
         """
-
+        self.external_library_labels = dict()
         if libraries is not None:
             for library_name in libraries:
                 library_file = os.path.join(path, library_name, 'reactions.py')
@@ -238,6 +239,7 @@ class KineticsDatabase(object):
                     library = KineticsLibrary(label=short_library_name)
                     library.load(library_file, self.local_context, self.global_context)
                     self.libraries[library.label] = library
+                    self.external_library_labels[library_name] = library.label
                 elif os.path.exists(library_file):
                     logging.info(f'Loading kinetics library {library_name} from {library_file}...')
                     library = KineticsLibrary(label=library_name)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1718,7 +1718,12 @@ class CoreEdgeReactionModel:
         num_old_edge_reactions = len(self.edge.reactions)
 
         logging.info("Adding reaction library {0} to model edge...".format(reaction_library))
-        reaction_library = database.kinetics.libraries[reaction_library]
+        if reaction_library in database.kinetics.libraries:
+            reaction_library = database.kinetics.libraries[reaction_library]
+        elif reaction_library in database.kinetics.external_library_labels:
+            reaction_library = database.kinetics.libraries[database.kinetics.external_library_labels[reaction_library]]
+        else:
+            raise ValueError(f'Library {reaction_library} not found.')
 
         rxns = reaction_library.get_library_reactions()
         for rxn in rxns:


### PR DESCRIPTION
### Motivation or Problem
Previously a feature (#2340) was added to allow RMG to load external thermo and kinetic libraries. That feature was incomplete, since reaction libraries are stored by their label, and RMG tries to load them by the name provided by the user which is their path.
This issue is not relevant for thermo libraries which are loaded differently in RMG.

### Description of Changes
A dictionary was added to `KineticsDatabase` to map paths to external kinetic libraries with their labels. It is used now in model.py if needed.

### Testing
The feature was tested locally only. Any tips for adding a path (absolute? relative?) to an RMG input file are welcomed to modify [the existing test](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/main/examples/rmg/external_library/input.py#L9).

### Reviewer Tips
Copy one of the RMG kinetic libraries to a different path and provide the full path in any RMG input file to see that RMG now loads the relevant library correctly.
