### PR TITLE
Remove `default` Channel from `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@
 # - August 4, 2024 Restricted pyrms to <2
 name: rmg_env
 channels:
-  - defaults
   - rmg
   - conda-forge
   - cantera


### PR DESCRIPTION
Update Before Merging from @JacksonBurns:

This PR tested and showed that we can remove the `default` channel from our `environment.yml` file. This is important since Anaconda has changed their Terms of Service, and this change brings many of our users back in line with said ToS.