### PR TITLE
Fix CCSD(T)-F12 energy parsing

### DIFF
--- a/arkane/ess/molpro.py
+++ b/arkane/ess/molpro.py
@@ -336,6 +336,7 @@ class MolproLog(ESSAdapter):
                         f12b = True  # MRCI could also have a v(4+)z basis, so don't break yet
                 elif 'ccsd' in line.lower() and 'f12' in line.lower():
                     f12 = True
+                    f12a_section, f12b_section = False, False
                 elif 'mrci' in line.lower():
                     mrci = True
                     f12a, f12b = False, False
@@ -350,11 +351,15 @@ class MolproLog(ESSAdapter):
             # Search for e_elect
             for line in lines:
                 if f12 and f12a:
-                    if ('CCSD(T)-F12a' in line or 'CCSD(T)-F12/' in line and '!' not in line) and 'energy' in line:
+                    if 'F12a energy' in line:
+                        f12a_section, f12b_section = True, False
+                    if 'CCSD(T)-F12' in line and 'energy' in line and f12a_section:
                         e_elect = float(line.split()[-1])
                         break
                 elif f12 and f12b:
-                    if 'CCSD(T)-F12b' in line and 'energy' in line:
+                    if 'F12b energy' in line:
+                        f12a_section, f12b_section = False, True
+                    if 'CCSD(T)-F12' in line and 'energy' in line and f12b_section:
                         e_elect = float(line.split()[-1])
                         break
                 elif mrci:

--- a/test/arkane/ess/molproTest.py
+++ b/test/arkane/ess/molproTest.py
@@ -110,7 +110,7 @@ class MolproLogTest:
 
         log = MolproLog(os.path.join(self.data_path, "C5OH5_CCSD(T)_F12.out"))
         e0 = log.load_energy()
-        assert round(abs(e0 / constants.Na / constants.E_h - -268.317057640597), 5) == 0
+        assert round(abs(e0 / constants.Na / constants.E_h - -268.336320614452), 5) == 0
 
     def test_load_hosi_from_molpro_log(self):
         """


### PR DESCRIPTION
### Motivation or Problem
Fix the `CCSD(T)-F12a` and `CCSD(T)-F12b` energies parsing issue. More details can be found at https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2814.

### Description of Changes
Added two variables to identify which sections (i.e., `a` or `b`) are present and parsed the energy based on the same keyword: `CCSD(T)-F12`.

### Testing
The test has been updated accordingly. Currently, only CCSD(T)-F12a is tested, as there are no CCSD(T)-F12 calculations performed using the 'vqz', 'v5z', 'v6z', 'v7z', or 'v8z' basis sets.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
