### PR TITLE
Pdep spin conservation

### DIFF
--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -436,6 +436,7 @@ and immediately used in input files without any additional changes.
         reaction_list = []
         if only_families is None:
             reaction_list.extend(self.generate_reactions_from_libraries(reactants, products))
+        
         reaction_list.extend(self.generate_reactions_from_families(reactants, products,
                                                                    only_families=only_families, resonance=resonance))
         return reaction_list

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1992,7 +1992,7 @@ class KineticsFamily(Database):
                 specified reactants and products within this family.
             Degenerate reactions are returned as separate reactions.
         """
-
+        check_spin = True
         rxn_list = []
 
         # Wrap each reactant in a list if not already done (this is done to
@@ -2048,7 +2048,9 @@ class KineticsFamily(Database):
                             pass
                         else:
                             if product_structures is not None:
-                                rxn = self._create_reaction(reactant_structures, product_structures, forward)
+                                if self.label in allowed_spin_violation_families:
+                                    check_spin = False
+                                rxn = self._create_reaction(reactant_structures, product_structures, forward, check_spin = check_spin)
                                 if rxn:
                                     rxn_list.append(rxn)
         # Bimolecular reactants: A + B --> products
@@ -2091,7 +2093,9 @@ class KineticsFamily(Database):
                                     pass
                                 else:
                                     if product_structures is not None:
-                                        rxn = self._create_reaction(reactant_structures, product_structures, forward)
+                                        if self.label in allowed_spin_violation_families:
+                                            check_spin = False
+                                        rxn = self._create_reaction(reactant_structures, product_structures, forward, check_spin = check_spin)
                                         if rxn:
                                             rxn_list.append(rxn)
 
@@ -2115,8 +2119,9 @@ class KineticsFamily(Database):
                                         pass
                                     else:
                                         if product_structures is not None:
-                                            rxn = self._create_reaction(reactant_structures, product_structures,
-                                                                        forward)
+                                            if self.label in allowed_spin_violation_families:
+                                               check_spin = False
+                                            rxn = self._create_reaction(reactant_structures, product_structures, forward, check_spin = check_spin)
                                             if rxn:
                                                 rxn_list.append(rxn)
 
@@ -2169,7 +2174,9 @@ class KineticsFamily(Database):
                             pass
                         else:
                             if product_structures is not None:
-                                rxn = self._create_reaction(reactant_structures, product_structures, forward)
+                                if self.label in allowed_spin_violation_families:
+                                    check_spin = False
+                                rxn = self._create_reaction(reactant_structures, product_structures, forward, check_spin = check_spin)
                                 if rxn:
                                     rxn_list.append(rxn)
             else:
@@ -2234,7 +2241,9 @@ class KineticsFamily(Database):
                             pass
                         else:
                             if product_structures is not None:
-                                rxn = self._create_reaction(reactant_structures, product_structures, forward)
+                                if self.label in allowed_spin_violation_families:
+                                    check_spin = False
+                                rxn = self._create_reaction(reactant_structures, product_structures, forward, check_spin = check_spin)
                                 if rxn:
                                     rxn_list.append(rxn)
 
@@ -4926,3 +4935,5 @@ def get_site_solute_data(rxn):
         return site_data
     else:
         return None
+
+allowed_spin_violation_families =['1,2-Birad_to_alkene','1,4_Cyclic_birad_scission','1,4_Linear_birad_scission']

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -59,6 +59,7 @@ from rmgpy.molecule.graph import Vertex, Edge, Graph, get_vertex_connectivity_va
 from rmgpy.molecule.kekulize import kekulize
 from rmgpy.molecule.pathfinder import find_shortest_path
 from rmgpy.molecule.fragment import CuttingLabel
+from rmgpy.molecule.util import generate_closed_shell_singlet, generate_singlet_diradicals
 
 ################################################################################
 
@@ -3005,6 +3006,20 @@ class Molecule(Graph):
                 logging.debug("After removing from surface:\n" + desorbed_molecule.to_adjacency_list())
 
         return desorbed_molecules
+    def update_to_closed_shell_singlet(self):
+        for i in range(len(self.atoms)):
+                self.atoms[i].id = i
+        assert self.multiplicity == 1 and self.get_radical_count()>0
+        radical_center_ids = [x.id for x in self.atoms if x.radical_electrons > 0]
+        # remove radicals from radical centers (2)
+        for radical_center_id in radical_center_ids:
+            self.atoms[radical_center_id].decrement_radical()
+        # add removed radicals (2) to one of the radical sites as a lone pair (1)
+        self.atoms[radical_center_ids[0]].increment_lone_pairs()
+        # pick the best resonance structure
+        self.generate_resonance_structures()
+        self.reactive = True
+
 
 # this variable is used to name atom IDs so that there are as few conflicts by 
 # using the entire space of integer objects

--- a/rmgpy/molecule/util.py
+++ b/rmgpy/molecule/util.py
@@ -179,3 +179,42 @@ def swap(to_be_swapped, sample):
     new_partner = (to_be_swapped - sample).pop()
 
     return central, original, new_partner
+
+def generate_closed_shell_singlet(m: Molecule):
+    for i in range(len(m.atoms)):
+            m.atoms[i].id = i
+    assert m.multiplicity == 1 and m.get_radical_count()>0
+    radical_center_ids = [x.id for x in m.atoms if x.radical_electrons > 0]
+    # remove radicals from radical centers (2)
+    for radical_center_id in radical_center_ids:
+        m.atoms[radical_center_id].decrement_radical()
+    # add removed radicals (2) to one of the radical sites as a lone pair (1)
+    m.atoms[radical_center_ids[0]].increment_lone_pairs()
+    # pick the best resonance structure
+    print([x.smiles for x in m.generate_resonance_structures()])
+    return m.generate_resonance_structures()[0]
+
+def generate_singlet_diradicals(m: Molecule):
+    for i in range(len(m.atoms)):
+        m.atoms[i].id = i
+    
+    singlet_diradicals = [] 
+    for edge in m.get_all_edges():
+        
+        M = m.copy(deep=True) 
+        if edge.get_order_num() > 1: # find a pi bond
+            atom1_id = edge.atom1.id
+            atom2_id = edge.atom2.id
+            M.atoms[atom1_id].increment_radical()  # add a radical to each atom of the pi bond
+            M.atoms[atom2_id].increment_radical()
+            M.get_bond(M.atoms[atom1_id], M.atoms[atom2_id]).decrement_order() # remove 1 pi bond
+            potential_singlet_diradicals = M.generate_resonance_structures()  # generate resonance structures
+            
+            for potential_singlet_diradical in potential_singlet_diradicals: # find all resonance structures with non-neighboring radical sites
+                radical_center_ids = sorted([x.id for x in potential_singlet_diradical.atoms if x.radical_electrons==1]) 
+                potential_singlet_diradical_edges = potential_singlet_diradical.get_all_edges()
+                potential_singlet_diradical_edge_ids = [sorted([x.atom1.id, x.atom2.id]) for x in potential_singlet_diradical_edges]
+                if radical_center_ids not in potential_singlet_diradical_edge_ids:
+                    if potential_singlet_diradical not in singlet_diradicals:
+                        singlet_diradicals.append(potential_singlet_diradical)
+    return singlet_diradicals

--- a/rmgpy/rmg/decay.py
+++ b/rmgpy/rmg/decay.py
@@ -47,7 +47,461 @@ decay_group_recipe_pairs = [(Group().from_adjacency_list("""
     ['LOSE_RADICAL', '*1','1'],
     ['GAIN_RADICAL','*3','1']
     ])),
