### PR TITLE
Modifying input.py in Arkane so it can read network.py files that hav…

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -60,6 +60,7 @@ from rmgpy.thermo.thermodata import ThermoData
 from rmgpy.thermo.wilhoit import Wilhoit
 from rmgpy.kinetics.uncertainties import RateUncertainty
 from rmgpy.transport import TransportData
+from rmgpy.data.solvation import SoluteTSData
 from rmgpy.util import as_list
 
 from arkane.common import is_pdep
@@ -637,6 +638,7 @@ def load_input_file(path):
         'database': database,
         # Jobs
         'kinetics': kinetics,
+        'SoluteTSData': SoluteTSData,
         'statmech': statmech,
         'thermo': thermo,
         'pressureDependence': pressureDependence,
@@ -654,10 +656,15 @@ def load_input_file(path):
     load_necessary_databases()
 
     with open(path, 'r') as f:
+        content = f.read()
         try:
-            exec(f.read(), global_context, local_context)
-        except (NameError, TypeError, SyntaxError):
+            exec(content, global_context, local_context)
+        except (NameError, TypeError, SyntaxError) as e:
             logging.error('The input file {0!r} was invalid:'.format(path))
+            line_number = e.__traceback__.tb_next.tb_lineno
+            logging.error(f'Error occurred at or near line {line_number} of {path}.')
+            lines = content.splitlines()
+            logging.error(f'Line: {lines[line_number - 1]}')
             raise
 
     model_chemistry = local_context.get('modelChemistry', None)


### PR DESCRIPTION
…e SoluteTSData. Also better debugging messages when arkane can't load in input file. 

### Motivation or Problem
When trying to load in a network.py file from an RMG pdep network using Arkane's `load_input_file()` function in input.py, the input file was being flagged as invalid because of the new SoluteTSData object added to RMG-Py in Nov 2024 ([see commit 0f6ab88](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/0f6ab88f848841bd99c3c82ac1d1ac5a9fc84f79)). Further, the error raised just complains that the network.py file is invalid by raising a TypeError, which isn't very helpful for debugging. 


### Description of Changes
In `arkane/input.py`,  this PR imports SoluteTSData from rmgpy and modifies `local_context` dictionary to include this. Now, `load_input_file` can load network.py files that have reactions with `SoluteTSData`. Also modified the reading in of the file so it gives a more helpful error (similar to what R West did in this [PR](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2661) for debugging database errors). 

### Testing
Tried to load in a pdep network.py file that had kinetics containing a SoluteTSData object. Got a 'TypeError: Nonetype object is not subscriptable" and a raised error stating "The input file {network file} was invalid:" 

With these proposed changes, the network.py file loads in fine.  

### Reviewer Tips
Very small PR, not much to check. 

