### PR TITLE
add yaml writer test to compare yaml file generated by RMG and the ya…

### DIFF
--- a/test/rmgpy/test_data/yaml_writer_data/cantera/chem47.yaml
+++ b/test/rmgpy/test_data/yaml_writer_data/cantera/chem47.yaml
@@ -1,0 +1,2778 @@
+generator: RMG
+date: Tue, 18 Feb 2025 15:33:45
+
+units: {length: cm, time: s, quantity: mol, activation-energy: kcal/mol}
+
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [H, C, O, N, Ne, Ar, He, Si, S, F, Cl, Br, I, D, T, CI, OI, X]
+  species: [Ar, Ne, N2, CH4(2), H2O(3), CO2(4), H2(5), CO(6), O2(7), C2H6(8), CH3(9), CH3OH(10), C2H4(11), CH3CHO(12), C3H6O(13), C2H6O(14), CH3COOCH3(15)]
+  kinetics: gas
+  reactions: [gas_reactions]
+  transport: mixture-averaged
+  state: {T: 300.0, P: 1 atm}
+
+- name: Pt_surface
+  thermo: ideal-surface
+  adjacent-phases: [gas]
+  elements: [H, C, O, N, Ne, Ar, He, Si, S, F, Cl, Br, I, D, T, CI, OI, X]
+  species: [X(1), HX(16), OX(17), CX(18), COX(19), CHX(20), CH2X(21), HCOX(22), HCOHX(23), CH3OX(24), CH3COOX(25), CH2COX(26), CH2COX2(27), CH3COOHX(28), C2H4X(29), C2H4X2(30), COOHX(31), CH3X(32), HOX(33), OCXOX(34), HOCXO(35), CO2X(36), H2OX(43), 'C.[Pt](84)', C2H3X(88), CHOX2(110), C2H3X2(120), 'CC#[Pt](307)', C2H2X2(338), 'C#C.[Pt](513)']
+  kinetics: surface
+  reactions: [surface_reactions]
+  site-density: 3.148e-09
+
+elements:
+- symbol: D
+  atomic-weight: 2.014102
+- symbol: T
+  atomic-weight: 3.016049
+- symbol: CI
+  atomic-weight: 13.003354
+- symbol: OI
+  atomic-weight: 17.999159
+- symbol: X
+  atomic-weight: 195.083
+
+species:
+- name: Ar
+  composition:
+    Ar: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 200.0
+    - 1000.0
+    - 6000.0
+    data:
+    - - 2.5
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - -745.375
+      - 4.37967
+    - - 2.5
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - -745.375
+      - 4.37967
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 3.3300000000000005
+    well-depth: 136.50054988458677
+  note: GRI-Mech
+- name: Ne
+  composition:
+    Ne: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 200.0
+    - 1000.0
+    - 6000.0
+    data:
+    - - 2.5
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - -745.375
+      - 3.35532
+    - - 2.5
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - -745.375
+      - 3.35532
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 3.7580000000000005
+    well-depth: 148.6
+  note: Epsilon & sigma estimated with fixed Lennard Jones Parameters. This is the
+    fallback method! Try improving transport databases!
+- name: N2
+  composition:
+    N: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 200.0
+    - 1000.0
+    - 6000.0
+    data:
+    - - 3.53101
+      - -0.000123661
+      - -5.02999e-07
+      - 2.43531e-09
+      - -1.40881e-12
+      - -1046.98
+      - 2.96747
+    - - 2.95258
+      - 0.0013969
+      - -4.92632e-07
+      - 7.8601e-11
+      - -4.60755e-15
+      - -923.949
+      - 5.87189
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.6210000000000013
+    well-depth: 97.53030619382686
+    polarizability: 1.7600000000000011
+    rotational-relaxation: 4.0
+  note: GRI-Mech
+- name: X(1)
+  composition:
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+- name: CH4(2)
+  composition:
+    C: 1.0
+    H: 4.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1084.1187337643662
+    - 5000.0
+    data:
+    - - 4.205416196255041
+      - -0.005355584631145938
+      - 2.5112363572294852e-05
+      - -2.137632989042285e-08
+      - 5.9752576676099345e-12
+      - -10161.943346777867
+      - -0.9212827273392239
+    - - 0.9082602129576632
+      - 0.011454094892455498
+      - -4.5717433924635545e-06
+      - 8.291928595922759e-10
+      - -5.6631586824980706e-14
+      - -9719.972022902222
+      - 13.993125635097375
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.746000000000001
+    well-depth: 141.400440100105
+    polarizability: 2.600000000000002
+    rotational-relaxation: 13.0
+  note: GRI-Mech
+- name: H2O(3)
+  composition:
+    H: 2.0
+    O: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1130.243284919479
+    - 5000.0
+    data:
+    - - 4.057636221872408
+      - -0.0007879402524835726
+      - 2.9087893225841516e-06
+      - -1.4752057824605237e-09
+      - 2.1284959599833601e-13
+      - -30281.586653679737
+      - -0.3113654695330764
+    - - 2.843247813270488
+      - 0.0027510897463440443
+      - -7.810338827223348e-07
+      - 1.0724419204775164e-10
+      - -5.793967385714403e-15
+      - -29958.611588952655
+      - 5.910434907048865
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 2.6050000000000004
+    well-depth: 572.4019516813576
+    dipole: 1.8439999999999999
+    rotational-relaxation: 4.0
+  note: GRI-Mech
+- name: CO2(4)
+  composition:
+    C: 1.0
+    O: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 978.2164247415373
+    - 5000.0
+    data:
+    - - 3.280844236561561
+      - 0.002501860004866126
+      - 8.08190843915926e-06
+      - -1.2051019574327036e-08
+      - 4.665419284125267e-12
+      - -48400.830312852784
+      - 6.00081543904009
+    - - 4.6742752757606745
+      - 0.0026096268846741164
+      - -9.856820820173133e-07
+      - 1.957120153217903e-10
+      - -1.4983471395230124e-14
+      - -48951.21731066457
+      - -2.1107803190827465
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.763
+    well-depth: 244.00106224424113
+    polarizability: 2.650000000000001
+    rotational-relaxation: 2.1
+  note: GRI-Mech
+- name: H2(5)
+  composition:
+    H: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1959.08462230851
+    - 5000.0
+    data:
+    - - 3.4353643375690575
+      - 0.00021270843056734023
+      - -2.7862068251219974e-07
+      - 3.4026374586351706e-10
+      - -7.760235284610629e-14
+      - -1031.3598528421899
+      - -3.908418170766748
+    - - 2.7881426891855945
+      - 0.000587671007977702
+      - 1.5899634118409258e-07
+      - -5.527107765047777e-11
+      - 4.342903937188434e-15
+      - -596.1306154450648
+      - 0.11286983601569868
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 2.9200000000000004
+    well-depth: 38.00012796964137
+    polarizability: 0.7900000000000005
+    rotational-relaxation: 280.0
+  note: GRI-Mech
+- name: CO(6)
+  composition:
+    C: 1.0
+    O: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1571.6593741294669
+    - 5000.0
+    data:
+    - - 3.5683789993113204
+      - -0.0008521161385230426
+      - 2.489153078746991e-06
+      - -1.5632874127406197e-09
+      - 3.1358850739748245e-13
+      - -14284.254889750642
+      - 3.5791254751491537
+    - - 2.913095893090424
+      - 0.0016465367644801375
+      - -6.885940678175395e-07
+      - 1.210329274784425e-10
+      - -7.839840585892357e-15
+      - -14180.899929543586
+      - 6.710287418337844
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.6500000000000004
+    well-depth: 98.10027624123336
+    polarizability: 1.9500000000000008
+    rotational-relaxation: 1.8
+  note: GRI-Mech
+- name: O2(7)
+  composition:
+    O: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1074.5555114962035
+    - 5000.0
+    data:
+    - - 3.537321799907554
+      - -0.0012157092105349748
+      - 5.316177942590317e-06
+      - -4.894433842532746e-09
+      - 1.4584502658366455e-12
+      - -1038.5884607015485
+      - 4.683684088842607
+    - - 3.1538242933344125
+      - 0.001678037943720445
+      - -7.699709798598658e-07
+      - 1.5127470439159983e-10
+      - -1.0878179254258219e-14
+      - -1040.818802796597
+      - 6.16753858679826
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.4580000000000015
+    well-depth: 107.40032560095216
+    polarizability: 1.6000000000000008
+    rotational-relaxation: 3.8
+  note: GRI-Mech
+- name: C2H6(8)
+  composition:
+    C: 2.0
+    H: 6.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1012.4143908176864
+    - 5000.0
+    data:
+    - - 3.7224027214290585
+      - 0.0016507216851436085
+      - 3.4417964169825765e-05
+      - -3.768635653272928e-08
+      - 1.2445292179204619e-11
+      - -11557.590566943427
+      - 4.682444888027526
+    - - 2.8284402467294902
+      - 0.017304128331706716
+      - -6.733383493412886e-06
+      - 1.2374299067889905e-09
+      - -8.656844034734494e-14
+      - -11997.790083232097
+      - 5.938355682638575
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 4.3020000000000005
+    well-depth: 252.30104810022812
+    rotational-relaxation: 1.5
+  note: GRI-Mech
+- name: CH3(9)
+  composition:
+    C: 1.0
+    H: 3.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 697.6534741766965
+    - 5000.0
+    data:
+    - - 3.9604315909856713
+      - 0.0005929325518967126
+      - 8.785780906372586e-06
+      - -9.880343260208576e-09
+      - 3.6323637393909093e-12
+      - 16421.88173561743
+      - 0.33986347561181546
+    - - 3.095112437831353
+      - 0.005554297527849976
+      - -1.8815877454521128e-06
+      - 3.1333480061460194e-10
+      - -2.051949923202252e-14
+      - 16542.619031157636
+      - 4.202975724684728
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.8
+    well-depth: 144.00072548202698
+  note: GRI-Mech
+- name: CH3OH(10)
+  composition:
+    C: 1.0
+    H: 4.0
+    O: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1035.7423959466812
+    - 5000.0
+    data:
+    - - 3.840067829214246
+      - 0.0013823530072473104
+      - 1.916695141756019e-05
+      - -2.0157162318442508e-08
+      - 6.391145984999754e-12
+      - -25608.308954921802
+      - 5.909760961217521
+    - - 2.7918159589998375
+      - 0.011582830476657863
+      - -4.515545111036702e-06
+      - 8.212127607375687e-10
+      - -5.6706824178167993e-14
+      - -25721.155782524937
+      - 9.410768406918132
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.626000000000001
+    well-depth: 481.802091582003
+    rotational-relaxation: 1.0
+  note: GRI-Mech
+- name: C2H4(11)
+  composition:
+    C: 2.0
+    H: 4.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 979.3618095206666
+    - 5000.0
+    data:
+    - - 3.974701280059024
+      - -0.004758264205082085
+      - 4.167773383176862e-05
+      - -4.5138395334516856e-08
+      - 1.5422102566698024e-11
+      - 4915.408091071431
+      - 3.624361133438067
+    - - 3.5566615930688514
+      - 0.011062651497825246
+      - -4.170135867268412e-06
+      - 7.85573759380627e-10
+      - -5.700500153666173e-14
+      - 4320.441720817992
+      - 2.1768826469836897
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.9710000000000005
+    well-depth: 280.80075319274636
+    rotational-relaxation: 1.5
+  note: GRI-Mech
+- name: CH3CHO(12)
+  composition:
+    C: 2.0
+    H: 4.0
+    O: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1028.8023918717618
+    - 5000.0
+    data:
+    - - 3.5799294150648864
+      - 0.005189770481773756
+      - 2.2689973566565946e-05
+      - -2.7374551494008247e-08
+      - 9.284917028878933e-12
+      - -21369.737609745825
+      - 8.969696167185589
+    - - 4.085613942096295
+      - 0.013906161620516692
+      - -5.593725835684122e-06
+      - 1.0460983036639744e-09
+      - -7.387431892572972e-14
+      - -22039.12378460797
+      - 3.768155983239756
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.9700000000000006
+    well-depth: 436.0012277388149
+    rotational-relaxation: 2.0
+  note: GRI-Mech
+- name: C3H6O(13)
+  composition:
+    C: 3.0
+    H: 6.0
+    O: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1023.9482752714948
+    - 5000.0
+    data:
+    - - 3.011401597809541
+      - 0.015468379714093743
+      - 2.1500989201259812e-05
+      - -3.246115535830465e-08
+      - 1.1787411835246626e-11
+      - -27871.24318665779
+      - 13.220327873565262
+    - - 5.795918074341681
+      - 0.02007633488334714
+      - -7.934302252265999e-06
+      - 1.4730506707783468e-09
+      - -1.037754392188254e-13
+      - -29253.28867814445
+      - -4.243346340276008
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 5.329790656420617
+    well-depth: 385.40650221034775
+  note: Epsilon & sigma estimated with Tc=500.53 K, Pc=48.02 bar (from Joback method)
+- name: C2H6O(14)
+  composition:
+    C: 2.0
+    H: 6.0
+    O: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 984.001074254348
+    - 5000.0
+    data:
+    - - 3.2402595276101858
+      - 0.01048595781146264
+      - 2.6396769615238197e-05
+      - -3.692935677602931e-08
+      - 1.3671059764757759e-11
+      - -29990.284414834074
+      - 11.143301888722519
+    - - 5.6849415341883915
+      - 0.016131329022904588
+      - -5.9636574154952995e-06
+      - 1.0889720834413842e-09
+      - -7.696209026654223e-14
+      - -31225.821127246145
+      - -4.444891933810413
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 4.530000000000001
+    well-depth: 362.6
+    rotational-relaxation: 1.5
+  note: NOx2018
+- name: CH3COOCH3(15)
+  composition:
+    C: 3.0
+    H: 6.0
+    O: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1154.014016522329
+    - 5000.0
+    data:
+    - - 2.7506220700391415
+      - 0.022081307138984107
+      - 1.2174217632822808e-05
+      - -2.192140560818284e-08
+      - 7.336202259824892e-12
+      - -51179.369924439074
+      - 16.500243824317018
+    - - 5.625264379169836
+      - 0.026109980413376352
+      - -1.1250095321623012e-05
+      - 2.1176510350057785e-09
+      - -1.4768311053277557e-13
+      - -52774.57988068857
+      - -1.8169541985155664
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 5.472740943122795
+    well-depth: 385.6333050074991
+  note: Epsilon & sigma estimated with Tc=500.82 K, Pc=44.39 bar (from Joback method)
+- name: HX(16)
+  composition:
+    H: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - -2.0151091
+      - 0.0127747196
+      - -1.36892852e-05
+      - 6.6707688e-09
+      - -1.15946694e-12
+      - -5530.52906
+      - 8.4468689
+    - - -0.184968995
+      - 0.00605229805
+      - -4.83715532e-06
+      - 1.81340221e-09
+      - -2.61948776e-13
+      - -5915.33033
+      - -0.504191778
+- name: OX(17)
+  composition:
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 0.195855852
+      - 0.0116923252
+      - -2.02271203e-05
+      - 1.61601691e-08
+      - -4.90070914e-12
+      - -26918.9243
+      - -2.01768707
+    - - 2.9043837
+      - -0.000274871763
+      - 5.38558858e-07
+      - -3.03946989e-10
+      - 5.63969783e-14
+      - -27441.1389
+      - -14.894415
+- name: CX(18)
+  composition:
+    C: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - -0.573265619
+      - 0.0144803183
+      - -2.45704673e-05
+      - 1.93668551e-08
+      - -5.81642502e-12
+      - 14766.1073
+      - 1.2024425
+    - - 2.71617577
+      - 1.99967762e-05
+      - 3.4803163e-07
+      - -2.47205634e-10
+      - 5.00169813e-14
+      - 14130.8872
+      - -14.4477318
+- name: COX(19)
+  composition:
+    C: 1.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 3.13851368
+      - 0.00737719433
+      - -1.21673211e-05
+      - 1.06231734e-08
+      - -3.55085256e-12
+      - -30101.1015
+      - -14.0684039
+    - - 4.39015575
+      - 0.00121423223
+      - 2.26543548e-08
+      - -2.74772156e-10
+      - 6.84375847e-14
+      - -30333.9593
+      - -19.9186406
+- name: CHX(20)
+  composition:
+    C: 1.0
+    H: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 0.444067538
+      - 0.00715965809
+      - -6.05381899e-06
+      - 4.41670377e-09
+      - -1.57758787e-12
+      - 2484.09325
+      - -2.97930741
+    - - 0.470984781
+      - 0.00644724983
+      - -3.18677769e-06
+      - 7.11925015e-10
+      - -5.43593812e-14
+      - 2479.24869
+      - -3.03223839
+- name: CH2X(21)
+  composition:
+    C: 1.0
+    H: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - -0.719249342
+      - 0.0165071735
+      - -1.7499851e-05
+      - 1.09676908e-08
+      - -2.88981251e-12
+      - 1684.1105
+      - 2.01831094
+    - - 0.983780574
+      - 0.00878623452
+      - -4.38766259e-06
+      - 1.09400822e-09
+      - -1.10409266e-13
+      - 1383.36061
+      - -5.98458146
+- name: HCOX(22)
+  composition:
+    C: 1.0
+    H: 1.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 1.67902911
+      - 0.0139424587
+      - -1.51013698e-05
+      - 9.67718274e-09
+      - -2.69733533e-12
+      - -21603.0349
+      - -8.23427981
+    - - 3.03186697
+      - 0.00802892147
+      - -4.79702422e-06
+      - 1.39761897e-09
+      - -1.61417712e-13
+      - -21871.1786
+      - -14.692113
+- name: HCOHX(23)
+  composition:
+    C: 1.0
+    H: 2.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 4.61466774
+      - 0.00197736658
+      - 1.13520606e-05
+      - -1.28686112e-08
+      - 4.2885424e-12
+      - -20840.5084
+      - -18.3405542
+    - - 2.12897595
+      - 0.0131031973
+      - -8.04327296e-06
+      - 2.48752777e-09
+      - -3.12401921e-13
+      - -20371.4667
+      - -6.56664446
+- name: CH3OX(24)
+  composition:
+    C: 1.0
+    H: 3.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 1.7232417
+      - 0.0246490814
+      - -2.80859624e-05
+      - 1.72678472e-08
+      - -4.26645223e-12
+      - -24826.2518
+      - -8.86801544
+    - - 5.35800551
+      - 0.00963360342
+      - -4.83501645e-06
+      - 1.27341188e-09
+      - -1.42248592e-13
+      - -25529.8238
+      - -26.2856418
+- name: CH3COOX(25)
+  composition:
+    C: 2.0
+    H: 3.0
+    O: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 984.4502139222707
+    - 5000.0
+    data:
+    - - 3.0282853872957953
+      - 0.011097067183045468
+      - 3.410822969173128e-05
+      - -5.160933164056478e-08
+      - 1.9982143865315682e-11
+      - -54520.69632435207
+      - -8.730480490792468
+    - - 9.444486719537982
+      - 0.010673683201819516
+      - -4.32452633752008e-06
+      - 8.806221183503701e-10
+      - -6.797188667517917e-14
+      - -57026.752669337715
+      - -45.89638982538467
+- name: CH2COX(26)
+  composition:
+    C: 2.0
+    H: 2.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 961.8130738795011
+    - 5000.0
+    data:
+    - - 3.229798787670243
+      - 0.014034493880911516
+      - -3.5635175509489443e-06
+      - -6.07820031229845e-09
+      - 3.5835890778420116e-12
+      - -16375.267112388028
+      - -9.064059038670354
+    - - 6.75419817602499
+      - 0.0062533297160098054
+      - -2.1521004340979795e-06
+      - 3.764954117945831e-10
+      - -2.6180574758258015e-14
+      - -17371.280801211917
+      - -27.58341878163746
+- name: CH2COX2(27)
+  composition:
+    C: 2.0
+    H: 2.0
+    O: 1.0
+    X: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 931.9596749658505
+    - 5000.0
+    data:
+    - - 3.260760856666871
+      - 0.008792868404480458
+      - 2.1750260488936235e-05
+      - -3.7766309190117125e-08
+      - 1.6029161308228003e-11
+      - -27693.57035991087
+      - -15.94297943957723
+    - - 8.931733274862362
+      - 0.003518335324596903
+      - -4.4639364401679375e-07
+      - 6.274599763837867e-11
+      - -6.937134991905615e-15
+      - -29578.557926265414
+      - -47.34459338652688
+  sites: 2.0
+- name: CH3COOHX(28)
+  composition:
+    C: 2.0
+    H: 4.0
+    O: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1048.6927918730498
+    - 5000.0
+    data:
+    - - 2.872390412336155
+      - 0.018692782822357902
+      - 1.0088838019164107e-05
+      - -2.2522588013533777e-08
+      - 8.700458244152892e-12
+      - -58658.66214149972
+      - -3.0090063326176133
+    - - 7.2879449832072405
+      - 0.016204123790062086
+      - -6.882018567881657e-06
+      - 1.317486847273241e-09
+      - -9.419821249936982e-14
+      - -60374.040285459865
+      - -28.284534598585417
+- name: C2H4X(29)
+  composition:
+    C: 2.0
+    H: 4.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 976.8436265767041
+    - 5000.0
+    data:
+    - - 3.685216178934138
+      - 0.0012945968754984705
+      - 3.3176137267299024e-05
+      - -3.9890486919105344e-08
+      - 1.4237552608182252e-11
+      - -4431.570030010382
+      - -13.498998817656203
+    - - 4.821013229386249
+      - 0.01113020205433694
+      - -4.17185100935598e-06
+      - 7.79847051312637e-10
+      - -5.6387930608821945e-14
+      - -5344.6367394882745
+      - -22.489711900200938
+- name: C2H4X2(30)
+  composition:
+    C: 2.0
+    H: 4.0
+    X: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 945.1403291172783
+    - 5000.0
+    data:
+    - - 3.754535541878106
+      - -0.00506560112870119
+      - 6.101248163934886e-05
+      - -7.417211487315022e-08
+      - 2.7631066157652903e-11
+      - -8730.580832162374
+      - -18.789366069986205
+    - - 7.011263300869909
+      - 0.007953792309555558
+      - -2.1873892586288053e-06
+      - 4.1088830330208845e-10
+      - -3.3391723754964167e-14
+      - -10543.311586131884
+      - -40.65046049272947
+  sites: 2.0
+- name: COOHX(31)
+  composition:
+    C: 1.0
+    H: 2.0
+    O: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1005.0397573487588
+    - 5000.0
+    data:
+    - - 3.530067790015102
+      - 0.004559423098264702
+      - 2.3765659789292852e-05
+      - -3.194061446233701e-08
+      - 1.1684384295981981e-11
+      - -55712.21822313507
+      - -7.021210403346891
+    - - 6.300815846986892
+      - 0.008206156270655643
+      - -3.577860107664541e-06
+      - 7.243419313446359e-10
+      - -5.45315780959017e-14
+      - -57010.28215992336
+      - -24.089422976242908
+- name: CH3X(32)
+  composition:
+    C: 1.0
+    H: 3.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - -0.552219087
+      - 0.0264420133
+      - -3.55617257e-05
+      - 2.60043628e-08
+      - -7.52706787e-12
+      - -4433.46585
+      - 0.692144274
+    - - 3.62557353
+      - 0.00739511955
+      - -2.43797398e-06
+      - 1.86159414e-10
+      - 3.64849549e-14
+      - -5187.22188
+      - -18.9668272
+- name: HOX(33)
+  composition:
+    H: 1.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 1.58477686
+      - 0.00387867982
+      - 1.34107764e-06
+      - -3.93949585e-09
+      - 1.68540254e-12
+      - -29097.7259
+      - -7.42452379
+    - - 1.42377797
+      - 0.00557119676
+      - -3.3929338e-06
+      - 1.09513419e-09
+      - -1.46734126e-13
+      - -29097.2119
+      - -6.85806991
+- name: OCXOX(34)
+  composition:
+    C: 1.0
+    O: 2.0
+    X: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 924.8149346547023
+    - 5000.0
+    data:
+    - - 2.9901603811856146
+      - 0.003950265663250455
+      - 2.3270925243420548e-05
+      - -3.788091049327452e-08
+      - 1.609372260468783e-11
+      - -72632.5758854125
+      - -13.569864903886618
+    - - 8.526431916439092
+      - -0.0012913980252163427
+      - 1.4361290679040488e-06
+      - -2.724575251059408e-10
+      - 1.5649962407485232e-14
+      - -74456.4313206594
+      - -44.170830096394226
+  sites: 2.0
+- name: HOCXO(35)
+  composition:
+    C: 1.0
+    H: 1.0
+    O: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 298.0
+    - 1000.0
+    - 2000.0
+    data:
+    - - 0.700750147
+      - 0.0322756606
+      - -4.70618414e-05
+      - 3.45557357e-08
+      - -1.00331658e-11
+      - -51855.3737
+      - -4.52637913
+    - - 6.47849692
+      - 0.007149868
+      - -4.22981914e-06
+      - 1.15767979e-09
+      - -1.19086295e-13
+      - -52980.8669
+      - -32.0736929
+- name: CO2X(36)
+  composition:
+    C: 1.0
+    O: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1008.2235261425308
+    - 5000.0
+    data:
+    - - 2.994866857501715
+      - 0.009185965397597364
+      - -4.122161692578258e-06
+      - -1.935816158040259e-09
+      - 1.5288955493336458e-12
+      - -55264.46837617401
+      - -8.958643829159964
+    - - 5.554429300534045
+      - 0.0031550056532338605
+      - -1.284729139174302e-06
+      - 2.447767889206642e-10
+      - -1.773040068390364e-14
+      - -55990.18484952258
+      - -22.367439172007717
+- name: H2OX(43)
+  composition:
+    H: 2.0
+    O: 1.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 992.6393062530135
+    - 5000.0
+    data:
+    - - 3.7690858809309806
+      - 0.006115636539300379
+      - -9.97117454956371e-06
+      - 9.221813664156919e-09
+      - -3.069185525117765e-12
+      - -36311.022062339456
+      - -15.097954047362785
+    - - 3.7268408601711056
+      - 0.00324910958290715
+      - -1.050582257160273e-06
+      - 1.4868915979446623e-10
+      - -7.880097929032964e-15
+      - -36153.02428458961
+      - -14.140856491737912
+- name: C.[Pt](84)
+  composition:
+    C: 1.0
+    H: 4.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1348.9311502867006
+    - 5000.0
+    data:
+    - - 3.887782472702934
+      - 0.0027361490104651303
+      - 9.453938595626752e-06
+      - -8.2759775831348e-09
+      - 2.024641540260794e-12
+      - -15276.057079508764
+      - -16.079012089650426
+    - - 2.1894466503348013
+      - 0.01161795956795771
+      - -4.698964270466673e-06
+      - 8.321263687950228e-10
+      - -5.5075822939835666e-14
+      - -15167.75573784068
+      - -8.674092181825085
+- name: CC#[Pt](307)
+  composition:
+    C: 2.0
+    H: 3.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 1264.6439155737378
+    - 5000.0
+    data:
+    - - 3.4862537885387392
+      - 0.009849878817112174
+      - -1.1267200588583303e-06
+      - -2.615286062460601e-09
+      - 9.946777681722443e-13
+      - -1928.4407523062412
+      - 2.7865704121767267
+    - - 4.8654401152953115
+      - 0.008678607649074351
+      - -3.52235379751616e-06
+      - 6.428208524842449e-10
+      - -4.3823505606222216e-14
+      - -2532.450472801898
+      - -5.199902432849851
+- name: C2H2X2(338)
+  composition:
+    C: 2.0
+    H: 2.0
+    X: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 928.3079710467081
+    - 5000.0
+    data:
+    - - 3.2450415145241576
+      - -0.0021760279300218313
+      - 3.9790552303925505e-05
+      - -5.1708764158564344e-08
+      - 2.0150909315109415e-11
+      - 258.438338362114
+      - -18.498014463671375
+    - - 6.796983480596255
+      - 0.002466403401318686
+      - 5.716816856572807e-08
+      - -2.6685918884386197e-11
+      - -1.2197921658526798e-15
+      - -1260.5121581118883
+      - -39.999189574344115
+  sites: 2.0
+- name: CHOX2(110)
+  composition:
+    C: 1.0
+    H: 1.0
+    O: 1.0
+    X: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 926.6175561296403
+    - 5000.0
+    data:
+    - - 3.832887645817746
+      - -0.0016603098100733647
+      - 2.6556713897985118e-05
+      - -3.486667445898292e-08
+      - 1.3687337795243619e-11
+      - -30357.121267473056
+      - -16.14033456421591
+    - - 6.41356232311081
+      - 0.0008722938691984814
+      - 3.235599313777351e-07
+      - -6.874946189041092e-11
+      - 2.5989383662306233e-15
+      - -31422.36787315482
+      - -31.561277079977994
+  sites: 2.0
+- name: C#C.[Pt](513)
+  composition:
+    C: 2.0
+    H: 2.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 946.8219136609066
+    - 5000.0
+    data:
+    - - 3.0605682811504953
+      - 0.007587280945224806
+      - 2.1447998330379788e-06
+      - -8.078886200693694e-09
+      - 3.699535187305503e-12
+      - 19021.04086436971
+      - -9.523873262329873
+    - - 4.940279088514483
+      - 0.004787222017554303
+      - -1.5639544457516475e-06
+      - 2.672761939001556e-10
+      - -1.841695486284534e-14
+      - 18434.64899528267
+      - -19.70659745238856
+- name: C2H3X(88)
+  composition:
+    C: 2.0
+    H: 3.0
+    X: 1.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 938.984342954222
+    - 5000.0
+    data:
+    - - 3.816855190619816
+      - -0.0049593108119074854
+      - 5.145610165712362e-05
+      - -6.314880718836221e-08
+      - 2.379473554513912e-11
+      - 486.18408661810673
+      - -15.88279550277611
+    - - 6.918140774103931
+      - 0.004845631548262949
+      - -9.746754689303066e-07
+      - 1.809288406885693e-10
+      - -1.6711133946479867e-14
+      - -1110.8861198152579
+      - -36.05241714942668
+- name: C2H3X2(120)
+  composition:
+    C: 2.0
+    H: 3.0
+    X: 2.0
+  thermo:
+    model: NASA7
+    reference-pressure: 10000.0
+    temperature-ranges:
+    - 100.0
+    - 931.2590940541667
+    - 5000.0
+    data:
+    - - 3.838841732956421
+      - -0.008209687907563478
+      - 6.656228164395793e-05
+      - -8.223152517465067e-08
+      - 3.138335541616925e-11
+      - -3285.263195765613
+      - -19.460852187070447
+    - - 8.291164052355008
+      - 0.0027943034954819776
+      - 3.102600442580014e-07
+      - -6.343890134318942e-11
+      - -1.0080105464031819e-15
+      - -5420.926456665365
+      - -47.63786342878039
+  sites: 2.0
+gas_reactions:
+- equation: 2 CH3(9) <=> C2H6(8)
+  rate-constant:
+    A: 945000000000.0001
+    b: -0.538
+    Ea: 565258.4
+- equation: CH4(2) + CO(6) <=> CH3CHO(12)
+  rate-constant:
+    A: 65.60000000000001
+    b: 2.86
+    Ea: 363590000.0000001
+- equation: C2H6(8) + CO(6) <=> C3H6O(13)
+  rate-constant:
+    A: 0.538
+    b: 3.29
+    Ea: 437228000.00000006
+- equation: C2H4(11) + H2O(3) <=> C2H6O(14)
+  rate-constant:
+    A: 0.5880000000000001
+    b: 2.94
+    Ea: 222170000.00000006
+- equation: C2H6(8) + CO2(4) <=> CH3COOCH3(15)
+  rate-constant:
+    A: 0.292
+    b: 3.13
+    Ea: 486722822.00474715
+surface_reactions:
+- equation: H2(5) + 2 X(1) <=> 2 HX(16)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.032
+    b: 0.0
+    Ea: 0.0
+- equation: O2(7) + 2 X(1) <=> 2 OX(17)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.0436
+    b: -0.206
+    Ea: 1500000.0
+- equation: CO(6) + X(1) <=> COX(19)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.5
+    b: 0.0
+    Ea: 0.0
+- equation: COX(19) + X(1) <=> CX(18) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1750000000000.0
+    b: 0.0
+    Ea: 116200000.0
+- equation: 2 COX(19) <=> CO2(4) + CX(18) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 16200000000000.0
+    b: 0.5
+    Ea: 241700000.00000003
+- equation: COX(19) + OX(17) <=> CO2(4) + 2 X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.0e+18
+    b: 0.0
+    Ea: 123600000.00000001
+- equation: CX(18) + HX(16) <=> CHX(20) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.7e+23
+    b: -0.5
+    Ea: 157900000.0
+- equation: COX(19) + HX(16) <=> CHX(20) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.26e+19
+    b: 0.073
+    Ea: 191627199.99999997
+- equation: CHX(20) + HX(16) <=> CH2X(21) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 9.77e+23
+    b: -0.087
+    Ea: 81000000.00000001
+- equation: CX(18) + H2(5) <=> CH2X(21)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.04
+    b: 0.0
+    Ea: 29700000.0
+- equation: CHX(20) + OX(17) <=> HCOX(22) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.59e+19
+    b: 0.0
+    Ea: 109900000.00000001
+- equation: HCOX(22) + X(1) <=> COX(19) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.71e+20
+    b: 0.0
+    Ea: 0.0
+- equation: CH3X(32) + HX(16) <=> CH4(2) + 2 X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.44e+21
+    b: -0.087
+    Ea: 63400000.00000001
+- equation: CH2X(21) + HX(16) <=> CH3X(32) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.09e+22
+    b: -0.087
+    Ea: 57200000.0
+- equation: CH3(9) + X(1) <=> CH3X(32)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.16
+    b: -0.099
+    Ea: 0.0
+- equation: CX(18) + HOX(33) <=> COX(19) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.88e+24
+    b: 0.188
+    Ea: 62500000.0
+- equation: CH3X(32) + HOX(33) <=> CH4(2) + OX(17) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.98e+21
+    b: 0.101
+    Ea: 25800000.0
+- equation: CH2X(21) + HOX(33) <=> CH3X(32) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: CHX(20) + HOX(33) <=> CH2X(21) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.4e+21
+    b: 0.101
+    Ea: 42400000.0
+- equation: CX(18) + HOX(33) <=> CHX(20) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.43e+20
+    b: -0.312
+    Ea: 118900000.0
+- equation: HOX(33) + HX(16) <=> H2O(3) + 2 X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.85e+19
+    b: 0.086
+    Ea: 41500000.0
+- equation: HOX(33) + X(1) <=> HX(16) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.25e+19
+    b: 0.188
+    Ea: 29600000.000000004
+- equation: 2 HOX(33) <=> H2O(3) + OX(17) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.34e+19
+    b: 0.274
+    Ea: 92300000.00000001
+- equation: HCOX(22) + HOX(33) <=> HOCXO(35) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.28e+19
+    b: 0.263
+    Ea: 15900000.000000002
+- equation: HOCXO(35) + X(1) <=> COX(19) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.46e+23
+    b: -0.213
+    Ea: 54300000.0
+- equation: HOCXO(35) + X(1) <=> CO2(4) + HX(16) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.73e+19
+    b: 0.475
+    Ea: 33600000.0
+- equation: 2 COX(19) <=> CO2X(36) + CX(18)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 16200000000000.0
+    b: 0.5
+    Ea: 241700000.00000003
+- equation: CO2(4) + X(1) <=> CO2X(36)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.005
+    b: 0.0
+    Ea: 0.0
+- equation: COX(19) + OX(17) <=> CO2X(36) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.7e+20
+    b: 0.0
+    Ea: 117600000.00000001
+- equation: COX(19) + HOX(33) <=> CO2X(36) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.0e+18
+    b: 0.0
+    Ea: 38700000.0
+- equation: HOCXO(35) + X(1) <=> CO2X(36) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.27e+18
+    b: 0.549
+    Ea: 4184000.0
+- equation: CO2X(36) + HOX(33) <=> HOCXO(35) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.15e+18
+    b: 0.097
+    Ea: 110876000.0
+- equation: CH2COX2(27) <=> CH2X(21) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4220000000000.0
+    b: 0.0
+    Ea: 104000000.00000001
+- equation: CH2COX(26) + X(1) <=> CH2COX2(27)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.0e+20
+    b: 0.0
+    Ea: 0.0
+- equation: C2H4(11) + X(1) <=> C2H4X(29)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 7.0e-06
+    b: 0.0
+    Ea: 0.0
+- equation: C2H4(11) + 2 X(1) <=> C2H4X2(30)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.69
+    b: 0.0
+    Ea: 0.0
+- equation: 2 CH2X(21) <=> C2H4X2(30)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 9.89e+22
+    b: 0.0
+    Ea: 154000000.0
+- equation: C2H4X(29) + X(1) <=> C2H4X2(30)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.78e+20
+    b: 0.0
+    Ea: 12000000.0
+- equation: CO2(4) + 2 X(1) <=> OCXOX(34)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 1.66
+    b: 0.0
+    Ea: 0.0
+- equation: OCXOX(34) <=> COX(19) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4220000000000.0
+    b: 0.0
+    Ea: 133318492.10043974
+- equation: CO2X(36) + X(1) <=> OCXOX(34)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.0e+20
+    b: 0.0
+    Ea: 0.0
+- equation: C2H6(8) + 2 X(1) <=> 2 CH3X(32)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.015
+    b: 0.0
+    Ea: 23107338.64226449
+- equation: CH3OH(10) + 2 X(1) <=> CH3X(32) + HOX(33)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.015
+    b: 0.0
+    Ea: 5000000.0
+- equation: CH3OH(10) + 2 X(1) <=> CH3OX(24) + HX(16)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.099
+    b: 0.0
+    Ea: 76543362.59050444
+- equation: C2H4(11) + 2 X(1) <=> 2 CH2X(21)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.01
+    b: 0.0
+    Ea: 41840000.00000001
+- equation: CH3CHO(12) + 2 X(1) <=> CH3X(32) + HCOX(22)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.015
+    b: 0.0
+    Ea: 5000000.0
+- equation: C2H6O(14) + 2 X(1) <=> CH3OX(24) + CH3X(32)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.015
+    b: 0.0
+    Ea: 10548863.324930396
+- equation: HCOHX(23) + X(1) <=> CHX(20) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.46e+23
+    b: -0.213
+    Ea: 54300000.00000001
+- equation: HCOHX(23) + X(1) <=> HCOX(22) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 58232049.1536672
+- equation: CH3OX(24) + X(1) <=> CH2X(21) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.46e+23
+    b: -0.213
+    Ea: 54300000.00000001
+- equation: CH3OX(24) + X(1) <=> HCOHX(23) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.42e+20
+    b: 0.0
+    Ea: 0.0
+- equation: CH3COOX(25) + X(1) <=> CH2X(21) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 152862746.7252149
+- equation: CH3COOX(25) + X(1) <=> CH2COX(26) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.5392202847961747e+20
+    b: 0.1314545095819981
+    Ea: 76771524.3146206
+- equation: CH2COX(26) + X(1) <=> CH2X(21) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.282e+19
+    b: 0.0
+    Ea: 241213355.90675473
+- equation: CH3COOHX(28) + X(1) <=> CH3X(32) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 142367281.8074835
+- equation: CH3COOHX(28) + X(1) <=> CH3COOX(25) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2116349673557.9387
+    b: 2.0707027167582193
+    Ea: 135191101.8241696
+- equation: C2H4X(29) + X(1) <=> 2 CH2X(21)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.282e+19
+    b: 0.0
+    Ea: 241213355.90675473
+- equation: COOHX(31) + X(1) <=> HCOHX(23) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.641e+19
+    b: 0.0
+    Ea: 241213355.90675473
+- equation: COOHX(31) + X(1) <=> HCOX(22) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.781e+20
+    b: 0.0
+    Ea: 157271108.0512041
+- equation: HOCXO(35) + HX(16) <=> COOHX(31) + X(1)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.308e+21
+    b: 0.0
+    Ea: 70434299.92477237
+- equation: HOCXO(35) + 2 X(1) <=> HX(16) + OCXOX(34)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.8566666666666664e+27
+    b: 0.0
+    Ea: 46000000.00000001
+- equation: CH2X(21) + COOHX(31) <=> CH3COOX(25) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: HCOX(22) + OX(17) <=> COX(19) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.298e+20
+    b: 0.0
+    Ea: 0.0
+- equation: HCOHX(23) + OX(17) <=> HCOX(22) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 0.0
+- equation: HCOHX(23) + HOX(33) <=> CH3OX(24) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: CH2COX2(27) + OX(17) <=> CH2X(21) + OCXOX(34)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.298e+20
+    b: 0.0
+    Ea: 0.0
+- equation: CH3COOHX(28) + OX(17) <=> CH3COOX(25) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.215e+23
+    b: -0.101
+    Ea: 92700000.00000001
+- equation: COOHX(31) + OX(17) <=> HOCXO(35) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.405e+23
+    b: -0.101
+    Ea: 92700000.00000001
+- equation: CH2X(21) + CX(18) <=> 2 CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 64390227.63121586
+- equation: CX(18) + HCOX(22) <=> CHX(20) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 36249036.34728507
+- equation: CX(18) + HCOHX(23) <=> CHX(20) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 24052724.51607596
+- equation: CH3OX(24) + CX(18) <=> CHX(20) + HCOHX(23)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.425803660210784e+20
+    b: 0.0
+    Ea: 37291008.396549925
+- equation: CH3COOHX(28) + CX(18) <=> CH3COOX(25) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: COOHX(31) + CX(18) <=> CHX(20) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH3X(32) + CX(18) <=> CH2X(21) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 9.894e+20
+    b: 0.0
+    Ea: 0.0
+- equation: CHX(20) + HCOX(22) <=> CH2X(21) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 71158808.71606924
+- equation: CHX(20) + HOCXO(35) <=> COX(19) + HCOHX(23)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.4e+21
+    b: 0.101
+    Ea: 42400000.0
+- equation: COX(19) + HCOHX(23) <=> 2 HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 184236253.79594633
+- equation: CH2X(21) + HOCXO(35) <=> CH3OX(24) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: HCOHX(23) + HCOX(22) <=> CH3OX(24) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 60967019.55418524
+- equation: CH3COOX(25) + COX(19) <=> CH2COX(26) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 257841657.858039
+- equation: CH3COOHX(28) + COX(19) <=> CH3COOX(25) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH2COX2(27) + CH2X(21) <=> C2H4X2(30) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: COOHX(31) + COX(19) <=> HCOX(22) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: COOHX(31) + COX(19) <=> HCOX(22) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: CH2X(21) + HCOX(22) <=> CH3X(32) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 55966956.128033236
+- equation: COX(19) + HOCXO(35) <=> CO2X(36) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 167509689.74174654
+- equation: CHX(20) + HCOHX(23) <=> CH2X(21) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 112742416.48001407
+- equation: CH2X(21) + HCOHX(23) <=> CH3OX(24) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: CH2X(21) + HCOHX(23) <=> CH3OX(24) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 89108210.838116
+  duplicate: true
+- equation: CH3COOHX(28) + CHX(20) <=> CH2X(21) + CH3COOX(25)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CHX(20) + COOHX(31) <=> HCOHX(23) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.3606654387125515e+20
+    b: -0.07441820738726125
+    Ea: 118482473.58896875
+- equation: CHX(20) + COOHX(31) <=> CH2X(21) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: 2 CH2X(21) <=> CH3X(32) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 84108147.41196401
+- equation: CH2X(21) + HCOHX(23) <=> CH3OX(24) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: CH2X(21) + HCOHX(23) <=> CH3OX(24) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 89108210.838116
+  duplicate: true
+- equation: CH2X(21) + HCOHX(23) <=> CH3X(32) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 74146899.09419289
+- equation: CH2X(21) + CH3OX(24) <=> CH3X(32) + HCOHX(23)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.425803660210784e+20
+    b: 0.0
+    Ea: 47149968.286924005
+- equation: CH2X(21) + CH3COOX(25) <=> CH2COX(26) + CH3OX(24)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 227644252.94263765
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3COOX(25) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3COOX(25) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: CH2X(21) + COOHX(31) <=> CH3OX(24) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH2X(21) + COOHX(31) <=> CH3X(32) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH2X(21) + HOCXO(35) <=> CH3X(32) + CO2X(36)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 57420335.03999308
+- equation: 2 HCOHX(23) <=> CH3OX(24) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 86849762.93360609
+- equation: CH3COOX(25) + HCOX(22) <=> CH2COX(26) + COOHX(31)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 130858280.6458121
+- equation: COOHX(31) + COX(19) <=> HCOX(22) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: COOHX(31) + COX(19) <=> HCOX(22) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: CH3COOHX(28) + HCOHX(23) <=> CH3COOX(25) + CH3OX(24)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: COOHX(31) + HCOHX(23) <=> CH3OX(24) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: HCOHX(23) + HOCXO(35) <=> CH3OX(24) + CO2X(36)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 70123198.87940632
+- equation: CH3COOHX(28) + HOCXO(35) <=> CH3COOX(25) + COOHX(31)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.254e+21
+    b: 0.0
+    Ea: 131383021.93699808
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3COOX(25) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3COOX(25) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+  duplicate: true
+- equation: CH3COOX(25) + HOCXO(35) <=> CH3COOHX(28) + CO2X(36)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 64004883.585984856
+- equation: 2 HOCXO(35) <=> CO2X(36) + COOHX(31)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 65511750.51913242
+- equation: CH4(2) + HOX(33) + X(1) <=> CH3X(32) + H2OX(43)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 1.0
+    b: 0.0
+    Ea: 10000000.0
+- equation: H2O(3) + X(1) <=> H2OX(43)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.75
+    b: 0.0
+    Ea: 0.0
+- equation: H2OX(43) + X(1) <=> HOX(33) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.15e+18
+    b: 0.0
+    Ea: 101400000.00000001
+- equation: H2OX(43) + OX(17) <=> 2 HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.0e+19
+    b: 0.0
+    Ea: 90500000.0
+- equation: COX(19) + H2OX(43) <=> HOCXO(35) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.43e+18
+    b: 0.492
+    Ea: 99160800.0
+- equation: CO2X(36) + H2OX(43) <=> HOCXO(35) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.48e+18
+    b: -0.031
+    Ea: 91434774.13589227
+- equation: CH2X(21) + H2OX(43) <=> CH3X(32) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.3e+18
+    b: 0.099
+    Ea: 58994400.00000001
+- equation: CHX(20) + H2OX(43) <=> CH2X(21) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.29e+18
+    b: 0.269
+    Ea: 142256000.0
+- equation: CX(18) + H2OX(43) <=> CHX(20) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.19e+18
+    b: 0.09
+    Ea: 65270400.00000001
+- equation: CHX(20) + H2OX(43) <=> HCOHX(23) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.932727848443955e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH2X(21) + H2OX(43) <=> CH3OX(24) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.932727848443955e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: HCOX(22) + HOX(33) <=> COX(19) + H2OX(43)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.261e+20
+    b: 0.0
+    Ea: 28945602.70881056
+- equation: H2OX(43) + HCOHX(23) <=> CH3OX(24) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.932727848443955e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH3COOHX(28) + HOX(33) <=> CH3COOX(25) + H2OX(43)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.254e+21
+    b: 0.0
+    Ea: 109509900.89857398
+- equation: COOHX(31) + HOX(33) <=> H2OX(43) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 107426878.96157578
+- equation: CH4(2) + X(1) <=> C.[Pt](84)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.008
+    b: 0.0
+    Ea: 0.0
+- equation: C.[Pt](84) + X(1) <=> CH3X(32) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.54e+20
+    b: 0.087
+    Ea: 55800000.000000015
+- equation: C.[Pt](84) + CX(18) <=> CH3X(32) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C.[Pt](84) + CHX(20) <=> CH2X(21) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C.[Pt](84) + COX(19) <=> CH3X(32) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 160116599.8927413
+- equation: C.[Pt](84) + HCOHX(23) <=> CH3OX(24) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH3COOHX(28) + CH3X(32) <=> C.[Pt](84) + CH3COOX(25)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.254e+21
+    b: 0.0
+    Ea: 80600444.07764292
+- equation: CH3X(32) + COOHX(31) <=> C.[Pt](84) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 78517422.1406448
+- equation: C.[Pt](84) + CH2X(21) <=> 2 CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C.[Pt](84) + OX(17) <=> CH3X(32) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 5.62e+23
+    b: -0.101
+    Ea: 92700000.00000001
+- equation: CH3X(32) + HOCXO(35) <=> C.[Pt](84) + CO2X(36)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 28775417.599598866
+- equation: CH3X(32) + H2OX(43) <=> C.[Pt](84) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 100390543.17906903
+- equation: CH3COOHX(28) + CX(18) <=> CC#[Pt](307) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.3606654387125515e+20
+    b: -0.07441820738726125
+    Ea: 118482473.58896875
+- equation: CC#[Pt](307) + X(1) <=> CH3X(32) + CX(18)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 197242288.50492182
+- equation: C.[Pt](84) + CX(18) <=> CC#[Pt](307) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H2X2(338) <=> 2 CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7930000000000.0
+    b: 0.0
+    Ea: 90000000.00000001
+- equation: HCOX(22) + X(1) <=> CHOX2(110)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.0e+20
+    b: 0.0
+    Ea: 0.0
+- equation: HCOHX(23) + 2 X(1) <=> CHOX2(110) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.8566666666666664e+27
+    b: 0.0
+    Ea: 46000000.00000001
+- equation: CHX(20) + OX(17) <=> CHOX2(110)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 6.54e+20
+    b: 0.0
+    Ea: 142000000.0
+- equation: CHOX2(110) + COX(19) <=> CHX(20) + OCXOX(34)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: C2H2X2(338) + OX(17) <=> CHOX2(110) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 6.596e+20
+    b: 0.0
+    Ea: 0.0
+- equation: C#C.[Pt](513) + X(1) <=> C2H2X2(338)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.0e+20
+    b: 0.0
+    Ea: 0.0
+- equation: C2H4(11) + 2 X(1) <=> C2H3X(88) + HX(16)
+  type: sticking-Arrhenius
+  sticking-coefficient:
+    A: 0.1
+    b: 0.0
+    Ea: 49942316.1792833
+- equation: C2H4X(29) + X(1) <=> C2H3X(88) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 10479056557881.693
+    b: 1.6009912295246733
+    Ea: 79448444.9235931
+- equation: C2H4X(29) + OX(17) <=> C2H3X(88) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 5.62e+23
+    b: -0.101
+    Ea: 92700000.00000001
+- equation: C2H4X(29) + CX(18) <=> C2H3X(88) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H4X(29) + COX(19) <=> C2H3X(88) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H3X(88) + X(1) <=> CH2X(21) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 145637492.82208303
+- equation: C2H4X(29) + CHX(20) <=> C2H3X(88) + CH2X(21)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H4X(29) + CH2X(21) <=> C2H3X(88) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H4X(29) + HCOHX(23) <=> C2H3X(88) + CH3OX(24)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H4X(29) + CH3COOX(25) <=> C2H3X(88) + CH3COOHX(28)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.672e+21
+    b: 0.0
+    Ea: 135491449.11999902
+- equation: C2H4X(29) + CH3X(32) <=> C.[Pt](84) + C2H3X(88)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.672e+21
+    b: 0.0
+    Ea: 86791893.19764192
+- equation: C2H4X(29) + HOX(33) <=> C2H3X(88) + H2OX(43)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.672e+21
+    b: 0.0
+    Ea: 115701350.01857296
+- equation: C2H4X(29) + HOCXO(35) <=> C2H3X(88) + COOHX(31)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.672e+21
+    b: 0.0
+    Ea: 137574471.05699712
+- equation: C2H3X(88) + HOCXO(35) <=> C2H4X(29) + CO2X(36)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 59525962.94598559
+- equation: C2H3X(88) + 2 X(1) <=> C2H2X2(338) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.8566666666666664e+27
+    b: 0.0
+    Ea: 46000000.00000001
+- equation: C2H3X(88) + CH3COOX(25) <=> C#C.[Pt](513) + CH3COOHX(28)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 188214833.61283815
+- equation: 2 C2H3X(88) <=> C#C.[Pt](513) + C2H4X(29)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 183735912.9728388
+- equation: C2H3X(88) + HOCXO(35) <=> C#C.[Pt](513) + COOHX(31)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 189721700.54598567
+- equation: C2H3X(88) + HOX(33) <=> C#C.[Pt](513) + H2OX(43)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 173898591.70967877
+- equation: C2H3X(88) + CH3X(32) <=> C#C.[Pt](513) + C.[Pt](84)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 152985367.6264521
+- equation: C2H4X2(30) + X(1) <=> C2H3X2(120) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.225e+20
+    b: 0.0
+    Ea: 59000000.00000001
+- equation: C2H3X2(120) + HOX(33) <=> C2H4X2(30) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: C2H4X2(30) + CX(18) <=> C2H3X2(120) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.4851607320421568e+21
+    b: 0.0
+    Ea: 39186738.0315976
+- equation: C2H3X2(120) + HCOX(22) <=> C2H4X2(30) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 57175560.28408988
+- equation: C2H3X2(120) <=> CH2X(21) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 27400000000000.0
+    b: 0.0
+    Ea: 140000000.00000003
+- equation: CH2COX2(27) + CHX(20) <=> C2H3X2(120) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.4e+21
+    b: 0.101
+    Ea: 42400000.0
+- equation: C2H3X2(120) + CH2X(21) <=> C2H4X2(30) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: C2H3X2(120) + CH2X(21) <=> C2H4X2(30) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 85316751.56802069
+  duplicate: true
+- equation: C2H4X2(30) + CH2X(21) <=> C2H3X2(120) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.4851607320421568e+21
+    b: 0.0
+    Ea: 49045697.92197167
+- equation: C2H3X2(120) + HCOHX(23) <=> C2H4X2(30) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.18e+20
+    b: 0.0
+    Ea: 77217406.95012063
+- equation: C2H3X2(120) + CH3OX(24) <=> C2H4X2(30) + HCOHX(23)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.425803660210784e+20
+    b: 0.0
+    Ea: 47754270.364952326
+- equation: C2H3X2(120) + CH3COOHX(28) <=> C2H4X2(30) + CH3COOX(25)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.1899091772665933e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C.[Pt](84) + C2H3X2(120) <=> C2H4X2(30) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H3X2(120) + H2OX(43) <=> C2H4X2(30) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.932727848443955e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H3X2(120) + COOHX(31) <=> C2H4X2(30) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.9663639242219776e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H3X2(120) + X(1) <=> C2H2X2(338) + HX(16)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 4.7500000000000007e+20
+    b: 0.0
+    Ea: 72000000.0
+- equation: C2H3X2(120) + CX(18) <=> C2H2X2(338) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 61189750.20487869
+  duplicate: true
+- equation: C2H3X2(120) + CHX(20) <=> C2H2X2(338) + CH2X(21)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 149879442.16881678
+  duplicate: true
+- equation: C2H2X2(338) + CH2X(21) <=> C2H3X2(120) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.78e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: C2H3X2(120) + COX(19) <=> C2H2X2(338) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 221373279.48474905
+  duplicate: true
+- equation: C2H2X2(338) + HCOHX(23) <=> C2H3X2(120) + HCOX(22)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 92162974.31119731
+- equation: C2H3X2(120) + HCOHX(23) <=> C2H2X2(338) + CH3OX(24)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 123986788.6224088
+  duplicate: true
+- equation: C2H2X2(338) + CH3COOHX(28) <=> C2H3X2(120) + CH3COOX(25)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.3798183545331866e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H2X2(338) + C2H4X(29) <=> C2H3X(88) + C2H3X2(120)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.173091139377582e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: 2 C2H3X2(120) <=> C2H2X2(338) + C2H4X2(30)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 114354432.63892333
+  duplicate: true
+- equation: C2H2X2(338) + COOHX(31) <=> C2H3X2(120) + HOCXO(35)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.932727848443955e+17
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H3X2(120) + CH2X(21) <=> C2H2X2(338) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 111283924.7829956
+  duplicate: true
+- equation: C2H3X2(120) + OX(17) <=> C2H2X2(338) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 140986479.30347368
+  duplicate: true
+- equation: C2H2X2(338) + H2OX(43) <=> C2H3X2(120) + HOX(33)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C.[Pt](84) + C2H2X2(338) <=> C2H3X2(120) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 3.173091139377582e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: CH2X(21) + CHOX2(110) <=> C2H3X2(120) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+- equation: C2H3X(88) + X(1) <=> C2H3X2(120)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.15e+19
+    b: 0.0
+    Ea: 3000000.0
+- equation: C2H3X2(120) + C2H4X(29) <=> C2H3X(88) + C2H4X2(30)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.586545569688791e+18
+    b: -0.047836414774522495
+    Ea: 144264947.1779375
+- equation: C2H2X2(338) + HOX(33) <=> C2H3X2(120) + OX(17)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.78e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: C2H3X2(120) + CX(18) <=> C2H2X2(338) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.425803660210784e+20
+    b: 0.0
+    Ea: 36245323.178619735
+  duplicate: true
+- equation: C2H2X2(338) + HCOX(22) <=> C2H3X2(120) + COX(19)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 63058389.99004559
+  duplicate: true
+- equation: C2H2X2(338) + CH2X(21) <=> C2H3X2(120) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 2.78e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: C2H2X2(338) + CH2X(21) <=> C2H3X2(120) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.672e+21
+    b: 0.0
+    Ea: 91199581.2739764
+  duplicate: true
+- equation: C2H3X2(120) + CH2X(21) <=> C2H2X2(338) + CH3X(32)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.425803660210784e+20
+    b: 0.0
+    Ea: 46104283.068993814
+  duplicate: true
+- equation: C2H3X2(120) + CH2X(21) <=> C2H4X2(30) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.39e+20
+    b: 0.101
+    Ea: 19000000.0
+  duplicate: true
+- equation: C2H3X2(120) + CH2X(21) <=> C2H4X2(30) + CHX(20)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 8.36e+20
+    b: 0.0
+    Ea: 85316751.56802069
+  duplicate: true
+- equation: C2H2X2(338) + CH3OX(24) <=> C2H3X2(120) + HCOHX(23)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 1.4851607320421568e+21
+    b: 0.0
+    Ea: 50695685.21793019
+  duplicate: true
+- equation: 2 C2H3X2(120) <=> C2H2X2(338) + C2H4X2(30)
+  type: interface-Arrhenius
+  rate-constant:
+    A: 7.425803660210784e+20
+    b: 0.0
+    Ea: 46708585.147022136
+  duplicate: true