-                            ]
+
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 O u0 p3 c-1 {2,S}
+2 *1 N  u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+3 *2 N  u1 p1 c0 {2,S} {4,S}
+4 O u0 p2 c0 {3,S} {7,S}
+5 *3 N  u1 p1 c0 {2,S} {8,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*1', 1, '*3'],
+    ['LOSE_RADICAL', '*3','1'],
+    ['GAIN_RADICAL','*2','1']
+ ])),       
+
+    
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *3 O u0 p3 c-1 {2,S}
+2 *5 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+3 *4 N u0 p1 c0 {2,S} {4,D}
+4 *1 N u0 p1 c0 {3,D} {7,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 *2 H u0 p0 c0 {4,S}
+"""),
+ ReactionRecipe(actions=[
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['BREAK_BOND', '*4', 1, '*5'],
+    ['FORM_BOND', '*2', 1, '*3'],
+    ['CHANGE_BOND', '*1', 1, '*4'],
+    ['LOSE_PAIR', '*3', 1],
+    ['GAIN_PAIR', '*5', 1],
+    
+ ])),          
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *5 N u0 p2 c-1 {2,S} {5,S}
+2 *4 O u0 p2 c0 {1,S} {3,S}
+3 *3 O u0 p2 c0 {2,S} {4,S}
+4 *2 N u0 p1 c0 {3,S} {5,S} {6,S}
+5 *1 N u0 p0 c+1 {1,S} {4,S} {7,S} {8,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+    ['BREAK_BOND', '*3', 1, '*4'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*2', 1, '*3'],
+    ['CHANGE_BOND', '*5', 1, '*4'],
+    ['LOSE_PAIR', '*5', 1],
+    ['GAIN_PAIR', '*1', 1],
+    
+ ])),    
+
+(Group().from_adjacency_list("""
+multiplicity [2]
+1 *4 O u0 p2 c0 {2,S} {6,S}
+2 *3 N u0 p1 c0 {1,S} {3,D}
+3 *1 N u0 p0 c+1 {2,D} {4,S} {5,S}
+4 *6 O u0 p2 c0 {3,S} {7,S}
+5 *2 N u1 p2 c-1 {3,S}
+6 *5 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {4,S}
+"""),
+ ReactionRecipe(actions=[
+    ['FORM_BOND', '*5', 1, '*6'],
+    ['BREAK_BOND', '*1', 1, '*6'],
+    ['BREAK_BOND', '*1', 2, '*3'],
+    ['BREAK_BOND', '*4', 1, '*5'],
+    ['CHANGE_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*1', 2, '*2'],
+    ['GAIN_RADICAL', '*3', '1'],
+    ['LOSE_RADICAL', '*2', '1'],
+    ['LOSE_PAIR', '*2', 1],
+    ['GAIN_PAIR', '*1', 1],
+    
+    
+ ])),    
+
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *1 N u2 p1 c0 {2,S}
+2 *2 N u0 p1 c0 {1,S} {3,S} {5,S}
+3 *3 N u0 p1 c0 {2,S} {4,S} {6,S}
+4 O u0 p2 c0 {3,S} {5,S}
+5 *4 O u0 p2 c0 {2,S} {4,S}
+6 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2', 1, '*3'],
+     ['BREAK_BOND', '*2', 1, '*4'],
+     ['CHANGE_BOND', '*1',2,'*2'],
+     ['LOSE_RADICAL','*1',2],
+     ['GAIN_RADICAL','*3',1],
+     ['GAIN_RADICAL','*4',1],
+    
+    
+ ])),    
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *1 N u2 p1 c0 {2,S}
+2 *2 O u0 p2 c0 {1,S} {3,S}
+3 *3 O u0 p2 c0 {2,S} {4,S}
+4 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['LOSE_RADICAL','*1',1],
+     ['GAIN_RADICAL','*3',1],
+ ])),    
+
+
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 N u0 p2 c-1 {2,D}
+2 *2 N u0 p0 c+1 {1,D} {3,S} {4,S}
+3 *4 O u0 p2 c0 {2,S} {4,S}
+4 *3 N u0 p1 c0 {2,S} {3,S} {5,S}
+5 O u0 p2 c0 {4,S} {6,S}
+6 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*4'],
+     ['CHANGE_BOND','*3',1,'*4'],
+     ['GAIN_PAIR','*2',1],
+     ['LOSE_PAIR','*3',1],
+     
+ ])),   
+
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 N u0 p2 c-1 {2,S} {5,S}
+2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {6,S}
+3 *3 N u0 p1 c0 {2,S} {4,S} {7,S}
+4 *4 O u0 p2 c0 {2,S} {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*4'],
+     ['CHANGE_BOND','*3',1,'*4'],
+     ['GAIN_PAIR','*2',1],
+     ['LOSE_PAIR','*3',1],
+     
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 O u0 p3 c-1 {2,S}
+2 *2 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+3 *3 N u0 p1 c0 {2,S} {4,D}
+4 *4 N u0 p1 c0 {3,D} {7,S}
+5 O u0 p2 c0 {2,S} {8,S}
+6 H u0 p0 c0 {2,S}
+7 *5 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+     ['FORM_BOND', '*1',1,'*5'],
+     ['BREAK_BOND','*4',1,'*5'],
+     ['CHANGE_BOND','*3',1,'*4'],
+     ['BREAK_BOND','*2',1,'*3'],
+     ['GAIN_PAIR','*2',1],
+     ['LOSE_PAIR','*1',1],
+     
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *1 N u1 p2 c-1 {2,S}
+2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {5,S}
+3 O u1 p2 c0 {2,S}
+4 N u0 p1 c0 {2,S} {5,S} {6,S}
+5 *3 O u0 p2 c0 {2,S} {4,S}
+6 H u0 p0 c0 {4,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND','*2',1,'*3'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['GAIN_RADICAL','*3',1],
+     ['LOSE_RADICAL','*1',1],
+     
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 N u0 p1 c0 {2,D} {6,S}
+2 *5 N u0 p1 c0 {1,D} {3,S}
+3 *4 O u0 p2 c0 {2,S} {4,S}
+4 *3 N u0 p1 c0 {3,S} {5,D}
+5 O u0 p2 c0 {4,D}
+6 *2 H u0 p0 c0 {1,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND','*4',1,'*5'],
+     ['BREAK_BOND', '*1',1,'*2'],
+     ['FORM_BOND','*2',1,'*3'],
+     ['GAIN_PAIR','*4',1],
+     ['CHANGE_BOND','*1',1,'*5'],
+     ['LOSE_PAIR','*3',1],
+     
+ ])), 
+
+(Group().from_adjacency_list(""" 
+multiplicity [1]
+1 N u0 p2 c-1 {2,D}
+2 *1 N u0 p0 c+1 {1,D} {3,S} {4,S}
+3 *2 N u0 p1 c0 {2,S} {4,S} {5,S}
+4 *3 O u0 p2 c0 {2,S} {3,S}
+5 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND','*1',1,'*3'],
+     ['CHANGE_BOND','*2',1,'*3'],
+     ['GAIN_PAIR','*1',1],
+     ['LOSE_PAIR','*2',1],
+     
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *1 N u1 p1 c0 {2,S} {5,S}
+2 *2 N u0 p1 c0 {1,S} {3,D}
+3 *3 N u0 p1 c0 {2,D} {4,S}
+4 *4 O u1 p2 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND','*2',2,'*3'],
+     ['CHANGE_BOND','*4',1,'*3'],
+     ['CHANGE_BOND','*1',1,'*2'],
+     ['GAIN_RADICAL','*3',1],
+     ['LOSE_RADICAL','*4',1],
+     ['GAIN_RADICAL','*2',1],
+     ['LOSE_RADICAL','*1',1],
+     
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 O u0 p3 c-1 {2,S}
+2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {6,S}
+3 *3 O u0 p2 c0 {2,S} {4,S}
+4 *4 N u0 p1 c0 {2,S} {3,S} {5,S}
+5 *5 N u0 p1 c0 {4,S} {7,S} {8,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['BREAK_BOND', '*2',1,'*4'],
+     ['CHANGE_BOND', '*3',1,'*4'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['LOSE_PAIR','*1',1],
+     ['GAIN_PAIR','*2',1],
+     
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [2]
+1 *2 N u0 p2 c-1 {2,S} {4,S}
+2 *3 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+3 N u0 p1 c0 {2,S} {7,S} {8,S}
+4 *1 O u1 p2 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['LOSE_RADICAL','*1',1],
+     ['GAIN_RADICAL','*2',1],
+     ['LOSE_PAIR','*2',1],
+     ['GAIN_PAIR','*3',1],
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 N u0 p2 c-1 {2,S} {6,S}
+2 *2 N u0 p0 c+1 {1,S} {3,S} {7,S} {8,S}
+3 *4 O u0 p2 c0 {2,S} {4,S}
+4 N u0 p1 c0 {3,S} {5,D}
+5 O u0 p2 c0 {4,D}
+6 H u0 p0 c0 {1,S}
+7 *3 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['BREAK_BOND', '*2',1,'*4'],
+     ['FORM_BOND','*3',1,'*4'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['LOSE_PAIR','*1',1],
+     ['GAIN_PAIR','*2',1],
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *3 N u2 p1 c0 {2,S}
+2 *2 N u0 p1 c0 {1,S} {3,S} {5,S}
+3 *4 N u0 p1 c0 {2,S} {4,D}
+4 O u0 p2 c0 {3,D}
+5 *1 O u0 p2 c0 {2,S} {6,S}
+6 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*1'],
+     ['BREAK_BOND', '*2',1,'*4'],
+     ['CHANGE_BOND', '*3',2,'*2'],
+     ['LOSE_RADICAL','*3',2],
+     ['GAIN_RADICAL','*1',1],
+     ['GAIN_RADICAL','*4',1],
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *2 N u0 p2 c-1 {2,S} {5,S}
+2 *3 O u0 p2 c0 {1,S} {3,S}
+3 *4 N u0 p1 c0 {2,S} {4,S} {6,S}
+4 *5 O u0 p2 c0 {3,S} {5,S}
+5 *1 N u0 p0 c+1 {1,S} {4,S} {7,S} {8,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*5',1,'*1'],
+     ['BREAK_BOND', '*3',1,'*4'],
+     ['CHANGE_BOND', '*4',1,'*5'],
+     ['CHANGE_BOND', '*2',1,'*3'],
+     ['LOSE_PAIR','*2',1],
+     ['GAIN_PAIR','*1',1],
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [1]
+1 *1 O u0 p3 c-1 {2,S}
+2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {5,S}
+3 N u0 p1 c0 {2,S} {6,S} {7,S}
+4 *3 N u0 p1 c0 {2,S} {5,S} {8,S}
+5 *4 O u0 p2 c0 {2,S} {4,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {4,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['BREAK_BOND', '*2',1,'*4'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['CHANGE_BOND', '*4',1,'*3'],
+     ['LOSE_PAIR','*1',1],
+     ['GAIN_PAIR','*2',1],
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *4 N u1 p1 c0 {2,S} {5,S}
+2 *3 N u0 p1 c0 {1,S} {3,S} {6,S}
+3 *2 O u0 p2 c0 {2,S} {4,S}
+4 *1 O u1 p2 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['CHANGE_BOND', '*4',1,'*3'],
+     ['LOSE_RADICAL','*4',1],
+     ['GAIN_RADICAL','*2',1],
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [2]
+1 *1 O u0 p3 c-1 {2,S}
+2 *2 O u0 p2 c0 {1,S} {3,S}
+3 *3 N u0 p0 c+1 {2,S} {4,D} {5,S}
+4 N u1 p1 c0 {3,D}
+5 N u0 p1 c0 {3,S} {6,S} {7,S}
+6 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {5,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['LOSE_PAIR','*1',1],
+     ['GAIN_PAIR','*3',1],
+     ['GAIN_RADICAL','*2',1],
+     ['GAIN_RADICAL','*1',1],
+ ])), 
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *1 N u1 p1 c0 {2,S} {5,S}
+2 *2 O u0 p2 c0 {1,S} {3,S}
+3 *3 N u0 p1 c0 {2,S} {4,D}
+4 *4 N u1 p1 c0 {3,D}
+5 H u0 p0 c0 {1,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['CHANGE_BOND', '*3',1,'*4'],
+     ['LOSE_RADICAL','*4',1],
+     ['GAIN_RADICAL','*2',1],
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [2]
+1 *1 O u0 p2 c0 {2,S} {4,S}
+2 *2 N u0 p1 c0 {1,S} {3,D}
+3 *3 N u1 p1 c0 {2,D}
+4 H u0 p0 c0 {1,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*1'],
+     ['CHANGE_BOND', '*3',1,'*2'],
+     ['LOSE_RADICAL','*3',1],
+     ['GAIN_RADICAL','*1',1],
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [3]
+1 *2 N u0 p2 c-1 {2,S} {4,S}
+2 *3 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+3 N u1 p1 c0 {2,S} {7,S}
+4 *1 O u1 p2 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['LOSE_RADICAL','*1',1],
+     ['GAIN_RADICAL','*2',1],
+     ['LOSE_PAIR','*2',1],
+     ['GAIN_PAIR','*3',1],
+ ])), 
+
+(Group().from_adjacency_list("""
+multiplicity [2]
+1 *1 N u1 p2 c-1 {2,S}
+2 *2 O u0 p2 c0 {1,S} {3,S}
+3 *3 N u0 p0 c+1 {2,S} {4,S} {5,S} {6,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+"""),
+ ReactionRecipe(actions=[
+     ['BREAK_BOND', '*2',1,'*3'],
+     ['CHANGE_BOND', '*1',1,'*2'],
+     ['LOSE_PAIR','*1',1],
+     ['GAIN_PAIR','*3',1],
+ ])), 
+]
 
 def decay_species(spc, check_deterministic=True):
     """

--- a/rmgpy/rmg/decay.py
+++ b/rmgpy/rmg/decay.py
@@ -48,459 +48,459 @@ decay_group_recipe_pairs = [(Group().from_adjacency_list("""
     ['GAIN_RADICAL','*3','1']
     ])),
 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 O u0 p3 c-1 {2,S}
-2 *1 N  u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
-3 *2 N  u1 p1 c0 {2,S} {4,S}
-4 O u0 p2 c0 {3,S} {7,S}
-5 *3 N  u1 p1 c0 {2,S} {8,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {4,S}
-8 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-    ['BREAK_BOND', '*1', 1, '*2'],
-    ['CHANGE_BOND', '*1', 1, '*3'],
-    ['LOSE_RADICAL', '*3','1'],
-    ['GAIN_RADICAL','*2','1']
- ])),       
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 O u0 p3 c-1 {2,S}
+# 2 *1 N  u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+# 3 *2 N  u1 p1 c0 {2,S} {4,S}
+# 4 O u0 p2 c0 {3,S} {7,S}
+# 5 *3 N  u1 p1 c0 {2,S} {8,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 H u0 p0 c0 {4,S}
+# 8 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#     ['BREAK_BOND', '*1', 1, '*2'],
+#     ['CHANGE_BOND', '*1', 1, '*3'],
+#     ['LOSE_RADICAL', '*3','1'],
+#     ['GAIN_RADICAL','*2','1']
+#  ])),       
 
     
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *3 O u0 p3 c-1 {2,S}
-2 *5 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
-3 *4 N u0 p1 c0 {2,S} {4,D}
-4 *1 N u0 p1 c0 {3,D} {7,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {2,S}
-7 *2 H u0 p0 c0 {4,S}
-"""),
- ReactionRecipe(actions=[
-    ['BREAK_BOND', '*1', 1, '*2'],
-    ['BREAK_BOND', '*4', 1, '*5'],
-    ['FORM_BOND', '*2', 1, '*3'],
-    ['CHANGE_BOND', '*1', 1, '*4'],
-    ['LOSE_PAIR', '*3', 1],
-    ['GAIN_PAIR', '*5', 1],
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *3 O u0 p3 c-1 {2,S}
+# 2 *5 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+# 3 *4 N u0 p1 c0 {2,S} {4,D}
+# 4 *1 N u0 p1 c0 {3,D} {7,S}
+# 5 H u0 p0 c0 {2,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 *2 H u0 p0 c0 {4,S}
+# """),
+#  ReactionRecipe(actions=[
+#     ['BREAK_BOND', '*1', 1, '*2'],
+#     ['BREAK_BOND', '*4', 1, '*5'],
+#     ['FORM_BOND', '*2', 1, '*3'],
+#     ['CHANGE_BOND', '*1', 1, '*4'],
+#     ['LOSE_PAIR', '*3', 1],
+#     ['GAIN_PAIR', '*5', 1],
     
