### PR TITLE
Improve SMILES translation for surface adsorbates

### DIFF
--- a/rmgpy/molecule/converter.pxd
+++ b/rmgpy/molecule/converter.pxd
@@ -29,7 +29,7 @@ cimport rmgpy.molecule.molecule as mm
 cimport rmgpy.molecule.element as elements
 
 
-cpdef to_rdkit_mol(mm.Molecule mol, bint remove_h=*, bint return_mapping=*, bint sanitize=*, bint save_order=?)
+cpdef to_rdkit_mol(mm.Molecule mol, bint remove_h=*, bint return_mapping=*, bint sanitize=*, bint save_order=?, int X=?)
 
 cpdef mm.Molecule from_rdkit_mol(mm.Molecule mol, object rdkitmol, bint raise_atomtype_exception=?)
 

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -49,11 +49,13 @@ import rmgpy.molecule.molecule as mm
 from rmgpy.exceptions import DependencyError
 
 
-def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True, save_order=False):
+def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True, save_order=False, X=0):
     """
     Convert a molecular structure to a RDKit rdmol object. Uses
     `RDKit <http://rdkit.org/>`_ to perform the conversion.
     Perceives aromaticity and, unless remove_h==False, removes Hydrogen atoms.
+    X is the atomic number or symbol to use for surface sites
+    (default is 0, which works well for SMILES, but you might want 78 (Pt) for InChIs).
 
     If return_mapping==True then it also returns a dictionary mapping the
     atoms to RDKit's atom indices.
@@ -69,7 +71,7 @@ def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True, save_o
     rdkitmol = Chem.rdchem.EditableMol(Chem.rdchem.Mol())
     for index, atom in enumerate(mol.vertices):
         if atom.element.symbol == 'X':
-            rd_atom = Chem.rdchem.Atom('Pt')  # not sure how to do this with linear scaling when this might not be Pt
+            rd_atom = Chem.rdchem.Atom(X) # set in the function call. Default 0
         else:
             rd_atom = Chem.rdchem.Atom(atom.element.symbol)
         if atom.element.isotope != -1:

--- a/rmgpy/molecule/inchi.py
+++ b/rmgpy/molecule/inchi.py
@@ -602,7 +602,7 @@ def create_augmented_layers(mol):
     else:
         molcopy = mol.copy(deep=True)
 
-        rdkitmol = to_rdkit_mol(molcopy, remove_h=True)
+        rdkitmol = to_rdkit_mol(molcopy, remove_h=True, X=78)
         _, auxinfo = Chem.MolToInchiAndAuxInfo(rdkitmol, options='-SNon')  # suppress stereo warnings
 
         hydrogens = [at for at in molcopy.atoms if at.number == 1]

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -441,6 +441,9 @@ def _openbabel_translator(input_object, identifier_type, mol=None):
             raise ValueError('Unexpected identifier type {0}.'.format(identifier_type))
         obmol = to_ob_mol(input_object)
         output = ob_conversion.WriteString(obmol).strip()
+        if identifier_type == 'smi':
+            # If we use * for surface sites, RDKit can read it again.
+            output = output.replace('[Pt]','*')
     else:
         raise ValueError('Unexpected input format. Should be a Molecule or a string.')
 

--- a/rmgpy/molecule/translator.py
+++ b/rmgpy/molecule/translator.py
@@ -373,7 +373,7 @@ def _rdkit_translator(input_object, identifier_type, mol=None):
         if identifier_type == 'smi':
             rdkitmol = to_rdkit_mol(input_object, sanitize=False)
         else:
-            rdkitmol = to_rdkit_mol(input_object, sanitize=True)
+            rdkitmol = to_rdkit_mol(input_object, sanitize=True, X=78) # Use Pt (78) for surface sites.
         if identifier_type == 'inchi':
             output = Chem.inchi.MolToInchi(rdkitmol, options='-SNon')
         elif identifier_type == 'inchikey':

--- a/test/rmgpy/molecule/converterTest.py
+++ b/test/rmgpy/molecule/converterTest.py
@@ -169,3 +169,17 @@ class ConverterTest:
             new_mol = from_ob_mol(Molecule(), ob_mol)
             assert mol.is_isomorphic(new_mol) or self.test_Hbond_free_mol.is_isomorphic(new_mol)
             assert mol.get_element_count() == new_mol.get_element_count()
+
+    def test_rdkit_adsorbate_round_trip(self):
+        """Test conversion to and from RDKitMol for adsorbates"""
+        adsorbates = [
+            Molecule().from_smiles("C*"),
+            Molecule().from_smiles("[*H]"),
+            Molecule().from_smiles("CC(=*)CO"),
+            Molecule().from_smiles("*COC*"),
+        ]
+        for mol in adsorbates:
+            rdkit_mol = to_rdkit_mol(mol)
+            new_mol = from_rdkit_mol(Molecule(), rdkit_mol)
+            assert mol.is_isomorphic(new_mol)
+            assert mol.get_element_count() == new_mol.get_element_count()

--- a/test/rmgpy/molecule/translatorTest.py
+++ b/test/rmgpy/molecule/translatorTest.py
@@ -966,9 +966,31 @@ class SMILESGenerationTest:
 5 X u0 p0 c0 {1,S}
 """
         )
