### PR TITLE
Check for adsorbates in resonance structure generation

### DIFF
--- a/rmgpy/molecule/resonance.py
+++ b/rmgpy/molecule/resonance.py
@@ -96,9 +96,9 @@ def populate_resonance_algorithms(features=None):
             method_list.append(generate_allyl_delocalization_resonance_structures)
         if features['is_cyclic']:
             method_list.append(generate_aryne_resonance_structures)
-        if features['hasNitrogenVal5']:
+        if features['hasNitrogenVal5'] and not features['is_adsorbate']:
             method_list.append(generate_N5dc_radical_resonance_structures)
-        if features['hasLonePairs']:
+        if features['hasLonePairs'] and not features['is_adsorbate']:
             method_list.append(generate_adj_lone_pair_radical_resonance_structures)
             method_list.append(generate_adj_lone_pair_multiple_bond_resonance_structures)
             method_list.append(generate_adj_lone_pair_radical_multiple_bond_resonance_structures)
@@ -130,6 +130,7 @@ def analyze_molecule(mol, save_order=False):
                 'is_aryl_radical': False,
                 'hasNitrogenVal5': False,
                 'hasLonePairs': False,
+                'is_adsorbate':mol.contains_surface_site(),
                 }
 
     if features['is_cyclic']:


### PR DESCRIPTION
### Motivation or Problem
@kirkbadger18 observed an issue when generating mechanisms with adsorbates that contain N atoms. RMG seems to generate species that have formal charges, although the reaction templates technically don't allow this reaction. This is described in issue #2716. The reason RMG found this issue is because of the resonance structure generation. Currently, there is no check if a species is an adsorbate or a gas-phase species, when applying the resonance algorithm. In this case, it produced a species with charge separation and then produced a whole bunch of weird reactions from that before crashing. 

In my opinion, we should not apply the resonance structure generation templates for gas-phase species to adsorbates because we don't really know if they exist (yet). But I'm open to discussion if something thinks that the gas-phase recipes should be applied to adsorbates. 

I have another PR open #2511 that adds resonance generation specifically for adsorbates. 

### Description of Changes
I added a check in `resonance.py` to only apply the resonance structure generation if a species is an adsorbate. 

### Testing
I confirmed that the issue is resolved. RMG passes the tests locally and I can also generate mechanisms without any errors. 

### Reviewer Tips
This should be fairly quick to review. It shouldn't affect the gas-phase chemistry and doesn't have any implications for catalysis mechanisms. It would be great, if someone could test this for a gas-phase reaction mechanism that involves N where resonance is important and confirm that this didn't change anything. 
@alongd It would be great if you could take a look at this . 