- ])),          
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *5 N u0 p2 c-1 {2,S} {5,S}
-2 *4 O u0 p2 c0 {1,S} {3,S}
-3 *3 O u0 p2 c0 {2,S} {4,S}
-4 *2 N u0 p1 c0 {3,S} {5,S} {6,S}
-5 *1 N u0 p0 c+1 {1,S} {4,S} {7,S} {8,S}
-6 H u0 p0 c0 {4,S}
-7 H u0 p0 c0 {5,S}
-8 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-    ['BREAK_BOND', '*3', 1, '*4'],
-    ['BREAK_BOND', '*1', 1, '*2'],
-    ['CHANGE_BOND', '*2', 1, '*3'],
-    ['CHANGE_BOND', '*5', 1, '*4'],
-    ['LOSE_PAIR', '*5', 1],
-    ['GAIN_PAIR', '*1', 1],
+#  ])),          
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *5 N u0 p2 c-1 {2,S} {5,S}
+# 2 *4 O u0 p2 c0 {1,S} {3,S}
+# 3 *3 O u0 p2 c0 {2,S} {4,S}
+# 4 *2 N u0 p1 c0 {3,S} {5,S} {6,S}
+# 5 *1 N u0 p0 c+1 {1,S} {4,S} {7,S} {8,S}
+# 6 H u0 p0 c0 {4,S}
+# 7 H u0 p0 c0 {5,S}
+# 8 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#     ['BREAK_BOND', '*3', 1, '*4'],
+#     ['BREAK_BOND', '*1', 1, '*2'],
+#     ['CHANGE_BOND', '*2', 1, '*3'],
+#     ['CHANGE_BOND', '*5', 1, '*4'],
+#     ['LOSE_PAIR', '*5', 1],
+#     ['GAIN_PAIR', '*1', 1],
     
