### PR TITLE
Changed Dockerfile to use Miniforge3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -401,7 +401,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: reactionmechanismgenerator/rmg:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ RUN apt-get update && \
     apt-get clean -y
 
 # Install conda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda && \
-    rm Miniconda3-latest-Linux-x86_64.sh
-ENV PATH="$PATH:/miniconda/bin"
+RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh" && \ 
+    bash Miniforge3-Linux-x86_64.sh -b -p /miniforge && \
+    rm Miniforge3-Linux-x86_64.sh
+ENV PATH="$PATH:/miniforge/bin"
 
 # Set solver backend to mamba for speed
 RUN conda install -n base conda-libmamba-solver && \
@@ -35,12 +35,18 @@ RUN conda install -n base conda-libmamba-solver && \
 # Set Bash as the default shell for following commands
 SHELL ["/bin/bash", "-c"]
 
+# Add build arguments for RMG-Py, RMG-database, and RMS branches.
+ARG RMG_Py_Branch=main
+ARG RMG_Database_Branch=main
+ARG RMS_Branch=main
+ENV rmsbranch=${RMS_Branch}
+
 # cd
 WORKDIR /rmg
 
 # Clone the RMG base and database repositories
-RUN git clone --single-branch --branch main --depth 1 https://github.com/ReactionMechanismGenerator/RMG-Py.git && \
-    git clone --single-branch --branch main --depth 1 https://github.com/ReactionMechanismGenerator/RMG-database.git
+RUN git clone --single-branch --branch ${RMG_Py_Branch} --depth 1 https://github.com/ReactionMechanismGenerator/RMG-Py.git && \
+    git clone --single-branch --branch ${RMG_Database_Branch} --depth 1 https://github.com/ReactionMechanismGenerator/RMG-database.git
 
 WORKDIR /rmg/RMG-Py
 # build the conda environment
@@ -64,7 +70,7 @@ ENV PATH="$RUNNER_CWD/RMG-Py:$PATH"
 # setting this env variable fixes an issue with Julia precompilation on Windows
 ENV JULIA_CPU_TARGET="x86-64,haswell,skylake,broadwell,znver1,znver2,znver3,cascadelake,icelake-client,cooperlake,generic"
 RUN make && \
-    julia -e 'using Pkg; Pkg.add(PackageSpec(name="PyCall",rev="master")); Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev="main")); using ReactionMechanismSimulator' && \
+    julia -e 'using Pkg; Pkg.add(PackageSpec(name="PyCall",rev="master")); Pkg.add(PackageSpec(name="ReactionMechanismSimulator",rev=ENV["rmsbranch"])); using ReactionMechanismSimulator' && \
     python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
 
 # RMG-Py should now be installed and ready - trigger precompilation and test run


### PR DESCRIPTION
This is a follow-up to #2718 . We missed the Docker build file when we updated our CI to use Miniforge3. 

I also added some arguments in the Dockerfile so the CI or an end user can configure it to use different branches for RMG-Py, RMG-database, and RMS. They are currently only used by the `echem-rebase` branch to push an `electrocat` version of the Docker image, but could also provides some flexibility for future projects. 

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Description of Changes

- Changed the Docker build file to use Miniforge3 instead of Miniconda and Mamba. 

- Added arguments in the Docker build file to allow different branches to be pulled instead of main. Default to main. 

- Updated the `docker-build-and-push` action to use the latest version. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
