### PR TITLE
Remove incorrectly calculated and applied energy_correction from pdep.py

### DIFF
--- a/rmgpy/rmg/pdep.py
+++ b/rmgpy/rmg/pdep.py
@@ -816,14 +816,6 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                     spec.conformer = Conformer(E0=spec.get_thermo_data().E0)
                 E0.append(spec.conformer.E0.value_si)
 
-        # Use the average E0 as the reference energy (`energy_correction`) for the network
-        # The `energy_correction` will be added to the free energies and enthalpies for each
-        # configuration in the network.
-        energy_correction = -np.array(E0).mean()
-        for spec in self.reactants + self.products + self.isomers:
-            spec.energy_correction = energy_correction
-        self.energy_correction = energy_correction
-
         # Determine transition state energies on potential energy surface
         # In the absence of any better information, we simply set it to
         # be the reactant ground-state energy + the activation energy
@@ -851,9 +843,9 @@ class PDepNetwork(rmgpy.pdep.network.Network):
                                 'type "{2!s}".'.format(rxn, self.index, rxn.kinetics.__class__))
             rxn.fix_barrier_height(force_positive=True)
             if rxn.network_kinetics is None:
-                E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.kinetics.Ea.value_si + energy_correction
+                E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.kinetics.Ea.value_si 
             else:
-                E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.network_kinetics.Ea.value_si + energy_correction
+                E0 = sum([spec.conformer.E0.value_si for spec in rxn.reactants]) + rxn.network_kinetics.Ea.value_si
             rxn.transition_state = rmgpy.species.TransitionState(conformer=Conformer(E0=(E0 * 0.001, "kJ/mol")))
 
         # Set collision model


### PR DESCRIPTION
After finding many submerged barriers when running RMG in pdep mode, I discovered that the `energy_correction` is calculated incorrectly *and* only applied to the transition state. The code calculates the `energy_correction` by averaging all species E0s. However, it should average the total energy for each stationary point (some of which are bimolecular), and I believe it would be more intuitive to use the minimum energy on the surface. A simple solution would be to remove the `energy_correction` altogether (what I've done here for now). If it is desired, we need to apply `energy_correction` to all stationary points, not just transition states, so that barriers are not submerged. 

The `energy_correction` could be calculated as follows...
```
stationary_point_E0s = [sum([spec.conformer.E0.value_si for spec in stationary_point]) for stationary_point  in self.reactants + self.isomers + self.products])]
energy_correction = -np.array(stationary_point_E0s).min()
```

I would need to track down where to apply it to the wells though.

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
A clear and concise description of what what you're trying to fix or improve. Please reference any issues that this addresses.

### Description of Changes
A clear and concise description of what what you've changed or added.

### Testing
A clear and concise description of testing that you've done or plan to do.

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