- ])),    
+#  ])),    
 
-(Group().from_adjacency_list("""
-multiplicity [2]
-1 *4 O u0 p2 c0 {2,S} {6,S}
-2 *3 N u0 p1 c0 {1,S} {3,D}
-3 *1 N u0 p0 c+1 {2,D} {4,S} {5,S}
-4 *6 O u0 p2 c0 {3,S} {7,S}
-5 *2 N u1 p2 c-1 {3,S}
-6 *5 H u0 p0 c0 {1,S}
-7 H u0 p0 c0 {4,S}
-"""),
- ReactionRecipe(actions=[
-    ['FORM_BOND', '*5', 1, '*6'],
-    ['BREAK_BOND', '*1', 1, '*6'],
-    ['BREAK_BOND', '*1', 2, '*3'],
-    ['BREAK_BOND', '*4', 1, '*5'],
-    ['CHANGE_BOND', '*3', 1, '*4'],
-    ['CHANGE_BOND', '*1', 2, '*2'],
-    ['GAIN_RADICAL', '*3', '1'],
-    ['LOSE_RADICAL', '*2', '1'],
-    ['LOSE_PAIR', '*2', 1],
-    ['GAIN_PAIR', '*1', 1],
-    
-    
- ])),    
-
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *1 N u2 p1 c0 {2,S}
-2 *2 N u0 p1 c0 {1,S} {3,S} {5,S}
-3 *3 N u0 p1 c0 {2,S} {4,S} {6,S}
-4 O u0 p2 c0 {3,S} {5,S}
-5 *4 O u0 p2 c0 {2,S} {4,S}
-6 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2', 1, '*3'],
-     ['BREAK_BOND', '*2', 1, '*4'],
-     ['CHANGE_BOND', '*1',2,'*2'],
-     ['LOSE_RADICAL','*1',2],
-     ['GAIN_RADICAL','*3',1],
-     ['GAIN_RADICAL','*4',1],
+# (Group().from_adjacency_list("""
+# multiplicity [2]
+# 1 *4 O u0 p2 c0 {2,S} {6,S}
+# 2 *3 N u0 p1 c0 {1,S} {3,D}
+# 3 *1 N u0 p0 c+1 {2,D} {4,S} {5,S}
+# 4 *6 O u0 p2 c0 {3,S} {7,S}
+# 5 *2 N u1 p2 c-1 {3,S}
+# 6 *5 H u0 p0 c0 {1,S}
+# 7 H u0 p0 c0 {4,S}
+# """),
+#  ReactionRecipe(actions=[
+#     ['FORM_BOND', '*5', 1, '*6'],
+#     ['BREAK_BOND', '*1', 1, '*6'],
+#     ['BREAK_BOND', '*1', 2, '*3'],
+#     ['BREAK_BOND', '*4', 1, '*5'],
+#     ['CHANGE_BOND', '*3', 1, '*4'],
+#     ['CHANGE_BOND', '*1', 2, '*2'],
+#     ['GAIN_RADICAL', '*3', '1'],
+#     ['LOSE_RADICAL', '*2', '1'],
+#     ['LOSE_PAIR', '*2', 1],
+#     ['GAIN_PAIR', '*1', 1],
     
     
- ])),    
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *1 N u2 p1 c0 {2,S}
-2 *2 O u0 p2 c0 {1,S} {3,S}
-3 *3 O u0 p2 c0 {2,S} {4,S}
-4 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['LOSE_RADICAL','*1',1],
-     ['GAIN_RADICAL','*3',1],
- ])),    
+#  ])),    
+
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *1 N u2 p1 c0 {2,S}
+# 2 *2 N u0 p1 c0 {1,S} {3,S} {5,S}
+# 3 *3 N u0 p1 c0 {2,S} {4,S} {6,S}
+# 4 O u0 p2 c0 {3,S} {5,S}
+# 5 *4 O u0 p2 c0 {2,S} {4,S}
+# 6 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2', 1, '*3'],
+#      ['BREAK_BOND', '*2', 1, '*4'],
+#      ['CHANGE_BOND', '*1',2,'*2'],
+#      ['LOSE_RADICAL','*1',2],
+#      ['GAIN_RADICAL','*3',1],
+#      ['GAIN_RADICAL','*4',1],
+    
+    
+#  ])),    
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *1 N u2 p1 c0 {2,S}
+# 2 *2 O u0 p2 c0 {1,S} {3,S}
+# 3 *3 O u0 p2 c0 {2,S} {4,S}
+# 4 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['LOSE_RADICAL','*1',1],
+#      ['GAIN_RADICAL','*3',1],
+#  ])),    
 
 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 N u0 p2 c-1 {2,D}