--- a/test/rmgpy/test_data/yaml_writer_data/chemkin/chem0047-gas.yaml
+++ b/test/rmgpy/test_data/yaml_writer_data/chemkin/chem0047-gas.yaml
@@ -1,0 +1,1117 @@
+generator: ck2yaml
+input-files: [chem0047-gas.inp, chem0047-surface.inp, tran.dat]
+cantera-version: 3.2.0a1
+date: Fri, 21 Feb 2025 07:38:38 -0500
+
+units: {length: cm, time: s, quantity: mol, activation-energy: kcal/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [H, D, T, C, Ci, O, Oi, N, Ne, Ar, He, Si, S, F, Cl, Br, I,
+    X]
+  species: [Ar, Ne, N2, CH4(2), H2O(3), CO2(4), H2(5), CO(6), O2(7), C2H6(8),
+    CH3(9), CH3OH(10), C2H4(11), CH3CHO(12), C3H6O(13), C2H6O(14), CH3COOCH3(15)]
+  kinetics: gas
+  reactions:
+  - gas-reactions
+  transport: mixture-averaged
+  state: {T: 300.0, P: 1 atm}
+- name: site0
+  thermo: ideal-surface
+  adjacent-phases: [gas]
+  elements: [H, D, T, C, Ci, O, Oi, N, Ne, Ar, He, Si, S, F, Cl, Br, I,
+    X]
+  species: [X(1), HX(16), OX(17), CX(18), COX(19), CHX(20), CH2X(21), HCOX(22),
+    HCOHX(23), CH3OX(24), CH3COOX(25), CH2COX(26), CH2COX2(27), CH3COOHX(28),
+    C2H4X(29), C2H4X2(30), COOHX(31), CH3X(32), HOX(33), OCXOX(34), HOCXO(35),
+    CO2X(36), H2OX(43), 'C.[Pt](84)', C2H3X(88), CHOX2(110), C2H3X2(120),
+    'CC#[Pt](307)', C2H2X2(338), 'C#C.[Pt](513)']
+  site-density: 3.148e-09
+  kinetics: surface
+  reactions:
+  - site0-reactions
+  state: {T: 300.0, P: 1 atm}
+
+elements:
+- symbol: Ci
+  atomic-weight: 13.003
+- symbol: D
+  atomic-weight: 2.014
+- symbol: Oi
+  atomic-weight: 17.999
+- symbol: T
+  atomic-weight: 3.016
+- symbol: X
+  atomic-weight: 195.083
+
+species:
+- name: Ar
+  composition: {Ar: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 6000.0]
+    data:
+    - [2.5, 0.0, 0.0, 0.0, 0.0, -745.375, 4.37967]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 136.501
+    diameter: 3.33
+    note: GRI-Mech
+- name: Ne
+  composition: {Ne: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 6000.0]
+    data:
+    - [2.5, 0.0, 0.0, 0.0, 0.0, -745.375, 3.35532]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 148.6
+    diameter: 3.758
+    note: Epsilon & sigma estimated with fixed Lennard Jones Parameters.
+      This is the fallback method! Try improving transport databases!
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [3.53101, -1.23661e-04, -5.02999e-07, 2.43531e-09, -1.40881e-12, -1046.98,
+      2.96747]
+    - [2.95258, 1.3969e-03, -4.92632e-07, 7.8601e-11, -4.60755e-15, -923.949,
+      5.87189]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 97.53
+    diameter: 3.621
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+    note: GRI-Mech
+- name: CH4(2)
+  composition: {C: 1, H: 4}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1084.12, 5000.0]
+    data:
+    - [4.2054162, -5.35558463e-03, 2.51123636e-05, -2.13763299e-08, 5.97525767e-12,
+      -1.01619433e+04, -0.921282727]
+    - [0.908260213, 0.0114540949, -4.57174339e-06, 8.2919286e-10, -5.66315868e-14,
+      -9719.97202, 13.9931256]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 141.4
+    diameter: 3.746
+    polarizability: 2.6
+    rotational-relaxation: 13.0
+    note: GRI-Mech
+- name: H2O(3)
+  composition: {H: 2, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1130.24, 5000.0]
+    data:
+    - [4.05763622, -7.87940252e-04, 2.90878932e-06, -1.47520578e-09, 2.12849596e-13,
+      -3.02815867e+04, -0.31136547]
+    - [2.84324781, 2.75108975e-03, -7.81033883e-07, 1.07244192e-10, -5.79396739e-15,
+      -2.99586116e+04, 5.91043491]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 572.402
+    diameter: 2.605
+    dipole: 1.844
+    rotational-relaxation: 4.0
+    note: GRI-Mech
+- name: CO2(4)
+  composition: {C: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 978.22, 5000.0]
+    data:
+    - [3.28084424, 2.50186e-03, 8.08190844e-06, -1.20510196e-08, 4.66541928e-12,
+      -4.84008303e+04, 6.00081544]
+    - [4.67427528, 2.60962688e-03, -9.85682082e-07, 1.95712015e-10, -1.49834714e-14,
+      -4.89512173e+04, -2.11078032]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 244.001
+    diameter: 3.763
+    polarizability: 2.65
+    rotational-relaxation: 2.1
+    note: GRI-Mech
+- name: H2(5)
+  composition: {H: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1959.08, 5000.0]
+    data:
+    - [3.43536434, 2.12708431e-04, -2.78620683e-07, 3.40263746e-10, -7.76023528e-14,
+      -1031.35985, -3.90841817]
+    - [2.78814269, 5.87671008e-04, 1.58996341e-07, -5.52710777e-11, 4.34290394e-15,
+      -596.130615, 0.112869836]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 38.0
+    diameter: 2.92
+    polarizability: 0.79
+    rotational-relaxation: 280.0
+    note: GRI-Mech
+- name: CO(6)
+  composition: {C: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1571.66, 5000.0]
+    data:
+    - [3.568379, -8.52116139e-04, 2.48915308e-06, -1.56328741e-09, 3.13588507e-13,
+      -1.42842549e+04, 3.57912548]
+    - [2.91309589, 1.64653676e-03, -6.88594068e-07, 1.21032927e-10, -7.83984059e-15,
+      -1.41808999e+04, 6.71028742]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 98.1
+    diameter: 3.65
+    polarizability: 1.95
+    rotational-relaxation: 1.8
+    note: GRI-Mech
+- name: O2(7)
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1074.56, 5000.0]
+    data:
+    - [3.5373218, -1.21570921e-03, 5.31617794e-06, -4.89443384e-09, 1.45845027e-12,
+      -1038.58846, 4.68368409]
+    - [3.15382429, 1.67803794e-03, -7.6997098e-07, 1.51274704e-10, -1.08781793e-14,
+      -1040.8188, 6.16753859]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 107.4
+    diameter: 3.458
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+    note: GRI-Mech
+- name: C2H6(8)
+  composition: {C: 2, H: 6}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1012.41, 5000.0]
+    data:
+    - [3.72240272, 1.65072169e-03, 3.44179642e-05, -3.76863565e-08, 1.24452922e-11,
+      -1.15575906e+04, 4.68244489]
+    - [2.82844025, 0.0173041283, -6.73338349e-06, 1.23742991e-09, -8.65684403e-14,
+      -1.19977901e+04, 5.93835568]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 252.301
+    diameter: 4.302
+    rotational-relaxation: 1.5
+    note: GRI-Mech
+- name: CH3(9)
+  composition: {C: 1, H: 3}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 697.65, 5000.0]
+    data:
+    - [3.96043159, 5.92932552e-04, 8.78578091e-06, -9.88034326e-09, 3.63236374e-12,
+      1.64218817e+04, 0.339863476]
+    - [3.09511244, 5.55429753e-03, -1.88158775e-06, 3.13334801e-10, -2.05194992e-14,
+      1.6542619e+04, 4.20297572]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 144.001
+    diameter: 3.8
+    note: GRI-Mech
+- name: CH3OH(10)
+  composition: {C: 1, H: 4, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1035.74, 5000.0]
+    data:
+    - [3.84006783, 1.38235301e-03, 1.91669514e-05, -2.01571623e-08, 6.39114598e-12,
+      -2.5608309e+04, 5.90976096]
+    - [2.79181596, 0.0115828305, -4.51554511e-06, 8.21212761e-10, -5.67068242e-14,
+      -2.57211558e+04, 9.41076841]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 481.802
+    diameter: 3.626
+    rotational-relaxation: 1.0
+    note: GRI-Mech
+- name: C2H4(11)
+  composition: {C: 2, H: 4}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 979.36, 5000.0]
+    data:
+    - [3.97470128, -4.75826421e-03, 4.16777338e-05, -4.51383953e-08, 1.54221026e-11,
+      4915.40809, 3.62436113]
+    - [3.55666159, 0.0110626515, -4.17013587e-06, 7.85573759e-10, -5.70050015e-14,
+      4320.44172, 2.17688265]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 280.801
+    diameter: 3.971
+    rotational-relaxation: 1.5
+    note: GRI-Mech
+- name: CH3CHO(12)
+  composition: {C: 2, H: 4, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1028.8, 5000.0]
+    data:
+    - [3.57992942, 5.18977048e-03, 2.26899736e-05, -2.73745515e-08, 9.28491703e-12,
+      -2.13697376e+04, 8.96969617]
+    - [4.08561394, 0.0139061616, -5.59372584e-06, 1.0460983e-09, -7.38743189e-14,
+      -2.20391238e+04, 3.76815598]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 436.001
+    diameter: 3.97
+    rotational-relaxation: 2.0
+    note: GRI-Mech
+- name: C3H6O(13)
+  composition: {C: 3, H: 6, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1023.95, 5000.0]
+    data:
+    - [3.0114016, 0.0154683797, 2.15009892e-05, -3.24611554e-08, 1.17874118e-11,
+      -2.78712432e+04, 13.2203279]
+    - [5.79591807, 0.0200763349, -7.93430225e-06, 1.47305067e-09, -1.03775439e-13,
+      -2.92532887e+04, -4.24334634]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 385.407
+    diameter: 5.33
+    note: Epsilon & sigma estimated with Tc=500.53 K, Pc=48.02 bar (from
+      Joback method)
+- name: C2H6O(14)
+  composition: {C: 2, H: 6, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 984.0, 5000.0]
+    data:
+    - [3.24025953, 0.0104859578, 2.63967696e-05, -3.69293568e-08, 1.36710598e-11,
+      -2.99902844e+04, 11.1433019]
+    - [5.68494153, 0.016131329, -5.96365742e-06, 1.08897208e-09, -7.69620903e-14,
+      -3.12258211e+04, -4.44489193]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 362.6
+    diameter: 4.53
+    rotational-relaxation: 1.5
+    note: NOx2018
+- name: CH3COOCH3(15)
+  composition: {C: 3, H: 6, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1154.01, 5000.0]
+    data:
+    - [2.75062207, 0.0220813071, 1.21742176e-05, -2.19214056e-08, 7.33620226e-12,
+      -5.11793699e+04, 16.5002438]
+    - [5.62526438, 0.0261099804, -1.12500953e-05, 2.11765104e-09, -1.47683111e-13,
+      -5.27745799e+04, -1.8169542]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 385.633
+    diameter: 5.473
+    note: Epsilon & sigma estimated with Tc=500.82 K, Pc=44.39 bar (from
+      Joback method)
+- name: X(1)
+  composition: {X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 2000.0]
+    data:
+    - [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+- name: HX(16)
+  composition: {H: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [-2.0151091, 0.0127747196, -1.36892852e-05, 6.6707688e-09, -1.15946694e-12,
+      -5530.52906, 8.4468689]
+    - [-0.184968995, 6.05229805e-03, -4.83715532e-06, 1.81340221e-09, -2.61948776e-13,
+      -5915.33033, -0.504191778]
+- name: OX(17)
+  composition: {O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [0.195855852, 0.0116923252, -2.02271203e-05, 1.61601691e-08, -4.90070914e-12,
+      -2.69189243e+04, -2.01768707]
+    - [2.9043837, -2.74871763e-04, 5.38558858e-07, -3.03946989e-10, 5.63969783e-14,
+      -2.74411389e+04, -14.894415]
+- name: CX(18)
+  composition: {C: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [-0.573265619, 0.0144803183, -2.45704673e-05, 1.93668551e-08, -5.81642502e-12,
+      1.47661073e+04, 1.2024425]
+    - [2.71617577, 1.99967762e-05, 3.4803163e-07, -2.47205634e-10, 5.00169813e-14,
+      1.41308872e+04, -14.4477318]
+- name: COX(19)
+  composition: {C: 1, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [3.13851368, 7.37719433e-03, -1.21673211e-05, 1.06231734e-08, -3.55085256e-12,
+      -3.01011015e+04, -14.0684039]
+    - [4.39015575, 1.21423223e-03, 2.26543548e-08, -2.74772156e-10, 6.84375847e-14,
+      -3.03339593e+04, -19.9186406]
+- name: CHX(20)
+  composition: {C: 1, H: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [0.444067538, 7.15965809e-03, -6.05381899e-06, 4.41670377e-09, -1.57758787e-12,
+      2484.09325, -2.97930741]
+    - [0.470984781, 6.44724983e-03, -3.18677769e-06, 7.11925015e-10, -5.43593812e-14,
+      2479.24869, -3.03223839]
+- name: CH2X(21)
+  composition: {C: 1, H: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [-0.719249342, 0.0165071735, -1.7499851e-05, 1.09676908e-08, -2.88981251e-12,
+      1684.1105, 2.01831094]
+    - [0.983780574, 8.78623452e-03, -4.38766259e-06, 1.09400822e-09, -1.10409266e-13,
+      1383.36061, -5.98458146]
+- name: HCOX(22)
+  composition: {C: 1, H: 1, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [1.67902911, 0.0139424587, -1.51013698e-05, 9.67718274e-09, -2.69733533e-12,
+      -2.16030349e+04, -8.23427981]
+    - [3.03186697, 8.02892147e-03, -4.79702422e-06, 1.39761897e-09, -1.61417712e-13,
+      -2.18711786e+04, -14.692113]
+- name: HCOHX(23)
+  composition: {C: 1, H: 2, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [4.61466774, 1.97736658e-03, 1.13520606e-05, -1.28686112e-08, 4.2885424e-12,
+      -2.08405084e+04, -18.3405542]
+    - [2.12897595, 0.0131031973, -8.04327296e-06, 2.48752777e-09, -3.12401921e-13,
+      -2.03714667e+04, -6.56664446]
+- name: CH3OX(24)
+  composition: {C: 1, H: 3, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [1.7232417, 0.0246490814, -2.80859624e-05, 1.72678472e-08, -4.26645223e-12,
+      -2.48262518e+04, -8.86801544]
+    - [5.35800551, 9.63360342e-03, -4.83501645e-06, 1.27341188e-09, -1.42248592e-13,
+      -2.55298238e+04, -26.2856418]
+- name: CH3COOX(25)
+  composition: {C: 2, H: 3, O: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 984.45, 5000.0]
+    data:
+    - [3.02828539, 0.0110970672, 3.41082297e-05, -5.16093316e-08, 1.99821439e-11,
+      -5.45206963e+04, -8.73048049]
+    - [9.44448672, 0.0106736832, -4.32452634e-06, 8.80622118e-10, -6.79718867e-14,
+      -5.70267527e+04, -45.8963898]
+- name: CH2COX(26)
+  composition: {C: 2, H: 2, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 961.81, 5000.0]
+    data:
+    - [3.22979879, 0.0140344939, -3.56351755e-06, -6.07820031e-09, 3.58358908e-12,
+      -1.63752671e+04, -9.06405904]
+    - [6.75419818, 6.25332972e-03, -2.15210043e-06, 3.76495412e-10, -2.61805748e-14,
+      -1.73712808e+04, -27.5834188]
+- name: CH2COX2(27)
+  composition: {C: 2, H: 2, O: 1, X: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 931.96, 5000.0]
+    data:
+    - [3.26076086, 8.7928684e-03, 2.17502605e-05, -3.77663092e-08, 1.60291613e-11,
+      -2.76935704e+04, -15.9429794]
+    - [8.93173327, 3.51833532e-03, -4.46393644e-07, 6.27459976e-11, -6.93713499e-15,
+      -2.95785579e+04, -47.3445934]
+  sites: 2.0
+- name: CH3COOHX(28)
+  composition: {C: 2, H: 4, O: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1048.69, 5000.0]
+    data:
+    - [2.87239041, 0.0186927828, 1.0088838e-05, -2.2522588e-08, 8.70045824e-12,
+      -5.86586621e+04, -3.00900633]
+    - [7.28794498, 0.0162041238, -6.88201857e-06, 1.31748685e-09, -9.41982125e-14,
+      -6.03740403e+04, -28.2845346]
+- name: C2H4X(29)
+  composition: {C: 2, H: 4, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 976.84, 5000.0]
+    data:
+    - [3.68521618, 1.29459688e-03, 3.31761373e-05, -3.98904869e-08, 1.42375526e-11,
+      -4431.57003, -13.4989988]
+    - [4.82101323, 0.0111302021, -4.17185101e-06, 7.79847051e-10, -5.63879306e-14,
+      -5344.63674, -22.4897119]
+- name: C2H4X2(30)
+  composition: {C: 2, H: 4, X: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 945.14, 5000.0]
+    data:
+    - [3.75453554, -5.06560113e-03, 6.10124816e-05, -7.41721149e-08, 2.76310662e-11,
+      -8730.58083, -18.7893661]
+    - [7.0112633, 7.95379231e-03, -2.18738926e-06, 4.10888303e-10, -3.33917238e-14,
+      -1.05433116e+04, -40.6504605]
+  sites: 2.0
+- name: COOHX(31)
+  composition: {C: 1, H: 2, O: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1005.04, 5000.0]
+    data:
+    - [3.53006779, 4.5594231e-03, 2.37656598e-05, -3.19406145e-08, 1.16843843e-11,
+      -5.57122182e+04, -7.0212104]
+    - [6.30081585, 8.20615627e-03, -3.57786011e-06, 7.24341931e-10, -5.45315781e-14,
+      -5.70102822e+04, -24.089423]
+- name: CH3X(32)
+  composition: {C: 1, H: 3, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [-0.552219087, 0.0264420133, -3.55617257e-05, 2.60043628e-08, -7.52706787e-12,
+      -4433.46585, 0.692144274]
+    - [3.62557353, 7.39511955e-03, -2.43797398e-06, 1.86159414e-10, 3.64849549e-14,
+      -5187.22188, -18.9668272]
+- name: HOX(33)
+  composition: {H: 1, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [1.58477686, 3.87867982e-03, 1.34107764e-06, -3.93949585e-09, 1.68540254e-12,
+      -2.90977259e+04, -7.42452379]
+    - [1.42377797, 5.57119676e-03, -3.3929338e-06, 1.09513419e-09, -1.46734126e-13,
+      -2.90972119e+04, -6.85806991]
+- name: OCXOX(34)
+  composition: {C: 1, O: 2, X: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 924.81, 5000.0]
+    data:
+    - [2.99016038, 3.95026566e-03, 2.32709252e-05, -3.78809105e-08, 1.60937226e-11,
+      -7.26325759e+04, -13.5698649]
+    - [8.52643192, -1.29139803e-03, 1.43612907e-06, -2.72457525e-10, 1.56499624e-14,
+      -7.44564313e+04, -44.1708301]
+  sites: 2.0
+- name: HOCXO(35)
+  composition: {C: 1, H: 1, O: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.0, 1000.0, 2000.0]
+    data:
+    - [0.700750147, 0.0322756606, -4.70618414e-05, 3.45557357e-08, -1.00331658e-11,
+      -5.18553737e+04, -4.52637913]
+    - [6.47849692, 7.149868e-03, -4.22981914e-06, 1.15767979e-09, -1.19086295e-13,
+      -5.29808669e+04, -32.0736929]
+- name: CO2X(36)
+  composition: {C: 1, O: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1008.22, 5000.0]
+    data:
+    - [2.99486686, 9.1859654e-03, -4.12216169e-06, -1.93581616e-09, 1.52889555e-12,
+      -5.52644684e+04, -8.95864383]
+    - [5.5544293, 3.15500565e-03, -1.28472914e-06, 2.44776789e-10, -1.77304007e-14,
+      -5.59901848e+04, -22.3674392]
+- name: H2OX(43)
+  composition: {H: 2, O: 1, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 992.64, 5000.0]
+    data:
+    - [3.76908588, 6.11563654e-03, -9.97117455e-06, 9.22181366e-09, -3.06918553e-12,
+      -3.63110221e+04, -15.097954]
+    - [3.72684086, 3.24910958e-03, -1.05058226e-06, 1.4868916e-10, -7.88009793e-15,
+      -3.61530243e+04, -14.1408565]
+- name: C.[Pt](84)
+  composition: {C: 1, H: 4, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1348.93, 5000.0]
+    data:
+    - [3.88778247, 2.73614901e-03, 9.4539386e-06, -8.27597758e-09, 2.02464154e-12,
+      -1.52760571e+04, -16.0790121]
+    - [2.18944665, 0.0116179596, -4.69896427e-06, 8.32126369e-10, -5.50758229e-14,
+      -1.51677557e+04, -8.67409218]
+- name: C2H3X(88)
+  composition: {C: 2, H: 3, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 938.98, 5000.0]
+    data:
+    - [3.81685519, -4.95931081e-03, 5.14561017e-05, -6.31488072e-08, 2.37947355e-11,
+      486.184087, -15.8827955]
+    - [6.91814077, 4.84563155e-03, -9.74675469e-07, 1.80928841e-10, -1.67111339e-14,
+      -1110.88612, -36.0524171]
+- name: CHOX2(110)
+  composition: {C: 1, H: 1, O: 1, X: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 926.62, 5000.0]
+    data:
+    - [3.83288765, -1.66030981e-03, 2.65567139e-05, -3.48666745e-08, 1.36873378e-11,
+      -3.03571213e+04, -16.1403346]
+    - [6.41356232, 8.72293869e-04, 3.23559931e-07, -6.87494619e-11, 2.59893837e-15,
+      -3.14223679e+04, -31.5612771]
+  sites: 2.0
+- name: C2H3X2(120)
+  composition: {C: 2, H: 3, X: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 931.26, 5000.0]
+    data:
+    - [3.83884173, -8.20968791e-03, 6.65622816e-05, -8.22315252e-08, 3.13833554e-11,
+      -3285.2632, -19.4608522]
+    - [8.29116405, 2.7943035e-03, 3.10260044e-07, -6.34389013e-11, -1.00801055e-15,
+      -5420.92646, -47.6378634]
+  sites: 2.0
+- name: CC#[Pt](307)
+  composition: {C: 2, H: 3, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 1264.64, 5000.0]
+    data:
+    - [3.48625379, 9.84987882e-03, -1.12672006e-06, -2.61528606e-09, 9.94677768e-13,
+      -1928.44075, 2.78657041]
+    - [4.86544012, 8.67860765e-03, -3.5223538e-06, 6.42820852e-10, -4.38235056e-14,
+      -2532.45047, -5.19990243]
+- name: C2H2X2(338)
+  composition: {C: 2, H: 2, X: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 928.31, 5000.0]
+    data:
+    - [3.24504151, -2.17602793e-03, 3.97905523e-05, -5.17087642e-08, 2.01509093e-11,
+      258.438338, -18.4980145]
+    - [6.79698348, 2.4664034e-03, 5.71681686e-08, -2.66859189e-11, -1.21979217e-15,
+      -1260.51216, -39.9991896]
+  sites: 2.0
+- name: C#C.[Pt](513)
+  composition: {C: 2, H: 2, X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [100.0, 946.82, 5000.0]
+    data:
+    - [3.06056828, 7.58728095e-03, 2.14479983e-06, -8.0788862e-09, 3.69953519e-12,
+      1.90210409e+04, -9.52387326]
+    - [4.94027909, 4.78722202e-03, -1.56395445e-06, 2.67276194e-10, -1.84169549e-14,
+      1.8434649e+04, -19.7065975]
+
+gas-reactions:
+- equation: CH3(9) + CH3(9) <=> C2H6(8)  # Reaction 1
+  rate-constant: {A: 9.45e+14, b: -0.538, Ea: 0.135}
+- equation: CO(6) + CH4(2) <=> CH3CHO(12)  # Reaction 2
+  rate-constant: {A: 6.56e+04, b: 2.86, Ea: 86.9}
+- equation: CO(6) + C2H6(8) <=> C3H6O(13)  # Reaction 3
+  rate-constant: {A: 538.0, b: 3.29, Ea: 104.5}
+- equation: H2O(3) + C2H4(11) <=> C2H6O(14)  # Reaction 4
+  rate-constant: {A: 588.0, b: 2.94, Ea: 53.1}
+- equation: CO2(4) + C2H6(8) <=> CH3COOCH3(15)  # Reaction 5
+  rate-constant: {A: 292.0, b: 3.13, Ea: 116.33}
+
+site0-reactions:
+- equation: X(1) + X(1) + H2(5) <=> HX(16) + HX(16)  # Reaction 1
+  sticking-coefficient: {A: 0.032, b: 0.0, Ea: 0.0}
+- equation: X(1) + X(1) + O2(7) <=> OX(17) + OX(17)  # Reaction 2
+  sticking-coefficient: {A: 0.0436, b: -0.206, Ea: 0.359}
+- equation: X(1) + CO(6) <=> COX(19)  # Reaction 3
+  sticking-coefficient: {A: 0.5, b: 0.0, Ea: 0.0}
+- equation: X(1) + COX(19) <=> OX(17) + CX(18)  # Reaction 4
+  rate-constant: {A: 1.75e+13, b: 0.0, Ea: 27.772}
+- equation: COX(19) + COX(19) <=> X(1) + CX(18) + CO2(4)  # Reaction 5
+  rate-constant: {A: 1.62e+14, b: 0.5, Ea: 57.768}
+- equation: OX(17) + COX(19) <=> X(1) + X(1) + CO2(4)  # Reaction 6
+  rate-constant: {A: 2.0e+19, b: 0.0, Ea: 29.541}
+- equation: HX(16) + CX(18) <=> X(1) + CHX(20)  # Reaction 7
+  rate-constant: {A: 1.7e+24, b: -0.5, Ea: 37.739}
+- equation: HX(16) + COX(19) <=> OX(17) + CHX(20)  # Reaction 8
+  rate-constant: {A: 1.26e+20, b: 0.073, Ea: 45.8}
+- equation: HX(16) + CHX(20) <=> X(1) + CH2X(21)  # Reaction 9
+  rate-constant: {A: 9.77e+24, b: -0.087, Ea: 19.359}
+- equation: H2(5) + CX(18) <=> CH2X(21)  # Reaction 10
+  sticking-coefficient: {A: 0.04, b: 0.0, Ea: 7.098}
+- equation: OX(17) + CHX(20) <=> X(1) + HCOX(22)  # Reaction 11
+  rate-constant: {A: 4.59e+20, b: 0.0, Ea: 26.267}
+- equation: X(1) + HCOX(22) <=> HX(16) + COX(19)  # Reaction 12
+  rate-constant: {A: 3.71e+21, b: 0.0, Ea: 0.0}
+- equation: HX(16) + CH3X(32) <=> X(1) + X(1) + CH4(2)  # Reaction 13
+  rate-constant: {A: 1.44e+22, b: -0.087, Ea: 15.153}
+- equation: HX(16) + CH2X(21) <=> X(1) + CH3X(32)  # Reaction 14
+  rate-constant: {A: 3.09e+23, b: -0.087, Ea: 13.671}
+- equation: X(1) + CH3(9) <=> CH3X(32)  # Reaction 15
+  sticking-coefficient: {A: 0.16, b: -0.099, Ea: 0.0}
+- equation: HOX(33) + CX(18) <=> HX(16) + COX(19)  # Reaction 16
+  rate-constant: {A: 3.88e+25, b: 0.188, Ea: 14.938}
+- equation: HOX(33) + CH3X(32) <=> X(1) + OX(17) + CH4(2)  # Reaction 17
+  rate-constant: {A: 2.98e+22, b: 0.101, Ea: 6.166}
+- equation: HOX(33) + CH2X(21) <=> OX(17) + CH3X(32)  # Reaction 18
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: HOX(33) + CHX(20) <=> OX(17) + CH2X(21)  # Reaction 19
+  rate-constant: {A: 4.4e+22, b: 0.101, Ea: 10.134}
+- equation: HOX(33) + CX(18) <=> OX(17) + CHX(20)  # Reaction 20
+  rate-constant: {A: 2.43e+21, b: -0.312, Ea: 28.418}
+- equation: HX(16) + HOX(33) <=> X(1) + X(1) + H2O(3)  # Reaction 21
+  rate-constant: {A: 1.85e+20, b: 0.086, Ea: 9.919}
+- equation: X(1) + HOX(33) <=> OX(17) + HX(16)  # Reaction 22
+  rate-constant: {A: 2.25e+20, b: 0.188, Ea: 7.075}
+- equation: HOX(33) + HOX(33) <=> X(1) + OX(17) + H2O(3)  # Reaction 23
+  rate-constant: {A: 2.34e+20, b: 0.274, Ea: 22.06}
+- equation: HOX(33) + HCOX(22) <=> HX(16) + HOCXO(35)  # Reaction 24
+  rate-constant: {A: 2.28e+20, b: 0.263, Ea: 3.8}
+- equation: X(1) + HOCXO(35) <=> HOX(33) + COX(19)  # Reaction 25
+  rate-constant: {A: 1.46e+24, b: -0.213, Ea: 12.978}
+- equation: X(1) + HOCXO(35) <=> X(1) + HX(16) + CO2(4)  # Reaction 26
+  rate-constant: {A: 3.73e+20, b: 0.475, Ea: 8.031}
+- equation: COX(19) + COX(19) <=> CX(18) + CO2X(36)  # Reaction 27
+  rate-constant: {A: 1.62e+14, b: 0.5, Ea: 57.768}
+- equation: X(1) + CO2(4) <=> CO2X(36)  # Reaction 28
+  sticking-coefficient: {A: 5.0e-03, b: 0.0, Ea: 0.0}
+- equation: OX(17) + COX(19) <=> X(1) + CO2X(36)  # Reaction 29
+  rate-constant: {A: 3.7e+21, b: 0.0, Ea: 28.107}
+- equation: HOX(33) + COX(19) <=> HX(16) + CO2X(36)  # Reaction 30
+  rate-constant: {A: 1.0e+19, b: 0.0, Ea: 9.25}
+- equation: X(1) + HOCXO(35) <=> HX(16) + CO2X(36)  # Reaction 31
+  rate-constant: {A: 4.27e+19, b: 0.549, Ea: 1.0}
+- equation: HOX(33) + CO2X(36) <=> OX(17) + HOCXO(35)  # Reaction 32
+  rate-constant: {A: 2.15e+19, b: 0.097, Ea: 26.5}
+- equation: CH2COX2(27) <=> COX(19) + CH2X(21)  # Reaction 33
+  rate-constant: {A: 4.22e+12, b: 0.0, Ea: 24.857}
+- equation: X(1) + CH2COX(26) <=> CH2COX2(27)  # Reaction 34
+  rate-constant: {A: 2.0e+21, b: 0.0, Ea: 0.0}
+- equation: X(1) + C2H4(11) <=> C2H4X(29)  # Reaction 35
+  sticking-coefficient: {A: 7.0e-06, b: 0.0, Ea: 0.0}
+- equation: X(1) + X(1) + C2H4(11) <=> C2H4X2(30)  # Reaction 36
+  sticking-coefficient: {A: 0.69, b: 0.0, Ea: 0.0}
+- equation: CH2X(21) + CH2X(21) <=> C2H4X2(30)  # Reaction 37
+  rate-constant: {A: 9.89e+23, b: 0.0, Ea: 36.807}
+- equation: X(1) + C2H4X(29) <=> C2H4X2(30)  # Reaction 38
+  rate-constant: {A: 1.78e+21, b: 0.0, Ea: 2.868}
+- equation: X(1) + X(1) + CO2(4) <=> OCXOX(34)  # Reaction 39
+  sticking-coefficient: {A: 1.66, b: 0.0, Ea: 0.0}
+- equation: OCXOX(34) <=> OX(17) + COX(19)  # Reaction 40
+  rate-constant: {A: 4.22e+12, b: 0.0, Ea: 31.864}
+- equation: X(1) + CO2X(36) <=> OCXOX(34)  # Reaction 41
+  rate-constant: {A: 4.0e+21, b: 0.0, Ea: 0.0}
+- equation: X(1) + X(1) + C2H6(8) <=> CH3X(32) + CH3X(32)  # Reaction 42
+  sticking-coefficient: {A: 0.015, b: 0.0, Ea: 5.523}
+- equation: X(1) + X(1) + CH3OH(10) <=> HOX(33) + CH3X(32)  # Reaction 43
+  sticking-coefficient: {A: 0.015, b: 0.0, Ea: 1.195}
+- equation: X(1) + X(1) + CH3OH(10) <=> HX(16) + CH3OX(24)  # Reaction 44
+  sticking-coefficient: {A: 0.099, b: 0.0, Ea: 18.294}
+- equation: X(1) + X(1) + C2H4(11) <=> CH2X(21) + CH2X(21)  # Reaction 45
+  sticking-coefficient: {A: 0.01, b: 0.0, Ea: 10.0}
+- equation: X(1) + X(1) + CH3CHO(12) <=> HCOX(22) + CH3X(32)  # Reaction 46
+  sticking-coefficient: {A: 0.015, b: 0.0, Ea: 1.195}
+- equation: X(1) + X(1) + C2H6O(14) <=> CH3X(32) + CH3OX(24)  # Reaction 47
+  sticking-coefficient: {A: 0.015, b: 0.0, Ea: 2.521}
+- equation: X(1) + HCOHX(23) <=> HOX(33) + CHX(20)  # Reaction 48
+  rate-constant: {A: 1.46e+24, b: -0.213, Ea: 12.978}
+- equation: X(1) + HCOHX(23) <=> HX(16) + HCOX(22)  # Reaction 49
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 13.918}
+- equation: X(1) + CH3OX(24) <=> HOX(33) + CH2X(21)  # Reaction 50
+  rate-constant: {A: 1.46e+24, b: -0.213, Ea: 12.978}
+- equation: X(1) + CH3OX(24) <=> HX(16) + HCOHX(23)  # Reaction 51
+  rate-constant: {A: 7.42e+21, b: 0.0, Ea: 0.0}
+- equation: X(1) + CH3COOX(25) <=> HOCXO(35) + CH2X(21)  # Reaction 52
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 36.535}
+- equation: X(1) + CH3COOX(25) <=> HOX(33) + CH2COX(26)  # Reaction 53
+  rate-constant: {A: 1.53922e+21, b: 0.131, Ea: 18.349}
+- equation: X(1) + CH2COX(26) <=> COX(19) + CH2X(21)  # Reaction 54
+  rate-constant: {A: 3.282e+20, b: 0.0, Ea: 57.651}
+- equation: X(1) + CH3COOHX(28) <=> HOCXO(35) + CH3X(32)  # Reaction 55
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 34.027}
+- equation: X(1) + CH3COOHX(28) <=> HX(16) + CH3COOX(25)  # Reaction 56
+  rate-constant: {A: 2.11635e+13, b: 2.071, Ea: 32.311}
+- equation: X(1) + C2H4X(29) <=> CH2X(21) + CH2X(21)  # Reaction 57
+  rate-constant: {A: 3.282e+20, b: 0.0, Ea: 57.651}
+- equation: X(1) + COOHX(31) <=> OX(17) + HCOHX(23)  # Reaction 58
+  rate-constant: {A: 1.641e+20, b: 0.0, Ea: 57.651}
+- equation: X(1) + COOHX(31) <=> HOX(33) + HCOX(22)  # Reaction 59
+  rate-constant: {A: 1.781e+21, b: 0.0, Ea: 37.589}
+- equation: HX(16) + HOCXO(35) <=> X(1) + COOHX(31)  # Reaction 60
+  rate-constant: {A: 2.308e+22, b: 0.0, Ea: 16.834}
+- equation: X(1) + X(1) + HOCXO(35) <=> HX(16) + OCXOX(34)  # Reaction 61
+  rate-constant: {A: 1.856667e+29, b: 0.0, Ea: 10.994}
+- equation: CH2X(21) + COOHX(31) <=> HX(16) + CH3COOX(25)  # Reaction 62
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: OX(17) + HCOX(22) <=> HOX(33) + COX(19)  # Reaction 63
+  rate-constant: {A: 3.298e+21, b: 0.0, Ea: 0.0}
+- equation: OX(17) + HCOHX(23) <=> HOX(33) + HCOX(22)  # Reaction 64
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 0.0}
+- equation: HOX(33) + HCOHX(23) <=> OX(17) + CH3OX(24)  # Reaction 65
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: OX(17) + CH2COX2(27) <=> OCXOX(34) + CH2X(21)  # Reaction 66
+  rate-constant: {A: 3.298e+21, b: 0.0, Ea: 0.0}
+- equation: OX(17) + CH3COOHX(28) <=> HOX(33) + CH3COOX(25)  # Reaction 67
+  rate-constant: {A: 4.215e+24, b: -0.101, Ea: 22.156}
+- equation: OX(17) + COOHX(31) <=> HOX(33) + HOCXO(35)  # Reaction 68
+  rate-constant: {A: 1.405e+24, b: -0.101, Ea: 22.156}
+- equation: CX(18) + CH2X(21) <=> CHX(20) + CHX(20)  # Reaction 69
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 15.39}
+- equation: CX(18) + HCOX(22) <=> COX(19) + CHX(20)  # Reaction 70
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 8.664}
+- equation: CX(18) + HCOHX(23) <=> CHX(20) + HCOX(22)  # Reaction 71
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 5.749}
+- equation: CX(18) + CH3OX(24) <=> CHX(20) + HCOHX(23)  # Reaction 72
+  rate-constant: {A: 7.425804e+21, b: 0.0, Ea: 8.913}
+- equation: CX(18) + CH3COOHX(28) <=> CHX(20) + CH3COOX(25)  # Reaction 73
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: CX(18) + COOHX(31) <=> CHX(20) + HOCXO(35)  # Reaction 74
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: CX(18) + CH3X(32) <=> CHX(20) + CH2X(21)  # Reaction 75
+  rate-constant: {A: 9.894e+21, b: 0.0, Ea: 0.0}
+- equation: CHX(20) + HCOX(22) <=> COX(19) + CH2X(21)  # Reaction 76
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 17.007}
+- equation: CHX(20) + HOCXO(35) <=> COX(19) + HCOHX(23)  # Reaction 77
+  rate-constant: {A: 4.4e+22, b: 0.101, Ea: 10.134}
+- equation: COX(19) + HCOHX(23) <=> HCOX(22) + HCOX(22)  # Reaction 78
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 44.034}
+- equation: HOCXO(35) + CH2X(21) <=> COX(19) + CH3OX(24)  # Reaction 79
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: HCOX(22) + HCOHX(23) <=> COX(19) + CH3OX(24)  # Reaction 80
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 14.571}
+- equation: COX(19) + CH3COOX(25) <=> HOCXO(35) + CH2COX(26)  # Reaction 81
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 61.626}
+- equation: COX(19) + CH3COOHX(28) <=> HCOX(22) + CH3COOX(25)  # Reaction 82
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + CH2COX2(27) <=> COX(19) + C2H4X2(30)  # Reaction 83
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: COX(19) + COOHX(31) <=> HCOX(22) + HOCXO(35)  # Reaction 84
+  duplicate: true
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: COX(19) + COOHX(31) <=> HCOX(22) + HOCXO(35)  # Reaction 85
+  duplicate: true
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: HCOX(22) + CH2X(21) <=> COX(19) + CH3X(32)  # Reaction 86
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 13.376}
+- equation: COX(19) + HOCXO(35) <=> CO2X(36) + HCOX(22)  # Reaction 87
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 40.036}
+- equation: CHX(20) + HCOHX(23) <=> HCOX(22) + CH2X(21)  # Reaction 88
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 26.946}
+- equation: CH2X(21) + HCOHX(23) <=> CHX(20) + CH3OX(24)  # Reaction 89
+  duplicate: true
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: CH2X(21) + HCOHX(23) <=> CHX(20) + CH3OX(24)  # Reaction 90
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 21.297}
+- equation: CHX(20) + CH3COOHX(28) <=> CH2X(21) + CH3COOX(25)  # Reaction 91
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: CHX(20) + COOHX(31) <=> HCOX(22) + HCOHX(23)  # Reaction 92
+  rate-constant: {A: 2.360665e+21, b: -0.074, Ea: 28.318}
+- equation: CHX(20) + COOHX(31) <=> HOCXO(35) + CH2X(21)  # Reaction 93
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + CH2X(21) <=> CHX(20) + CH3X(32)  # Reaction 94
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 20.102}
+- equation: CH2X(21) + HCOHX(23) <=> CHX(20) + CH3OX(24)  # Reaction 95
+  duplicate: true
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: CH2X(21) + HCOHX(23) <=> CHX(20) + CH3OX(24)  # Reaction 96
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 21.297}
+- equation: CH2X(21) + HCOHX(23) <=> HCOX(22) + CH3X(32)  # Reaction 97
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 17.722}
+- equation: CH2X(21) + CH3OX(24) <=> HCOHX(23) + CH3X(32)  # Reaction 98
+  rate-constant: {A: 7.425804e+21, b: 0.0, Ea: 11.269}
+- equation: CH2X(21) + CH3COOX(25) <=> CH3OX(24) + CH2COX(26)  # Reaction 99
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 54.408}
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3X(32) + CH3COOX(25)  # Reaction 100
+  duplicate: true
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3X(32) + CH3COOX(25)  # Reaction 101
+  duplicate: true
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + COOHX(31) <=> HCOX(22) + CH3OX(24)  # Reaction 102
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + COOHX(31) <=> HOCXO(35) + CH3X(32)  # Reaction 103
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: HOCXO(35) + CH2X(21) <=> CO2X(36) + CH3X(32)  # Reaction 104
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 13.724}
+- equation: HCOHX(23) + HCOHX(23) <=> HCOX(22) + CH3OX(24)  # Reaction 105
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 20.758}
+- equation: HCOX(22) + CH3COOX(25) <=> COOHX(31) + CH2COX(26)  # Reaction 106
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 31.276}
+- equation: COX(19) + COOHX(31) <=> HCOX(22) + HOCXO(35)  # Reaction 107
+  duplicate: true
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: COX(19) + COOHX(31) <=> HCOX(22) + HOCXO(35)  # Reaction 108
+  duplicate: true
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: HCOHX(23) + CH3COOHX(28) <=> CH3OX(24) + CH3COOX(25)  # Reaction 109
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: HCOHX(23) + COOHX(31) <=> HOCXO(35) + CH3OX(24)  # Reaction 110
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: HOCXO(35) + HCOHX(23) <=> CO2X(36) + CH3OX(24)  # Reaction 111
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 16.76}
+- equation: HOCXO(35) + CH3COOHX(28) <=> COOHX(31) + CH3COOX(25)  # Reaction 112
+  rate-constant: {A: 1.254e+22, b: 0.0, Ea: 31.401}
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3X(32) + CH3COOX(25)  # Reaction 113
+  duplicate: true
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + CH3COOHX(28) <=> CH3X(32) + CH3COOX(25)  # Reaction 114
+  duplicate: true
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: HOCXO(35) + CH3COOX(25) <=> CO2X(36) + CH3COOHX(28)  # Reaction 115
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 15.298}
+- equation: HOCXO(35) + HOCXO(35) <=> CO2X(36) + COOHX(31)  # Reaction 116
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 15.658}
+- equation: X(1) + HOX(33) + CH4(2) <=> H2OX(43) + CH3X(32)  # Reaction 117
+  sticking-coefficient: {A: 1.0, b: 0.0, Ea: 2.39}
+- equation: X(1) + H2O(3) <=> H2OX(43)  # Reaction 118
+  sticking-coefficient: {A: 0.75, b: 0.0, Ea: 0.0}
+- equation: X(1) + H2OX(43) <=> HX(16) + HOX(33)  # Reaction 119
+  rate-constant: {A: 1.15e+19, b: 0.0, Ea: 24.235}
+- equation: OX(17) + H2OX(43) <=> HOX(33) + HOX(33)  # Reaction 120
+  rate-constant: {A: 1.0e+20, b: 0.0, Ea: 21.63}
+- equation: H2OX(43) + COX(19) <=> HX(16) + HOCXO(35)  # Reaction 121
+  rate-constant: {A: 4.43e+19, b: 0.492, Ea: 23.7}
+- equation: H2OX(43) + CO2X(36) <=> HOX(33) + HOCXO(35)  # Reaction 122
+  rate-constant: {A: 3.48e+19, b: -0.031, Ea: 21.853}
+- equation: H2OX(43) + CH2X(21) <=> HOX(33) + CH3X(32)  # Reaction 123
+  rate-constant: {A: 3.3e+19, b: 0.099, Ea: 14.1}
+- equation: H2OX(43) + CHX(20) <=> HOX(33) + CH2X(21)  # Reaction 124
+  rate-constant: {A: 7.29e+19, b: 0.269, Ea: 34.0}
+- equation: H2OX(43) + CX(18) <=> HOX(33) + CHX(20)  # Reaction 125
+  rate-constant: {A: 4.19e+19, b: 0.09, Ea: 15.6}
+- equation: H2OX(43) + CHX(20) <=> HX(16) + HCOHX(23)  # Reaction 126
+  rate-constant: {A: 7.932728e+18, b: -0.048, Ea: 34.48}
+- equation: H2OX(43) + CH2X(21) <=> HX(16) + CH3OX(24)  # Reaction 127
+  rate-constant: {A: 7.932728e+18, b: -0.048, Ea: 34.48}
+- equation: HOX(33) + HCOX(22) <=> H2OX(43) + COX(19)  # Reaction 128
+  rate-constant: {A: 3.261e+21, b: 0.0, Ea: 6.918}
+- equation: H2OX(43) + HCOHX(23) <=> HOX(33) + CH3OX(24)  # Reaction 129
+  rate-constant: {A: 7.932728e+18, b: -0.048, Ea: 34.48}
+- equation: HOX(33) + CH3COOHX(28) <=> H2OX(43) + CH3COOX(25)  # Reaction 130
+  rate-constant: {A: 1.254e+22, b: 0.0, Ea: 26.173}
+- equation: HOX(33) + COOHX(31) <=> H2OX(43) + HOCXO(35)  # Reaction 131
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 25.676}
+- equation: X(1) + CH4(2) <=> C.[Pt](84)  # Reaction 132
+  sticking-coefficient: {A: 8.0e-03, b: 0.0, Ea: 0.0}
+- equation: X(1) + C.[Pt](84) <=> HX(16) + CH3X(32)  # Reaction 133
+  rate-constant: {A: 1.54e+21, b: 0.087, Ea: 13.337}
+- equation: CX(18) + C.[Pt](84) <=> CHX(20) + CH3X(32)  # Reaction 134
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: CHX(20) + C.[Pt](84) <=> CH2X(21) + CH3X(32)  # Reaction 135
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: COX(19) + C.[Pt](84) <=> HCOX(22) + CH3X(32)  # Reaction 136
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 38.269}
+- equation: HCOHX(23) + C.[Pt](84) <=> CH3X(32) + CH3OX(24)  # Reaction 137
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: CH3X(32) + CH3COOHX(28) <=> C.[Pt](84) + CH3COOX(25)  # Reaction 138
+  rate-constant: {A: 1.254e+22, b: 0.0, Ea: 19.264}
+- equation: COOHX(31) + CH3X(32) <=> HOCXO(35) + C.[Pt](84)  # Reaction 139
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 18.766}
+- equation: CH2X(21) + C.[Pt](84) <=> CH3X(32) + CH3X(32)  # Reaction 140
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: OX(17) + C.[Pt](84) <=> HOX(33) + CH3X(32)  # Reaction 141
+  rate-constant: {A: 5.62e+24, b: -0.101, Ea: 22.156}
+- equation: HOCXO(35) + CH3X(32) <=> CO2X(36) + C.[Pt](84)  # Reaction 142
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 6.877}
+- equation: H2OX(43) + CH3X(32) <=> HOX(33) + C.[Pt](84)  # Reaction 143
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 23.994}
+- equation: CX(18) + CH3COOHX(28) <=> HOCXO(35) + CC#[Pt](307)  # Reaction 144
+  rate-constant: {A: 2.360665e+21, b: -0.074, Ea: 28.318}
+- equation: X(1) + CC#[Pt](307) <=> CX(18) + CH3X(32)  # Reaction 145
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 47.142}
+- equation: CX(18) + C.[Pt](84) <=> HX(16) + CC#[Pt](307)  # Reaction 146
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: C2H2X2(338) <=> CHX(20) + CHX(20)  # Reaction 147
+  rate-constant: {A: 7.93e+12, b: 0.0, Ea: 21.511}
+- equation: X(1) + HCOX(22) <=> CHOX2(110)  # Reaction 148
+  rate-constant: {A: 1.0e+21, b: 0.0, Ea: 0.0}
+- equation: X(1) + X(1) + HCOHX(23) <=> HX(16) + CHOX2(110)  # Reaction 149
+  rate-constant: {A: 1.856667e+29, b: 0.0, Ea: 10.994}
+- equation: OX(17) + CHX(20) <=> CHOX2(110)  # Reaction 150
+  rate-constant: {A: 6.54e+21, b: 0.0, Ea: 33.939}
+- equation: COX(19) + CHOX2(110) <=> OCXOX(34) + CHX(20)  # Reaction 151
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: OX(17) + C2H2X2(338) <=> CHX(20) + CHOX2(110)  # Reaction 152
+  rate-constant: {A: 6.596e+21, b: 0.0, Ea: 0.0}
+- equation: X(1) + C#C.[Pt](513) <=> C2H2X2(338)  # Reaction 153
+  rate-constant: {A: 1.0e+21, b: 0.0, Ea: 0.0}
+- equation: X(1) + X(1) + C2H4(11) <=> HX(16) + C2H3X(88)  # Reaction 154
+  sticking-coefficient: {A: 0.1, b: 0.0, Ea: 11.937}
+- equation: X(1) + C2H4X(29) <=> HX(16) + C2H3X(88)  # Reaction 155
+  rate-constant: {A: 1.047906e+14, b: 1.601, Ea: 18.989}
+- equation: OX(17) + C2H4X(29) <=> HOX(33) + C2H3X(88)  # Reaction 156
+  rate-constant: {A: 5.62e+24, b: -0.101, Ea: 22.156}
+- equation: CX(18) + C2H4X(29) <=> CHX(20) + C2H3X(88)  # Reaction 157
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: COX(19) + C2H4X(29) <=> HCOX(22) + C2H3X(88)  # Reaction 158
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: X(1) + C2H3X(88) <=> CHX(20) + CH2X(21)  # Reaction 159
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 34.808}
+- equation: CHX(20) + C2H4X(29) <=> CH2X(21) + C2H3X(88)  # Reaction 160
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + C2H4X(29) <=> CH3X(32) + C2H3X(88)  # Reaction 161
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: HCOHX(23) + C2H4X(29) <=> CH3OX(24) + C2H3X(88)  # Reaction 162
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: CH3COOX(25) + C2H4X(29) <=> C2H3X(88) + CH3COOHX(28)  # Reaction 163
+  rate-constant: {A: 1.672e+22, b: 0.0, Ea: 32.383}
+- equation: CH3X(32) + C2H4X(29) <=> C.[Pt](84) + C2H3X(88)  # Reaction 164
+  rate-constant: {A: 1.672e+22, b: 0.0, Ea: 20.744}
+- equation: HOX(33) + C2H4X(29) <=> H2OX(43) + C2H3X(88)  # Reaction 165
+  rate-constant: {A: 1.672e+22, b: 0.0, Ea: 27.653}
+- equation: HOCXO(35) + C2H4X(29) <=> COOHX(31) + C2H3X(88)  # Reaction 166
+  rate-constant: {A: 1.672e+22, b: 0.0, Ea: 32.881}
+- equation: HOCXO(35) + C2H3X(88) <=> CO2X(36) + C2H4X(29)  # Reaction 167
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 14.227}
+- equation: X(1) + X(1) + C2H3X(88) <=> HX(16) + C2H2X2(338)  # Reaction 168
+  rate-constant: {A: 1.856667e+29, b: 0.0, Ea: 10.994}
+- equation: C2H3X(88) + CH3COOX(25) <=> C#C.[Pt](513) + CH3COOHX(28)  # Reaction 169
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 44.984}
+- equation: C2H3X(88) + C2H3X(88) <=> C#C.[Pt](513) + C2H4X(29)  # Reaction 170
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 43.914}
+- equation: HOCXO(35) + C2H3X(88) <=> COOHX(31) + C#C.[Pt](513)  # Reaction 171
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 45.345}
+- equation: HOX(33) + C2H3X(88) <=> H2OX(43) + C#C.[Pt](513)  # Reaction 172
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 41.563}
+- equation: CH3X(32) + C2H3X(88) <=> C.[Pt](84) + C#C.[Pt](513)  # Reaction 173
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 36.564}
+- equation: X(1) + C2H4X2(30) <=> HX(16) + C2H3X2(120)  # Reaction 174
+  rate-constant: {A: 2.225e+21, b: 0.0, Ea: 14.101}
+- equation: HOX(33) + C2H3X2(120) <=> OX(17) + C2H4X2(30)  # Reaction 175
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: CX(18) + C2H4X2(30) <=> CHX(20) + C2H3X2(120)  # Reaction 176
+  rate-constant: {A: 1.485161e+22, b: 0.0, Ea: 9.366}
+- equation: HCOX(22) + C2H3X2(120) <=> COX(19) + C2H4X2(30)  # Reaction 177
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 13.665}
+- equation: C2H3X2(120) <=> CHX(20) + CH2X(21)  # Reaction 178
+  rate-constant: {A: 2.74e+13, b: 0.0, Ea: 33.461}
+- equation: CHX(20) + CH2COX2(27) <=> COX(19) + C2H3X2(120)  # Reaction 179
+  rate-constant: {A: 4.4e+22, b: 0.101, Ea: 10.134}
+- equation: CH2X(21) + C2H3X2(120) <=> CHX(20) + C2H4X2(30)  # Reaction 180
+  duplicate: true
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: CH2X(21) + C2H3X2(120) <=> CHX(20) + C2H4X2(30)  # Reaction 181
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 20.391}
+- equation: CH2X(21) + C2H4X2(30) <=> CH3X(32) + C2H3X2(120)  # Reaction 182
+  rate-constant: {A: 1.485161e+22, b: 0.0, Ea: 11.722}
+- equation: HCOHX(23) + C2H3X2(120) <=> HCOX(22) + C2H4X2(30)  # Reaction 183
+  rate-constant: {A: 4.18e+21, b: 0.0, Ea: 18.455}
+- equation: CH3OX(24) + C2H3X2(120) <=> HCOHX(23) + C2H4X2(30)  # Reaction 184
+  rate-constant: {A: 7.425804e+21, b: 0.0, Ea: 11.414}
+- equation: C2H3X2(120) + CH3COOHX(28) <=> CH3COOX(25) + C2H4X2(30)  # Reaction 185
+  rate-constant: {A: 1.189909e+19, b: -0.048, Ea: 34.48}
+- equation: C.[Pt](84) + C2H3X2(120) <=> CH3X(32) + C2H4X2(30)  # Reaction 186
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: H2OX(43) + C2H3X2(120) <=> HOX(33) + C2H4X2(30)  # Reaction 187
+  rate-constant: {A: 7.932728e+18, b: -0.048, Ea: 34.48}
+- equation: COOHX(31) + C2H3X2(120) <=> HOCXO(35) + C2H4X2(30)  # Reaction 188
+  rate-constant: {A: 3.966364e+18, b: -0.048, Ea: 34.48}
+- equation: X(1) + C2H3X2(120) <=> HX(16) + C2H2X2(338)  # Reaction 189
+  rate-constant: {A: 4.75e+21, b: 0.0, Ea: 17.208}
+- equation: CX(18) + C2H3X2(120) <=> CHX(20) + C2H2X2(338)  # Reaction 190
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 14.625}
+- equation: CHX(20) + C2H3X2(120) <=> CH2X(21) + C2H2X2(338)  # Reaction 191
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 35.822}
+- equation: CH2X(21) + C2H2X2(338) <=> CHX(20) + C2H3X2(120)  # Reaction 192
+  duplicate: true
+  rate-constant: {A: 2.78e+21, b: 0.101, Ea: 4.541}
+- equation: COX(19) + C2H3X2(120) <=> HCOX(22) + C2H2X2(338)  # Reaction 193
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 52.909}
+- equation: HCOHX(23) + C2H2X2(338) <=> HCOX(22) + C2H3X2(120)  # Reaction 194
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 22.027}
+- equation: HCOHX(23) + C2H3X2(120) <=> CH3OX(24) + C2H2X2(338)  # Reaction 195
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 29.634}
+- equation: C2H2X2(338) + CH3COOHX(28) <=> C2H3X2(120) + CH3COOX(25)  # Reaction 196
+  rate-constant: {A: 2.379818e+19, b: -0.048, Ea: 34.48}
+- equation: C2H2X2(338) + C2H4X(29) <=> C2H3X(88) + C2H3X2(120)  # Reaction 197
+  rate-constant: {A: 3.173091e+19, b: -0.048, Ea: 34.48}
+- equation: C2H3X2(120) + C2H3X2(120) <=> C2H2X2(338) + C2H4X2(30)  # Reaction 198
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 27.331}
+- equation: COOHX(31) + C2H2X2(338) <=> HOCXO(35) + C2H3X2(120)  # Reaction 199
+  rate-constant: {A: 7.932728e+18, b: -0.048, Ea: 34.48}
+- equation: CH2X(21) + C2H3X2(120) <=> CH3X(32) + C2H2X2(338)  # Reaction 200
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 26.597}
+- equation: OX(17) + C2H3X2(120) <=> HOX(33) + C2H2X2(338)  # Reaction 201
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 33.697}
+- equation: H2OX(43) + C2H2X2(338) <=> HOX(33) + C2H3X2(120)  # Reaction 202
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: C.[Pt](84) + C2H2X2(338) <=> CH3X(32) + C2H3X2(120)  # Reaction 203
+  rate-constant: {A: 3.173091e+19, b: -0.048, Ea: 34.48}
+- equation: CHOX2(110) + CH2X(21) <=> OX(17) + C2H3X2(120)  # Reaction 204
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: X(1) + C2H3X(88) <=> C2H3X2(120)  # Reaction 205
+  rate-constant: {A: 7.15e+20, b: 0.0, Ea: 0.717}
+- equation: C2H3X2(120) + C2H4X(29) <=> C2H3X(88) + C2H4X2(30)  # Reaction 206
+  rate-constant: {A: 1.586546e+19, b: -0.048, Ea: 34.48}
+- equation: HOX(33) + C2H2X2(338) <=> OX(17) + C2H3X2(120)  # Reaction 207
+  duplicate: true
+  rate-constant: {A: 2.78e+21, b: 0.101, Ea: 4.541}
+- equation: CX(18) + C2H3X2(120) <=> CHX(20) + C2H2X2(338)  # Reaction 208
+  duplicate: true
+  rate-constant: {A: 7.425804e+21, b: 0.0, Ea: 8.663}
+- equation: HCOX(22) + C2H2X2(338) <=> COX(19) + C2H3X2(120)  # Reaction 209
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 15.071}
+- equation: CH2X(21) + C2H2X2(338) <=> CHX(20) + C2H3X2(120)  # Reaction 210
+  duplicate: true
+  rate-constant: {A: 2.78e+21, b: 0.101, Ea: 4.541}
+- equation: CH2X(21) + C2H2X2(338) <=> CHX(20) + C2H3X2(120)  # Reaction 211
+  duplicate: true
+  rate-constant: {A: 1.672e+22, b: 0.0, Ea: 21.797}
+- equation: CH2X(21) + C2H3X2(120) <=> CH3X(32) + C2H2X2(338)  # Reaction 212
+  duplicate: true
+  rate-constant: {A: 7.425804e+21, b: 0.0, Ea: 11.019}
+- equation: CH2X(21) + C2H3X2(120) <=> CHX(20) + C2H4X2(30)  # Reaction 213
+  duplicate: true
+  rate-constant: {A: 1.39e+21, b: 0.101, Ea: 4.541}
+- equation: CH2X(21) + C2H3X2(120) <=> CHX(20) + C2H4X2(30)  # Reaction 214
+  duplicate: true
+  rate-constant: {A: 8.36e+21, b: 0.0, Ea: 20.391}
+- equation: CH3OX(24) + C2H2X2(338) <=> HCOHX(23) + C2H3X2(120)  # Reaction 215
+  duplicate: true
+  rate-constant: {A: 1.485161e+22, b: 0.0, Ea: 12.117}
+- equation: C2H3X2(120) + C2H3X2(120) <=> C2H2X2(338) + C2H4X2(30)  # Reaction 216
+  duplicate: true
+  rate-constant: {A: 7.425804e+21, b: 0.0, Ea: 11.164}

