### PR TITLE
Py39/cantera26 arm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,6 @@ jobs:
           activate-environment: rmg_env
           auto-update-conda: true
           show-channel-urls: true
-          channels: conda-forge,cantera,rmg
           conda-remove-defaults: "true"
 
       # list the environment for debugging purposes
@@ -158,7 +157,6 @@ jobs:
           activate-environment: rmg_env
           auto-update-conda: true
           show-channel-urls: true
-          channels: conda-forge,cantera,rmg
           conda-remove-defaults: "true"
 
       # list the environment for debugging purposes

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,8 +58,6 @@ jobs:
         os: [macos-13, macos-latest, ubuntu-latest]
         include-rms: ["", "with RMS"]
         exclude:
-          - os: macos-latest  # needs Cantera 3 b/c x86 emulation breaks with Julia
-            include-rms: 'with RMS'
           - os: macos-13  # GitHub's runners just aren't up to the task of installing Julia
             include-rms: 'with RMS'
     runs-on: ${{ matrix.os }}
@@ -72,10 +70,6 @@ jobs:
     steps:
       - name: Checkout RMG-Py
         uses: actions/checkout@v4
-
-      - name: Compel Arm-based Mac to use x86
-        if: matrix.os == 'macos-latest'
-        run: echo "CONDA_SUBDIR=osx-64" >> $GITHUB_ENV
 
       - name: Setup Miniforge Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,6 @@ jobs:
           activate-environment: rmg_env
           use-mamba: true
           show-channel-urls: true
-          channels: conda-forge,cantera,rmg
 
       - name: Install sphinx
         run: mamba install -y sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@
 name: rmg_env
 channels:
   - conda-forge
-  - cantera
   - rmg
 dependencies:
 # System-level dependencies - we could install these at the OS level

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
 
 # external software tools for chemistry
   - conda-forge::coolprop
-  - cantera::cantera =2.6
+  - conda-forge::cantera =2.6
   - conda-forge::mopac
   # see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2639#issuecomment-2050292972
   - conda-forge::cclib >=1.6.3,<1.9

--- a/environment.yml
+++ b/environment.yml
@@ -59,7 +59,7 @@ dependencies:
   - conda-forge::cython >=0.25.2
   - conda-forge::scikit-learn
   - conda-forge::scipy >=1.9
-  - conda-forge::numpy >=1.10.0
+  - conda-forge::numpy >=1.10.0,<2
   - conda-forge::pydot
   - conda-forge::jinja2
   - conda-forge::jupyter

--- a/test/rmgpy/solver/liquidTest.py
+++ b/test/rmgpy/solver/liquidTest.py
@@ -167,21 +167,21 @@ class LiquidReactorTest:
 
         # Check that we're computing the species fluxes correctly
         for i in range(t.shape[0]):
-            assert abs(reaction_rates[i, 0] - species_rates[i, 0]) < abs(
+            assert abs(reaction_rates[i, 0] - species_rates[i, 0]) <= abs(
                 1e-6 * reaction_rates[i, 0]
             )
-            assert abs(reaction_rates[i, 0] - -species_rates[i, 1]) < abs(
+            assert abs(reaction_rates[i, 0] - -species_rates[i, 1]) <= abs(
                 1e-6 * reaction_rates[i, 0]
             )
-            assert abs(reaction_rates[i, 0] - -species_rates[i, 2]) < abs(
+            assert abs(reaction_rates[i, 0] - -species_rates[i, 2]) <= abs(
                 1e-6 * reaction_rates[i, 0]
             )
-            assert abs(reaction_rates[i, 0] - species_rates[i, 3]) < abs(
+            assert abs(reaction_rates[i, 0] - species_rates[i, 3]) <= abs(
                 1e-6 * reaction_rates[i, 0]
             )
 
         # Check that we've reached equilibrium
-        assert abs(reaction_rates[-1, 0] - 0.0) < 1e-2
+        assert abs(reaction_rates[-1, 0] - 0.0) <= 1e-2
 
     def test_jacobian(self):
         """


### PR DESCRIPTION
Python 3.9 upgrade doesn't work with ARM Mac + RMS.

This is because we currently run ARM macs in x86 emulation mode (since `cantera` doesn't have ARM Mac binaries) which (for some reason) breaks RMS compatibility.

Instead of upgrading cantera version (https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2751) to resolve this, we will just change the channel from which we install `cantera` to one which has binaries we need.