### PR TITLE
Draw reversible arrow if reaction is reversible

### DIFF
--- a/rmgpy/molecule/draw.py
+++ b/rmgpy/molecule/draw.py
@@ -1644,6 +1644,7 @@ class ReactionDrawer(object):
         self.options = MoleculeDrawer().options.copy()
         self.options.update({
             'arrowLength': 36,
+            'drawReversibleArrow': True
         })
         if options:
             self.options.update(options)
@@ -1744,11 +1745,30 @@ class ReactionDrawer(object):
         rxn_cr.save()
         rxn_cr.set_source_rgba(0.0, 0.0, 0.0, 1.0)
         rxn_cr.set_line_width(1.0)
-        rxn_cr.move_to(rxn_x + 8, rxn_top + 0.5 * rxn_height)
-        rxn_cr.line_to(rxn_x + arrow_width - 8, rxn_top + 0.5 * rxn_height)
-        rxn_cr.move_to(rxn_x + arrow_width - 14, rxn_top + 0.5 * rxn_height - 3.0)
-        rxn_cr.line_to(rxn_x + arrow_width - 8, rxn_top + 0.5 * rxn_height)
-        rxn_cr.line_to(rxn_x + arrow_width - 14, rxn_top + 0.5 * rxn_height + 3.0)
+        if self.options['drawReversibleArrow'] and reaction.reversible:  # draw double harpoons
+            TOP_HARPOON_Y = rxn_top + (0.5 * rxn_height - 1.75)
+            BOTTOM_HARPOON_Y = rxn_top + (0.5 * rxn_height + 1.75)
+
+            # Draw top harpoon
+            rxn_cr.move_to(rxn_x + 8, TOP_HARPOON_Y)
+            rxn_cr.line_to(rxn_x + arrow_width - 8, TOP_HARPOON_Y)
+            rxn_cr.move_to(rxn_x + arrow_width - 14, TOP_HARPOON_Y - 3.0)
+            rxn_cr.line_to(rxn_x + arrow_width - 8, TOP_HARPOON_Y)
+
+            # Draw bottom harpoon
+            rxn_cr.move_to(rxn_x + arrow_width - 8, BOTTOM_HARPOON_Y)
+            rxn_cr.line_to(rxn_x + 8, BOTTOM_HARPOON_Y)
+            rxn_cr.move_to(rxn_x + 14, BOTTOM_HARPOON_Y + 3.0)
+            rxn_cr.line_to(rxn_x + 8, BOTTOM_HARPOON_Y)
+
+            
+        else:  # draw forward arrow
+            rxn_cr.move_to(rxn_x + 8, rxn_top + 0.5 * rxn_height)
+            rxn_cr.line_to(rxn_x + arrow_width - 8, rxn_top + 0.5 * rxn_height)
+            rxn_cr.move_to(rxn_x + arrow_width - 14, rxn_top + 0.5 * rxn_height - 3.0)
+            rxn_cr.line_to(rxn_x + arrow_width - 8, rxn_top + 0.5 * rxn_height)
+            rxn_cr.line_to(rxn_x + arrow_width - 14, rxn_top + 0.5 * rxn_height + 3.0)
+
         rxn_cr.stroke()
         rxn_cr.restore()
         rxn_x += arrow_width


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
RMG reactions are typically reversible, but they are always drawn with a forward arrow → instead of the double harpoons. ⇌

### Description of Changes
This PR makes it the default to draw the arrow as described by the `reaction.reversible` property (→ for `False` and ⇌ for `True`). If someone wants to revert to the way things were and always draw the arrow as →, they can set the ReactionDrawer option 'drawReversibleArrow' to `False`.

### Testing
Here's some code to test out the results in a Jupyter notebook (note the last example writes to a file)

```
import rmgpy.reaction

# make an example reaction
my_reaction = rmgpy.reaction.Reaction()
my_reaction.reactants = [rmgpy.species.Species(smiles='CCCC'), rmgpy.species.Species(smiles='[OH]')]
my_reaction.products = [rmgpy.species.Species(smiles='O'), rmgpy.species.Species(smiles='[CH2]CCC')]

# show it with reversible arrows
display(my_reaction)

# show it with forward arrow
my_reaction.reversible = False
display(my_reaction)

# save an image of the reaction using the old method of always drawing just a forward arrow
my_reaction.reversible = True
rmgpy.molecule.draw.ReactionDrawer(options={'drawReversibleArrow': False}).draw(my_reaction, 'png', 'temp_reaction.png', )
```

### Reviewer Tips
Any other thoughts on changing the default from →? Possible consequences downstream?
