### PR TITLE
Add optional ML-based solvation correction pathway

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -2221,12 +2221,45 @@ class SolvationDatabase(object):
         """
         Given a solute_data and solvent_data object, calculates the enthalpy, entropy,
         and Gibbs free energy of solvation at 298 K. Returns a SolvationCorrection
-        object
+        object.
+        Note: This method utilizes the LSER method for solvation correction with parameters
+        from the RMG-database.
         """
         correction = SolvationCorrection(0.0, 0.0, 0.0)
         correction.enthalpy = self.calc_h(solute_data, solvent_data)
         correction.gibbs = self.calc_g(solute_data, solvent_data)
         correction.entropy = self.calc_s(correction.gibbs, correction.enthalpy)
+        return correction
+    
+    def get_solvation_correction_ml_LSER(self, solute_mol, solvent_mol):
+        """
+        Given a solute_mol and solvent_mol object, calculates the enthalpy, entropy,
+        and Gibbs free energy of solvation at 298 K. Returns a SolvationCorrection object.
+        Note: This method utilizes the LSER method for solvation correction with parameters
+        predicted from the ML model.
+        """
+        correction = SolvationCorrection(0.0, 0.0, 0.0)
+
+        ### ML MODEL HERE ###
+        
+        correction.enthalpy = 0
+        correction.gibbs = 0
+        correction.entropy = 0
+        return correction
+    
+    def get_solvation_correction_ml(self, solute_mol, solvent_mol):
+        """
+        Given a solute_mol and solvent_mol object, calculates the enthalpy, entropy,
+        and Gibbs free energy of solvation at 298 K using a machine learning model.
+        Returns a SolvationCorrection object.
+        """
+        correction = SolvationCorrection(0.0, 0.0, 0.0)
+
+        ### ML MODEL HERE ###
+        
+        correction.enthalpy = 0
+        correction.gibbs = 0
+        correction.entropy = 0
         return correction
 
     def get_Kfactor(self, delG298, delH298, delS298, solvent_name, T):

--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -48,6 +48,7 @@ from rmgpy.data.thermo import is_aromatic_ring, is_bicyclic, find_aromatic_bonds
     convert_ring_to_sub_molecule, is_ring_partial_matched, bicyclic_decomposition_for_polyring, \
     split_bicyclic_into_single_rings, saturate_ring_bonds
 
+from rdkit import Chem
 
 ################################################################################
 
@@ -2231,37 +2232,6 @@ class SolvationDatabase(object):
         correction.entropy = self.calc_s(correction.gibbs, correction.enthalpy)
         return correction
     
