### PR TITLE
require a more recent version of mkl for Cantera

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -110,6 +110,7 @@ dependencies:
 # depends on OpenBLAS instead
   - conda-forge::mkl >=2023.1.0
   - conda-forge::libcurl <= 8.9  # this is because of a Julia bug associated with libcurl 8.10+
+  - conda-forge::pyopenssl >20
 
 # additional packages that are required, but not specified here (and why)
   # pydqed, pydas, mopac, and likely others require a fortran compiler (specifically gfortran)

--- a/environment.yml
+++ b/environment.yml
@@ -109,6 +109,7 @@ dependencies:
 # but if we can switch over to the conda-forge version, we should be able to remove this line because it
 # depends on OpenBLAS instead
   - conda-forge::mkl >=2023.1.0
+  - conda-forge::libcurl <= 8.9  # this is because of a Julia bug associated with libcurl 8.10+
 
 # additional packages that are required, but not specified here (and why)
   # pydqed, pydas, mopac, and likely others require a fortran compiler (specifically gfortran)

--- a/environment.yml
+++ b/environment.yml
@@ -105,12 +105,17 @@ dependencies:
 # configure packages to use OpenBLAS instead of Intel MKL
   - blas=*=openblas
 
-# except that Cantera is configured to use Intel MKL, so we have to make sure its version is recent
-# but if we can switch over to the conda-forge version, we should be able to remove this line because it
-# depends on OpenBLAS instead
+# Cantera 2.6 on the Cantera channel is configured to use Intel MKL. It doesn't specify a version minimum
+# but crashes if MKL is too old, so we have to enforce a minimum version here. But, if we can switch over
+# to the conda-forge version, we should be able to remove this line (and maybe the two after it)
+# because it use OpenBLAS instead. 
   - conda-forge::mkl >=2023.1.0
-  - conda-forge::libcurl <= 8.9  # this is because of a Julia bug associated with libcurl 8.10+
+  # 2023.1.0 is just a guess at the minimum version. Older versions might work too.
+  - conda-forge::libcurl <= 8.9 
+  # There's a Julia/PyCall installation bug associated with libcurl 8.10+:
+  # https://discourse.julialang.org/t/curl-multi-assign-and-segmentation-fault-when-installing-package/120901/3
   - conda-forge::pyopenssl >20
+  # ThermoCentralDatabaseInterface fails if pyopenssl is too old. 20 is just a guess at the version number. 
 
 # additional packages that are required, but not specified here (and why)
   # pydqed, pydas, mopac, and likely others require a fortran compiler (specifically gfortran)

--- a/environment.yml
+++ b/environment.yml
@@ -105,6 +105,11 @@ dependencies:
 # configure packages to use OpenBLAS instead of Intel MKL
   - blas=*=openblas
 
+# except that Cantera is configured to use Intel MKL, so we have to make sure its version is recent
+# but if we can switch over to the conda-forge version, we should be able to remove this line because it
+# depends on OpenBLAS instead
+  - conda-forge::mkl >=2023.1.0
+
 # additional packages that are required, but not specified here (and why)
   # pydqed, pydas, mopac, and likely others require a fortran compiler (specifically gfortran)
   # in the environment. Normally we would add this to the environment file with

--- a/test/rmgpy/rmg/inputTest.py
+++ b/test/rmgpy/rmg/inputTest.py
@@ -117,7 +117,7 @@ class TestInputMLEstimator:
         assert isinstance(rmg.ml_settings, dict)
 
 
-class TestInputThemoCentralDatabase:
+class TestInputThermoCentralDatabase:
     """
     Contains unit tests rmgpy.rmg.input.thermo_central_database
     """
@@ -127,7 +127,7 @@ class TestInputThemoCentralDatabase:
         global rmg
         rmg.thermo_central_database = None
 
-    def test_themo_central_database(self):
+    def test_thermo_central_database(self):
         """
         Test that we can input.
         """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The RMG-database continuous integration is failing because it can't find the right mkl library file: https://github.com/ReactionMechanismGenerator/RMG-database/issues/683

Rather than slap a bandaid over the problem (this PR: https://github.com/ReactionMechanismGenerator/RMG-database/pull/684), this PR tries to fix the versions conda requires.

From what I've seen, I believe it's Cantera that has the MKL dependency. It doesn't specify a version and then errors out when conda grabs something so old it can't find the right file name.

### Description of Changes
I added a version requirement for MKL to the RMG-Py environment file. I chose the version 2023.1.0 because it's what I have on my local Window's subsystem linux and I was worried that choosing the latest 2025 version would be too strict and cause the conda solver to fail.

### Testing
I'm not really sure how to test this besides letting the usual Github actions run. Then we merge it and see if that fixes the database tests? Let me know if you have any ideas.
