### PR TITLE
Allow scratch dir as input for arkane symmetry calculation

### DIFF
--- a/arkane/ess/adapter.py
+++ b/arkane/ess/adapter.py
@@ -45,10 +45,11 @@ class ESSAdapter(ABC):
     An abstract ESS Adapter class
     """
 
-    def __init__(self, path, check_for_errors=True):
+    def __init__(self, path, check_for_errors=True, scratch_directory=None):
         self.path = path
         if check_for_errors:
             self.check_for_errors()
+        self.scratch_directory = scratch_directory if scratch_directory is not None else os.path.join(os.path.abspath('.'), str('scratch'))
 
     @abstractmethod
     def check_for_errors(self):
@@ -174,7 +175,7 @@ class ESSAdapter(ABC):
         coordinates, atom_numbers, _ = self.load_geometry()
         unique_id = '0'  # Just some name that the SYMMETRY code gives to one of its jobs
         # Scratch directory that the SYMMETRY code writes its files in:
-        scr_dir = os.path.join(os.path.abspath('.'), str('scratch'))
+        scr_dir = self.scratch_directory
         if not os.path.exists(scr_dir):
             os.makedirs(scr_dir)
         try:

--- a/arkane/ess/factory.py
+++ b/arkane/ess/factory.py
@@ -61,6 +61,7 @@ def register_ess_adapter(ess: str,
 
 def ess_factory(fullpath: str,
                 check_for_errors: bool = True,
+                scratch_directory: str = None,
                 ) -> Type[ESSAdapter]:
     """
     A factory generating the ESS adapter corresponding to ``ess_adapter``.
@@ -106,4 +107,4 @@ def ess_factory(fullpath: str,
         raise InputError(f'The file at {fullpath} could not be identified as a '
                          f'Gaussian, Molpro, Orca, Psi4, QChem, or TeraChem log file.')
 
-    return _registered_ess_adapters[ess_name](path=fullpath, check_for_errors=check_for_errors)
+    return _registered_ess_adapters[ess_name](path=fullpath, check_for_errors=check_for_errors, scratch_directory=scratch_directory)


### PR DESCRIPTION
### Motivation or Problem
Currently, the scratch directory in Arkane symmetry calculation is hardcoded to be "./scratch". It makes parallelization difficult as all the jobs will use the same scratch directory name.

### Description of Changes
I allow the scratch directory to be a user input with default being "./scratch".

### Testing
After this changes, my script was able to run in parallel without crashing due to scratch directory related errors.

### Reviewer Tips
