### PR TITLE
fix species_to_dict function to use correct parameter as reaction species

### DIFF
--- a/rmgpy/cantera_.py
+++ b/rmgpy/cantera_.py
@@ -302,18 +302,18 @@ def reaction_to_dicts(obj, spcs):
 
 def species_to_dict(obj, spc, names=None, label="solvent"):
     """
-    Takes an RMG species object (spc), returns a list of dictionaries
+    Takes an RMG species object (obj), returns a list of dictionaries
     for YAML properties. Also adds in the number of surface sites
     ('sites') to dictionary.
     """
 
     result_dict = dict()
 
-    if isinstance(spc, Species):
-        s = spc.to_cantera(use_chemkin_identifier=True)
+    if isinstance(obj, Species):
+        s = obj.to_cantera(use_chemkin_identifier=True)
         species_data = s.input_data
         try:
-            result_dict["note"] = spc.transport_data.comment
+            result_dict["note"] = obj.transport_data.comment
         except:
             pass
         if "size" in species_data:
@@ -324,6 +324,8 @@ def species_to_dict(obj, spc, names=None, label="solvent"):
         return (
             species_data  # returns composition, name, thermo, and transport, and note
         )
+    else:
+        raise Exception("Species object must be an RMG Species object")
 
 
 class CanteraWriter(object):


### PR DESCRIPTION
### Motivation or Problem
The yaml_writer_addition branch no longer correctly adds reaction species to the Cantera yaml output file. Species block is always a list of nulls. This issue originated during a rebase of the branch.

### Description of Changes

* changes to `rmgpy/cantera_.py`:
    - `species_to_dict()` method updated to correctly use the parameter `obj` as the RMG species object.

### Testing
Tested on minimal example and minimal_surface example (minimal_surface errors unless commit [feb70e2](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2321/commits/feb70e275fe16e53a14788c83bc7b9404dc7510f) is reverted/fixed)

### Reviewer Tips
Comment out the temporary "raise exception" calls in `to_cantera_kinetics()` to test on any example that requires this method.
