### PR TITLE
Fix database issues with loading new kinetic libraries

### DIFF
--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -268,7 +268,16 @@ class KineticsDatabase(object):
                 for f in files:
                     if f.lower() == 'reactions.py':
                         library_file = os.path.join(root, f)
-                        label = os.path.dirname(library_file)[len(path) + 1:]
+                        dirname = os.path.dirname(library_file)
+                        if dirname == path:
+                            label = os.path.basename(dirname)
+                        else:
+                            label = os.path.relpath(dirname, path)
+
+                        if not label:
+                            logging.warning(f"Empty label for {library_file}. Using 'default'.")
+                            label = "default"
+                        
                         logging.info(f'Loading kinetics library {label} from {library_file}...')
                         library = KineticsLibrary(label=label)
                         try:

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -46,7 +46,8 @@ from rmgpy.kinetics import Arrhenius, ArrheniusEP, ThirdBody, Lindemann, Troe, \
                            PDepArrhenius, MultiArrhenius, MultiPDepArrhenius, \
                            Chebyshev, KineticsData, StickingCoefficient, \
                            StickingCoefficientBEP, SurfaceArrhenius, SurfaceArrheniusBEP, \
-                           ArrheniusBM, SurfaceChargeTransfer, KineticsModel, Marcus
+                           ArrheniusBM, SurfaceChargeTransfer, KineticsModel, Marcus, \
+                           ArrheniusChargeTransfer
 from rmgpy.molecule import Molecule, Group
 from rmgpy.reaction import Reaction, same_species_lists
 from rmgpy.species import Species
@@ -70,6 +71,7 @@ class KineticsDatabase(object):
             'KineticsData': KineticsData,
             'Arrhenius': Arrhenius,
             'ArrheniusEP': ArrheniusEP,
+            'ArrheniusChargeTransfer': ArrheniusChargeTransfer,
             'MultiArrhenius': MultiArrhenius,
             'MultiPDepArrhenius': MultiPDepArrhenius,
             'PDepArrhenius': PDepArrhenius,

--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -47,7 +47,8 @@ from rmgpy.kinetics import Arrhenius, ArrheniusEP, ThirdBody, Lindemann, Troe, \
                            Chebyshev, KineticsData, StickingCoefficient, \
                            StickingCoefficientBEP, SurfaceArrhenius, SurfaceArrheniusBEP, \
                            ArrheniusBM, SurfaceChargeTransfer, KineticsModel, Marcus, \
-                           ArrheniusChargeTransfer
+                           ArrheniusChargeTransfer, ArrheniusChargeTransferBM
+from rmgpy.kinetics.uncertainties import RateUncertainty
 from rmgpy.molecule import Molecule, Group
 from rmgpy.reaction import Reaction, same_species_lists
 from rmgpy.species import Species
@@ -86,11 +87,13 @@ class KineticsDatabase(object):
             'SurfaceChargeTransfer': SurfaceChargeTransfer,
             'R': constants.R,
             'ArrheniusBM': ArrheniusBM,
+            'ArrheniusChargeTransferBM': ArrheniusChargeTransferBM,
             'SoluteData': SoluteData,
             'SoluteTSData': SoluteTSData,
             'SoluteTSDiffData': SoluteTSDiffData,
             'KineticsModel': KineticsModel,
             'Marcus': Marcus,
+            'RateUncertainty': RateUncertainty,
         }
         self.global_context = {}
 

--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -464,11 +464,16 @@ class KineticsLibrary(Database):
             local_context[key] = value
 
         # Process the file
-        f = open(path, 'r')
+        with open(path, 'r') as f:
+            content = f.read()
         try:
-            exec(f.read(), global_context, local_context)
-        except Exception:
-            logging.error('Error while reading database {0!r}.'.format(path))
+            exec(content, global_context, local_context)
+        except Exception as e:
+            logging.exception(f'Error while reading database file {path}.')
+            line_number = e.__traceback__.tb_next.tb_lineno
+            logging.error(f'Error occurred at or near line {line_number} of {path}.')
+            lines = content.splitlines()
+            logging.error(f'Line: {lines[line_number - 1]}')
             raise
         f.close()
 


### PR DESCRIPTION
See https://github.com/ReactionMechanismGenerator/RMG-database/issues/678. 

Some of the new libraries are causing issues with loading the relevant kinetics data into the RMG database.

(1) `LithiumPrimaryChargedKinetics`. The cause of this error was `ArrheniusChargeTransfer` not being included in the local context. **This has been fixed in this PR.**
(2) `LithiumAnalogyKinetics`. The cause of this error is not clear to me yet; still investigating.  As this gets fixed (and if any other errors pop up), they will be addressed in this PR.

To reproduce, try:

```
from rmgpy.data.rmg import RMGDatabase
from rmgpy import settings

database = RMGDatabase()

database.load(settings['database.directory'], thermo_libraries = []', 
              kinetics_families=[], kinetics_depositories=[], reaction_libraries=None) # None loads all libraries
```