--- a/test/rmgpy/yaml_writer/compare_yaml_outputs.py
+++ b/test/rmgpy/yaml_writer/compare_yaml_outputs.py
@@ -1,0 +1,137 @@
+import os
+import yaml
+import pandas as pd
+import re
+
+class YamlAnalyst:
+    def __init__(self, path_to_chemkin_yaml, chemkin_yaml_file):
+        self.path_to_chemkin_yaml = path_to_chemkin_yaml
+        self.chemkin_yaml_file = chemkin_yaml_file
+
+    def get_absolute_path(self):
+        return os.path.join(os.getcwd(), self.path_to_chemkin_yaml, self.chemkin_yaml_file)
+
+    def load_yaml_file(self):
+        with open(self.get_absolute_path(), 'r') as file:
+            return yaml.safe_load(file)
+
+    def get_species(self):
+        return self.load_yaml_file()['species']
+
+    def get_species_count(self):
+        return len(self.get_species())
+
+    def get_species_names(self):
+        return [specie['name'] for specie in self.get_species()]
+
+    def get_species_count_per_phase(self):
+        return {f"specie_count_{phase['name']}": len(phase['species']) for phase in self.load_yaml_file()['phases']}
+
+    def get_reactions_dict(self):
+        reactions_dict = {}
+        for key, values in self.load_yaml_file().items():
+            if key in [f"{phase['name']}-reactions" for phase in self.load_yaml_file()['phases']]:
+                reactions_dict[key] = self.load_yaml_file()[key]
+            elif key == 'gas_reactions':
+                reactions_dict['gas_reactions'] = self.load_yaml_file()['gas_reactions']
+            elif key == 'surface_reactions':
+                reactions_dict['surface_reactions'] = self.load_yaml_file()['surface_reactions']
+        return reactions_dict
+
+    def create_reaction_df(self, reactions):
+        data = []
+        for reaction in reactions:
+            row = {'equation': reaction['equation']}
+            if 'rate-constant' in reaction:
+                row.update(reaction['rate-constant'])
+            elif 'sticking-coefficient' in reaction:
+                row.update(reaction['sticking-coefficient'])
+            data.append(row)
+        return pd.DataFrame(data)
+    def get_reaction_df(self):
+        reaction_dfs = {key: self.create_reaction_df(value) for key, value in self.get_reactions_dict().items()}
+        return reaction_dfs
+
+    def get_reaction_count(self):
+        return {key: len(value) for key, value in self.get_reactions_dict().items()}
+
+class CompareYaml:
+    '''
+    Takes a dictionary with keys yaml1 and yaml2, and values a 
+    list of the directory and file name of the yaml files.
+
+    e.g.
+
+    yaml_files = {
+        'yaml1': [yaml1_file_directory, file1.yaml],
+        'yaml2': [yaml2_file_directory, file2.yaml]
+    }
+    '''
+    def __init__(self, yaml_files):
+        self.yaml1 = YamlAnalyst(yaml_files['yaml1'][0], yaml_files['yaml1'][1])
+        self.yaml2 = YamlAnalyst(yaml_files['yaml2'][0], yaml_files['yaml2'][1])
+
+    def compare_species_count(self):
+        count1 = self.yaml1.get_species_count()
+        count2 = self.yaml2.get_species_count()
+        if count1 - count2 == 0:
+            return True
+        else:
+            return False
+        
+    def compare_species_names(self):
+        names1 = set(self.yaml1.get_species_names())
+        names2 = set(self.yaml2.get_species_names())
+        if set(names1) == set(names2):
+            return True
+        else:
+            return False
+    
+    def compare_species_count_per_phase(self):
+        count_per_phase1 = self.yaml1.get_species_count_per_phase()
+        count_per_phase2 = self.yaml2.get_species_count_per_phase()
+        phase_names1 = [phase['name'] for phase in self.yaml1.load_yaml_file()['phases']]
+        phase_names2 = [phase['name'] for phase in self.yaml2.load_yaml_file()['phases']]
+        all_phase_names = set(phase_names1).union(set(phase_names2))
+        count_diff = {'gas': count_per_phase1[f"specie_count_{phase_names1[0]}"] - count_per_phase2[f"specie_count_{phase_names2[0]}"], 
+                      'surface': count_per_phase1[f"specie_count_{phase_names1[1]}"] - count_per_phase2[f"specie_count_{phase_names2[1]}"]
+                      }
+        if count_diff['gas'] == 0 and count_diff['surface'] == 0:
+            return True
+        else:
+            return False
+    
+    def normalize_equation(self, equation):
+        def process_side(side):
+            components = side.split(' + ')
+            normalized_components = []
+            for component in components:
+                # Remove any prefix integers/coefficients
+                normalized_component = re.sub(r'^\d*\s*', '', component).strip()
+                normalized_components.append(normalized_component)
+            return ' + '.join(sorted(set(normalized_components)))
+
+        reactants, products = equation.split('<=>')
+        normalized_reactants = process_side(reactants)
+        normalized_products = process_side(products)
+        return f"{normalized_reactants} <=> {normalized_products}"
+
+    def compare_reactions(self):
+        reactions1 = self.yaml1.get_reaction_df()
+        reactions2 = self.yaml2.get_reaction_df()
+        comparison_results = {}
+
+        for key1, df1 in reactions1.items():
+            df1['normalized_equation'] = df1['equation'].apply(self.normalize_equation)
+            for key2, df2 in reactions2.items():
+                df2['normalized_equation'] = df2['equation'].apply(self.normalize_equation)
+                merged_df = pd.merge(df1, df2, on='normalized_equation', suffixes=('_1', '_2'), how='inner')
+                if not merged_df.empty:
+                    merged_df['A_diff'] = merged_df['A_1'].round(2) - merged_df['A_2'].round(2)
+                    merged_df['b_diff'] = merged_df['b_1'].round(2) - merged_df['b_2'].round(2)
+                    merged_df['Ea_diff'] = merged_df['Ea_1'].round(2) - merged_df['Ea_2'].round(2)
+                    comparison_results[f'{key1}_{key2}'] = merged_df[['normalized_equation', 'A_diff', 'b_diff', 'Ea_diff']]
+        for key, df in comparison_results.items():
+            if not (df['A_diff'].eq(0).all() and df['b_diff'].eq(0).all() and df['Ea_diff'].eq(0).all()):
+                return False
+        return True

