### PR TITLE
Vdw bonds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ concurrency:
 env:
   # if running on RMG-Py but requiring changes on an un-merged branch of RMG-database, replace
   # main with the name of the branch
-  RMG_DATABASE_BRANCH: main
+  RMG_DATABASE_BRANCH: formate_families
   # RMS branch to use for ReactionMechanismSimulator installation
   RMS_BRANCH: for_rmg
   # RMS mode used for install_rms.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ concurrency:
 env:
   # if running on RMG-Py but requiring changes on an un-merged branch of RMG-database, replace
   # main with the name of the branch
-  RMG_DATABASE_BRANCH: formate_families
+  RMG_DATABASE_BRANCH: main
   # RMS branch to use for ReactionMechanismSimulator installation
   RMS_BRANCH: for_rmg
   # RMS mode used for install_rms.sh

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1678,11 +1678,15 @@ class KineticsFamily(Database):
         # forbid vdw multi-dentate molecules for surface families
         surface_sites = []
         if "surface" in self.label.lower():
+            # Within the surface_monodentate_to_vdw_bidentate, allow (don't forbid)
+            # vdW in multi-dentate molecules if at least one bond to the surface
+            # is covalent (not vdW).
             if "surface_monodentate_to_vdw_bidentate" in self.label.lower() and molecule.get_num_atoms('X') > 1:
                 surface_sites = [atom.atomtype.label for atom in molecule.atoms if 'X' in atom.atomtype.label]
                 if all(site == 'Xv' for site in surface_sites):
                     return True
             else:
+                # for all other families, forbid multi-dentate molecules with any vdW bonds
                 if molecule.get_num_atoms('X') > 1:
                     for atom in molecule.atoms:
                         if atom.atomtype.label == 'Xv':

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1655,8 +1655,7 @@ class KineticsFamily(Database):
         for struct in product_structures:
             if self.is_molecule_forbidden(struct):
                 raise ForbiddenStructureException()
