### PR TITLE
Fix bug in electrons initialization for depository reaction data

### DIFF
--- a/rmgpy/data/kinetics/depository.py
+++ b/rmgpy/data/kinetics/depository.py
@@ -62,7 +62,7 @@ class DepositoryReaction(Reaction):
                  depository=None,
                  family=None,
                  entry=None,
-                 electrons=None,
+                 electrons=0,
                  ):
         Reaction.__init__(self,
                           index=index,


### PR DESCRIPTION
This PR fixes a small bug:

- `Reaction` expects `electrons` to be an integer, but the constructor for Depository reactions initializes `electrons` as `None`. This can lead to crashes (as was observed for the `RMG-website`: https://github.com/ReactionMechanismGenerator/RMG-website/issues/288)
- This PR simply changes the constructor to use a default value of `0` rather than `None` like other classes that inherit from `Reaction`.