### PR TITLE
Lazy loading of Julia things

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -47,7 +47,6 @@ from rmgpy.molecule.group import Group
 from rmgpy.quantity import Energy, Quantity, RateCoefficient, SurfaceConcentration
 from rmgpy.rmg.model import CoreEdgeReactionModel
 from rmgpy.rmg.reactionmechanismsimulator_reactors import (
-    NO_JULIA,
     ConstantTLiquidSurfaceReactor,
     ConstantTPIdealGasReactor,
     ConstantTVLiquidReactor,
@@ -1593,11 +1592,6 @@ def read_input_file(path, rmg0):
         exec(f.read(), global_context, local_context)
     except (NameError, TypeError, SyntaxError) as e:
         logging.error('The input file "{0}" was invalid:'.format(full_path))
-        if NO_JULIA:
-            logging.error(
-                "During runtime, import of Julia dependencies failed. To use phase systems and RMS reactors, install RMG-Py with RMS."
-                " (https://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/installation/anacondaDeveloper.html)"
-            )
         logging.exception(e)
         raise
     finally:

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -75,7 +75,6 @@ from rmgpy.rmg.listener import SimulationProfilePlotter, SimulationProfileWriter
 from rmgpy.rmg.model import CoreEdgeReactionModel, Species
 from rmgpy.rmg.output import OutputHTMLWriter
 from rmgpy.rmg.pdep import PDepNetwork, PDepReaction
-from rmgpy.rmg.reactionmechanismsimulator_reactors import NO_JULIA
 from rmgpy.rmg.reactionmechanismsimulator_reactors import Reactor as RMSReactor
 from rmgpy.rmg.settings import ModelSettings
 from rmgpy.solver.base import TerminationConversion, TerminationTime

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -57,7 +57,6 @@ from rmgpy.rmg.decay import decay_species
 from rmgpy.rmg.pdep import PDepNetwork, PDepReaction
 from rmgpy.rmg.react import react_all
 from rmgpy.rmg.reactionmechanismsimulator_reactors import (
-    NO_JULIA,
     Interface,
     Phase,
     PhaseSystem,
@@ -81,7 +80,7 @@ class ReactionModel:
         if phases is None:
             phases = {"Default": Phase(), "Surface": Phase()}
             interfaces = {frozenset({"Default", "Surface"}): Interface(list(phases.values()))}
-        self.phase_system = None if NO_JULIA else PhaseSystem(phases, interfaces)
+        self.phase_system = PhaseSystem(phases, interfaces)
 
     def __reduce__(self):
         """
@@ -355,7 +354,7 @@ class CoreEdgeReactionModel:
         orilabel = spec.label
         label = orilabel
         i = 2
-        if self.edge.phase_system:  # None when RMS not installed
+        if self.edge.phase_system:  # !!! Not maintained when operating with require_rms=False?
             while any([label in phase.names for phase in self.edge.phase_system.phases.values()]):
                 label = orilabel + "-" + str(i)
                 i += 1

--- a/rmgpy/rmg/reactionmechanismsimulator_reactors.py
+++ b/rmgpy/rmg/reactionmechanismsimulator_reactors.py
@@ -35,6 +35,7 @@ import logging
 import os
 
 import numpy as np
+import rmgpy
 
 from rmgpy.data.solvation import SolventData
 from rmgpy.kinetics.arrhenius import (
@@ -59,25 +60,32 @@ from rmgpy.species import Species
 from rmgpy.thermo.nasa import NASA, NASAPolynomial
 from rmgpy.thermo.thermodata import ThermoData
 
+class MainProxy:
+    """
+    A proxy for the juliacall Main module, that will replace itself
+    with the real thing the first time it's accessed.
+    This is to delay loading Julia until it's really needed.
+    """
+    def __getattr__(self, name):
+        if hasattr(rmgpy, 'DISABLE_JULIA') and rmgpy.DISABLE_JULIA:
+            raise ImportError("Julia imports disabled via rmgpy.DISABLE_JULIA flag")
+        elif os.environ.get('RMG_DISABLE_JULIA', '').lower() in ('1', 'true', 'yes'):
+            raise ImportError("Julia imports disabled via RMG_DISABLE_JULIA environment variable")
 
-NO_JULIA = True
-
-# Check if Julia should be disabled via module-level variable or environment variable
-import rmgpy
-if hasattr(rmgpy, 'DISABLE_JULIA') and rmgpy.DISABLE_JULIA:
-    logging.info("Julia imports disabled via rmgpy.DISABLE_JULIA flag")
-elif os.environ.get('RMG_DISABLE_JULIA', '').lower() in ('1', 'true', 'yes'):
-    logging.info("Julia imports disabled via RMG_DISABLE_JULIA environment variable")
-else:
-    try:
-        from juliacall import Main
-        Main.seval("using PythonCall")
-        Main.seval("using ReactionMechanismSimulator")
-        Main.seval("using ReactionMechanismSimulator.Sundials")
-        NO_JULIA = False
-    except ImportError as e:
-        logging.warning("Julia import failed, RMS reactors not available. "
-                       "Exception: %s", str(e))
+        try:
+            from juliacall import Main as JuliaMain
+            Main = JuliaMain
+            Main.seval("using PythonCall")
+            Main.seval("using ReactionMechanismSimulator")
+            Main.seval("using ReactionMechanismSimulator.Sundials")
+        except Exception as e:
+            logging.error("Failed to import Julia and load ReactionmechanismSimulator. "
+                          "To use phase systems and RMS reactors, install RMG-Py with RMS.")
+            logging.exception(e)
+            raise
+        globals()['Main'] = JuliaMain  # Replace proxy with real thing, for next time it's called
+        return getattr(JuliaMain, name) # Return the attribute for the first time it's called
+Main = MainProxy()
 
 
 def to_julia(obj):
@@ -95,6 +103,7 @@ def to_julia(obj):
     object : Main.Dict | Main.Vector | Main.Matrix | object
         The Julia object
     """
+    
     if isinstance(obj, dict):
         return Main.PythonCall.pyconvert(Main.Dict, obj)
     elif isinstance(obj, (list, np.ndarray)):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Loading Julia and RMS can take many minutes to compile.
It's nice to avoid this when you can.
Until recently it was unavoidable.
Current options are  either not have Julia/juliacall/RMS so it just fails and warns (#2741) , or even more recently, use (#2802) a module level variable `rmgpy.DISABLE_JULIA` or an environment variable `RMG_DISABLE_JULIA=True`.


### Description of Changes
With this PR, the goal is to just defer the loading of Julia and RMS until it is actually needed.
Thus if you don't ever call an RMS reactor type, then it never loads them, even if you have RMS installed and haven't explicitly forbidden it.   
There is still some cleaning up to do of some of the previous methods of avoiding it.

### Testing
I've run an example that doesn't use RMS `make eg1`  and it loaded fast, and an example that does `make eg8` and it worked, and then did `RMG_DISABLE_JULIA=1 python rmg.py testing/eg8/input.py` (the `RMG_DISABLE_JULIA` option is still there, although it could probably be removed if this lazy loading works well) and it gave an `ImportError: Julia imports disabled via RMG_DISABLE_JULIA environment variable`. 

### Reviewer Tips

?

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
