### PR TITLE
Process monoatomic molecules in Arkane's Orca ESS adapter

### DIFF
--- a/arkane/data/orca/N_MRCI.log
+++ b/arkane/data/orca/N_MRCI.log
@@ -1,0 +1,1662 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ######   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #        #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,         ##   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     #####' # '####'        
+
+
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #    Directorship and core code : Frank Neese         #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 5.0.4 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CC/C-PCM, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : MC-RPA, TRAH-SCF, COSX integrals
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Marcus Kettner         : VPT2
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : Initial AUTO-CI
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert          DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 5.1.0
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.15  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Zen SINGLE_THREADED
+        Core in use  :  Zen
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: aug-cc-pVTZ 
+    H, B-Ne : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              R. A. Kendall, T. H. Dunning, Jr., R. J. Harrison, J. Chem. Phys. 96, 6796 (1992)
+         He : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              D. E. Woon, T. H. Dunning, Jr., J. Chem. Phys. 100, 2975 (1994)
+  Li-Be, Na : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              B. P. Prascher, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., A. K. Wilson, Theor. Chem. Acc. 128, 69 (2011)
+         Mg : Obtained from the Peterson Research Group Website (tyr0.chem.wsu.edu/~kipeters) Feb. 2017
+              B. P. Prascher, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., A. K. Wilson, Theor. Chem. Acc. 128, 69 (2011)
+      Al-Ar : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              D. E. Woon, T. H. Dunning, Jr., J. Chem. Phys. 98, 1358 (1993)
+      Sc-Zn : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              N. B. Balabanov, K. A. Peterson, J. Chem. Phys. 123, 064107 (2005)
+              N. B. Balabanov, K. A. Peterson, J. Chem. Phys. 125, 074110 (2006)
+      Ga-Kr : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              A. K. Wilson, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., J. Chem. Phys. 110, 7667 (1999)
+     Ag, Au : Obtained from the Peterson Research Group Website (tyr0.chem.wsu.edu/~kipeters) Feb. 2017
+              K. A. Peterson, C. Puzzarini, Theor. Chem. Acc. 114, 283 (2005)
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of the SHARK integral package has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> !uHF  aug-cc-pvtz  tightscf
+|  2> !sp 
+|  3> 
+|  4> %maxcore 3200
+|  5> %pal nprocs 16 end
+|  6> 
+|  7> * xyz 0 4
+|  8> N       0.00000000    0.00000000    0.00000000
+|  9> *
+| 10> 
+| 11> %scf
+| 12> MaxIter 999
+| 13> end
+| 14> 
+| 15> 
+| 16> %mp2
+| 17>     RI true
+| 18> end
+| 19> 
+| 20> %casscf
+| 21>     nel 5
+| 22>     norb 4
+| 23>     nroots 1
+| 24>     maxiter 999
+| 25> end
+| 26> 
+| 27> %mrci
+| 28>     citype MRCI
+| 29>     davidsonopt true
+| 30>     maxiter 999
+| 31> end
+| 32> 
+| 33> 
+| 34>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  N      0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 N     7.0000    0    14.007    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ N      0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ N      0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type N   : 19s6p3d2f contracted to 5s4p3d2f pattern {88111/3111/111/11}
+
+Atom   0N    basis set group =>   1
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021                                                         
+------------------------------------------------------------------------------
+
+
+Reading SHARK input file input.SHARKINP.tmp ... ok
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      1
+Number of basis functions                   ...     52
+Number of shells                            ...     20
+Maximum angular momentum                    ...      3
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... PARTIAL GENERAL contraction
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+Auxiliary Coulomb fitting basis             ... NOT available
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+Integral threshold                          ...     2.500000e-11
+Primitive cut-off                           ...     2.500000e-12
+Primitive pair pre-selection threshold      ...     2.500000e-12
+
+Calculating pre-screening integrals         ... done (  0.0 sec) Dimension = 20
+Calculating pre-screening integrals (ORCA)  ... done (  0.1 sec) Dimension = 14
+Organizing shell pair data                  ... done (  0.0 sec)
+Shell pair information
+Total number of shell pairs                 ...       210
+Shell pairs after pre-screening             ...       210
+Total number of primitive shell pairs       ...       256
+Primitive shell pairs kept                  ...       256
+          la=0 lb=0:     66 shell pairs
+          la=1 lb=0:     44 shell pairs
+          la=1 lb=1:     10 shell pairs
+          la=2 lb=0:     33 shell pairs
+          la=2 lb=1:     12 shell pairs
+          la=2 lb=2:      6 shell pairs
+          la=3 lb=0:     22 shell pairs
+          la=3 lb=1:      8 shell pairs
+          la=3 lb=2:      6 shell pairs
+          la=3 lb=3:      3 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      0.000000000000 Eh
+
+SHARK setup successfully completed in   0.2 seconds
+
+Maximum memory used throughout the entire GTOINT-calculation: 16.0 MB
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    4
+ Number of Electrons    NEL             ....    7
+ Basis Dimension        Dim             ....   46
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 2.690e-02
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.001 sec
+
+Time for model grid setup =    0.007 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (4 configurations for Mult=4)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    5
+Number of active orbitals           ...    4
+Total number of electrons           ...    7
+Total number of orbitals            ...   46
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   45 (  41 orbitals)
+Number of rotation parameters      ...    209
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of multiplicity blocks       ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    4
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  2.50e-09
+  Residual Tolerance CI             ...  2.50e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  2.50e-11
+  Primitive cutoff TCut             ...  2.50e-12
+  Energy convergence tolerance      ...  2.50e-08
+  Orbital gradient convergence      ...  2.50e-04
+  Max. number of iterations         ...       999  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -44.72092697 Eh
+CI-ITERATION   0: 
+   -54.381848153   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 4 NROOTS= 1 
+ROOT   0:  E=     -54.3818481526 Eh
+      1.00000 [     3]: 2111
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -54.381848153 Eh DE=    0.000000e+00
+   --- Energy gap subspaces: Ext-Act = 0.358   Act-Int = 14.743
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     8.377747e-01 Max(G)=   -7.011926e-01 Rot=45,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=1): ||X|| =      0.097273197 Max(X)(6,2) =     -0.044359639 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -44.72879418 Eh
+CI-ITERATION   0: 
+   -54.396929340   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -54.396929340 Eh DE=   -1.508119e-02
+   --- Energy gap subspaces: Ext-Act = 0.317   Act-Int = 14.676
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     8.661958e-02 Max(G)=   -4.686820e-02 Rot=45,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=1): ||X|| =      0.018251693 Max(X)(6,2) =     -0.008989526 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -44.72888355 Eh
+CI-ITERATION   0: 
+   -54.397580561   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -54.397580561 Eh DE=   -6.512206e-04
+   --- Energy gap subspaces: Ext-Act = 0.318   Act-Int = 14.686
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     1.169199e-02 Max(G)=   -3.787582e-03 Rot=17,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=1): ||X|| =      0.004765813 Max(X)(8,2) =      0.002361881 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -44.72891366 Eh
+CI-ITERATION   0: 
+   -54.397608742   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -54.397608742 Eh DE=   -2.818090e-05
+   --- Energy gap subspaces: Ext-Act = 0.316   Act-Int = 14.684
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     3.401689e-03 Max(G)=    1.928798e-03 Rot=45,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=1): ||X|| =      0.000448352 Max(X)(5,1) =     -0.000198017 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -44.72890218 Eh
+CI-ITERATION   0: 
+   -54.397609514   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -54.397609514 Eh DE=   -7.726311e-07
+   --- Energy gap subspaces: Ext-Act = 0.316   Act-Int = 14.684
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     3.651368e-04 Max(G)=   -2.086419e-04 Rot=45,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=1): ||X|| =      0.000048550 Max(X)(5,1) =     -0.000029015 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -44.72890337 Eh
+CI-ITERATION   0: 
+   -54.397609522   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -54.397609522 Eh DE=   -7.825491e-09
+   --- Energy gap subspaces: Ext-Act = 0.316   Act-Int = 14.684
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     5.710511e-05 Max(G)=    3.612727e-05 Rot=45,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                     ---- THE CAS-SCF GRADIENT HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -44.72890337 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -54.397609522   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -54.397609522 Eh DE=   -1.004565e-10
+   --- Energy gap subspaces: Ext-Act = 0.311   Act-Int = 14.684
+   N(occ)=  2.00000 1.00000 1.00000 1.00000
+   ||g|| =     5.710508e-05 Max(G)=    3.643662e-05 Rot=45,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -54.397609522 Eh   -1480.2342 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -15.630414      -425.3252 
+   1   2.0000      -0.946888       -25.7661 
+   2   1.0000      -0.180692        -4.9169 
+   3   1.0000      -0.180692        -4.9169 
+   4   1.0000      -0.180692        -4.9169 
+   5   0.0000       0.129931         3.5356 
+   6   0.0000       0.137198         3.7333 
+   7   0.0000       0.137198         3.7333 
+   8   0.0000       0.137198         3.7333 
+   9   0.0000       0.464734        12.6461 
+  10   0.0000       0.464734        12.6461 
+  11   0.0000       0.464734        12.6461 
+  12   0.0000       0.464734        12.6461 
+  13   0.0000       0.464734        12.6461 
+  14   0.0000       0.779518        21.2118 
+  15   0.0000       0.779518        21.2118 
+  16   0.0000       0.779518        21.2118 
+  17   0.0000       1.009605        27.4727 
+  18   0.0000       1.496268        40.7155 
+  19   0.0000       1.496268        40.7155 
+  20   0.0000       1.496268        40.7155 
+  21   0.0000       1.496268        40.7155 
+  22   0.0000       1.496268        40.7155 
+  23   0.0000       1.496268        40.7155 
+  24   0.0000       1.496268        40.7155 
+  25   0.0000       1.559115        42.4257 
+  26   0.0000       1.559115        42.4257 
+  27   0.0000       1.559115        42.4257 
+  28   0.0000       1.559115        42.4257 
+  29   0.0000       1.559115        42.4257 
+  30   0.0000       3.350863        91.1816 
+  31   0.0000       3.350863        91.1816 
+  32   0.0000       3.350863        91.1816 
+  33   0.0000       4.877040       132.7110 
+  34   0.0000       4.877040       132.7110 
+  35   0.0000       4.877040       132.7110 
+  36   0.0000       4.877040       132.7110 
+  37   0.0000       4.877040       132.7110 
+  38   0.0000       4.877040       132.7110 
+  39   0.0000       4.877040       132.7110 
+  40   0.0000       5.059015       137.6628 
+  41   0.0000       5.059015       137.6628 
+  42   0.0000       5.059015       137.6628 
+  43   0.0000       5.059015       137.6628 
+  44   0.0000       5.059015       137.6628 
+  45   0.0000       6.334698       172.3759 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 4 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -54.3976095224 Eh
+      1.00000 [     3]: 2111
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                  0          1          2          3    
+      0       2.000000   0.000000   0.000000   0.000000
+      1       0.000000   1.000000   0.000000   0.000000
+      2       0.000000   0.000000   1.000000   0.000000
+      3       0.000000   0.000000   0.000000   1.000000
+Trace of the electron density:  5.000000
+Extracting Spin-Density from 2-RDM (MULT=4) ... done
+
+-------------------
+SPIN-DENSITY MATRIX
+-------------------
+
+                  0          1          2          3    
+      0       0.000000   0.000000   0.000000   0.000000
+      1       0.000000   1.000000   0.000000   0.000000
+      2       0.000000   0.000000   1.000000   0.000000
+      3       0.000000   0.000000   0.000000   1.000000
+Trace of the spin density:  3.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -73.937937606 Eh       -2011.9536 eV
+Two electron energy          :     19.540328083 Eh         531.7194 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -54.397609522
+
+Kinetic energy               :     54.383096271 Eh        1479.8393 eV
+Potential energy             :   -108.780705794 Eh       -2960.0735 eV
+Virial ratio                 :     -2.000266871 
+                               ----------------
+                                  -54.397609522
+
+Core energy                  :    -44.728903374 Eh    -1217.1353 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                 -15.63041  -0.94689  -0.18069  -0.18069  -0.18069   0.12993
+                   2.00000   2.00000   1.00000   1.00000   1.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 N  pz              0.0       0.0      98.7       1.3       0.0       0.0
+ 0 N  px              0.0       0.0       1.3      98.7       0.0       0.0
+ 0 N  py              0.0       0.0       0.0       0.0     100.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.13720   0.13720   0.13720   0.46473   0.46473   0.46473
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  pz              0.6      28.8      70.6       0.0       0.0       0.0
+ 0 N  px              0.2      70.6      29.2       0.0       0.0       0.0
+ 0 N  py             99.2       0.6       0.2       0.0       0.0       0.0
+ 0 N  dz2             0.0       0.0       0.0       0.0       1.2      86.4
+ 0 N  dxz             0.0       0.0       0.0      69.8      23.3       0.0
+ 0 N  dyz             0.0       0.0       0.0       3.5       0.0      11.6
+ 0 N  dx2y2           0.0       0.0       0.0      12.1      66.6       0.9
+ 0 N  dxy             0.0       0.0       0.0      14.6       8.9       1.2
+
+                     12        13        14        15        16        17   
+                   0.46473   0.46473   0.77952   0.77952   0.77952   1.00960
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  s               0.0       0.0       0.0       0.0       0.0     100.0
+ 0 N  pz              0.0       0.0       0.0      27.3      72.7       0.0
+ 0 N  px              0.0       0.0       0.1      72.6      27.3       0.0
+ 0 N  py              0.0       0.0      99.9       0.0       0.0       0.0
+ 0 N  dz2             0.9      11.5       0.0       0.0       0.0       0.0
+ 0 N  dxz             3.6       3.3       0.0       0.0       0.0       0.0
+ 0 N  dyz             1.2      83.7       0.0       0.0       0.0       0.0
+ 0 N  dx2y2          19.3       1.1       0.0       0.0       0.0       0.0
+ 0 N  dxy            75.0       0.3       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.49627   1.49627   1.49627   1.49627   1.49627   1.49627
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  f0              5.6      24.2      37.4      21.3       4.3       2.9
+ 0 N  f+1            46.0       0.9       0.5      24.9       1.5       4.7
+ 0 N  f-1            18.8      40.5       9.7       5.5       0.0       0.5
+ 0 N  f+2             2.5       2.5      11.3       4.0      70.8       8.9
+ 0 N  f-2             1.7       9.1       3.0      18.4      20.1      29.2
+ 0 N  f+3            22.5       3.1      31.4      24.5       0.5      17.9
+ 0 N  f-3             2.8      19.7       6.7       1.3       2.8      35.9
+
+                     24        25        26        27        28        29   
+                   1.49627   1.55912   1.55912   1.55912   1.55912   1.55912
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  dz2             0.0       5.6      15.9      74.3       1.7       2.5
+ 0 N  dxz             0.0      12.7       2.5       0.9       6.7      77.2
+ 0 N  dyz             0.0       5.3      37.5      20.9      35.1       1.2
+ 0 N  dx2y2           0.0      65.9      18.1       0.9       0.0      15.1
+ 0 N  dxy             0.0      10.6      26.0       3.0      56.4       4.0
+ 0 N  f0              4.2       0.0       0.0       0.0       0.0       0.0
+ 0 N  f+1            21.5       0.0       0.0       0.0       0.0       0.0
+ 0 N  f-1            25.0       0.0       0.0       0.0       0.0       0.0
+ 0 N  f-2            18.5       0.0       0.0       0.0       0.0       0.0
+ 0 N  f-3            30.8       0.0       0.0       0.0       0.0       0.0
+
+                     30        31        32        33        34        35   
+                   3.35086   3.35086   3.35086   4.87704   4.87704   4.87704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  pz             23.6      12.5      63.8       0.0       0.0       0.0
+ 0 N  px             56.8       8.5      34.6       0.0       0.0       0.0
+ 0 N  py             19.5      78.9       1.6       0.0       0.0       0.0
+ 0 N  f0              0.0       0.0       0.0       5.7       0.4      27.9
+ 0 N  f+1             0.0       0.0       0.0       5.5       0.0       0.0
+ 0 N  f-1             0.0       0.0       0.0       0.5       2.4       0.5
+ 0 N  f+2             0.0       0.0       0.0      36.3      53.6       2.9
+ 0 N  f-2             0.0       0.0       0.0       5.6       1.5      55.0
+ 0 N  f+3             0.0       0.0       0.0      12.8       0.1       0.3
+ 0 N  f-3             0.0       0.0       0.0      33.6      42.0      13.5
+
+                     36        37        38        39        40        41   
+                   4.87704   4.87704   4.87704   4.87704   5.05902   5.05902
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  dz2             0.0       0.0       0.0       0.0      44.5       6.2
+ 0 N  dxz             0.0       0.0       0.0       0.0       1.2       0.0
+ 0 N  dyz             0.0       0.0       0.0       0.0       3.8      33.6
+ 0 N  dx2y2           0.0       0.0       0.0       0.0      47.3       7.1
+ 0 N  dxy             0.0       0.0       0.0       0.0       3.2      53.1
+ 0 N  f0              8.9       0.1       3.3      53.6       0.0       0.0
+ 0 N  f+1            10.6      64.8      19.1       0.0       0.0       0.0
+ 0 N  f-1             1.1      26.1      66.5       3.0       0.0       0.0
+ 0 N  f+2             5.1       0.8       0.1       1.3       0.0       0.0
+ 0 N  f-2             0.1       0.0       1.3      36.6       0.0       0.0
+ 0 N  f+3            66.4       8.1       7.1       5.2       0.0       0.0
+ 0 N  f-3             7.9       0.1       2.6       0.3       0.0       0.0
+
+                     42        43        44        45   
+                   5.05902   5.05902   5.05902   6.33470
+                   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------
+ 0 N  s               0.0       0.0       0.0     100.0
+ 0 N  dz2            32.3      16.9       0.0       0.0
+ 0 N  dxz             1.5       0.1      97.2       0.0
+ 0 N  dyz            19.7      41.9       1.1       0.0
+ 0 N  dx2y2           5.9      39.0       0.8       0.0
+ 0 N  dxy            40.7       2.1       0.9       0.0
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                 -15.63041  -0.94689  -0.18069  -0.18069  -0.18069   0.12993
+                   2.00000   2.00000   1.00000   1.00000   1.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 N  s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 N  pz              0.0       0.0      98.7       1.3       0.0       0.0
+ 0 N  px              0.0       0.0       1.3      98.7       0.0       0.0
+ 0 N  py              0.0       0.0       0.0       0.0     100.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... input.scfp
+Input spin density                  ... input.scfr
+BaseName (.gbw .S,...)              ... input
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+------------------------------------------
+MULLIKEN ATOMIC CHARGES AND SPIN DENSITIES
+------------------------------------------
+   0 N :   -0.000000    3.000000
+Sum of atomic charges       :   -0.0000000
+Sum of atomic spin densities:    3.0000000
+
+---------------------------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES AND SPIN DENSITIES
+---------------------------------------------------
+CHARGE
+  0 N s       :     4.000000  s :     4.000000
+      pz      :     1.000000  p :     3.000000
+      px      :     1.000000
+      py      :     1.000000
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+SPIN
+  0 N s       :     0.000000  s :     0.000000
+      pz      :     1.000000  p :     3.000000
+      px      :     1.000000
+      py      :     1.000000
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+-----------------------------------------
+LOEWDIN ATOMIC CHARGES AND SPIN DENSITIES
+-----------------------------------------
+   0 N :   -0.000000    3.000000
+
+--------------------------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES AND SPIN DENSITIES
+--------------------------------------------------
+CHARGE
+  0 N s       :     4.000000  s :     4.000000
+      pz      :     1.000000  p :     3.000000
+      px      :     1.000000
+      py      :     1.000000
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+SPIN
+  0 N s       :     0.000000  s :     0.000000
+      pz      :     1.000000  p :     3.000000
+      px      :     1.000000
+      py      :     1.000000
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 N      7.0000     7.0000    -0.0000     3.0000     0.0000     3.0000
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.074753310 (     0.008585038,      0.000026009,     -0.074258695)
+ MO   3:      0.074753310 (    -0.074258616,     -0.000109345,     -0.008585067)
+ MO   4:      0.074753310 (    -0.000111609,      0.074753225,      0.000013280)
+MO   1:
+ MO   2:      0.777510748 (     0.089293158,      0.000270525,     -0.772366248)
+ MO   3:      0.777510748 (    -0.772365423,     -0.001137300,     -0.089293461)
+ MO   4:      0.777510748 (    -0.001160843,      0.777509869,      0.000138122)
+MO   2:
+MO   3:
+MO   4:
+  newgto N 
+  0 18
+    1      11420.000000000000         0.000522768355
+    2       1712.000000000000         0.004043208403
+    3        389.300000000000         0.020765798413
+    4        110.000000000000         0.080691244693
+    5         35.570000000000         0.232970767719
+    6         12.540000000000         0.433308995327
+    7          4.644000000000         0.347318098976
+    8          0.511800000000        -0.008504231668
+    9      11420.000000000000        -0.000000607139
+   10       1712.000000000000        -0.000004725125
+   11        389.300000000000        -0.000024412268
+   12        110.000000000000        -0.000097818014
+   13         35.570000000000        -0.000302719511
+   14         12.540000000000        -0.000697291235
+   15          4.644000000000        -0.000910761311
+   16          0.511800000000         0.003167386147
+   17          1.293000000000         0.042437946502
+   18          0.178700000000         0.006072346930
+  0 18
+    1      11420.000000000000         0.000002720308
+    2       1712.000000000000         0.000021039475
+    3        389.300000000000         0.000108058121
+    4        110.000000000000         0.000419889672
+    5         35.570000000000         0.001212300289
+    6         12.540000000000         0.002254791986
+    7          4.644000000000         0.001807324738
+    8      11420.000000000000         0.000115506572
+    9       1712.000000000000         0.000898942453
+   10        389.300000000000         0.004644368606
+   11        110.000000000000         0.018609615382
+   12         35.570000000000         0.057591576877
+   13         12.540000000000         0.132657791513
+   14          4.644000000000         0.173269902282
+   15          0.511800000000        -0.602586738479
+   16          1.293000000000        -0.151583562870
+   17          0.178700000000        -0.380619025879
+   18          0.057600000000        -0.006167374158
+  1 6
+    1         26.630000000000         0.014646107832
+    2          5.948000000000         0.091614549360
+    3          1.742000000000         0.298196552532
+    4          0.555000000000         0.500982554894
+    5          0.172500000000         0.327306035784
+    6          0.049100000000         0.015517087267
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000164 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the Dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0            0.00000   0.00000   0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        7.2 sec
+Sum of individual times          ...        3.1 sec ( 42.6%)
+
+Calculation of AO operators
+   F(Core) operator              ...        1.4 sec ( 18.9%)
+   G(Act) operator               ...        0.3 sec (  4.1%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.1 sec (  1.2%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  0.0%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.0%)
+   CI-solution phase             ...        0.4 sec (  6.0%)
+   Generation of densities       ...        0.0 sec (  0.0%)
+Orbital improvement steps
+   Orbital gradient              ...        0.9 sec ( 12.4%)
+   O(1) converger                ...        0.0 sec (  0.0%)
+Properties                       ...        0.0 sec (  0.0%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 117.8 MB
+Warning: no block have been defined for MRCI - copying CASSCF information!
+
+
+           ************************************************************
+           *        Program running with 16 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+------------------------------------------------------------------------------
+                               ORCA MRCI
+------------------------------------------------------------------------------
+
+Transformed one-electron integrals ... input.cih.tmp
+Transformed RI-integrals           ... input.rijt.tmp
+Output vectors                     ... input.mrci
+
+----------------
+MRCI-SETUP PHASE
+----------------
+
+GBW-Name                     ... input.gbw
+IVO-Name                     ... input.ivo
+HName                        ... input.H.tmp
+SName                        ... input.S.tmp
+CIHName                      ... input.cih.tmp
+CIFName                      ... input.cif.tmp
+MRCIName                     ... input.mrci
+IntFiles                     ... input.rijt.tmp
+LocName                      ... input.loc
+MRCIInput                    ... input.mrciinp
+Basis dimension              ... 46
+Improved Virtual Orbitals    ... OFF
+Orbital localization         ... OFF
+
+Figured out Orbital ranges
+Set data to blocks
+
+-----------------------
+FROZEN CORE FOCK MATRIX
+-----------------------
+
+Improved virtual orbitals (IVOs) WILL NOT be constructed
+Orbital Range is before PREP ... Int=  1-  0 Act=  1-  4 Ext=  5- 45
+Calculating Frozen Core Matrices ... (look at input.lastciprep)
+Warning: FirstInternal=1 LastInternal=0 NInternals=0 - setting LastInternal for FI=-1
+
+------------------------------------------------------------------------------
+                             ORCA CI-PREPARATION
+------------------------------------------------------------------------------
+Reading the GBW file               ... done
+
+
+One-Electron Matrix                ... input.H.tmp
+GBW-File                           ... input.gbw
+First MO in the CI                 ... 1
+Integral package used              ... LIBINT
+Reading the GBW file               ... done
+
+Reading the one-electron matrix    ... done
+Forming inactive density           ... done
+Forming Fock matrix/matrices       ... 
+Nuclear repulsion    ...     0.000000 
+Core repulsion       ...     0.000000 
+One-electron energy  ...   -48.843003 
+Fock-energy          ...   -40.614803 
+Final value          ...   -44.728903 
+done
+Transforming integrals             ... done
+Storing passive energy             ... done (    -44.72890337 Eh)
+The internal FI matrix is equal to the CIH matrix; storing it as such!
+             .... done with the Frozen Core Fock matrices
+Final Orbital Range is now   ... Int=  1-  0 Act=  1-  4 Ext=  5- 45
+
+------------------------------
+PARTIAL COULOMB TRANSFORMATION
+------------------------------
+
+Dimension of the basis                     ...           46
+Number of internal MOs                     ...           45 (1-45)
+Pair cutoff                                ...    2.500e-12 Eh
+Number of AO pairs included in the trafo   ...         1081
+Total Number of distinct AO pairs          ...         1081
+Memory devoted for trafo                   ...         3200 MB 
+Memory needed per MO pair                  ...            0 MB
+Max. Number of MO pairs treated together   ...       388002 
+Memory needed per MO                       ...            0 MB
+Max. Number of MOs treated per batch       ...           45 
+Number Format for Storage                  ... Double (8 Byte)
+Integral package used                      ... LIBINT
+
+ --->>> The Coulomb operators (i,j|mue,nue) will be calculated
+
+Starting integral evaluation:
+<ss|**>: <sp|**>:         1575 b        0 skpd     0.002 s (  0.001 ms/b)
+<sd|**>:         2100 b        0 skpd     0.002 s (  0.001 ms/b)
+<sf|**>:         1575 b        0 skpd     0.001 s (  0.001 ms/b)
+<pp|**>:         1050 b        0 skpd     0.002 s (  0.002 ms/b)
+<pd|**>:         1050 b        0 skpd     0.001 s (  0.001 ms/b)
+<pf|**>:         1260 b        0 skpd     0.001 s (  0.001 ms/b)
+<dd|**>:          840 b        0 skpd     0.002 s (  0.003 ms/b)
+         630 b        0 skpd     0.002 s (  0.003 ms/b)
+<df|**>:          630 b        0 skpd     0.003 s (  0.005 ms/b)
+<ff|**>:          315 b        0 skpd     0.004 s (  0.014 ms/b)
+Collecting buffer AOJ 
+    ... done with AO integral generation
+Closing buffer AOJ ( 0.00 GB; CompressionRatio= 1.77)
+Number of MO pairs included in the trafo   ... 1035
+    ... Now sorting integrals
+IBATCH = 1 of  2
+IBATCH = 2 of  2
+Closing buffer JAO ( 0.01 GB; CompressionRatio= 1.00)
+TOTAL TIME for half transformation ...     0.030 sec
+AO-integral generation             ...     0.020 sec
+Half transformation                ...     0.003 sec
+J-integral sorting                 ...     0.007 sec
+Collecting buffer JAO 
+
+-------------------
+FULL TRANSFORMATION
+-------------------
+
+Processing MO  10
+Processing MO  20
+Processing MO  30
+Processing MO  40
+Full transformation done
+Number of integrals made            ...       536130
+Number of integrals stored          ...       261508
+Timings:
+Time for first half transformation  ...     0.032 sec
+Time for second half transformation ...     0.002 sec
+Total time                          ...     0.037 sec
+
+------------------
+CI-BLOCK STRUCTURE
+------------------
+
+Number of CI-blocks                ... 1
+
+===========
+CI BLOCK 1
+===========
+Multiplicity             ...   4
+Irrep                    ...  -1
+Number of reference defs ...   1
+  Reference   1: CAS(5,4)
+
+Excitation type          ... CISD
+Excitation flags for singles:
+    1 1 1 1
+Excitation flags for doubles:
+    1 1 1 / 1 1 1 / 1 1 1
+
+
+
+        --------------------------------------------------------------------
+        -------------------- ALL SETUP TASKS ACCOMPLISHED ------------------
+        --------------------      (     0.258 sec)        ------------------
+        --------------------------------------------------------------------
+
+
+
+            ###################################################
+            #                                                 #
+            #                       M R C I                   #
+            #                                                 #
+            # TSel    =   1.000e-06 Eh                        #
+            # TPre    =   1.000e-04                           #
+            # TIntCut =   1.000e-10 Eh                        #
+            # Extrapolation to unselected MR-CI by full MP2   #
+            # DAVIDSON-1 Correction to full CI                #
+            #                                                 #
+            ###################################################
+
+
+---------------------
+INTEGRAL ORGANIZATION
+---------------------
+
+Reading the one-Electron matrix             ... done
+E0 read was -44.728903374198
+Reading the internal Fock matrix            ... done
+Preparing the integral list                 ... done
+Loading the full integral list              ... done
+Making the simple integrals                 ... done
+
+                  ***************************************
+                  *              CI-BLOCK  1            *
+                  ***************************************
+
+Configurations with insufficient # of SOMOs WILL be rejected
+Building a CAS(5,4) for multiplicity 4
+Reference Space:
+ Initial Number of Configurations :      4
+ Internal Orbitals :    1 -    0
+ Active Orbitals   :    1 -    4
+ External Orbitals :    5 -   45
+The number of CSFs in the reference is 4
+Calling MRPT_Selection with N(ref)=4
+------------------
+REFERENCE SPACE CI
+------------------
+
+ Pre-diagonalization threshold                 : 1.000e-04
+Warning: Setting NGuessMat to 512
+N(ref-CFG)=4 N(ref-CSF)=4
+
+                       ****Iteration    0****
+   Lowest Energy          :   -54.397609522415
+   Maximum Energy change  :    54.397609522415 (vector 0)
+   Maximum residual norm  :     0.000000000000
+
+      *** CONVERGENCE OF RESIDUAL NORM REACHED ***
+Reference space selection using TPre= 1.00e-04
+
+    ... found 1 reference configurations (1 CSFs)
+        ... now redoing the reference space CI ...
+
+Warning: Setting NGuessMat to 512
+N(ref-CFG)=1 N(ref-CSF)=1
+
+                       ****Iteration    0****
+   Lowest Energy          :   -54.397609522415
+   Maximum Energy change  :    54.397609522415 (vector 0)
+   Maximum residual norm  :     0.000000000000
+
+      *** CONVERGENCE OF RESIDUAL NORM REACHED ***
+
+----------
+CI-RESULTS
+----------
+
+The threshold for printing is  0.30 percent
+The weights of configurations will be printed. The weights are summed over
+all CSFs that belong to a given configuration before printing
+
+STATE   0:  Energy=    -54.397609522 Eh RefWeight=  1.0000  0.00 eV      0.0 cm**-1
+      1.0000  : h---h---[2111]
+
+------------------------------
+MR-PT SELECTION TSel= 1.00e-06
+------------------------------
+
+
+Setting reference configurations WITHOUT use of symmetry
+Building active patterns WITHOUT use of symmetry
+
+Selection will be done from 1 spatial configurations
+ ( 0) Refs        : Sel:         1CFGs/         1CSFs Gen:           1CFGs/           1CSFs  (       0.000 sec)
+Building active space densities            ...        0.002 sec
+Building active space Fock operators       ...        0.000 sec
+ ( 1) (p,q)->(r,s): Sel:         3CFGs/         3CSFs Gen:           3CFGs/           3CSFs  (       0.001 sec)
+ ( 5) (p,-)->(a,-): Sel:       164CFGs/       287CSFs Gen:         164CFGs/         287CSFs  (       0.001 sec)
+ ( 6) (i,-)->(a,-): Sel:         0CFGs/         0CSFs Gen:           0CFGs/           0CSFs  (       0.001 sec)
+ ( 7) (i,j)->(p,a): Sel:         0CFGs/         0CSFs Gen:           0CFGs/           0CSFs  (       0.000 sec)
+ ( 8) (i,p)->(q,a): Sel:         0CFGs/         0CSFs Gen:           0CFGs/           0CSFs  (       0.001 sec)
+ ( 9) (p,q)->(r,a): Sel:       108CFGs/       108CSFs Gen:         369CFGs/         369CSFs  (       0.001 sec)
+ (10) (i,p)->(a,b): Sel:         0CFGs/         0CSFs Gen:           0CFGs/           0CSFs  (       0.001 sec)
+ (11) (p,q)->(a,b): Sel:      1279CFGs/      3493CSFs Gen:        5904CFGs/       15744CSFs  (       0.002 sec)
+ (12) (i,j)->(a,b): Sel:         0CFGs/         0CSFs Gen:           0CFGs/           0CSFs  (       2.945 sec)
+
+Selection results:
+Total number of generated configurations:       6441
+Number of selected configurations       :       1555 ( 24.1%)
+Total number of generated CSFs          :      16404
+Number of selected CSFS                 :       3892 ( 23.7%)
+
+The selected tree structure:
+Number of selected Internal Portions       :      4
+Number of selected Singly External Portions:     13
+   average number of VMOs/Portion          :  19.43
+   percentage of selected singly externals :  50.94
+Number of selected Doubly External Portions:      7
+   average number of VMOs/Portion          : 159.88
+   percentage of selected doubly externals :  22.28
+
+Diagonal second order perturbation results:
+State      E(tot)           E(0)+E(1)     E2(sel)      E2(unsel)
+             Eh                Eh           Eh           Eh     
+----------------------------------------------------------------
+ 0     -54.503566265    -54.397609522    -0.105685    -0.000272
+
+Computing the reference space Hamiltonian ... done (DIM=1)
+Storing the reference space Hamiltonian   ... done
+Finding start and stop indices            ... done
+Collecting additional information         ... done
+Entering the DIIS solver section
+------------------------
+MULTIROOT DIIS CI SOLVER
+------------------------
+
+Number of CSFs                          ...    3892   
+Number of configurations                ...    1555   
+Maximum number of DIIS vectors stored   ...       5   
+Level shift                             ...   0.20
+Convergence tolerance on energies       ... 2.500e-07 
+Convergence tolerance on residual       ... 2.500e-07 
+Partitioning used                       ... MOELLER-PLESSET
+
+
+                       ****Iteration    0****
+  State   0: E=   -54.466179124 Ec=-0.068569602 R= 0.299648465 W0=  0.96521
+  Max energy change = 6.8570e-02 Eh
+  Max Residual Norm = 2.9965e-01   
+
+                       ****Iteration    1****
+  State   0: E=   -54.512269425 Ec=-0.114659903 R= 0.002512143 W0=  0.95744
+  Max energy change = 4.6090e-02 Eh
+  Max Residual Norm = 2.5121e-03   
+
+                       ****Iteration    2****
+  State   0: E=   -54.512978160 Ec=-0.115368637 R= 0.000325639 W0=  0.96224
+  Max energy change = 7.0873e-04 Eh
+  Max Residual Norm = 3.2564e-04   
+
+                       ****Iteration    3****
+  State   0: E=   -54.513035558 Ec=-0.115426036 R= 0.000008152 W0=  0.96143
+  Max energy change = 5.7399e-05 Eh
+  Max Residual Norm = 8.1520e-06   
+
+                       ****Iteration    4****
+  State   0: E=   -54.513039684 Ec=-0.115430162 R= 0.000001364 W0=  0.96186
+  Max energy change = 4.1259e-06 Eh
+  Max Residual Norm = 1.3636e-06   
+
+                       ****Iteration    5****
+  State   0: residual converged
+  State   0: E=   -54.513040333 Ec=-0.115430811 R= 0.000000068 W0=  0.96184
+  Max energy change = 0.0000e+00 Eh
+  Max Residual Norm = 6.7607e-08   
+                *** Convergence of energies reached ***
+                *** Convergence of residual reached ***
+                *** All vectors converged ***
+Returned from DIIS section
+
+----------------------------------------------
+MULTI-REFERENCE/MULTI-ROOT DAVIDSON CORRECTION
+----------------------------------------------
+
+
+Summary of multireference corrections:
+
+Root  W(ref)       E(MR-CI)         E(ref)       Delta-E      None  Davidson-1 Davidson-2 Siegbahn   Pople
+------------------------------------------------------------------------------------------------------------
+ 0    0.962    -54.513040333    -54.397609522  0.115430811  0.000000 -0.004405 -0.004769 -0.004580 -0.002769
+------------------------------------------------------------------------------------------------------------
+Active option = Davidson-1
+
+Unselected CSF estimate:
+Full relaxed MR-MP2 calculation           ... 
+
+Selection will be done from 1 spatial configurations
+
+Selection will be done from 1 spatial configurations
+
+Selection will be done from 1 spatial configurations
+done
+Selected MR-MP2 energies                  ... 
+
+ Root=  0  E(unsel)=     -0.000272010 
+
+----------
+CI-RESULTS
+----------
+
+The threshold for printing is  0.30 percent
+The weights of configurations will be printed. The weights are summed over
+all CSFs that belong to a given configuration before printing
+
+STATE   0:  Energy=    -54.517717250 Eh RefWeight=  0.9618  0.00 eV      0.0 cm**-1
+      0.9618  : h---h---[2111]
+Now choosing densities with flags StateDens=3 and TransDens=1 NStates(total)=1
+State density of the lowest state in each block NStateDens= 2
+GS to excited state transition electron densities NTransDens=0
+NDens(total)=2
+All lowest density information prepared Cnt(Dens)=2
+GS to ES state electron density information prepared Cnt(Dens)=2
+
+------------------
+DENSITY GENERATION
+------------------
+
+   ... generating densities (input.mrci.vec0) ... o.k.
+MRCI-Population analysis: looping over 2 densities
+Found state electron-density state=0 block=0
+Found state spin-density state=0 block=0
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... input.state_0_block_0.el.tmp
+Input spin density                  ... input.state_0_block_0.spin.tmp
+BaseName (.gbw .S,...)              ... input
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+------------------------------------------
+MULLIKEN ATOMIC CHARGES AND SPIN DENSITIES
+------------------------------------------
+   0 N :   -0.000000    3.000000
+Sum of atomic charges       :   -0.0000000
+Sum of atomic spin densities:    3.0000000
+
+---------------------------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES AND SPIN DENSITIES
+---------------------------------------------------
+CHARGE
+  0 N s       :     3.975014  s :     3.975014
+      pz      :     0.998985  p :     2.996924
+      px      :     0.998969
+      py      :     0.998970
+      dz2     :     0.005285  d :     0.026369
+      dxz     :     0.005270
+      dyz     :     0.005265
+      dx2y2   :     0.005292
+      dxy     :     0.005257
+      f0      :     0.000241  f :     0.001693
+      f+1     :     0.000239
+      f-1     :     0.000253
+      f+2     :     0.000241
+      f-2     :     0.000236
+      f+3     :     0.000234
+      f-3     :     0.000251
+
+SPIN
+  0 N s       :     0.021881  s :     0.021881
+      pz      :     0.984931  p :     2.954801
+      px      :     0.984937
+      py      :     0.984933
+      dz2     :     0.004517  d :     0.022525
+      dxz     :     0.004496
+      dyz     :     0.004491
+      dx2y2   :     0.004526
+      dxy     :     0.004496
+      f0      :     0.000113  f :     0.000793
+      f+1     :     0.000112
+      f-1     :     0.000119
+      f+2     :     0.000112
+      f-2     :     0.000109
+      f+3     :     0.000110
+      f-3     :     0.000117
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+-----------------------------------------
+LOEWDIN ATOMIC CHARGES AND SPIN DENSITIES
+-----------------------------------------
+   0 N :   -0.000000    3.000000
+
+--------------------------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES AND SPIN DENSITIES
+--------------------------------------------------
+CHARGE
+  0 N s       :     3.975014  s :     3.975014
+      pz      :     0.998985  p :     2.996924
+      px      :     0.998969
+      py      :     0.998970
+      dz2     :     0.005285  d :     0.026369
+      dxz     :     0.005270
+      dyz     :     0.005265
+      dx2y2   :     0.005292
+      dxy     :     0.005257
+      f0      :     0.000241  f :     0.001693
+      f+1     :     0.000239
+      f-1     :     0.000253
+      f+2     :     0.000241
+      f-2     :     0.000236
+      f+3     :     0.000234
+      f-3     :     0.000251
+
+SPIN
+  0 N s       :     0.021881  s :     0.021881
+      pz      :     0.984931  p :     2.954801
+      px      :     0.984937
+      py      :     0.984933
+      dz2     :     0.004517  d :     0.022525
+      dxz     :     0.004496
+      dyz     :     0.004491
+      dx2y2   :     0.004526
+      dxy     :     0.004496
+      f0      :     0.000113  f :     0.000793
+      f+1     :     0.000112
+      f-1     :     0.000119
+      f+2     :     0.000112
+      f-2     :     0.000109
+      f+3     :     0.000110
+      f-3     :     0.000117
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 N      7.0000     7.0000    -0.0000     3.1783     0.0000     3.1783
+
+
+
+
+---------------------
+CI-EXCITATION SPECTRA
+---------------------
+
+Center of mass = (  0.0000,  0.0000,  0.0000)
+
+Nuclear contribution to the dipole moment=     0.000000,    0.000000,    0.000000 au
+
+Calculating the Dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular momentum integrals        ... done
+Transforming integrals                            ... done
+
+------------------------------------------------------------------------------------------
+                                ABSORPTION SPECTRUM
+------------------------------------------------------------------------------------------
+     States         Energy   Wavelength   fosc          T2        TX        TY        TZ  
+                    (cm-1)     (nm)                   (D**2)     (D)       (D)       (D)  
+------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+                             CD SPECTRUM
+------------------------------------------------------------------------------
+      States        Energy   Wavelength   R*T        RX        RY        RZ   
+                    (cm-1)      (nm)    (1e40*sgs)  (au)      (au)      (au)  
+------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+                             STATE DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0            0.00000   0.00000   0.00000      0.00000
+
+Maximum memory used throughout the entire MRCI-calculation: 76.9 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -54.517717249721
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... input.gbw
+Electron density                                ... input.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000       0.00000       0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000000     0.000000     0.000000 
+x,y,z [Debye]:     0.000000     0.000000     0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...       17.846 sec (=   0.297 min)
+GTO integral calculation        ...        0.534 sec (=   0.009 min)   3.0 %
+SCF iterations                  ...        0.410 sec (=   0.007 min)   2.3 %
+CASSCF iterations               ...        9.882 sec (=   0.165 min)  55.4 %
+Multireference CI module        ...        7.020 sec (=   0.117 min)  39.3 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 18 seconds 202 msec

--- a/arkane/ess/orca.py
+++ b/arkane/ess/orca.py
@@ -109,6 +109,9 @@ class OrcaLog(ESSAdapter):
         The units of the returned force constants are J/m^2.
         If no force constant matrix can be found, ``None`` is returned.
         """
+        n_atoms = self.get_number_of_atoms()
+        if n_atoms == 1:
+            return None
         hess_files = list()
         for (_, _, files) in os.walk(os.path.dirname(self.path)):
             for file_ in files:
@@ -196,7 +199,7 @@ class OrcaLog(ESSAdapter):
         you can use the `symmetry` parameter to substitute your own value; if
         not provided, the value in the Orca log file will be adopted.
         """
-        freq, mmass, rot, unscaled_frequencies = [], [], [], []
+        freq, mmass, rot, unscaled_frequencies, modes = [], [], [], [], []
         e0 = 0.0
 
         if optical_isomers is None or symmetry is None:
@@ -230,7 +233,7 @@ class OrcaLog(ESSAdapter):
         symbols = [symbol_by_number[i] for i in number]
         inertia = get_principal_moments_of_inertia(coord, numbers=number, symbols=symbols)
         inertia = list(inertia[0])
-        if len(inertia):
+        if len(inertia) and not all(i == 0.0 for i in inertia):
             if any(i == 0.0 for i in inertia):
                 inertia.remove(0.0)
                 rot.append(LinearRotor(inertia=(inertia, "amu*angstrom^2"), symmetry=symmetry))
@@ -241,7 +244,11 @@ class OrcaLog(ESSAdapter):
         mmass.append(translation)
 
         # Take only the last modes found (in the event of multiple jobs).
-        modes = [mmass[-1], rot[-1], freq[-1]]
+        modes = [mmass[-1]]
+        if len(rot):
+            modes.append(rot[-1])
+        if len(freq):
+            modes.append(freq[-1])
 
         return Conformer(E0=(e0 * 0.001, "kJ/mol"),
                          modes=modes,

--- a/test/arkane/ess/orcaTest.py
+++ b/test/arkane/ess/orcaTest.py
@@ -65,6 +65,8 @@ class OrcaTest:
         Uses Orca log files to test that
         number of atoms can be properly read.
         """
+        log = OrcaLog(os.path.join(self.data_path, "N_MRCI.log"))
+        assert log.get_number_of_atoms() == 1
         log = OrcaLog(os.path.join(self.data_path, "Orca_opt_freq_test.log"))
         assert log.get_number_of_atoms() == 3
         log = OrcaLog(os.path.join(self.data_path, "Orca_dlpno_test.log"))
@@ -143,6 +145,13 @@ class OrcaTest:
         assert len([mode for mode in conformer.modes if isinstance(mode, NonlinearRotor)]) == 1
         assert len([mode for mode in conformer.modes if isinstance(mode, HarmonicOscillator)]) == 1
         assert len(unscaled_frequencies) == 3
+
+        log = OrcaLog(os.path.join(self.data_path, "N_MRCI.log"))
+        conformer, unscaled_frequencies = log.load_conformer()
+        assert len([mode for mode in conformer.modes if isinstance(mode, IdealGasTranslation)]) == 1
+        assert len([mode for mode in conformer.modes if isinstance(mode, NonlinearRotor)]) == 0
+        assert len([mode for mode in conformer.modes if isinstance(mode, HarmonicOscillator)]) == 0
+        assert len(unscaled_frequencies) == 0
 
     def test_spin_multiplicity_from_orca_log(self):
         """


### PR DESCRIPTION
### Motivation or Problem
The current Orca ESS adapter in Arkane does not support monoatomic molecules (e.g., `O`, `N`, ...).
This is probably because DKPNO calcs do not support monoatomics. However, we would like to use Orca for other LOTs which can be applied for monoatomics.

### Description of Changes
Modifications were made to Arkane's Orca ESS adapter to support monoatomics. Most modifications are minor.

### Testing
Tests were added for the Orca adapter modifications.
