### PR TITLE
Deprecate the nomkl mutex metapackage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,16 @@ jobs:
       - name: Checkout RMG-Py
         uses: actions/checkout@v4
 
+      # Step to create a custom condarc.yml before setting up conda
+      - name: Create custom conda config file
+        run: |
+          RUNNER_CWD=$(pwd)
+          echo "channels:" > $RUNNER_CWD/condarc.yml
+          echo "  - conda-forge" >> $RUNNER_CWD/condarc.yml
+          echo "  - rmg" >> $RUNNER_CWD/condarc.yml
+          echo "  - cantera" >> $RUNNER_CWD/condarc.yml
+          echo "show_channel_urls: true" >> $RUNNER_CWD/condarc.yml
+
       # configures the mamba environment manager and builds the environment
       - name: Setup Miniforge Python 3.7
         uses: conda-incubator/setup-miniconda@v3
@@ -70,6 +80,7 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           python-version: 3.7
+          condarc-file: condarc.yml
           activate-environment: rmg_env
           use-mamba: true
 
@@ -112,6 +123,16 @@ jobs:
       - name: Checkout RMG-Py
         uses: actions/checkout@v4
 
+      # Step to create a custom condarc.yml before setting up conda
+      - name: Create custom condarc.yml
+        run: |
+          RUNNER_CWD=$(pwd)
+          echo "channels:" > $RUNNER_CWD/condarc.yml
+          echo "  - conda-forge" >> $RUNNER_CWD/condarc.yml
+          echo "  - rmg" >> $RUNNER_CWD/condarc.yml
+          echo "  - cantera" >> $RUNNER_CWD/condarc.yml
+          echo "show_channel_urls: true" >> $RUNNER_CWD/condarc.yml
+
       # configures the mamba environment manager and builds the environment
       - name: Setup Miniforge Python 3.7
         uses: conda-incubator/setup-miniconda@v3
@@ -120,6 +141,7 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           python-version: 3.7
+          condarc-file: condarc.yml
           activate-environment: rmg_env
           use-mamba: true
 

--- a/environment.yml
+++ b/environment.yml
@@ -101,8 +101,8 @@ dependencies:
   # Note that _some other_ dep. in this list requires diffeqpy in its recipe
   # which will cause it to be downloaded from the rmg conda channel
 
-# conda mutex metapackage
-  - nomkl
+# configure packages to use OpenBLAS instead of Intel MKL
+  - blas=*=openblas
 
 # additional packages that are required, but not specified here (and why)
   # pydqed, pydas, mopac, and likely others require a fortran compiler (specifically gfortran)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Resolves issue #2722 .

### Description of Changes

- Added a step in the CI workflow to create a custom conda config files that excludes the default channel. 
- Replaced the nomkl mutex metapackage that controls whether packages should use MKL or OpenBLAS. 