### PR TITLE
Switch `muq`, `lpsolve55`, and `RingDecomposerLib` from `rmg` to `conda-forge`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 #
 ################################################################################
 
+CC=gcc
+CXX=g++
+
 .PHONY : all minimal main solver check pycheck arkane clean install decython documentation test q2dtor
 
 all: pycheck main solver check

--- a/environment.yml
+++ b/environment.yml
@@ -81,13 +81,13 @@ dependencies:
   - conda-forge::gprof2dot
   - conda-forge::numdifftools
   - conda-forge::quantities
+  - conda-forge::muq
+  - conda-forge::lpsolve55
+  - conda-forge::ringdecomposerlib-python
 
 # packages we maintain
-  - rmg::lpsolve55
-  - rmg::muq2
   - rmg::pydas >=1.0.3
   - rmg::pydqed >=1.0.3
-  - rmg::pyrdl
   - rmg::pyrms
   - rmg::symmetry
 


### PR DESCRIPTION
This PR changes a number of `rmg` channel packages to their official `conda-forge` variants maintained by other people:
 - `rmg::muq2` -> `conda-forge::muq` (different name, same version)
 - `rmg::lpsolve55` -> `conda-forge::lpsolve55`
 - `rmg::py_rdl` -> `conda-forge::ringdecomposerlib-python` (different name, same package and version)

The first change also required adding a new line to the `Makefile` to ensure that correct compiler is used when installing RMG.
