### PR TITLE
Restrict pyrms to <2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@
 #   made dependency list more explicit (@JacksonBurns).
 # - October 16, 2023 Switched RDKit and descripatastorus to conda-forge,
 #   moved diffeqpy to pip and (temporarily) removed chemprop
-#
+# - August 4, 2024 Restricted pyrms to <2
 name: rmg_env
 channels:
   - defaults
@@ -88,7 +88,7 @@ dependencies:
 # packages we maintain
   - rmg::pydas >=1.0.3
   - rmg::pydqed >=1.0.3
-  - rmg::pyrms
+  - rmg::pyrms <2
   - rmg::symmetry
 
 # packages we would like to stop maintaining (and why)


### PR DESCRIPTION
I'm planning to release pyrms v2.0.0 which will mark a switch to pyjuliacall. This PR prevents current RMG-Py from grabbing the new version it isn't compatible with. 