### PR TITLE
Patch `minimal_surface` Regression Test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
         id: regression-execution
         timeout-minutes: 60
         run: |
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation RMS_liquidSurface_ch4o2cat fragment RMS_constantVIdealGasReactor_fragment minimal_surface;
           do
             if python-jl rmg.py test/regression/"$regr_test"/input.py; then
               echo "$regr_test" "Executed Successfully"
@@ -243,7 +243,7 @@ jobs:
         run: |
           exec 2> >(tee -a regression.stderr >&2) 1> >(tee -a regression.stdout)
           mkdir -p "test/regression-diff"
-          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation fragment RMS_constantVIdealGasReactor_fragment;
+          for regr_test in aromatics liquid_oxidation nitrogen oxidation sulfur superminimal RMS_constantVIdealGasReactor_superminimal RMS_CSTR_liquid_oxidation fragment RMS_constantVIdealGasReactor_fragment minimal_surface;
           do
             echo ""
             echo "### Regression test $regr_test:"

--- a/test/regression/minimal_surface/input.py
+++ b/test/regression/minimal_surface/input.py
@@ -104,7 +104,8 @@ model(
     toleranceKeepInEdge=0.0,
     toleranceMoveToCore=1e-1,
     toleranceInterruptSimulation=0.1,
-    maximumEdgeSpecies=100000,
+    maximumEdgeSpecies=100,
+    maxNumSpecies=10,
 )
 options(
     units='si',


### PR DESCRIPTION
Edit 9/15/24: the runner is crashing due to OOM errors. There is a solution to this that involves reducing the memory usage in the regression tests, but implementing this solution is hard. We have opted for an easier solution: severely limit the size of the mechanism. This does not cover as much 'science' as we would like the regression test to do, but does at least offer some basic correctness checks. At this point this is preferable to not testing at all, as we are currently doing since the 'better' solution is quite challenging.

Original PR content follows:

### Problem
I discovered in #2595 and #2669 that the `minimal_surface` regression test comparison causes the runners to crash with exit code 143. To allow things to still be merged in the meantime, I have removed that test from the CI and intend to fix it in this PR.

### TODO:
 - diagnose the issue(s)
 - implement a patch
 - drop 862adb831fdb2e43f36f13c94704932b506dfea0
 - merge, hopefully passing all tests (unit and regression)

Calling in @sevyharris for some help on this one!
