### PR TITLE
Selective Solvation Corrections

### DIFF
--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -1187,6 +1187,19 @@ def solvation(solvent, solventData=None, excludedSpecies=None, excludedLibraries
     rmg.solvation_excluded_species = excludedSpecies if excludedSpecies is not None else []
     rmg.solvation_excluded_libraries = excludedLibraries if excludedLibraries is not None else []
 
+    # Log species and libraries excluded from solvation corrections
+    if rmg.solvation_excluded_species:
+        logging.info(
+            f"Solvation corrections will be skipped for the following species: "
+            f"{', '.join(rmg.solvation_excluded_species)}"
+        )
+    if rmg.solvation_excluded_libraries:
+        logging.info(
+            f"Solvation corrections will be skipped for species from the following thermo libraries: "
+            f"{', '.join(rmg.solvation_excluded_libraries)}"
+        )
+
+
 def model(toleranceMoveToCore=None, toleranceRadMoveToCore=np.inf,
           toleranceMoveEdgeReactionToCore=np.inf, toleranceKeepInEdge=0.0,
           toleranceInterruptSimulation=1.0,
@@ -1769,7 +1782,16 @@ def save_input_file(path, rmg):
         f.write(')\n\n')
 
     if rmg.solvent:
-        f.write("solvation(\n    solvent = '{0!s}'\n)\n\n".format(rmg.solvent))
+        f.write("solvation(\n")
+        f.write("    solvent = '{0!s}',\n".format(rmg.solvent))
+
+        if rmg.solvation_excluded_species:
+            f.write("    excludedSpecies = {0},\n".format(repr(rmg.solvation_excluded_species)))
+
+        if rmg.solvation_excluded_libraries:
+            f.write("    excludedLibraries = {0},\n".format(repr(rmg.solvation_excluded_libraries)))
+
+        f.write(")\n\n")
 
     # Simulator tolerances
     f.write('simulator(\n')

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -237,6 +237,8 @@ class CoreEdgeReactionModel:
         self.new_surface_spcs_loss = set()
         self.new_surface_rxns_loss = set()
         self.solvent_name = ""
+        self.solvation_excluded_species = []
+        self.solvation_excluded_libraries = []
         self.surface_site_density = None
         self.unrealgroups = [
             Group().from_adjacency_list(
@@ -557,7 +559,7 @@ class CoreEdgeReactionModel:
             elif isinstance(forward, LibraryReaction) and forward.is_surface_reaction():
                 # do fix the library reaction barrier if this is scaled from another metal
                 if any(['Binding energy corrected by LSR' in x.thermo.comment for x in forward.reactants + forward.products]):
-                    forward.fix_barrier_height(solvent=self.solvent_name)            
+                    forward.fix_barrier_height(solvent=self.solvent_name)
             elif forward.kinetics.solute:
                 forward.apply_solvent_correction(solvent=self.solvent_name)
             if self.pressure_dependence and forward.is_unimolecular():
@@ -1601,7 +1603,7 @@ class CoreEdgeReactionModel:
         self.new_reaction_list = []
         self.new_species_list = []
         edge_species_to_move = []
-        
+
         num_old_core_species = len(self.core.species)
         num_old_core_reactions = len(self.core.reactions)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Currently, RMG applies implicit solvation corrections to all species in the solvent phase. However, in some cases, species thermochemistry is obtained from DFT calculations that already include explicit solvation effects. Applying an additional implicit correction to these species would result in double counting, reducing the accuracy of the model. This change would allow users to opt out of solvation corrections on a per-species basis, ensuring more accurate and flexible thermochemistry handling.

### Description of Changes
Introduces the ability to selectively disable implicit solvation corrections for individual species in the solution phase when the solvent attribute is set in the RMG input file.

Companion PR to https://github.com/ReactionMechanismGenerator/RMG-database/pull/695

### Testing
- [ ] Add excluded species and libraries when solvation is specified in an input file.
- [ ] Apply dummy solvent correction (zero effects) to species thermo if it's in the list of excluded species or libraries.
- [ ] Add appropriate info for the user to know whether solvation effects are excluded for a species.  
- [ ] Create a unit test. 

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
