### PR TITLE
A note about installing developer version from Docker.

### DIFF
--- a/documentation/source/users/rmg/faq.rst
+++ b/documentation/source/users/rmg/faq.rst
@@ -28,8 +28,7 @@ Running RMG
 
 #. **How do I run a basic RMG job?**
 
-   Please see step-by-step instructions in the either the :ref:`binary<anacondaUser>` or :ref:`source <anacondaDeveloper>`
-   installation instructions. In general, the syntax is ::
+   Please see step-by-step instructions in the installation instructions. In general, the syntax is ::
 
     rmg.py input.py
 

--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -40,9 +40,9 @@ For users unfamiliar with bash or Linux, we recommend looking at
 `Must Know Linux/Unix Commands <https://www.guru99.com/must-know-linux-commands.html>`_.
 
 .. NOTE::
-    The instructions above are for the release version 3.2.0 of RMG-Py (August 2023).
-    If you want to use the latest development version, you can replace the version number in the docker pull command with "latest" or omit it entirely.
-    For example, you can run ``docker pull reactionmechanismgenerator/rmg:latest`` or ``docker pull reactionmechanismgenerator/rmg`` to get the latest development version corresponding to `here <https://github.com/ReactionMechanismGenerator/RMG-Py/commits/main/>`_.
+    The docker instructions above which specify ``rmg:3.2.0`` are for the version 3.2.0 release of RMG-Py (August 2023), the user guide for which is archived in a `4mb PDF here <https://github.com/ReactionMechanismGenerator/RMG-Py/blob/3.2.0/documentation/RMG-Py_and_Arkane_Documentation.pdf?raw=true>`_.
+    If you want to use the latest development version, which corresponds to the user guide you are reading online `on the RMG website <https://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/>`_, you can replace the version number in the docker pull command with "latest" or omit it entirely.
+    For example, you can run ``docker pull reactionmechanismgenerator/rmg:latest`` or ``docker pull reactionmechanismgenerator/rmg`` to get the latest development version corresponding to `the main branch <https://github.com/ReactionMechanismGenerator/RMG-Py/commits/main/>`_.
     Be sure to also change the version number in the docker run commands to match the version you pulled.
     A full list of available docker images can be found at `Docker Hub <https://hub.docker.com/r/reactionmechanismgenerator/rmg/tags>`_.
 

--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -39,6 +39,12 @@ For users unfamiliar with bash or Linux, we recommend looking at
 `Terminal vs File Manager <https://www.guru99.com/terminal-file-manager.html>`_, and
 `Must Know Linux/Unix Commands <https://www.guru99.com/must-know-linux-commands.html>`_.
 
+.. NOTE::
+    The instructions above are for the release version 3.2.0 of RMG-Py (August 2023).
+    If you want to use the latest development version, you can replace the version number in the docker pull command with "latest" or omit it entirely.
+    For example, you can run ``docker pull reactionmechanismgenerator/rmg:latest`` or ``docker pull reactionmechanismgenerator/rmg`` to get the latest development version corresponding to `here <https://github.com/ReactionMechanismGenerator/RMG-Py/commits/main/>`_.
+    Be sure to also change the version number in the docker run commands to match the version you pulled.
+    A full list of available docker images can be found at `Docker Hub <https://hub.docker.com/r/reactionmechanismgenerator/rmg/tags>`_.
 
 Alternative Install: Binary Installation Using Anaconda
 ===========================================================

--- a/documentation/source/users/rmg/installation/index.rst
+++ b/documentation/source/users/rmg/installation/index.rst
@@ -46,26 +46,15 @@ For users unfamiliar with bash or Linux, we recommend looking at
     Be sure to also change the version number in the docker run commands to match the version you pulled.
     A full list of available docker images can be found at `Docker Hub <https://hub.docker.com/r/reactionmechanismgenerator/rmg/tags>`_.
 
-Alternative Install: Binary Installation Using Anaconda
-===========================================================
-
-If you are accustomed to using the Anaconda package manager or cannot tolerate the storage overhead of Docker, installation from conda is also available.
-This is recommended for users who want to use RMG out of the box and are not interested in changing the RMG code or making many additions to RMG's thermodynamic and kinetics databases.
-If this does interest you, please see the Developer Install below.
-    
-.. toctree::
-    :maxdepth: 1
-    
-    anacondaUser
-
 
 Developer Install: Installation from Source
 ===========================================================
 
-RMG-Py can now be built by source using the Anaconda Python Platform to assist in installing
-all necessary dependencies. This is recommended for a developer who may be altering the RMG source code
-or someone who expects to manipulate the databases extensively.  You will also be able to access the latest
-source code updates and patches through Github.
+RMG-Py can be built from source using the Anaconda Python Platform to assist in installing all necessary dependencies. 
+This is recommended for a developer who may be altering the RMG source code or someone who expects to manipulate the databases extensively. 
+You will also be able to access the latest source code updates and patches through Github.
+It is also currently the only option to avoid the storage and memory overhead of Docker.
+Installation by Conda without compiling from source is limited to `older versions of RMG-Py <https://anaconda.org/RMG/rmg>`_ and is not currently recommended (but would follow instructions below if you needed).
 
 .. toctree::
     :maxdepth: 1
@@ -85,6 +74,7 @@ not recommended for use.
     
     linux
     macos
+    anacondaUser
     anacondaUserWindows
     anacondaDeveloperWindows
     windowsEnvironment


### PR DESCRIPTION
The last Docker release was 2 years ago. Users might want to use Docker to get a more recent version. This PR updates the installation instructions to tell them how.

The last Conda binary was 4+ years ago, so I hid/removed the instructions recommending that installation method.
As noted in a commit message, we should re-visit these instructions once we've fixed conda builds.

I also found a link to the pdf of the 3.2.0 user guide, so included that link (for people following the instructions to install it), partially addressing #2809.

