### PR TITLE
Fix library reaction barrier heights for linear scaling

### DIFF
--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -548,6 +548,10 @@ class CoreEdgeReactionModel:
             #  correct barrier heights of estimated kinetics
             if isinstance(forward, (TemplateReaction, DepositoryReaction)):  # i.e. not LibraryReaction
                 forward.fix_barrier_height()  # also converts ArrheniusEP to Arrhenius.
+            elif isinstance(forward, LibraryReaction) and forward.is_surface_reaction():
+                # do fix the library reaction barrier if this is scaled from another metal
+                if any(['Binding energy corrected by LSR' in x.thermo.comment for x in forward.reactants + forward.products]):
+                    forward.fix_barrier_height()            
 
             if self.pressure_dependence and forward.is_unimolecular():
                 # If this is going to be run through pressure dependence code,


### PR DESCRIPTION
### Motivation or Problem
If you include a library for a surface mechanism that uses linear scaling, this can cause some reaction barriers to be below the endothermicity of the reaction. This PR fixes the barrier heights for library reactions that have been scaled across metals.

See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2726 for more details of the issue.

### Description of Changes
This PR adds a call to fix_barrier_height() if the library reaction is a surface reaction with any species thermo that has been scaled across metals.

### Testing
I have tested with this CPOX on Rh RMG [input.txt](https://github.com/user-attachments/files/17718558/input.txt) and confirmed that it raises the barrier for the O2 dissociative adsorption reaction taken from the Surface/CPOX_Pt/Deutschmann2006_adjusted library:

```
! Reaction index: Chemkin #4; RMG #6
! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
! Flux pairs: OX(25), O2(3); OX(25), X(1); OX(25), X(1);
!
! Ea raised from 278.7 to 418.8 kJ/mol to match endothermicity of reaction.
OX(25)+OX(25)<=>X(1)+X(1)+O2(3)                     3.700000e+21 0.000     100.098
```

vs, the original:

```
! Reaction index: Chemkin #4; RMG #6
! Library reaction: Surface/CPOX_Pt/Deutschmann2006_adjusted
! Flux pairs: OX(25), O2(3); OX(25), X(1); OX(25), X(1);
OX(25)+OX(25)<=>X(1)+X(1)+O2(3)                     3.700000e+21 0.000     66.611
```


<s>I have not yet tested that it _doesn't_ scale the same input file if you try to generate a Pt mechanism, but I plan to.</s>
have now confirmed it doesn't bother fixing barriers for regular Pt mechanism.
