### PR TITLE
switch `rmg::pyrdl` to `conda-forge::ringdecomposerlib-python`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -81,6 +81,7 @@ dependencies:
   - conda-forge::gprof2dot
   - conda-forge::numdifftools
   - conda-forge::quantities
+  - conda-forge::ringdecomposerlib-python
 
 # packages we maintain
   - rmg::lpsolve55


### PR DESCRIPTION
Also also like number #2680 it turns out that `pyrdl` is also already on `conda-forge`, and @mjohnson541 was the one who prompted the developers to get it listed! See: https://github.com/conda-forge/staged-recipes/pull/19942

This PR will test if it works for us