-2 *2 N u0 p0 c+1 {1,D} {3,S} {4,S}
-3 *4 O u0 p2 c0 {2,S} {4,S}
-4 *3 N u0 p1 c0 {2,S} {3,S} {5,S}
-5 O u0 p2 c0 {4,S} {6,S}
-6 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*4'],
-     ['CHANGE_BOND','*3',1,'*4'],
-     ['GAIN_PAIR','*2',1],
-     ['LOSE_PAIR','*3',1],
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 N u0 p2 c-1 {2,D}
+# 2 *2 N u0 p0 c+1 {1,D} {3,S} {4,S}
+# 3 *4 O u0 p2 c0 {2,S} {4,S}
+# 4 *3 N u0 p1 c0 {2,S} {3,S} {5,S}
+# 5 O u0 p2 c0 {4,S} {6,S}
+# 6 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*4'],
+#      ['CHANGE_BOND','*3',1,'*4'],
+#      ['GAIN_PAIR','*2',1],
+#      ['LOSE_PAIR','*3',1],
      
- ])),   
+#  ])),   
 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 N u0 p2 c-1 {2,S} {5,S}
-2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {6,S}
-3 *3 N u0 p1 c0 {2,S} {4,S} {7,S}
-4 *4 O u0 p2 c0 {2,S} {3,S}
-5 H u0 p0 c0 {1,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*4'],
-     ['CHANGE_BOND','*3',1,'*4'],
-     ['GAIN_PAIR','*2',1],
-     ['LOSE_PAIR','*3',1],
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 N u0 p2 c-1 {2,S} {5,S}
+# 2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {6,S}
+# 3 *3 N u0 p1 c0 {2,S} {4,S} {7,S}
+# 4 *4 O u0 p2 c0 {2,S} {3,S}
+# 5 H u0 p0 c0 {1,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*4'],
+#      ['CHANGE_BOND','*3',1,'*4'],
+#      ['GAIN_PAIR','*2',1],
+#      ['LOSE_PAIR','*3',1],
      
- ])), 
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 O u0 p3 c-1 {2,S}
-2 *2 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
-3 *3 N u0 p1 c0 {2,S} {4,D}
-4 *4 N u0 p1 c0 {3,D} {7,S}
-5 O u0 p2 c0 {2,S} {8,S}
-6 H u0 p0 c0 {2,S}
-7 *5 H u0 p0 c0 {4,S}
-8 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-     ['FORM_BOND', '*1',1,'*5'],
-     ['BREAK_BOND','*4',1,'*5'],
-     ['CHANGE_BOND','*3',1,'*4'],
-     ['BREAK_BOND','*2',1,'*3'],
-     ['GAIN_PAIR','*2',1],
-     ['LOSE_PAIR','*1',1],
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 O u0 p3 c-1 {2,S}
+# 2 *2 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+# 3 *3 N u0 p1 c0 {2,S} {4,D}
+# 4 *4 N u0 p1 c0 {3,D} {7,S}
+# 5 O u0 p2 c0 {2,S} {8,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 *5 H u0 p0 c0 {4,S}
+# 8 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['FORM_BOND', '*1',1,'*5'],
+#      ['BREAK_BOND','*4',1,'*5'],
+#      ['CHANGE_BOND','*3',1,'*4'],
+#      ['BREAK_BOND','*2',1,'*3'],
+#      ['GAIN_PAIR','*2',1],
+#      ['LOSE_PAIR','*1',1],
      
