### PR TITLE
Molpro f12a

### DIFF
--- a/arkane/data/molpro/C5OH5_CCSD(T)_F12.out
+++ b/arkane/data/molpro/C5OH5_CCSD(T)_F12.out
@@ -1,0 +1,556 @@
+
+ Working directory              : /gtmp/nellymitnik/scratch/molpro/1108436.zeus-master/molpro.jdnheJygkZ/
+ Global scratch directory       : /gtmp/nellymitnik/scratch/molpro/1108436.zeus-master/molpro.jdnheJygkZ/
+ Wavefunction directory         : /home/nellymitnik/wfu/
+ Main file repository           : /gtmp/nellymitnik/scratch/molpro/1108436.zeus-master/molpro.jdnheJygkZ/
+
+ id        : dana
+
+ Nodes                   nprocs
+ n173.zeus.technion.ac.il   16
+ GA implementation: MPI file
+ GA implementation (serial work in mppx): MPI file
+
+ Using customized tuning parameters: mindgm=1; mindgv=20; mindgc=4; mindgr=1; noblas=0; minvec=7
+ default implementation of scratch files=sf  
+
+
+ Variables initialized (1042), CPU time= 0.02 sec
+ ***,MF_rad
+ memory,1678,m;
+ 
+ geometry={angstrom;
+ C       2.01049400   -0.22330900    0.10546000
+ C       0.64687900   -0.10437400    0.03800100
+ C      -0.20404500    0.99554400   -0.13241300
+ C      -1.52073600    0.50065400   -0.12127200
+ C      -1.42312300   -0.84841500    0.05126400
+ O      -0.13385700   -1.23256100    0.14903500
+ H       2.47222500   -1.18730500    0.24386300
+ H       2.62697700    0.65596200    0.01923200
+ H       0.11894800    2.01522600   -0.24752400
+ H      -2.43493800    1.05807500   -0.22625800
+ H      -2.15882400   -1.62949600    0.12061100}
+ 
+ basis=cc-pvtz
+ 
+ 
+ 
+ int;
+ {hf;
+ maxit,1000;
+ wf,spin=1,charge=0;}
+ 
+ uccsd(t)-f12;
+ 
+ 
+ 
+ Commands initialized (847), CPU time= 0.01 sec, 718 directives.
+ Default parameters read. Elapsed time= 0.11 sec
+
+ Checking input...
+ Passed
+1
+
+
+                                         ***  PROGRAM SYSTEM MOLPRO  ***
+                                       Copyright, TTI GmbH Stuttgart, 2015
+                                    Version 2024.1 linked Mon Jun 17 14:53:25 2024
+
+
+ **********************************************************************************************************************************
+ LABEL *   MF_rad                                                                                                                                                        
+  (16 PROC) 64 bit mpp version                                                           DATE: 01-Mar-25          TIME: 12:49:44  
+ **********************************************************************************************************************************
+
+ SHA1:             0134236b472f03f1f5189f93707d8671e415b05c
+ **********************************************************************************************************************************
+
+ Memory per process:      1678 MW
+ Total memory per node:  26848 MW
+
+ GA preallocation disabled
+ GA check disabled
+
+ Variable memory set to 1678.0 MW
+
+
+ Geometry recognized as XYZ
+
+ SETTING BASIS          =    CC-PVTZ
+
+
+ Using spherical harmonics
+
+ Library entry C      S cc-pVTZ              selected for orbital group  1
+ Library entry C      P cc-pVTZ              selected for orbital group  1
+ Library entry C      D cc-pVTZ              selected for orbital group  1
+ Library entry C      F cc-pVTZ              selected for orbital group  1
+ Library entry O      S cc-pVTZ              selected for orbital group  2
+ Library entry O      P cc-pVTZ              selected for orbital group  2
+ Library entry O      D cc-pVTZ              selected for orbital group  2
+ Library entry O      F cc-pVTZ              selected for orbital group  2
+ Library entry H      S cc-pVTZ              selected for orbital group  3
+ Library entry H      P cc-pVTZ              selected for orbital group  3
+ Library entry H      D cc-pVTZ              selected for orbital group  3
+
+
+ PROGRAM * SEWARD (Integral evaluation for generally contracted gaussian basis sets)     Author: Roland Lindh, 1990
+
+ Geometry written to block  1 of record 700
+
+
+ Point group  C1  
+
+
+
+ ATOMIC COORDINATES
+
+ NR  ATOM    CHARGE       X              Y              Z
+
+   1  C       6.00    3.799283035   -0.421992851    0.199290517
+   2  C       6.00    1.222424146   -0.197238275    0.071811482
+   3  C       6.00   -0.385589167    1.881305505   -0.250224305
+   4  C       6.00   -2.873774548    0.946098943   -0.229170867
+   5  C       6.00   -2.689312712   -1.603271990    0.096874920
+   6  O       8.00   -0.252953070   -2.329202722    0.281635333
+   7  H       1.00    4.671828168   -2.243681276    0.460834282
+   8  H       1.00    4.964267066    1.239588528    0.036343213
+   9  H       1.00    0.224779143    3.808225219   -0.467752569
+  10  H       1.00   -4.601365950    1.999471969   -0.427565654
+  11  H       1.00   -4.079586111   -3.079301161    0.227921758
+
+ Bond lengths in Bohr (Angstrom)
+
+ 1-2  2.589781315  1-7  2.036734855  1-8  2.035827177  2-3  2.647594778  2-6  2.601160584
+     ( 1.370453253)     ( 1.077793670)     ( 1.077313348)     ( 1.401046820)     ( 1.376474903)
+
+  3- 4  2.658217645   3- 9  2.032950468   4- 5  2.576746821   4-10  2.033107788   5- 6  2.548913522
+       ( 1.406668199)       ( 1.075791058)       ( 1.363555696)       ( 1.075874309)       ( 1.348826948)
+
+  5-11  2.031919170
+       ( 1.075245319)
+
+ Bond angles
+
+  1-2-3  132.72168468   1-2-6  119.29246985   2-1-7  120.67777126   2-1-8  119.64432955
+
+  2-3-4  106.93794667   2-3-9  125.08482451   2-6-5  107.63056573   3-2-6  107.98584546
+
+  3- 4- 5  106.38399614   3- 4-10  127.75772373   4- 3- 9  127.97722882   4- 5- 6  111.06164599
+
+  4- 5-11  132.67844514   5- 4-10  125.85828012   6- 5-11  116.25990887   7- 1- 8  119.67789920
+
+ NUCLEAR CHARGE:                   43
+ NUMBER OF PRIMITIVE AOS:         367
+ NUMBER OF SYMMETRY AOS:          332
+ NUMBER OF CONTRACTIONS:          250   (  250A   )
+ NUMBER OF INNER CORE ORBITALS:     0   (    0A   )
+ NUMBER OF OUTER CORE ORBITALS:     6   (    6A   )
+ NUMBER OF VALENCE ORBITALS:       29   (   29A   )
+
+
+ NUCLEAR REPULSION ENERGY  214.99376514
+
+
+ Eigenvalues of metric
+
+         1 0.925E-04 0.387E-03 0.564E-03 0.983E-03 0.103E-02 0.113E-02 0.123E-02 0.131E-02
+
+
+ Contracted 2-electron integrals neglected if value below      1.0D-11
+ AO integral compression algorithm  1   Integral accuracy      1.0D-11
+
+     1743.782 MB (compressed) written to integral file ( 42.0%)
+
+     Node minimum: 99.090 MB, node maximum: 128.713 MB
+
+
+ NUMBER OF SORTED TWO-ELECTRON INTEGRALS:   30748480.     BUFFER LENGTH:  32768
+ NUMBER OF SEGMENTS:   2  SEGMENT LENGTH:   15983856      RECORD LENGTH: 524288
+
+ Memory used in sort:      16.54 MW
+
+ SORT1 READ   519482517. AND WROTE    26725222. INTEGRALS IN     77 RECORDS. CPU TIME:     5.16 SEC, REAL TIME:     5.27 SEC
+ SORT2 READ   428058370. AND WROTE   492211000. INTEGRALS IN   6912 RECORDS. CPU TIME:     0.26 SEC, REAL TIME:     0.37 SEC
+
+ Node minimum:    30748480.  Node maximum:    30777895. integrals
+
+ OPERATOR DM      FOR CENTER  0  COORDINATES:    0.000000    0.000000    0.000000
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      18       30.98       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1700   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    OPER   
+
+ PROGRAMS   *        TOTAL       INT
+ CPU TIMES  *         7.23      7.11
+ REAL TIME  *         7.95 SEC
+ DISK USED  *        31.53 MB (local),        6.88 GB (total)
+ GA USED    *         0.00 MB       (max)       0.00 MB       (current)
+ **********************************************************************************************************************************
+
+
+ Program * Restricted Hartree-Fock
+
+ Orbital guess generated from atomic densities. Full valence occupancy:   35
+
+ Initial alpha occupancy:  22
+ Initial beta  occupancy:  21
+
+ NELEC=   43   SYM=1   MS2= 1   THRE=1.0D-08   THRD=3.2D-06   THRG=3.2D-06  HFMA2=F  DIIS_START=2   DIIS_MAX=10   DIIS_INCORE=F
+
+ Level shifts:    0.00 (CLOSED)    0.00 (OPEN)    0.30 (GAP_MIN)
+
+ ITER           ETOT              DE          GRAD        DDIFF     DIIS  NEXP   TIME(IT)  TIME(TOT)  DIAG
+   1     -267.06828554    -267.06828554     0.00D+00     0.49D-01     0     0       0.14      0.29    start
+   2     -267.12231439      -0.05402885     0.31D-02     0.43D-02     1     0       0.18      0.47    diag2
+   3     -267.13103902      -0.00872463     0.13D-02     0.16D-02     2     0       0.16      0.63    diag2
+   4     -267.13281195      -0.00177293     0.43D-03     0.63D-03     3     0       0.17      0.80    diag2
+   5     -267.13314409      -0.00033214     0.15D-03     0.19D-03     4     0       0.17      0.97    diag2
+   6     -267.13335259      -0.00020850     0.65D-04     0.10D-03     5     0       0.18      1.15    diag2
+   7     -267.13360315      -0.00025055     0.48D-04     0.14D-03     6     0       0.17      1.32    diag2
+   8     -267.13377607      -0.00017292     0.37D-04     0.11D-03     7     0       0.17      1.49    fixocc
+   9     -267.13395385      -0.00017778     0.31D-04     0.13D-03     8     0       0.16      1.65    diag2
+  10     -267.13417308      -0.00021923     0.28D-04     0.19D-03     9     0       0.16      1.81    diag2/orth
+  11     -267.13438092      -0.00020784     0.23D-04     0.30D-03     9     0       0.15      1.96    diag2
+  12     -267.13439155      -0.00001062     0.17D-04     0.27D-04     9     0       0.16      2.12    diag2
+  13     -267.13440553      -0.00001398     0.11D-04     0.73D-04     9     0       0.17      2.29    diag2
+  14     -267.13440738      -0.00000185     0.74D-05     0.21D-04     9     0       0.17      2.46    diag2
+  15     -267.13440752      -0.00000014     0.24D-05     0.78D-05     9     0       0.15      2.61    diag2
+  16     -267.13440755      -0.00000003     0.16D-05     0.80D-05     9     0       0.17      2.78    diag2
+  17     -267.13440757      -0.00000002     0.76D-06     0.45D-05     9     0       0.16      2.94    diag2
+  18     -267.13440757      -0.00000000     0.26D-06     0.16D-05     9     0       0.17      3.11    diag2
+  19     -267.13440757      -0.00000000     0.87D-07     0.12D-06     0     0       0.17      3.28    diag
+
+ Final alpha occupancy:  22
+ Final beta  occupancy:  21
+
+ !RHF STATE 1.1 Energy               -267.134407573902
+  RHF One-electron energy            -788.061392880482
+  RHF Two-electron energy             305.933220164603
+  RHF Kinetic energy                  266.814528694546
+  RHF Nuclear energy                  214.993765141977
+  RHF Virial quotient                  -1.001198881039
+
+ !RHF STATE 1.1 Dipole moment          -0.19676582     0.28198137    -0.04286384
+ Dipole moment /Debye                  -0.50012883     0.71672516    -0.10894903
+
+ Orbital energies:
+
+           1.1          2.1          3.1          4.1          5.1          6.1          7.1          8.1          9.1         10.1
+    -20.617954   -11.292577   -11.291607   -11.233165   -11.230003   -11.229662    -1.457517    -1.088031    -1.052238    -0.910316
+
+          11.1         12.1         13.1         14.1         15.1         16.1         17.1         18.1         19.1         20.1
+     -0.808147    -0.764930    -0.711038    -0.636180    -0.622882    -0.586293    -0.569458    -0.562698    -0.528119    -0.404613
+
+          21.1         22.1         23.1         24.1
+     -0.360251    -0.279600     0.152895     0.163918
+
+
+ HOMO     22.1    -0.279600 =      -7.6083eV
+ LUMO     23.1     0.152895 =       4.1605eV
+ LUMO-HOMO         0.432496 =      11.7688eV
+
+ Orbitals saved in record  2100.2
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      18       30.98       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1700   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    OPER   
+
+              2       4        2.50       700     1000      520     2100   
+                                         GEOM     BASIS   MCVARS     RHF  
+
+ PROGRAMS   *        TOTAL    HF-SCF       INT
+ CPU TIMES  *        10.57      3.32      7.11
+ REAL TIME  *        12.51 SEC
+ DISK USED  *        42.20 MB (local),        7.05 GB (total)
+ GA USED    *         0.00 MB       (max)       0.00 MB       (current)
+ **********************************************************************************************************************************
+
+
+ PROGRAM * CCSD (Unrestricted open-shell coupled cluster)     Authors: C. Hampel, H.-J. Werner, 1991, M. Deegan, P.J. Knowles, 1992
+
+                           UCCSD-F12 implementation by G. Knizia and H.-J. Werner, 2008
+
+                   Density fitting integral evaluation by F.R. Manby, 2003,2007, G. Knizia, 2010
+
+
+ Basis set VTZ/JKFIT generated.          Number of basis functions:   624 
+ Basis set CC-PVTZ/MP2FIT generated.     Number of basis functions:   636 
+
+ Convergence thresholds:  THRVAR = 1.00D-08  THRDEN = 1.00D-06
+
+ CCSD(T)     terms to be evaluated (factor= 1.000)
+
+
+ Number of core orbitals:           6 (   6 )
+ Number of closed-shell orbitals:  15 (  15 )
+ Number of active  orbitals:        1 (   1 )
+ Number of external orbitals:     228 ( 228 )
+
+ Memory could be reduced to 336.05 Mwords without degradation in triples
+
+ Number of N-1 electron functions:              31
+ Number of N-2 electron functions:             465
+ Number of singly external CSFs:              7099
+ Number of doubly external CSFs:          18459690
+ Total number of CSFs:                    18466789
+
+ Molecular orbitals read from record     2100.2  Type=RHF/CANONICAL  
+
+ Integral transformation finished. Total CPU:  21.19 sec, npass=  1  Memory used: 148.62 MW
+
+ Geminal basis:    OPTFULL  GEM_TYPE=SLATER  BETA=1.0  NGEM=6
+
+ Optimizing Gaussian exponents for each gem_beta
+
+ Geminal optimization for beta= 1.0000
+ Weight function:   m=0, omega= 1.4646
+
+ Augmented Hessian optimization of geminal fit. Trust ratio= 0.40000
+ Convergence reached after   2 iterations. Final gradient= 8.43D-16, Step= 4.28D-06, Delta= 1.28D-09
+
+ Alpha:                 0.19532     0.81920     2.85917     9.50073    35.69989   197.79328
+ Coeff:                 0.27070     0.30552     0.18297     0.10986     0.06810     0.04224
+
+
+ WFN_F12=FIX,EG    DECOUPLE_EXPL=F   HYBRID=0    NOX=F   SEMIINT_F12=T   CORE_SINGLES=F
+
+
+ AO(A)-basis ORBITAL           loaded. Number of functions:     250
+ RI(R)-basis VTZ/JKFIT         loaded. Number of functions:     624
+ DF-basis VTZ/JKFIT            loaded. Number of functions:     624
+
+ Screening thresholds:   THRAO=  1.00D-14  THRMO=  1.00D-14  THRPROD=  1.00D-14
+                         THRSW=  1.00D-14  THROV=  1.00D-14  THRAOF12= 1.00D-08
+
+ CPU time for one-electron matrices               0.81 sec
+
+ Construction of ABS:
+ Pseudo-inverse stability          5.61E-11
+ Smallest eigenvalue of S          1.47E-05  (threshold= 1.00E-08)
+ Ratio eigmin/eigmax               1.95E-06  (threshold= 1.00E-09)
+ Smallest eigenvalue of S kept     1.47E-05  (threshold= 1.47E-05, 0 functions deleted, 624 kept)
+
+ Construction of CABS:
+ Pseudo-inverse stability          2.42E-09
+ Smallest eigenvalue of S          4.40E-08  (threshold= 1.00E-08)
+ Ratio eigmin/eigmax               4.40E-08  (threshold= 1.00E-09)
+ Smallest eigenvalue of S kept     4.40E-08  (threshold= 4.40E-08, 0 functions deleted, 624 kept)
+
+ CPU time for basis constructions                 0.16 sec
+ Fock operators(MO) rebuilt from dump record.
+ CPU time for Fock operator transformation        0.25 sec
+
+                                      TOTAL          ALPHA          BETA    
+  Singles Contributions MO        -0.005701972   -0.002855383   -0.002846589
+  Singles Contributions CABS      -0.013677883   -0.006998341   -0.006679542
+  Pure DF-RHF relaxation          -0.013609865
+
+ CPU time for RHF CABS relaxation                 0.28 sec
+ CPU time for singles (tot)                       0.61 sec
+
+ AO(A)-basis ORBITAL           loaded. Number of functions:     250
+ RI(R)-basis VTZ/JKFIT         loaded. Number of functions:     624
+ DF-basis CC-PVTZ/MP2FIT       loaded. Number of functions:     636
+
+ Screening thresholds:   THRAO=  1.00D-14  THRMO=  1.00D-14  THRPROD=  1.00D-14
+                         THRSW=  1.00D-14  THROV=  1.00D-14  THRAOF12= 1.00D-08
+
+ CPU time for transformed integrals              10.80 sec
+ CPU time for F12 matrices                       11.34 sec
+
+ Diagonal F12 ansatz with fixed amplitudes:   TS= 0.5000  TT= 0.2500  TN= 0.3750
+
+ ITER.     SQ.NORM      CORR.ENERGY   TOTAL ENERGY  ENERGY CHANGE      VAR         CPU   MICRO    DIIS
+   1      1.32665519    -1.13388831  -268.28190575    -1.1475E+00   3.19E-01      0.58  1  1  1   0  0
+   2      1.32766419    -1.13407635  -268.28209378    -1.8803E-04   2.49E-04      2.82  0  0  0   1  1
+   3      1.32818061    -1.13445316  -268.28247060    -3.7681E-04   2.69E-06      5.70  0  0  0   2  2
+   4      1.32819607    -1.13445629  -268.28247373    -3.1346E-06   1.98E-08      9.24  0  0  0   3  3
+   5      1.32819872    -1.13445632  -268.28247376    -2.4367E-08   1.13E-10     13.39  0  0  0   4  4
+
+ - - Continuing with F12/conv. amplitude coupling turned on.
+
+   6      1.32818574    -1.13610949  -268.28412692    -1.6532E-03   1.86E-04     16.18  1  1  1   1  1
+   7      1.32818452    -1.13610977  -268.28412721    -2.8062E-07   9.69E-09     19.44  1  1  1   2  2
+
+ CPU time for iterative RMP2-F12                 19.44 sec
+
+
+ DF-RMP2-F12 doubles corrections:
+ - - - - - - - - - - - - - - - - 
+  Approx.                             TOTAL           A-B            A-A            B-B    
+  RMP2-F12/3C(FIX)                -0.111296967   -0.100174079   -0.005978060   -0.005144828
+  RMP2-F12/3*C(FIX)               -0.109643519   -0.098836532   -0.005813826   -0.004993161
+  RMP2-F12/3*C(DX)                -0.111345502   -0.100368013   -0.005902977   -0.005074512
+  RMP2-F12/3*C(FIX,DX)            -0.121778719   -0.110230731   -0.006167524   -0.005380465
+
+ DF-RMP2-F12 doubles energies:
+ - - - - - - - - - - - - - - -
+  Approx.                             TOTAL           A-B            A-A            B-B    
+  RMP2                            -1.019110827   -0.759819848   -0.135765711   -0.123525268
+  RMP2-F12/3C(FIX)                -1.130407794   -0.859993927   -0.141743771   -0.128670096
+  RMP2-F12/3*C(FIX)               -1.128754346   -0.858656380   -0.141579537   -0.128518430
+  RMP2-F12/3*C(DX)                -1.130456329   -0.860187861   -0.141668688   -0.128599780
+  RMP2-F12/3*C(FIX,DX)            -1.140889546   -0.870050579   -0.141933235   -0.128905733
+
+
+  Reference energy                   -267.134407573901
+  CABS relaxation correction to RHF    -0.013609864831
+  New reference energy               -267.148017438732
+
+  RMP2-F12 singles (MO) energy         -0.005701972237
+  RMP2-F12 pair energy                 -1.130407794032
+  RMP2-F12 correlation energy          -1.136109766269
+
+ !RMP2-F12/3C(FIX) energy            -268.284127205001
+
+ Starting RMP2 calculation, locsing= 0
+
+ ITER.      SQ.NORM     CORR.ENERGY   TOTAL ENERGY   ENERGY CHANGE        DEN1      VAR(S)    VAR(P)  DIIS     TIME
+   1      1.32251756    -1.01992399  -268.15433157    -1.01992399    -0.00441354  0.17D-03  0.19D-02  1  1    80.01
+   2      1.32775392    -1.02472940  -268.15913697    -0.00480541    -0.00002609  0.90D-05  0.15D-04  2  2    82.10
+   3      1.32817491    -1.02490064  -268.15930822    -0.00017124    -0.00000040  0.34D-06  0.13D-06  3  3    84.32
+   4      1.32820545    -1.02490601  -268.15931358    -0.00000536    -0.00000001  0.67D-08  0.77D-09  4  4    86.82
+   5      1.32820747    -1.02490641  -268.15931399    -0.00000041    -0.00000000  0.85D-10  0.18D-10  5  5    89.41
+
+ Norm of t1 vector:      0.08469801      S-energy:    -0.00570190      T1 diagnostic:  0.00141717
+ Norm of t2 vector:      0.56659837      P-energy:    -1.01920451
+                                         Alpha-Beta:  -0.76007084
+                                         Alpha-Alpha: -0.13567957
+                                         Beta-Beta:   -0.12345410
+
+ Spin contamination <S**2-Sz**2-Sz>     0.00091192
+  Reference energy                   -267.134407573901
+  CABS singles correction              -0.013609864831
+  New reference energy               -267.148017438732
+  RHF-RMP2 correlation energy          -1.024906412896
+ !RHF-RMP2 energy                    -268.172923851628
+
+  F12/3C(FIX) correction               -0.111296966811
+  RHF-RMP2-F12 correlation energy      -1.136203379707
+ !RHF-RMP2-F12 total energy          -268.284220818439
+
+ Starting UCCSD calculation
+
+ ITER.      SQ.NORM     CORR.ENERGY   TOTAL ENERGY   ENERGY CHANGE        DEN1      VAR(S)    VAR(P)  DIIS     TIME
+   1      1.30980465    -0.99385441  -268.12826198    -0.99385441    -0.02747617  0.58D-02  0.53D-02  1  1   119.67
+   2      1.33748933    -1.01920430  -268.15361187    -0.02534989    -0.00265512  0.49D-03  0.90D-03  2  2   145.68
+   3      1.35001757    -1.02379334  -268.15820092    -0.00458905    -0.00043637  0.30D-03  0.10D-03  3  3   171.60
+   4      1.35821840    -1.02590391  -268.16031149    -0.00211057    -0.00013475  0.11D-03  0.29D-04  4  4   197.81
+   5      1.36397651    -1.02656345  -268.16097103    -0.00065954    -0.00005610  0.61D-04  0.88D-05  5  5   225.34
+   6      1.36933220    -1.02691966  -268.16132723    -0.00035620    -0.00002046  0.19D-04  0.44D-05  6  6   253.14
+   7      1.37332193    -1.02715150  -268.16155907    -0.00023184    -0.00000590  0.45D-05  0.16D-05  6  2   280.95
+   8      1.37530681    -1.02724922  -268.16165679    -0.00009772    -0.00000087  0.43D-06  0.26D-06  6  1   308.74
+   9      1.37580899    -1.02727308  -268.16168065    -0.00002386    -0.00000013  0.74D-07  0.33D-07  6  3   335.09
+  10      1.37590754    -1.02727519  -268.16168276    -0.00000211    -0.00000002  0.13D-07  0.58D-08  6  4   361.56
+  11      1.37589172    -1.02726718  -268.16167476     0.00000800    -0.00000001  0.28D-08  0.15D-08  6  6   387.80
+  12      1.37591311    -1.02726686  -268.16167444     0.00000032    -0.00000000  0.65D-09  0.27D-09  6  5   412.58
+
+ Norm of t1 vector:      0.20094805      S-energy:    -0.00796282      T1 diagnostic:  0.01949703
+                                                                       D1 diagnostic:  0.06698239
+                                                                       D2 diagnostic:  0.19512021 (internal)
+ Norm of t2 vector:      0.57925209      P-energy:    -1.01930404
+                                         Alpha-Beta:  -0.78896301
+                                         Alpha-Alpha: -0.12154717
+                                         Beta-Beta:   -0.10879386
+
+ Singles amplitudes (print threshold =  0.500E-01):
+
+         I         SYM. A    A   T(IA) [Alpha-Alpha]
+
+        15         1         3      0.06704235
+        16         1         3      0.06259481
+
+         I         SYM. A    A   T(IA) [Beta-Beta]
+
+        15         1         1     -0.09169987
+        15         1         3     -0.06359934
+
+ Doubles amplitudes (print threshold =  0.500E-01):
+
+         I         J         SYM. A    SYM. B    A         B      T(IJ, AB) [Alpha-Beta]
+
+        15        15         1         1         3         3     -0.05717715
+        16        15         1         1         3         1     -0.07113266
+
+ Spin contamination <S**2-Sz**2-Sz>     0.00449438
+
+ Memory could be reduced to 364.30 Mwords without degradation in triples
+
+
+ RESULTS
+ =======
+
+  Reference energy                   -267.134407573901
+  CABS relaxation correction to RHF    -0.013609864831
+  New reference energy               -267.148017438732
+
+  F12 corrections for ansatz 3C(FIX) added to UCCSD energy. Coupling mode: 15
+
+  UCCSD-F12a singles energy            -0.007962822923
+  UCCSD-F12a pair energy               -1.129333793559
+  UCCSD-F12a correlation energy        -1.137296616482
+  Triples (T) contribution             -0.051006559238
+  Total correlation energy             -1.188303175720
+
+  RHF-UCCSD-F12a energy              -268.285314055214
+  RHF-UCCSD[T]-F12 energy            -268.337906507729
+  RHF-UCCSD-T-F12a energy            -268.335946960551
+ !RHF-UCCSD(T)-F12 energy            -268.336320614452
+
+  F12 corrections for ansatz 3C(FIX) added to UCCSD energy. Coupling mode: 15
+
+  UCCSD-F12b singles energy            -0.007962822923
+  UCCSD-F12b pair energy               -1.110070819705
+  UCCSD-F12b correlation energy        -1.118033642628
+  Triples (T) contribution             -0.051006559238
+  Total correlation energy             -1.169040201866
+
+  RHF-UCCSD-F12b energy              -268.266051081360
+  RHF-UCCSD[T]-F12 energy            -268.318643533875
+  RHF-UCCSD-T-F12b energy            -268.316683986696
+ !RHF-UCCSD(T)-F12 energy            -268.317057640597
+
+ Program statistics:
+
+ Available memory in ccsd:              1677997770
+ Min. memory needed in ccsd:              51754788
+ Max. memory used in ccsd:                75147181
+ Max. memory used in cckext:              60188337 (13 integral passes)
+ Max. memory used in cckint:             148621172 ( 1 integral passes)
+
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      18       30.98       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1700   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    OPER   
+
+              2       5        2.97       700     1000      520     2100     7360   
+                                         GEOM     BASIS   MCVARS     RHF    F12ABS    
+
+ PROGRAMS   *        TOTAL  UCCSD(T)    HF-SCF       INT
+ CPU TIMES  *       665.30    654.72      3.32      7.11
+ REAL TIME  *       694.41 SEC
+ DISK USED  *         2.21 GB (local),       41.82 GB (total)
+ SF USED    *        17.02 GB
+ GA USED    *         3.05 MB       (max)       0.00 MB       (current)
+ **********************************************************************************************************************************
+
+ UCCSD(T)-F12/cc-pVTZ energy=   -268.317057640597
+
+    UCCSD(T)-F12          HF-SCF
+   -268.31705764   -267.13440757
+ **********************************************************************************************************************************
+ Molpro calculation terminated

