### PR TITLE
Fix Conda build workflow

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -11,48 +11,88 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - name: Create custom conda config file
+        run: |
+          RUNNER_CWD=$(pwd)
+          echo "channels:" > $RUNNER_CWD/condarc.yml
+          echo "  - rmg" >> $RUNNER_CWD/condarc.yml
+          echo "show_channel_urls: true" >> $RUNNER_CWD/condarc.yml
+      - name: Setup Conda       
+        uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: environment.yml
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
           python-version: 3.7
           activate-environment: rmg_env
+          use-mamba: true
       - name: Conda info
         run: |
-          conda info
-          conda list
-      - name: Build Binary
-        env: 
-          CONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          mamba info
+          mamba list
+      - name: Install Build Tools
         run: |
-          conda install -y conda-build 
-          conda install -y anaconda-client 
-          conda config --add channels rmg
-          conda config --set anaconda_upload yes
-          conda build --token $CONDA_TOKEN --user rmg .conda
+          mamba install -y anaconda-client conda-build conda-verify
+      - name: Configure Auto-Upload
+        run: |
+          conda config --set anaconda_upload yes          
+      - name: Build Binary
+        run: |
+          # Set the CONDA_TOKEN environment variable
+          if [ -z "${{ secrets.ANACONDA_TOKEN }}" ]; then
+            export CONDA_TOKEN="default_value"
+          else
+            export CONDA_TOKEN="${{ secrets.ANACONDA_TOKEN }}"
+          fi
+
+          echo "CONDA_TOKEN=$CONDA_TOKEN" >> $GITHUB_ENV
+      
+          # Build the Conda binary
+          conda-build --token "$CONDA_TOKEN" --user rmg .conda
+  
   build-osx:
     runs-on: macos-latest
     defaults:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - name: Create custom conda config file
+        run: |
+          RUNNER_CWD=$(pwd)
+          echo "channels:" > $RUNNER_CWD/condarc.yml
+          echo "  - rmg" >> $RUNNER_CWD/condarc.yml
+          echo "show_channel_urls: true" >> $RUNNER_CWD/condarc.yml    
+      - name: Setup Conda       
+        uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: environment.yml
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
           python-version: 3.7
           activate-environment: rmg_env
+          use-mamba: true
       - name: Conda info
         run: |
-          conda info
-          conda list
-      - name: Build Binary
-        env: 
-          CONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          mamba info
+          mamba list
+      - name: Install Build Tools
         run: |
-            conda install -y conda-build 
-            conda install -y anaconda-client 
-            conda config --add channels rmg
-            conda config --set anaconda_upload yes
-            xcrun --show-sdk-path
-            conda build --token $CONDA_TOKEN --user rmg .conda
+          mamba install -y anaconda-client conda-build conda-verify
+      - name: Configure Auto-Upload
+        run: |
+          conda config --set anaconda_upload yes   
+      - name: Build Binary
+        run: |
+          # Set the CONDA_TOKEN environment variable
+          if [ -z "${{ secrets.ANACONDA_TOKEN }}" ]; then
+            export CONDA_TOKEN="default_value"
+          else
+            export CONDA_TOKEN="${{ secrets.ANACONDA_TOKEN }}"
+          fi
+
+          echo "CONDA_TOKEN=$CONDA_TOKEN" >> $GITHUB_ENV
+
+          xcrun --show-sdk-path
+          conda build --token $CONDA_TOKEN --user rmg .conda


### PR DESCRIPTION
This is the mirror PR to [this](https://github.com/ReactionMechanismGenerator/RMG-database/pull/671).

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The old Conda build workflow to set up Miniconda no longer works due to deprecation of the `default` channel. Now only the `conda-forge` channel will be used. Furthermore, the new workflow directly uses Miniforge3 which has built-in mamba solver. 

### Testing
Currently, this workflow only triggers upon releasing a stable version of RMG-Py. So I've set this PR to WIP until I've tested it to prevent overwriting the current stable RMG-Py package on the rmg channel. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