- ])), 
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *1 N u1 p2 c-1 {2,S}
-2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {5,S}
-3 O u1 p2 c0 {2,S}
-4 N u0 p1 c0 {2,S} {5,S} {6,S}
-5 *3 O u0 p2 c0 {2,S} {4,S}
-6 H u0 p0 c0 {4,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND','*2',1,'*3'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['GAIN_RADICAL','*3',1],
-     ['LOSE_RADICAL','*1',1],
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *1 N u1 p2 c-1 {2,S}
+# 2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {5,S}
+# 3 O u1 p2 c0 {2,S}
+# 4 N u0 p1 c0 {2,S} {5,S} {6,S}
+# 5 *3 O u0 p2 c0 {2,S} {4,S}
+# 6 H u0 p0 c0 {4,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND','*2',1,'*3'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['GAIN_RADICAL','*3',1],
+#      ['LOSE_RADICAL','*1',1],
      
- ])), 
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 N u0 p1 c0 {2,D} {6,S}
-2 *5 N u0 p1 c0 {1,D} {3,S}
-3 *4 O u0 p2 c0 {2,S} {4,S}
-4 *3 N u0 p1 c0 {3,S} {5,D}
-5 O u0 p2 c0 {4,D}
-6 *2 H u0 p0 c0 {1,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND','*4',1,'*5'],
-     ['BREAK_BOND', '*1',1,'*2'],
-     ['FORM_BOND','*2',1,'*3'],
-     ['GAIN_PAIR','*4',1],
-     ['CHANGE_BOND','*1',1,'*5'],
-     ['LOSE_PAIR','*3',1],
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 N u0 p1 c0 {2,D} {6,S}
+# 2 *5 N u0 p1 c0 {1,D} {3,S}
+# 3 *4 O u0 p2 c0 {2,S} {4,S}
+# 4 *3 N u0 p1 c0 {3,S} {5,D}
+# 5 O u0 p2 c0 {4,D}
+# 6 *2 H u0 p0 c0 {1,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND','*4',1,'*5'],
+#      ['BREAK_BOND', '*1',1,'*2'],
+#      ['FORM_BOND','*2',1,'*3'],
+#      ['GAIN_PAIR','*4',1],
+#      ['CHANGE_BOND','*1',1,'*5'],
+#      ['LOSE_PAIR','*3',1],
      
- ])), 
+#  ])), 
 
