### PR TITLE
Ignore more example output files in git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,6 @@ test_log.txt
 rmgpy/tools/data/flux/flux/1/*.dot
 
 # example directory - save the inputs but not the outputs
-# cantera input files
 examples/**/chem.inp
 # log files from the runs
 examples/**/arkane.log
@@ -124,3 +123,12 @@ examples/**/reactions.py
 examples/**/RMG_libraries
 examples/**/species
 examples/**/plots
+examples/**/chemkin/*.inp
+examples/**/chemkin/tran.dat
+examples/**/chemkin/*dictionary.txt
+examples/**/chem*.yaml
+examples/**/rms/*.rms
+examples/**/output*.html
+examples/**/restart_from_seed.py
+examples/**/seed/filters
+examples/**/statistics.xls


### PR DESCRIPTION
### Motivation or Problem
My git diffs and status were polluted with lots of output files from running examples.

### Description of Changes
Added more templates to the .gitignore file, so git ignores changes to these files.

### Testing
I checked locally that my git status was cleaner.

### Reviewer Tips
This is a small PR and should be quick to review.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