-        smiles = "C[Pt]"
+        smiles = "C*"
         assert to_smiles(mol, backend="openbabel") == smiles
 
+    def test_smiles_adsorbates_round_trip(self):
+        """
+        Test that we can get from an adsorbate SMILES and back again,
+        by whatever back-end is chosen automatically.
+        """
+        def check(s0):
+            m = Molecule(smiles=s0)
+            s1 = m.to_smiles()
+            m2 = Molecule(smiles=s1)
+            assert m.is_isomorphic(m2)
+            s2 = m2.to_smiles()
+            assert s1 == s2
+        check("*C")
+        check("*CC")
+        check("*=C")
+        check("*[H]")
+        check("*=O")
+        check("*COC*")
+        check("*CNC")
+        check("*C1CCCC1")
+        check("*N")
+        check("*N(Cl)")
 
 class ParsingTest:
     def setup_class(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
I recently discovered (a happy accident) that you can put `*` in a SMILES string and RDKit will use it as a dummy atom, with an atomic number of 0, which RMG happens to interpret as a surface site, so you can easily enter adsorbates as SMILES strings this way. (Was I the last to realize this? seems super convenient!). 

Anyway, the round trip didn't work,  because it would output the atom as `[Pt]` when you convert things _into_ a SMILES string.

### Description of Changes
This PR changes it so you can do round-trip read and write SMILES with `*` for surface sites.

The default atom for a surface site being turned into an RDKit molecule is now the wildcard 0. When you're dealing with InChI conversion it instead uses atom 78 (platinum), because otherwise the inchi stuff crashes. 
Molecules with an N atom in are by default converted to SMILES by OpenBabel, which used the `[Pt]` syntax, which made things look inconsistent and prevented a round-trip conversion for those adsorbates only. So then I made the OpenBabel converter replace `[Pt]` with `*` after it's made a SMILES.

Now you can do round-trip conversion to and from SMILES for at least these adsorbates:
`*C`, `*CC`, `*=C`, `*[H]`, `*=O`, `*COC*`, `*CNC`, `*C1CCCC1`, `*N`, `*N(Cl)`

### Testing
I wrote unit tests, (that was the lion's share of the work, as usual).
Locally, I'm getting some weird augmented inchi error when I debug in VSCode (`'CH2O2/c2-1-3/h1-2H/u1,3' == 'CH2O2/c2-1-3/h1H,(H,2,3)/u1,2'`) but I can't see why that would have changed.  When I run in my console with `make test` I instead get a TestSoluteDatabase::test_saturation_density error (`1.93 == 0`). 
I'm hoping neither of these are actual problems and the GitHub CI runs smoothly. 🤞

### Reviewer Tips
The output, log files, etc. will look different.
Species names are now more likely to have `*` in them (than `[Pt]`).
Hopefully filenames with `*` in aren't a problem.
Maybe there are other unintended consequences we'll have to deal with?
Will this mess up anyone's workflows (in ways that they shouldn't just improve their workflows?).
Try it out and report back.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