-(Group().from_adjacency_list(""" 
-multiplicity [1]
-1 N u0 p2 c-1 {2,D}
-2 *1 N u0 p0 c+1 {1,D} {3,S} {4,S}
-3 *2 N u0 p1 c0 {2,S} {4,S} {5,S}
-4 *3 O u0 p2 c0 {2,S} {3,S}
-5 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND','*1',1,'*3'],
-     ['CHANGE_BOND','*2',1,'*3'],
-     ['GAIN_PAIR','*1',1],
-     ['LOSE_PAIR','*2',1],
+# (Group().from_adjacency_list(""" 
+# multiplicity [1]
+# 1 N u0 p2 c-1 {2,D}
+# 2 *1 N u0 p0 c+1 {1,D} {3,S} {4,S}
+# 3 *2 N u0 p1 c0 {2,S} {4,S} {5,S}
+# 4 *3 O u0 p2 c0 {2,S} {3,S}
+# 5 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND','*1',1,'*3'],
+#      ['CHANGE_BOND','*2',1,'*3'],
+#      ['GAIN_PAIR','*1',1],
+#      ['LOSE_PAIR','*2',1],
      
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *1 N u1 p1 c0 {2,S} {5,S}
-2 *2 N u0 p1 c0 {1,S} {3,D}
-3 *3 N u0 p1 c0 {2,D} {4,S}
-4 *4 O u1 p2 c0 {3,S}
-5 H u0 p0 c0 {1,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND','*2',2,'*3'],
-     ['CHANGE_BOND','*4',1,'*3'],
-     ['CHANGE_BOND','*1',1,'*2'],
-     ['GAIN_RADICAL','*3',1],
-     ['LOSE_RADICAL','*4',1],
-     ['GAIN_RADICAL','*2',1],
-     ['LOSE_RADICAL','*1',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *1 N u1 p1 c0 {2,S} {5,S}
+# 2 *2 N u0 p1 c0 {1,S} {3,D}
+# 3 *3 N u0 p1 c0 {2,D} {4,S}
+# 4 *4 O u1 p2 c0 {3,S}
+# 5 H u0 p0 c0 {1,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND','*2',2,'*3'],
+#      ['CHANGE_BOND','*4',1,'*3'],
+#      ['CHANGE_BOND','*1',1,'*2'],
+#      ['GAIN_RADICAL','*3',1],
+#      ['LOSE_RADICAL','*4',1],
+#      ['GAIN_RADICAL','*2',1],
+#      ['LOSE_RADICAL','*1',1],
      
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 O u0 p3 c-1 {2,S}
-2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {6,S}
-3 *3 O u0 p2 c0 {2,S} {4,S}
-4 *4 N u0 p1 c0 {2,S} {3,S} {5,S}
-5 *5 N u0 p1 c0 {4,S} {7,S} {8,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {5,S}
-8 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['BREAK_BOND', '*2',1,'*4'],
-     ['CHANGE_BOND', '*3',1,'*4'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['LOSE_PAIR','*1',1],
-     ['GAIN_PAIR','*2',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 O u0 p3 c-1 {2,S}
+# 2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {6,S}
+# 3 *3 O u0 p2 c0 {2,S} {4,S}
+# 4 *4 N u0 p1 c0 {2,S} {3,S} {5,S}
+# 5 *5 N u0 p1 c0 {4,S} {7,S} {8,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 H u0 p0 c0 {5,S}
+# 8 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['BREAK_BOND', '*2',1,'*4'],
+#      ['CHANGE_BOND', '*3',1,'*4'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['LOSE_PAIR','*1',1],
+#      ['GAIN_PAIR','*2',1],
      
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [2]
-1 *2 N u0 p2 c-1 {2,S} {4,S}
-2 *3 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
-3 N u0 p1 c0 {2,S} {7,S} {8,S}
-4 *1 O u1 p2 c0 {1,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['LOSE_RADICAL','*1',1],
-     ['GAIN_RADICAL','*2',1],
-     ['LOSE_PAIR','*2',1],
-     ['GAIN_PAIR','*3',1],
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 N u0 p2 c-1 {2,S} {6,S}
-2 *2 N u0 p0 c+1 {1,S} {3,S} {7,S} {8,S}
-3 *4 O u0 p2 c0 {2,S} {4,S}
-4 N u0 p1 c0 {3,S} {5,D}
-5 O u0 p2 c0 {4,D}
-6 H u0 p0 c0 {1,S}
-7 *3 H u0 p0 c0 {2,S}
-8 H u0 p0 c0 {2,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['BREAK_BOND', '*2',1,'*4'],
-     ['FORM_BOND','*3',1,'*4'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['LOSE_PAIR','*1',1],
-     ['GAIN_PAIR','*2',1],
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *3 N u2 p1 c0 {2,S}
-2 *2 N u0 p1 c0 {1,S} {3,S} {5,S}
-3 *4 N u0 p1 c0 {2,S} {4,D}
-4 O u0 p2 c0 {3,D}
-5 *1 O u0 p2 c0 {2,S} {6,S}
-6 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*1'],
-     ['BREAK_BOND', '*2',1,'*4'],
-     ['CHANGE_BOND', '*3',2,'*2'],
-     ['LOSE_RADICAL','*3',2],
-     ['GAIN_RADICAL','*1',1],
-     ['GAIN_RADICAL','*4',1],
- ])), 
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [2]
+# 1 *2 N u0 p2 c-1 {2,S} {4,S}
+# 2 *3 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+# 3 N u0 p1 c0 {2,S} {7,S} {8,S}
+# 4 *1 O u1 p2 c0 {1,S}
+# 5 H u0 p0 c0 {2,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 H u0 p0 c0 {3,S}
+# 8 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['LOSE_RADICAL','*1',1],
+#      ['GAIN_RADICAL','*2',1],
+#      ['LOSE_PAIR','*2',1],
+#      ['GAIN_PAIR','*3',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 N u0 p2 c-1 {2,S} {6,S}
+# 2 *2 N u0 p0 c+1 {1,S} {3,S} {7,S} {8,S}
+# 3 *4 O u0 p2 c0 {2,S} {4,S}
+# 4 N u0 p1 c0 {3,S} {5,D}
+# 5 O u0 p2 c0 {4,D}
+# 6 H u0 p0 c0 {1,S}
+# 7 *3 H u0 p0 c0 {2,S}
+# 8 H u0 p0 c0 {2,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['BREAK_BOND', '*2',1,'*4'],
+#      ['FORM_BOND','*3',1,'*4'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['LOSE_PAIR','*1',1],
+#      ['GAIN_PAIR','*2',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *3 N u2 p1 c0 {2,S}
+# 2 *2 N u0 p1 c0 {1,S} {3,S} {5,S}
+# 3 *4 N u0 p1 c0 {2,S} {4,D}
+# 4 O u0 p2 c0 {3,D}
+# 5 *1 O u0 p2 c0 {2,S} {6,S}
+# 6 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*1'],
+#      ['BREAK_BOND', '*2',1,'*4'],
+#      ['CHANGE_BOND', '*3',2,'*2'],
+#      ['LOSE_RADICAL','*3',2],
+#      ['GAIN_RADICAL','*1',1],
+#      ['GAIN_RADICAL','*4',1],
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *2 N u0 p2 c-1 {2,S} {5,S}
-2 *3 O u0 p2 c0 {1,S} {3,S}
-3 *4 N u0 p1 c0 {2,S} {4,S} {6,S}
-4 *5 O u0 p2 c0 {3,S} {5,S}
-5 *1 N u0 p0 c+1 {1,S} {4,S} {7,S} {8,S}
-6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {5,S}
-8 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*5',1,'*1'],
-     ['BREAK_BOND', '*3',1,'*4'],
-     ['CHANGE_BOND', '*4',1,'*5'],
-     ['CHANGE_BOND', '*2',1,'*3'],
-     ['LOSE_PAIR','*2',1],
-     ['GAIN_PAIR','*1',1],
- ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *2 N u0 p2 c-1 {2,S} {5,S}
+# 2 *3 O u0 p2 c0 {1,S} {3,S}
+# 3 *4 N u0 p1 c0 {2,S} {4,S} {6,S}
+# 4 *5 O u0 p2 c0 {3,S} {5,S}
+# 5 *1 N u0 p0 c+1 {1,S} {4,S} {7,S} {8,S}
+# 6 H u0 p0 c0 {3,S}
+# 7 H u0 p0 c0 {5,S}
+# 8 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*5',1,'*1'],
+#      ['BREAK_BOND', '*3',1,'*4'],
+#      ['CHANGE_BOND', '*4',1,'*5'],
+#      ['CHANGE_BOND', '*2',1,'*3'],
+#      ['LOSE_PAIR','*2',1],
+#      ['GAIN_PAIR','*1',1],
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [1]
-1 *1 O u0 p3 c-1 {2,S}
-2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {5,S}
-3 N u0 p1 c0 {2,S} {6,S} {7,S}
-4 *3 N u0 p1 c0 {2,S} {5,S} {8,S}
-5 *4 O u0 p2 c0 {2,S} {4,S}
-6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {4,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['BREAK_BOND', '*2',1,'*4'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['CHANGE_BOND', '*4',1,'*3'],
-     ['LOSE_PAIR','*1',1],
-     ['GAIN_PAIR','*2',1],
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *4 N u1 p1 c0 {2,S} {5,S}
-2 *3 N u0 p1 c0 {1,S} {3,S} {6,S}
-3 *2 O u0 p2 c0 {2,S} {4,S}
-4 *1 O u1 p2 c0 {3,S}
-5 H u0 p0 c0 {1,S}
-6 H u0 p0 c0 {2,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['CHANGE_BOND', '*4',1,'*3'],
-     ['LOSE_RADICAL','*4',1],
-     ['GAIN_RADICAL','*2',1],
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [2]
-1 *1 O u0 p3 c-1 {2,S}
-2 *2 O u0 p2 c0 {1,S} {3,S}
-3 *3 N u0 p0 c+1 {2,S} {4,D} {5,S}
-4 N u1 p1 c0 {3,D}
-5 N u0 p1 c0 {3,S} {6,S} {7,S}
-6 H u0 p0 c0 {5,S}
-7 H u0 p0 c0 {5,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['LOSE_PAIR','*1',1],
-     ['GAIN_PAIR','*3',1],
-     ['GAIN_RADICAL','*2',1],
-     ['GAIN_RADICAL','*1',1],
- ])), 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *1 N u1 p1 c0 {2,S} {5,S}
-2 *2 O u0 p2 c0 {1,S} {3,S}
-3 *3 N u0 p1 c0 {2,S} {4,D}
-4 *4 N u1 p1 c0 {3,D}
-5 H u0 p0 c0 {1,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['CHANGE_BOND', '*3',1,'*4'],
-     ['LOSE_RADICAL','*4',1],
-     ['GAIN_RADICAL','*2',1],
- ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [1]
+# 1 *1 O u0 p3 c-1 {2,S}
+# 2 *2 N u0 p0 c+1 {1,S} {3,S} {4,S} {5,S}
+# 3 N u0 p1 c0 {2,S} {6,S} {7,S}
+# 4 *3 N u0 p1 c0 {2,S} {5,S} {8,S}
+# 5 *4 O u0 p2 c0 {2,S} {4,S}
+# 6 H u0 p0 c0 {3,S}
+# 7 H u0 p0 c0 {3,S}
+# 8 H u0 p0 c0 {4,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['BREAK_BOND', '*2',1,'*4'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['CHANGE_BOND', '*4',1,'*3'],
+#      ['LOSE_PAIR','*1',1],
+#      ['GAIN_PAIR','*2',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *4 N u1 p1 c0 {2,S} {5,S}
+# 2 *3 N u0 p1 c0 {1,S} {3,S} {6,S}
+# 3 *2 O u0 p2 c0 {2,S} {4,S}
+# 4 *1 O u1 p2 c0 {3,S}
+# 5 H u0 p0 c0 {1,S}
+# 6 H u0 p0 c0 {2,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['CHANGE_BOND', '*4',1,'*3'],
+#      ['LOSE_RADICAL','*4',1],
+#      ['GAIN_RADICAL','*2',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [2]
+# 1 *1 O u0 p3 c-1 {2,S}
+# 2 *2 O u0 p2 c0 {1,S} {3,S}
+# 3 *3 N u0 p0 c+1 {2,S} {4,D} {5,S}
+# 4 N u1 p1 c0 {3,D}
+# 5 N u0 p1 c0 {3,S} {6,S} {7,S}
+# 6 H u0 p0 c0 {5,S}
+# 7 H u0 p0 c0 {5,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['LOSE_PAIR','*1',1],
+#      ['GAIN_PAIR','*3',1],
+#      ['GAIN_RADICAL','*2',1],
+#      ['GAIN_RADICAL','*1',1],
+#  ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *1 N u1 p1 c0 {2,S} {5,S}
+# 2 *2 O u0 p2 c0 {1,S} {3,S}
+# 3 *3 N u0 p1 c0 {2,S} {4,D}
+# 4 *4 N u1 p1 c0 {3,D}
+# 5 H u0 p0 c0 {1,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['CHANGE_BOND', '*3',1,'*4'],
+#      ['LOSE_RADICAL','*4',1],
+#      ['GAIN_RADICAL','*2',1],
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [2]
-1 *1 O u0 p2 c0 {2,S} {4,S}
-2 *2 N u0 p1 c0 {1,S} {3,D}
-3 *3 N u1 p1 c0 {2,D}
-4 H u0 p0 c0 {1,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*1'],
-     ['CHANGE_BOND', '*3',1,'*2'],
-     ['LOSE_RADICAL','*3',1],
-     ['GAIN_RADICAL','*1',1],
- ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [2]
+# 1 *1 O u0 p2 c0 {2,S} {4,S}
+# 2 *2 N u0 p1 c0 {1,S} {3,D}
+# 3 *3 N u1 p1 c0 {2,D}
+# 4 H u0 p0 c0 {1,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*1'],
+#      ['CHANGE_BOND', '*3',1,'*2'],
+#      ['LOSE_RADICAL','*3',1],
+#      ['GAIN_RADICAL','*1',1],
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [3]
-1 *2 N u0 p2 c-1 {2,S} {4,S}
-2 *3 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
-3 N u1 p1 c0 {2,S} {7,S}
-4 *1 O u1 p2 c0 {1,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['LOSE_RADICAL','*1',1],
-     ['GAIN_RADICAL','*2',1],
-     ['LOSE_PAIR','*2',1],
-     ['GAIN_PAIR','*3',1],
- ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [3]
+# 1 *2 N u0 p2 c-1 {2,S} {4,S}
+# 2 *3 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+# 3 N u1 p1 c0 {2,S} {7,S}
+# 4 *1 O u1 p2 c0 {1,S}
+# 5 H u0 p0 c0 {2,S}
+# 6 H u0 p0 c0 {2,S}
+# 7 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['LOSE_RADICAL','*1',1],
+#      ['GAIN_RADICAL','*2',1],
+#      ['LOSE_PAIR','*2',1],
+#      ['GAIN_PAIR','*3',1],
+#  ])), 
 
-(Group().from_adjacency_list("""
-multiplicity [2]
-1 *1 N u1 p2 c-1 {2,S}
-2 *2 O u0 p2 c0 {1,S} {3,S}
-3 *3 N u0 p0 c+1 {2,S} {4,S} {5,S} {6,S}
-4 H u0 p0 c0 {3,S}
-5 H u0 p0 c0 {3,S}
-6 H u0 p0 c0 {3,S}
-"""),
- ReactionRecipe(actions=[
-     ['BREAK_BOND', '*2',1,'*3'],
-     ['CHANGE_BOND', '*1',1,'*2'],
-     ['LOSE_PAIR','*1',1],
-     ['GAIN_PAIR','*3',1],
- ])), 
+# (Group().from_adjacency_list("""
+# multiplicity [2]
+# 1 *1 N u1 p2 c-1 {2,S}
+# 2 *2 O u0 p2 c0 {1,S} {3,S}
+# 3 *3 N u0 p0 c+1 {2,S} {4,S} {5,S} {6,S}
+# 4 H u0 p0 c0 {3,S}
+# 5 H u0 p0 c0 {3,S}
+# 6 H u0 p0 c0 {3,S}
+# """),
+#  ReactionRecipe(actions=[
+#      ['BREAK_BOND', '*2',1,'*3'],
+#      ['CHANGE_BOND', '*1',1,'*2'],
+#      ['LOSE_PAIR','*1',1],
+#      ['GAIN_PAIR','*3',1],
+#  ])), 
 ]
 
 def decay_species(spc, check_deterministic=True):

--- a/rmgpy/rmg/decay.py
+++ b/rmgpy/rmg/decay.py
@@ -38,7 +38,7 @@ from rmgpy.data.kinetics.family import ReactionRecipe
 decay_group_recipe_pairs = [(Group().from_adjacency_list("""
     1  *3 O u0 p2 c0 {2,S} {4,S}
     2  *2 O u0 p2 c0 {1,S} {3,S}
-    3  *1 R!H u1 px c0 {2,S}
+    3  *1 C u1 px c0 {2,S}
     4  H u0 p0  c0 {1,S}
     """),
     ReactionRecipe(actions=[

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -858,6 +858,8 @@ class CoreEdgeReactionModel:
                 pdep = rxn.generate_high_p_limit_kinetics()
             elif any([any([x.is_subgraph_isomorphic(q) for q in self.unrealgroups]) for y in rxn.reactants + rxn.products for x in y.molecule]):
                 pdep = False
+            elif not rxn.reversible:
+                pdep = False
 
             # If pressure dependence is on, we only add reactions that are not unimolecular;
             # unimolecular reactions will be added after processing the associated networks


### PR DESCRIPTION

### Motivation or Problem
For pressure dependent networks, strange reactions that do not conserve spin are created. 

Examples:
N2 + HNO(S) (+M) <=> N2 + HNO(T) (+M)
HNO(S)  + HNO(S) (+M) <=> N2 + HNO(T) + HNO(T) (+M)
HNO(S) + N2H2 (+M) <=> HNO(T) + N2H2 (+M)
HNO(S)  + HNO(S) (+M) <=> N2 + HNO(S) + HNO(T) (+M)
...

This happens when intermediates can be formed from reactants with different multiplicities.

For example,
HNO(S) + NH2 <=> N2H3O
HNO(T) + NH2 <=> N2H3O
...
HNO(S) + NH2 <=> HNO(T) + NH2


### Description of Changes
In `arkane/explorer.py`, in the function `execute`, in the same loop that checks for forbidden structures,  I calculate the number of unpaired electrons on each side of the reaction. If there are >1 reactants and >1 products, and the number of unpaired electrons changes from reactants to products, I add the reaction to the list to be removed. 

Edit: I think this part of the code is only checking `path_reactions` which are directly connected. The problematic reactions are `net_reactions` 

### Testing
I tested this by generated a mechanism with pressure dependence and then running a pressure dependence job with Arkane.

In the resulting chem.inp file, one of the problematic reactions is commented out, but its reverse is not

```
! HNO(T)(118)+NH2(8)(+M)<=>HNO(15)+NH2(8)(+M)
HNO(15)+NH2(8)(+M)<=>HNO(T)(118)+NH2(8)(+M)
```

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