--- a/test/rmgpy/yaml_writer/test_yaml.py
+++ b/test/rmgpy/yaml_writer/test_yaml.py
@@ -1,0 +1,23 @@
+from compare_yaml_outputs import *
+import pytest
+
+@pytest.fixture
+def compare_manager():
+    '''Create instance of a Compare Yaml before each test'''
+    yaml_files = {
+        'yaml1': ['RMG_yaml_writer_addition/RMG-Py/test/rmgpy/test_data/yaml_writer_data/chemkin/', 'chem0047-gas.yaml'],
+        'yaml2': ['RMG_yaml_writer_addition/RMG-Py/test/rmgpy/test_data/yaml_writer_data/cantera/', 'chem47.yaml']
+    }
+    return CompareYaml(yaml_files)
+
+def test_compare_number_of_species(compare_manager):
+    assert compare_manager.compare_species_count() == True
+
+def test_compare_species_names(compare_manager):
+    assert compare_manager.compare_species_names() == True
+
+def test_compare_species_count_per_phase(compare_manager):
+    assert compare_manager.compare_species_count_per_phase() == True
+
+def test_compare_reactions(compare_manager):
+    assert compare_manager.compare_reactions() == True


### PR DESCRIPTION
### Motivation or Problem
Disparities were observed in the Ea, b, and A values for gas and surface reactions when comparing Cantera YAML files generated directly versus those converted from Chemkin files using the `cantera.ck2yaml` command. A script and corresponding tests have been written to facilitate this comparison.

### Description of Changes
- Added a new test directory containing a script for comparing the two different YAML files.
- Created a test file for validating the comparison process.
- Added test data to the YAML files located in the `yaml_writer_data` directory.
  - The directly generated YAML file is located in `/test/rmgpy/test_data/yaml_writer_data/cantera/`.
  - The YAML file converted from Chemkin files is located in `/test/rmgpy/test_data/yaml_writer_data/chemkin/`.

### Testing
A test script was written to compare species names, the number of species, reaction parameters, and the number of reactions in the YAML files generated by both methods.

### Reviewer Tips
To review this PR, run the tests in `/RMG-Py/test/rmgpy/yaml_writer/test_yaml.py`. Note: You may need to adjust the file paths in `test_yaml.py` to match your local setup.
