### PR TITLE
Arkane: add check for iop(2/9=2000) in Gaussian load geometry

### DIFF
--- a/arkane/ess/gaussian.py
+++ b/arkane/ess/gaussian.py
@@ -164,12 +164,18 @@ class GaussianLog(ESSAdapter):
         Return the optimum geometry of the molecular configuration from the
         Gaussian log file. If multiple such geometries are identified, only the
         last is returned.
+        Also checks that the Cartesian coordinates are printed in the input orientation:
+        IOP(2/9=2000) must be specified for large cases (14+ atoms)
         """
         number, coord, mass = [], [], []
 
+        iop2_9_equals_2000 = False
         with open(self.path, 'r') as f:
             line = f.readline()
             while line != '':
+                if '2/9=2000' in line:
+                    iop2_9_equals_2000 = True
+
                 # Automatically determine the number of atoms
                 if 'Input orientation:' in line:
                     number, coord = [], []
@@ -195,6 +201,11 @@ class GaussianLog(ESSAdapter):
                            'Make sure the output file is not corrupt.\nNote: if your species has '
                            '50 or more atoms, you will need to add the `iop(2/9=2000)` keyword to your '
                            'input file so Gaussian will print the input orientation geometry.'.format(self.path))
+
+        if len(number) > 13 and not iop2_9_equals_2000:
+            raise LogError(f'Gaussian output file {self.path} contains more than 13 atoms. '
+                           f'Please add the `iop(2/9=2000)` keyword to your input file '
+                           f'so Gaussian will print the geometry using the input orientation.')
 
         return coord, number, mass
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
By default, Gaussian only prints Cartesians in the input orientation for small cases. Add a check for the IOP(2/9=2000) keyword so users don't get tripped up like I did here: https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2757 with coordinates that don't match the Hessian.

### Description of Changes
I added a check for the IOP(2/9=2000 keyword) when loading the geometry. If the molecule has 14+ atoms (this seems to be the threshold according to my experiments), this will raise a LogError if the keyword hasn't been specified. 

### Testing
I tested this using one Gaussian logfile that has the IOP and one that doesn't.
[conformer_0002_iop.log](https://github.com/user-attachments/files/18709550/conformer_0002_iop.log)
[conformer_0002_no_iop.log](https://github.com/user-attachments/files/18709559/conformer_0002_no_iop.log)
