### PR TITLE
update user and developer installation instructions to point towards miniforge

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaUser.rst
+++ b/documentation/source/users/rmg/installation/anacondaUser.rst
@@ -5,26 +5,7 @@ Binary Installation Using Anaconda for Unix-Based Systems: Linux and Mac OSX
 ****************************************************************************
 
 
-#. Install the `conda` package manager, if you do not already have it (or Anaconda).
-   Select one of the following options:
-
-   a. Users of Fedora Linux and Red Hat derivatives (RHEL, CentOS Stream) may install from the official repositories and EPEL, respectively, with the command ::
-
-       sudo dnf install conda
-
-   b. All other users, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
-
-      The download will be a .sh file with a name like ``Miniconda3-latest-Linux-x86_64.sh``.
-      Open a terminal in the same directory as this file, and type the following to install Conda
-      (replace the name of your .sh file below). ::
-
-       bash Miniconda3-latest-Linux-x86_64.sh
-
-      **When prompted to append Anaconda to your PATH, select or type Yes**. 
-      Install the Conda folder inside your home directory 
-      (typically ``/home/YourUsername/`` in Linux and ``/Users/YourUsername`` in Mac).
-
-      Note that you should reinitialize or restart your terminal in order for the changes to take effect, as the installer will tell you.
+#. Install the `conda` package manager via `miniforge`, if you do not already have it (or Anaconda), by following the `Miniforge installation instructions <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_.
 
 #. Install both RMG and the RMG-database binaries through the terminal.   Dependencies will be installed automatically. It is safest to make a new conda environment for RMG and its dependencies. Type the following command into the terminal to create the new environment named 'rmg_env' containing the latest stable version of the RMG program and its database. ::
 


### PR DESCRIPTION
Installing `conda` via other providers can result in non-free channels being used, violating the `conda` terms of service for many of our users. Pointing users towards this new installation method for `conda` guarantees that they will not access non-free channels.

Related to #2712 