-    def get_solvation_correction_ml_LSER(self, solute_mol, solvent_mol):
-        """
-        Given a solute_mol and solvent_mol object, calculates the enthalpy, entropy,
-        and Gibbs free energy of solvation at 298 K. Returns a SolvationCorrection object.
-        Note: This method utilizes the LSER method for solvation correction with parameters
-        predicted from the ML model.
-        """
-        correction = SolvationCorrection(0.0, 0.0, 0.0)
-
-        ### ML MODEL HERE ###
-        
-        correction.enthalpy = 0
-        correction.gibbs = 0
-        correction.entropy = 0
-        return correction
-    
-    def get_solvation_correction_ml(self, solute_mol, solvent_mol):
-        """
-        Given a solute_mol and solvent_mol object, calculates the enthalpy, entropy,
-        and Gibbs free energy of solvation at 298 K using a machine learning model.
-        Returns a SolvationCorrection object.
-        """
-        correction = SolvationCorrection(0.0, 0.0, 0.0)
-
-        ### ML MODEL HERE ###
-        
-        correction.enthalpy = 0
-        correction.gibbs = 0
-        correction.entropy = 0
-        return correction
-
     def get_Kfactor(self, delG298, delH298, delS298, solvent_name, T):
         """Returns a K-factor for the input temperature given the solvation properties of a solute in a solvent
         at 298 K.
@@ -2484,3 +2454,32 @@ class SolvationDatabase(object):
             else:
                 logging.info('One of the initial species must be the solvent with the same string name')
                 logging.warning("Solvent is not an initial species with the same string name")
+
+class MLSolvation:
+    """
+    A dummy class for machine learning-based solvation correction.
+    """
+    def __init__(self, model_path: str):
+        # ex) model_path = "RMG-database/input/thermo/ml/solvation"
+        self.model_path = model_path
+        self.model = self.load_model(model_path)
+
+    def load_model(self, model_path):
+        # Need to implement model loading code (e.g., joblib.load, torch.load, etc.)
+        print(f"[NOTICE] Dummy ML model loaded from: {model_path}")
+        return None  # Need to return something like "return joblib.load(os.path.join(model_path, "model.pkl"))"
+
+    def get_solvation_correction(self, solute_mol, solvent_mol):
+        """
+        Given a solute_mol and solvent_mol object, calculates the enthalpy, entropy,
+        and Gibbs free energy of solvation at 298 K using a machine learning model.
+        Returns a SolvationCorrection object.
+        """
+        # Need to implement: solute_mol, solvent_mol → feature vector → ML prediction
+        print(f"[NOTICE] Dummy ML model utilized")
+        enthalpy = 0.0  #self.model.predict([...])[0]
+        gibbs = 0.0
+        entropy = 0.0
+
+        from rmgpy.data.solvation import SolvationCorrection
+        return SolvationCorrection(enthalpy, gibbs, entropy)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1312,7 +1312,7 @@ def ml_solvation(use_ml_solvation=True, name='solvation'):
 
     from rmgpy.data.solvation import MLSolvation
     if use_ml_solvation:
-        model_path = os.path.join(settings['database.directory'], 'thermo', 'ml', name) # Need to add ML model at RMG-database/thermo/ml/solvation
+        model_path = os.path.join(settings['database.directory'], 'thermo', 'ml', name) # Need to add ML model at RMG-database/input/thermo/ml/solvation
         if not os.path.exists(model_path):
             raise InputError('Cannot find ML models folder {}'.format(model_path))
         rmg.ml_solvation = MLSolvation(model_path)

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1305,6 +1305,17 @@ def ml_estimator(thermo=True,
         logging.warning('"onlyCyclics" should be True when "onlyHeterocyclics" is True. '
                         'Machine learning estimator is restricted to only heterocyclic species thermo')
 
+def ml_solvation(use_ml_solvation=True, name='solvation'):
+    """
+    Enable the use of machine learning model for solvation correction
+    """
+
+    from rmgpy.data.solvation import MLSolvation
+    if use_ml_solvation:
+        model_path = os.path.join(settings['database.directory'], 'thermo', 'ml', name) # Need to add ML model at RMG-database/thermo/ml/solvation
+        if not os.path.exists(model_path):
+            raise InputError('Cannot find ML models folder {}'.format(model_path))
+        rmg.ml_solvation = MLSolvation(model_path)
 
 def pressure_dependence(
         method,
@@ -1565,6 +1576,7 @@ def read_input_file(path, rmg0):
         'model': model,
         'quantumMechanics': quantum_mechanics,
         'mlEstimator': ml_estimator,
+        'mlSolvation': ml_solvation,
         'pressureDependence': pressure_dependence,
         'options': options,
         'generatedSpeciesConstraints': generated_species_constraints,
@@ -1645,6 +1657,7 @@ def read_thermo_input_file(path, rmg0):
         'adjacencyList': adjacency_list,
         'quantumMechanics': quantum_mechanics,
         'mlEstimator': ml_estimator,
+        'mlSolvation': ml_solvation,
     }
 
     try:
@@ -1851,6 +1864,8 @@ def get_input(name):
             return rmg.quantum_mechanics
         elif name == 'ml_estimator':
             return rmg.ml_estimator, rmg.ml_settings
+        elif name == 'ml_solvation':
+            return rmg.ml_solvation
         elif name == 'thermo_central_database':
             return rmg.thermo_central_database
         else:


### PR DESCRIPTION
### Summary
This PR introduces an optional ML-based solvation correction pathway into RMG’s thermochemistry pipeline. It provides an interface for estimating solvation effects using a pre-trained ML model, while preserving the existing LSER (Linear Solvation Energy Relationship) method as a fallback mechanism.

### Motivation or Problem
Currently, RMG uses LSER for solvation corrections for thermo. At this stage, the ML component is implemented as a **dummy version** that always outputs zero corrections. This is intentional — actual ML functionality will be introduced later, after transitioning to Python 3.11 for better compatibility.

### Description of Changes

#### Add `MLSolvation` class to `rmgpy/data/solvation.py`
- Introduced a new `MLSolvation` class that mirrors the structure of `MLEstimator` from `mlEstimator`.
- Accepts the same kind of `mlSolvation` block in the input file, with options like `use_ml_solvation=True` and `name='solvation'`.
- Unlike `MLEstimator`, which resides in `rmgpy/ml/estimator.py`, this new class is defined within `rmgpy/data/solvation.py`.
- The class exposes a `get_solvation_correction()` method, analogous to `SolvationDatabase`, and returns a `SolvationCorrection` object.

#### Add `ml_solvation()` function to `rmgpy/rmg/input.py`
- Mirrors the implementation of the `ml_estimator()` block and allows ML solvation to be optionally configured via the input file.

#### Modify `rmgpy/thermo/thermoengine.py` to support fallback logic
- At the point where solvation corrections are applied to thermo, the code now tries to use the ML-based model via `get_input("ml_solvation")`.
- If this fails (e.g., due to configuration or import issues), the code gracefully falls back to the default LSER method.
- This behavior is wrapped in a `try-except` block.

### Testing
- Two minimal examples were tested:
  1. **Without** an `mlSolvation` block → expected warning:
     ```
     Warning: ML solvation correction not used: 'RMG' object has no attribute 'ml_solvation'
     ```
     The system then falls back to LSER as expected.
  2. **With** an `mlSolvation` block → dummy ML model successfully invoked:
     ```
     [NOTICE] Dummy ML model loaded from: /Users/bon/rmg/RMG-database/input/thermo/ml/solvation
     [NOTICE] Dummy ML model utilized
     ```

### Reviewer Tips
- Please check whether the following imports are appropriate and safe:
  - `from rmgpy.data.solvation import SolvationCorrection` in `solvation.py`
  - `from rmgpy.rmg.input import get_input` in `thermoengine.py`
- Note that `MLSolvation` is currently a dummy implementation and does not load an actual model. It is prepared to be upgraded in future commits after Python 3.11 migration.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