--- a/arkane/ess/molpro.py
+++ b/arkane/ess/molpro.py
@@ -350,7 +350,7 @@ class MolproLog(ESSAdapter):
             # Search for e_elect
             for line in lines:
                 if f12 and f12a:
-                    if 'CCSD(T)-F12a' in line and 'energy' in line:
+                    if ('CCSD(T)-F12a' in line or 'CCSD(T)-F12/' in line and '!' not in line) and 'energy' in line:
                         e_elect = float(line.split()[-1])
                         break
                 elif f12 and f12b:

--- a/test/arkane/ess/molproTest.py
+++ b/test/arkane/ess/molproTest.py
@@ -106,8 +106,11 @@ class MolproLogTest:
         """
         log = MolproLog(os.path.join(self.data_path, "OH_f12.out"))
         e0 = log.load_energy()
-
         assert round(abs(e0 / constants.Na / constants.E_h - -75.663696424380), 5) == 0
+
+        log = MolproLog(os.path.join(self.data_path, "C5OH5_CCSD(T)_F12.out"))
+        e0 = log.load_energy()
+        assert round(abs(e0 / constants.Na / constants.E_h - -268.317057640597), 5) == 0
 
     def test_load_hosi_from_molpro_log(self):
         """


### PR DESCRIPTION
### Motivation or Problem
Some Molpro versions list the CCSD(T)-F12 energy as CCSD(T)-F12 (without the "a"), and Arkane is unable to not find the energy.

### Description of Changes
Relax the requirement to have "a" present in the energy line, it's enough to have both "CCSD(T)-F12" and "energy" on the same line.

### Testing
A test was added