### PR TITLE
switch `rmg::lpsolve55` to `conda-forge::lpsolve55` channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -81,9 +81,9 @@ dependencies:
   - conda-forge::gprof2dot
   - conda-forge::numdifftools
   - conda-forge::quantities
+  - conda-forge::lpsolve55
 
 # packages we maintain
-  - rmg::lpsolve55
   - rmg::muq2
   - rmg::pydas >=1.0.3
   - rmg::pydqed >=1.0.3


### PR DESCRIPTION
In the same vein as #2671, I just discovered that someone has been thanklessly maintaining an official `conda-forge` binary of `lpsolve55`: https://github.com/conda-forge/lpsolve55-feedstock

This PR will see if it works for us.