-            reason = fails_species_constraints(struct)
-            if reason:
+            if (reason := fails_species_constraints(struct)):
                 raise ForbiddenStructureException(
                     "Species constraints forbids product species {0}. Please "
                     "reformulate constraints, or explicitly "

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1676,7 +1676,13 @@ class KineticsFamily(Database):
 
         # forbid vdw multi-dentate molecules for surface families
         if "surface" in self.label.lower() and molecule.is_multidentate():
-            if "surface_monodentate_to_vdw_bidentate" in self.label.lower():
+            allowed_vdw_families = [
+                "surface_monodentate_to_vdw_bidentate",
+                "surface_dissociation_vdw_bidentate",
+                "surface_dissociation_vdw_bidentate_beta",
+                "surface_abstraction_vdw_bidentate_beta"
+            ]
+            if any(name in self.label.lower() for name in allowed_vdw_families):
                 # Within the surface_monodentate_to_vdw_bidentate family, allow
                 # (don't forbid) vdW in multi-dentate molecules if at least one
                 # bond to the surface is covalent (not vdW).

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1685,9 +1685,8 @@ class KineticsFamily(Database):
                     return True
             else:
                 # for all other families, forbid multi-dentate molecules with any vdW bonds
-                for atom in molecule.atoms:
-                    if atom.atomtype.label == 'Xv':
-                        return True
+                if molecule.has_vdw_surface_bond():
+                    return True
 
         return False
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1676,11 +1676,17 @@ class KineticsFamily(Database):
             return True
 
         # forbid vdw multi-dentate molecules for surface families
+        surface_sites = []
         if "surface" in self.label.lower():
-            if molecule.get_num_atoms('X') > 1:
-                for atom in molecule.atoms:
-                    if atom.atomtype.label == 'Xv':
-                        return True
+            if "surface_monodentate_to_vdw_bidentate" in self.label.lower() and molecule.get_num_atoms('X') > 1:
+                surface_sites = [atom.atomtype.label for atom in molecule.atoms if 'X' in atom.atomtype.label]
+                if all(site == 'Xv' for site in surface_sites):
+                    return True
+            else:
+                if molecule.get_num_atoms('X') > 1:
+                    for atom in molecule.atoms:
+                        if atom.atomtype.label == 'Xv':
+                            return True
 
         return False
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1676,21 +1676,18 @@ class KineticsFamily(Database):
             return True
 
         # forbid vdw multi-dentate molecules for surface families
-        surface_sites = []
-        if "surface" in self.label.lower():
-            # Within the surface_monodentate_to_vdw_bidentate, allow (don't forbid)
-            # vdW in multi-dentate molecules if at least one bond to the surface
-            # is covalent (not vdW).
-            if "surface_monodentate_to_vdw_bidentate" in self.label.lower() and molecule.get_num_atoms('X') > 1:
-                surface_sites = [atom.atomtype.label for atom in molecule.atoms if 'X' in atom.atomtype.label]
-                if all(site == 'Xv' for site in surface_sites):
+        if "surface" in self.label.lower() and molecule.is_multidentate():
+            if "surface_monodentate_to_vdw_bidentate" in self.label.lower():
+                # Within the surface_monodentate_to_vdw_bidentate family, allow
+                # (don't forbid) vdW in multi-dentate molecules if at least one
+                # bond to the surface is covalent (not vdW).
+                if not molecule.has_covalent_surface_bond():
                     return True
             else:
                 # for all other families, forbid multi-dentate molecules with any vdW bonds
-                if molecule.get_num_atoms('X') > 1:
-                    for atom in molecule.atoms:
-                        if atom.atomtype.label == 'Xv':
-                            return True
+                for atom in molecule.atoms:
+                    if atom.atomtype.label == 'Xv':
+                        return True
 
         return False
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1676,16 +1676,10 @@ class KineticsFamily(Database):
 
         # forbid vdw multi-dentate molecules for surface families
         if "surface" in self.label.lower() and molecule.is_multidentate():
-            allowed_vdw_families = [
-                "surface_monodentate_to_vdw_bidentate",
-                "surface_dissociation_vdw_bidentate",
-                "surface_dissociation_vdw_bidentate_beta",
-                "surface_abstraction_vdw_bidentate_beta"
-            ]
-            if any(name in self.label.lower() for name in allowed_vdw_families):
-                # Within the surface_monodentate_to_vdw_bidentate family, allow
-                # (don't forbid) vdW in multi-dentate molecules if at least one
-                # bond to the surface is covalent (not vdW).
+            if "vdwbidentate" in self.label.lower():
+                # Within vdWBidentate families, allow vdW in
+                # multi-dentate molecules if at least one bond to the surface
+                # is covalent.
                 if not molecule.has_covalent_surface_bond():
                     return True
             else:

--- a/rmgpy/molecule/converter.py
+++ b/rmgpy/molecule/converter.py
@@ -99,10 +99,10 @@ def to_rdkit_mol(mol, remove_h=True, return_mapping=False, sanitize=True,
             label_dict[index] = atom.label
 
     rd_bonds = Chem.rdchem.BondType
-    # no vdW bond in RDKit, so "ZERO" or "OTHER" might be OK
+    # no vdW bond in RDKit, so use UNSPECIFIED
     orders = {'S': rd_bonds.SINGLE, 'D': rd_bonds.DOUBLE,
               'T': rd_bonds.TRIPLE, 'B': rd_bonds.AROMATIC,
-              'Q': rd_bonds.QUADRUPLE, 'vdW': rd_bonds.ZERO,
+              'Q': rd_bonds.QUADRUPLE, 'vdW': rd_bonds.UNSPECIFIED,
               'H': rd_bonds.HYDROGEN, 'R': rd_bonds.UNSPECIFIED,
               None: rd_bonds.UNSPECIFIED}
     # Add the bonds

--- a/rmgpy/molecule/draw.py
+++ b/rmgpy/molecule/draw.py
@@ -1215,7 +1215,7 @@ class MoleculeDrawer(object):
                 dv *= 1.6
                 self._draw_line(cr, x1 - du, y1 - dv, x2 - du, y2 - dv)
                 self._draw_line(cr, x1 + du, y1 + dv, x2 + du, y2 + dv, dashed=True)
-            elif bond.is_hydrogen_bond():
+            elif bond.is_hydrogen_bond() or bond.is_van_der_waals():
                 # Draw a dashed line
                 self._draw_line(cr, x1, y1, x2, y2, dashed=True, dash_sizes=[0.5, 3.5])
             else:

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -208,6 +208,8 @@ cdef class Molecule(Graph):
 
     cpdef bint has_covalent_surface_bond(self)
 
+    cpdef bint has_vdw_surface_bond(self)
+
     cpdef bint is_surface_site(self)
 
     cpdef remove_atom(self, Atom atom)

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -206,6 +206,8 @@ cdef class Molecule(Graph):
 
     cpdef int number_of_surface_sites(self) except -1
 
+    cpdef bint has_covalent_surface_bond(self)
+
     cpdef bint is_surface_site(self)
 
     cpdef remove_atom(self, Atom atom)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1288,17 +1288,11 @@ class Molecule(Graph):
         Remove all van der Waals bonds.
         """
         cython.declare(bond=Bond)
-        if self.is_multidentate():
-            if self.has_covalent_surface_bond():
-                return #preserve the remaining vdW bonds for this structure
-            else:
-                for bond in self.get_all_edges():
-                    if bond.is_van_der_waals():
-                        self.remove_bond(bond)
-        else:
-            for bond in self.get_all_edges():
-                if bond.is_van_der_waals():
-                    self.remove_bond(bond)
+        if self.has_covalent_surface_bond():
+            return # preserve any vdW bonds if there's also a covalent X
+        for bond in self.get_all_edges():
+            if bond.is_van_der_waals():
+                self.remove_bond(bond)
 
     def sort_atoms(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1223,13 +1223,12 @@ class Molecule(Graph):
         """
         Return True if any bond in this molecule connects a surface site (X) via a covalent bond.
         """
-        cython.declare(bond=Bond)
-        for bond in self.get_all_edges():
-            if bond.is_van_der_waals():
-                continue
-            atom1, atom2 = bond.atom1, bond.atom2
-            if atom1.is_surface_site() or atom2.is_surface_site():
-                return True
+        cython.declare(atom=Atom, bond=Bond)
+        for atom in self.atoms:
+            if atom.is_surface_site():
+                for bond in atom.bonds.values():
+                    if not bond.is_van_der_waals():
+                            return True
         return False
 
     def contains_surface_site(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -67,7 +67,7 @@ from rmgpy.molecule.fragment import CuttingLabel
 def _skip_first(in_tuple):
     return in_tuple[1:]
 
-bond_orders = {'S': 1, 'D': 2, 'T': 3, 'B': 1.5}
+bond_orders = {'S': 1, 'D': 2, 'T': 3, 'B': 1.5, 'vdW': 0}
 
 globals().update({
     'bond_orders': bond_orders,
@@ -3132,6 +3132,8 @@ class Molecule(Graph):
                     bonded_atom.increment_radical()
                     bonded_atom.increment_lone_pairs()
                     bonded_atom.label = '*4'
+                elif bond.is_van_der_waals():
+                    bonded_atom.label = '*5'
                 else:
                     raise NotImplementedError("Can't remove surface bond of type {}".format(bond.order))
             desorbed_molecule.remove_atom(site)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1233,14 +1233,20 @@ class Molecule(Graph):
 
     def has_vdw_surface_bond(self):
         """
-        Return True if any bond in this molecule connects a surface site (X) via a van der Waals bond.
+        Return True if any bond in this molecule connects a surface site (X)
+        via a van der Waals bond, or there's a surface site with no bonds
+        (but at least one other atom in the molecule).
         """
         cython.declare(atom=Atom, bond=Bond)
         for atom in self.atoms:
             if atom.is_surface_site():
+                if not atom.bonds:  # if there are no bonds at all
+                    if len(self.atoms) > 1:  # and there's something besides the surface site
+                        return True  # then treat as vdW bonded
                 for bond in atom.bonds.values():
                     if bond.is_van_der_waals():
                         return True
+                
         return False
 
     def contains_surface_site(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1219,6 +1219,19 @@ class Molecule(Graph):
         """
         return self.has_edge(atom1, atom2)
 
+    def has_covalent_surface_bond(self):
+        """
+        Return True if any bond in this molecule connects a surface site (X) via a covalent bond.
+        """
+        cython.declare(bond=Bond)
+        for bond in self.get_all_edges():
+            if bond.is_van_der_waals():
+                continue
+            atom1, atom2 = bond.atom1, bond.atom2
+            if atom1.is_surface_site() or atom2.is_surface_site():
+                return True
+        return False
+
     def contains_surface_site(self):
         """
         Returns ``True`` iff the molecule contains an 'X' surface site.
@@ -1276,9 +1289,17 @@ class Molecule(Graph):
         Remove all van der Waals bonds.
         """
         cython.declare(bond=Bond)
-        for bond in self.get_all_edges():
-            if bond.is_van_der_waals():
-                self.remove_bond(bond)
+        if self.is_multidentate():
+            if self.has_covalent_surface_bond():
+                return #preserve the remaining vdW bonds for this structure
+            else:
+                for bond in self.get_all_edges():
+                    if bond.is_van_der_waals():
+                        self.remove_bond(bond)
+        else:
+            for bond in self.get_all_edges():
+                if bond.is_van_der_waals():
+                    self.remove_bond(bond)
 
     def sort_atoms(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -3062,9 +3062,13 @@ class Molecule(Graph):
         Return ``True`` if the adsorbate contains at least two binding sites,
         or ``False`` otherwise.
         """
-        cython.declare(atom=Atom)
-        if len([atom for atom in self.vertices if atom.is_surface_site()])>=2:
-            return True
+        cython.declare(atom=Atom, found_one=cython.bint)
+        found_one = False
+        for atom in self.atoms:
+            if atom.is_surface_site():
+                if found_one:
+                    return True
+                found_one = True
         return False
 
     def get_adatoms(self):

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1285,7 +1285,10 @@ class Molecule(Graph):
 
     def remove_van_der_waals_bonds(self):
         """
-        Remove all van der Waals bonds.
+        Remove all van der Waals bonds. For multidentate species,
+        vdW bonds are preserved when there are still other
+        covalent bonds with the surface present. If no covalent surface bonds are present,
+        all vdW bonds are removed.
         """
         cython.declare(bond=Bond)
         if self.has_covalent_surface_bond():
@@ -3094,6 +3097,7 @@ class Molecule(Graph):
         ``*2`` - double bond
         ``*3`` - triple bond
         ``*4`` - quadruple bond
+        ``*0`` - vdW bond
         """
         cython.declare(desorbed_molecules=list, desorbed_molecule=Molecule, sites_to_remove=list, adsorbed_atoms=list,
                        site=Atom, numbonds=cython.int, bonded_atom=Atom, bond=Bond, i=cython.int, j=cython.int, atom0=Atom,
@@ -3133,7 +3137,7 @@ class Molecule(Graph):
                     bonded_atom.increment_lone_pairs()
                     bonded_atom.label = '*4'
                 elif bond.is_van_der_waals():
-                    bonded_atom.label = '*5'
+                    bonded_atom.label = '*0'
                 else:
                     raise NotImplementedError("Can't remove surface bond of type {}".format(bond.order))
             desorbed_molecule.remove_atom(site)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1231,6 +1231,18 @@ class Molecule(Graph):
                             return True
         return False
 
+    def has_vdw_surface_bond(self):
+        """
+        Return True if any bond in this molecule connects a surface site (X) via a van der Waals bond.
+        """
+        cython.declare(atom=Atom, bond=Bond)
+        for atom in self.atoms:
+            if atom.is_surface_site():
+                for bond in atom.bonds.values():
+                    if bond.is_van_der_waals():
+                        return True
+        return False
+
     def contains_surface_site(self):
         """
         Returns ``True`` iff the molecule contains an 'X' surface site.

--- a/rmgpy/molecule/pathfinder.pxd
+++ b/rmgpy/molecule/pathfinder.pxd
@@ -62,3 +62,5 @@ cpdef bint is_atom_able_to_lose_lone_pair(Vertex atom)
 cpdef list find_adsorbate_delocalization_paths(Vertex atom1)
 
 cpdef list find_adsorbate_conjugate_delocalization_paths(Vertex atom1)
+
+cpdef list find_formate_delocalization_paths(Vertex atom1)

--- a/rmgpy/molecule/pathfinder.pxd
+++ b/rmgpy/molecule/pathfinder.pxd
@@ -26,6 +26,7 @@
 ###############################################################################
 
 from .graph cimport Vertex, Edge, Graph
+from .molecule cimport Atom, Bond, Molecule
 
 cpdef list find_butadiene(Vertex start, Vertex end)
 

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -556,10 +556,10 @@ def find_adsorbate_conjugate_delocalization_paths(atom1):
 
 def find_formate_delocalization_paths(atom1):
     """
-    Find all resonance structures which have a bonding configuration X...O-C-O-X.
+    Find all resonance structures which have a bonding configuration X~O=C-O-X.
     Examples:
 
-    - XOC(H)XO/XOC(H)XO, where X is the surface site. The adsorption site X
+    - [X]~OC(H)O[X]/[X]OC(H)O~[X], where '~' denotes a vdW bond and X is the surface site. The adsorption site X
       is always placed on the left-hand side of the adatom and every adatom
       is bonded to only one surface site X.
 
@@ -583,10 +583,10 @@ def find_formate_delocalization_paths(atom1):
         for atom2, bond12 in atom1.edges.items():
             if atom2.is_oxygen() and bond12.is_van_der_waals():
                 for atom3, bond23 in atom2.edges.items():
-                    if atom3.is_carbon():
+                    if atom3.is_carbon() and bond23.is_double():
                         for atom4, bond34 in atom3.edges.items():
-                            if atom2 is not atom4 and atom4.is_oxygen():
+                            if atom2 is not atom4 and atom4.is_oxygen() and bond34.is_single():
                                 for atom5, bond45 in atom4.edges.items():
-                                    if atom5.is_surface_site():
+                                    if atom5.is_surface_site() and bond45.is_single():
                                         paths.append([atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45])
     return paths

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -36,7 +36,7 @@ from queue import Queue
 
 import cython
 
-from rmgpy.molecule.molecule import Atom
+from rmgpy.molecule.molecule import Atom, Bond
 from rmgpy.molecule.graph import Vertex, Edge
 
 def find_butadiene(start, end):
@@ -494,7 +494,15 @@ def find_adsorbate_delocalization_paths(atom1):
     In this transition atom1 and atom4 are surface sites while atom2 and atom3
     are carbon or nitrogen atoms.
     """
-    cython.declare(paths=list, atom2=Vertex, atom3=Vertex, atom4=Vertex, bond12=Edge, bond23=Edge, bond34=Edge)
+    cython.declare(
+        paths=list,
+        atom2=Atom,
+        atom3=Atom,
+        atom4=Atom,
+        bond12=Bond,
+        bond23=Bond,
+        bond34=Bond,
+    )
 
     paths = []
     if atom1.is_surface_site():
@@ -521,7 +529,17 @@ def find_adsorbate_conjugate_delocalization_paths(atom1):
     and atom4 are carbon or nitrogen atoms.
     """
 
-    cython.declare(paths=list, atom2=Vertex, atom3=Vertex, atom4=Vertex, atom5=Vertex, bond12=Edge, bond23=Edge, bond34=Edge, bond45=Edge)
+    cython.declare(
+        paths=list,
+        atom2=Atom,
+        atom3=Atom,
+        atom4=Atom,
+        atom5=Atom,
+        bond12=Bond,
+        bond23=Bond,
+        bond34=Bond,
+        bond45=Bond,
+    )
 
     paths = []
     if atom1.is_surface_site():
@@ -549,8 +567,17 @@ def find_formate_delocalization_paths(atom1):
     and atom4 are oxygen and atom3 is a carbon atom.
     """
 
-    cython.declare(paths=list, atom2=Vertex, atom3=Vertex, atom4=Vertex, atom5=Vertex, bond12=Edge, bond23=Edge, bond34=Edge, bond45=Edge)
-
+    cython.declare(
+        paths=list,
+        atom2=Atom,
+        atom3=Atom,
+        atom4=Atom,
+        atom5=Atom,
+        bond12=Bond,
+        bond23=Bond,
+        bond34=Bond,
+        bond45=Bond,
+    )
     paths = []
     if atom1.is_surface_site():
         for atom2, bond12 in atom1.edges.items():

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -535,3 +535,31 @@ def find_adsorbate_conjugate_delocalization_paths(atom1):
                                     if atom5.is_surface_site():
                                         paths.append([atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45])
     return paths
+
+def find_formate_delocalization_paths(atom1):
+    """
+    Find all resonance structures which have a bonding configuration X...O-C-O-X.
+    Examples:
+
+    - XOC(H)XO/XOC(H)XO, where X is the surface site. The adsorption site X
+      is always placed on the left-hand side of the adatom and every adatom
+      is bonded to only one surface site X.
+
+    In this transition atom1 and atom5 are surface sites while atom2
+    and atom4 are oxygen and atom3 is a carbon atom.
+    """
+
+    cython.declare(paths=list, atom2=Vertex, atom3=Vertex, atom4=Vertex, atom5=Vertex, bond12=Edge, bond23=Edge, bond34=Edge, bond45=Edge)
+
+    paths = []
+    if atom1.is_surface_site():
+        for atom2, bond12 in atom1.edges.items():
+            if atom2.is_oxygen() and bond12.is_van_der_waals():
+                for atom3, bond23 in atom2.edges.items():
+                    if atom3.is_carbon():
+                        for atom4, bond34 in atom3.edges.items():
+                            if atom2 is not atom4 and atom4.is_oxygen():
+                                for atom5, bond45 in atom4.edges.items():
+                                    if atom5.is_surface_site():
+                                        paths.append([atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45])
+    return paths

--- a/rmgpy/molecule/pathfinder.py
+++ b/rmgpy/molecule/pathfinder.py
@@ -583,7 +583,7 @@ def find_formate_delocalization_paths(atom1):
         for atom2, bond12 in atom1.edges.items():
             if atom2.is_oxygen() and bond12.is_van_der_waals():
                 for atom3, bond23 in atom2.edges.items():
-                    if atom3.is_carbon() and bond23.is_double():
+                    if (atom3.is_carbon() or atom3.is_nitrogen()) and bond23.is_double():
                         for atom4, bond34 in atom3.edges.items():
                             if atom2 is not atom4 and atom4.is_oxygen() and bond34.is_single():
                                 for atom5, bond45 in atom4.edges.items():

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -73,3 +73,5 @@ cpdef list generate_adsorbate_shift_down_resonance_structures(Graph mol)
 cpdef list generate_adsorbate_shift_up_resonance_structures(Graph mol)
 
 cpdef list generate_adsorbate_conjugate_resonance_structures(Graph mol)
+
+cpdef list generate_formate_resonance_structures(Graph mol)

--- a/rmgpy/molecule/resonance.pxd
+++ b/rmgpy/molecule/resonance.pxd
@@ -74,4 +74,4 @@ cpdef list generate_adsorbate_shift_up_resonance_structures(Graph mol)
 
 cpdef list generate_adsorbate_conjugate_resonance_structures(Graph mol)
 
-cpdef list generate_formate_resonance_structures(Graph mol)
+cpdef list generate_adsorbate_formate_resonance_structures(Graph mol)

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -1262,9 +1262,9 @@ def generate_adsorbate_conjugate_resonance_structures(mol):
 
 def generate_formate_resonance_structures(mol):
     """
-    Generate all of the resonance structures formed by the shift of two
-    electrons in a conjugated pi bond system of a bidentate adsorbate
-    with a bridging atom in between.
+    Generate all resonance structures formed by the shift of two
+    electrons in a conjugated bonding system of a bidentate adsorbate
+    with a bridging atom in between, where one bond to the surface is vdW.
 
     Example [X]OC(H)O[X]: [X]~OC(H)O[X] <=> [X]OC(H)O~[X]
     (where '~' denotes a vdW bond)
@@ -1279,7 +1279,8 @@ def generate_formate_resonance_structures(mol):
             paths = pathfinder.find_formate_delocalization_paths(atom)
             for atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45 in paths:
                 if ((atom2.is_oxygen() and bond12.is_van_der_waals()) and
-                        (atom4.is_oxygen() and atom5.is_surface_site() and bond45.is_single())):
+                        (atom4.is_oxygen() and atom5.is_surface_site() and
+                         bond45.is_single() and bond23.is_double() and bond34.is_single())):
                     bond12.increment_order()
                     bond23.decrement_order()
                     bond34.increment_order()

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -96,7 +96,8 @@ def populate_resonance_algorithms(features=None):
             generate_clar_structures,
             generate_adsorbate_shift_down_resonance_structures,
             generate_adsorbate_shift_up_resonance_structures,
-            generate_adsorbate_conjugate_resonance_structures
+            generate_adsorbate_conjugate_resonance_structures,
+            generate_formate_resonance_structures,
         ]
     else:
         # If the molecule is aromatic, then radical resonance has already been considered

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -97,7 +97,7 @@ def populate_resonance_algorithms(features=None):
             generate_adsorbate_shift_down_resonance_structures,
             generate_adsorbate_shift_up_resonance_structures,
             generate_adsorbate_conjugate_resonance_structures,
-            generate_formate_resonance_structures,
+            generate_adsorbate_formate_resonance_structures,
         ]
     else:
         # If the molecule is aromatic, then radical resonance has already been considered
@@ -125,7 +125,7 @@ def populate_resonance_algorithms(features=None):
             method_list.append(generate_adsorbate_shift_down_resonance_structures)
             method_list.append(generate_adsorbate_shift_up_resonance_structures)
             method_list.append(generate_adsorbate_conjugate_resonance_structures)
-            method_list.append(generate_formate_resonance_structures)
+            method_list.append(generate_adsorbate_formate_resonance_structures)
     return method_list
 
 
@@ -1261,7 +1261,7 @@ def generate_adsorbate_conjugate_resonance_structures(mol):
     return structures
 
 
-def generate_formate_resonance_structures(mol):
+def generate_adsorbate_formate_resonance_structures(mol):
     """
     Generate all resonance structures formed by the shift of two
     electrons in a conjugated bonding system of a bidentate adsorbate

--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -124,6 +124,7 @@ def populate_resonance_algorithms(features=None):
             method_list.append(generate_adsorbate_shift_down_resonance_structures)
             method_list.append(generate_adsorbate_shift_up_resonance_structures)
             method_list.append(generate_adsorbate_conjugate_resonance_structures)
+            method_list.append(generate_formate_resonance_structures)
     return method_list
 
 
@@ -1256,4 +1257,43 @@ def generate_adsorbate_conjugate_resonance_structures(mol):
                                     pass
                                 else:
                                     structures.append(structure)
+    return structures
+
+
+def generate_formate_resonance_structures(mol):
+    """
+    Generate all of the resonance structures formed by the shift of two
+    electrons in a conjugated pi bond system of a bidentate adsorbate
+    with a bridging atom in between.
+
+    Example [X]OC(H)O[X]: [X]~OC(H)O[X] <=> [X]OC(H)O~[X]
+    (where '~' denotes a vdW bond)
+    """
+    cython.declare(structures=list, paths=list, index=cython.int, structure=Graph)
+    cython.declare(atom=Vertex, atom1=Vertex, atom2=Vertex, atom3=Vertex, atom4=Vertex, atom5=Vertex, bond12=Edge, bond23=Edge, bond34=Edge, bond45=Edge)
+    cython.declare(v1=Vertex, v2=Vertex)
+
+    structures = []
+    if mol.is_multidentate():
+        for atom in mol.vertices:
+            paths = pathfinder.find_formate_delocalization_paths(atom)
+            for atom1, atom2, atom3, atom4, atom5, bond12, bond23, bond34, bond45 in paths:
+                if ((atom2.is_oxygen() and bond12.is_van_der_waals()) and
+                        (atom4.is_oxygen() and atom5.is_surface_site() and bond45.is_single())):
+                    bond12.increment_order()
+                    bond23.decrement_order()
+                    bond34.increment_order()
+                    bond45.decrement_order()
+                    structure = mol.copy(deep=True)
+                    bond12.decrement_order()
+                    bond23.increment_order()
+                    bond34.decrement_order()
+                    bond45.increment_order()
+                    try:
+                        structure.update_atomtypes(log_species=False)
+                    except AtomTypeError:
+                        pass
+                    else:
+                        structures.append(structure)
+
     return structures

--- a/test/database/databaseTest.py
+++ b/test/database/databaseTest.py
@@ -1577,7 +1577,22 @@ Origin Group AdjList:
                 output += "\n" + s.to_adjacency_list(label=s.to_smiles())
             return output
 
-        if len(sample_reactants) == 1 == len(family.forward_template.reactants):
+        expected_reactants = [str(r) for r in family.forward_template.reactants]
+        roots_with_samples = [str(k) for k in sample_reactants.keys()]
+        roots_without_samples = [r for r in expected_reactants if r not in roots_with_samples]
+        if len(sample_reactants) != len(family.forward_template.reactants):
+            # One or more reactant roots produced no usable sample molecule (every candidate was
+            # forbidden by is_molecule_forbidden, or raised UnexpectedChargeError/
+            # ImplicitBenzeneError during make_sample_molecule). Record a descriptive error so it
+            # is logged below alongside any per-sample errors, instead of raising opaquely here.
+            test1.append(
+                f"In family {family_name}, {len(roots_without_samples)} reactant root(s) produced "
+                f"no usable sample molecule: {roots_without_samples}. The family template expects "
+                f"{len(expected_reactants)} reactant(s) {expected_reactants}; only these root(s) "
+                f"yielded samples: {roots_with_samples}. Check the group definitions for the "
+                f"missing reactant root(s)."
+            )
+        elif len(sample_reactants) == 1:
             reactants = list(sample_reactants.values())[0]
             for reactant in reactants:
                 try:
@@ -1670,7 +1685,13 @@ Origin Group AdjList:
                     species = rmgpy.species.Species(index=1, molecule=[molecule])
                     species.generate_resonance_structures()
         else:
-            raise ValueError(f"Family had {len(sample_reactants)} reactants?: " f"{', '.join(map(str,sample_reactants.keys())) }")
+            # Reactant count matches the template but is not 1, 2, or 3 (RMG only supports up to
+            # trimolecular). This is not expected for any well-formed family.
+            raise ValueError(
+                f"In family {family_name}, the number of sampled reactant roots "
+                f"({len(sample_reactants)}) matches the template reactant count but is not 1, 2, "
+                f"or 3, which is unexpected: {roots_with_samples}."
+            )
 
         # print out entries skipped from exception we can't currently handle
         if skipped:

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -3110,6 +3110,44 @@ multiplicity 2
         mol.remove_van_der_waals_bonds()
         assert len(mol.get_all_edges()) == 1
 
+    def test_has_covalent_surface_bond(self):
+        """Test Molecule.has_covalent_surface_bond() distinguishes vdW from covalent X bonds."""
+        # X present but only physisorbed via a vdW bond
+        vdw_only = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0 {2,vdW}
+2 H u0 p0 c0 {1,vdW} {3,S}
+3 H u0 p0 c0 {2,S}
+"""
+        )
+        assert not vdw_only.has_covalent_surface_bond()
+
+        # X covalently bonded (chemisorbed)
+        chemisorbed = Molecule().from_adjacency_list(
+            """
+1 H u0 p0 c0 {2,S}
+2 X u0 p0 c0 {1,S}
+"""
+        )
+        assert chemisorbed.has_covalent_surface_bond()
+
+        # Two X atoms: one vdW, one covalent
+        mixed = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {4,vdW}
+3 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 H u0 p0 c0 {2,vdW} {3,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+"""
+        )
+        assert mixed.has_covalent_surface_bond()
+
+        # No surface sites at all
+        gas = Molecule().from_smiles("CCO")
+        assert not gas.has_covalent_surface_bond()
+
     def test_get_relevant_cycles(self):
         """
         Test the Molecule.get_relevant_cycles() raises correct error after deprecation.

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -3098,7 +3098,7 @@ multiplicity 2
 
         assert result == [2, 1, 0]
 
-    def test_remove_van_der_waals_bonds(self):
+    def test_remove_van_der_waals_bond(self):
         """Test we can remove a van-der-Waals bond"""
         adjlist = """
 1 X  u0 p0 c0 {2,vdW}
@@ -3109,6 +3109,49 @@ multiplicity 2
         assert len(mol.get_all_edges()) == 2
         mol.remove_van_der_waals_bonds()
         assert len(mol.get_all_edges()) == 1
+
+    def test_remove_van_der_waals_bonds_bidentate(self):
+        """vdW bonds are preserved on bidentates that also have a covalent X bond, removed otherwise."""
+        # Bidentate ethyl-like fragment: one C–X covalent, one C~X vdW. The vdW should be preserved.
+        mixed = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {4,vdW}
+3 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 C u0 p0 c0 {2,vdW} {3,S} {7,S} {8,S} {9,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {4,S}
+9 H u0 p0 c0 {4,S}
+"""
+        )
+        assert mixed.has_covalent_surface_bond()
+        n_edges_before = len(mixed.get_all_edges())
+        mixed.remove_van_der_waals_bonds()
+        assert len(mixed.get_all_edges()) == n_edges_before  # nothing removed
+        assert any(bond.is_van_der_waals() for bond in mixed.get_all_edges())
+
+        # Bidentate physisorbed: both C~X bonds are vdW. All vdW bonds should be removed.
+        vdw_only = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0 {3,vdW}
+2 X u0 p0 c0 {4,vdW}
+3 C u0 p0 c0 {1,vdW} {4,S} {5,S} {6,S} {7,S}
+4 C u0 p0 c0 {2,vdW} {3,S} {8,S} {9,S} {10,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {4,S}
+9 H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+"""
+        )
+        assert not vdw_only.has_covalent_surface_bond()
+        n_edges_before = len(vdw_only.get_all_edges())
+        vdw_only.remove_van_der_waals_bonds()
+        assert len(vdw_only.get_all_edges()) == n_edges_before - 2
+        assert not any(bond.is_van_der_waals() for bond in vdw_only.get_all_edges())
 
     def test_has_covalent_surface_bond(self):
         """Test Molecule.has_covalent_surface_bond() distinguishes vdW from covalent X bonds."""

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -3229,6 +3229,20 @@ multiplicity 2
         gas = Molecule().from_smiles("CCO")
         assert not gas.has_vdw_surface_bond()
 
+        # An unbonded X atom counts as a vdW surface bond
+        unbonded = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0
+2 H u0 p0 c0 {3,S}
+3 H u0 p0 c0 {2,S}
+"""
+        )
+        assert unbonded.has_vdw_surface_bond()
+
+        # vacant site alone is not a vdW surface bond
+        vacant = Molecule().from_adjacency_list("1 X u0 p0 c0")
+        assert not vacant.has_vdw_surface_bond()
+
     def test_get_relevant_cycles(self):
         """
         Test the Molecule.get_relevant_cycles() raises correct error after deprecation.

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -3191,6 +3191,44 @@ multiplicity 2
         gas = Molecule().from_smiles("CCO")
         assert not gas.has_covalent_surface_bond()
 
+    def test_has_vdw_surface_bond(self):
+        """Test Molecule.has_vdw_surface_bond() detects any vdW X bond."""
+        # X present but only physisorbed via a vdW bond
+        vdw_only = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0 {2,vdW}
+2 H u0 p0 c0 {1,vdW} {3,S}
+3 H u0 p0 c0 {2,S}
+"""
+        )
+        assert vdw_only.has_vdw_surface_bond()
+
+        # X covalently bonded (chemisorbed) — no vdW bond
+        chemisorbed = Molecule().from_adjacency_list(
+            """
+1 H u0 p0 c0 {2,S}
+2 X u0 p0 c0 {1,S}
+"""
+        )
+        assert not chemisorbed.has_vdw_surface_bond()
+
+        # Two X atoms: one vdW, one covalent
+        mixed = Molecule().from_adjacency_list(
+            """
+1 X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {4,vdW}
+3 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 H u0 p0 c0 {2,vdW} {3,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+"""
+        )
+        assert mixed.has_vdw_surface_bond()
+
+        # No surface sites at all
+        gas = Molecule().from_smiles("CCO")
+        assert not gas.has_vdw_surface_bond()
+
     def test_get_relevant_cycles(self):
         """
         Test the Molecule.get_relevant_cycles() raises correct error after deprecation.


### PR DESCRIPTION
### Motivation or Problem
There are a couple of species that we currently cannot handle in RMG when generating mechanisms for heterogeneously catalyzed  reactions, because we have no way to represent them in RMG. One of these species is bidentate formate *OC(H)*O. 
![formate_resonance](https://github.com/user-attachments/assets/3a03b2e2-8c3c-4f42-8156-56146db9064f)

This adsorbate is a bidentate species, where both oxygen adatoms have the same distance to the surface. Formate is an important intermediate in many reactions mechanisms, like methanation or methanol synthesis. The only way to draw a Lewis structure for this species is to assume a resonance structure, where one of the oxygens doesn't have a bond to the surface. It is necessary to tell RMG that this is a bidentate species and that both oxygen atoms are coordinated with the surface atoms. There is also a stable monodentate formate species and our Lewis structure for the bidentate needs to be different from the monodentate.

### Description of Changes
I adjusted RMG to handle this structure (and similar adsorbates) by introducing a vdW bond between the oxygen and the surface atom. This tells RMG that the oxygen and the surface atom are connected. 

![HCXOXO(5)](https://github.com/user-attachments/assets/850bcc1d-72c1-47a3-8325-6ea074247671)

These vdW bonds occur only in multidentate adsorbates that have another covalent bond with the surface. If a reaction recipe leads to a species with only vdW bonds to the surface, RMG still removes those and forms a physisorbed structure. 

### Testing
I was able to generate a mechanism with the bidentate formate and it can also participate in reactions, when I provide new reaction families that can form and break this bond. 

### Reviewer Tips
This is still a work in progress and requires further updates. I'm just looking for initial thoughts on whether this approach is the right one to address this issue. 