### PR TITLE
Dockerfile: use miniforge instead of miniconda to avoid `defaults`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,6 @@ RUN rm -rf examples/rmg/rms_constant_V/* && \
     git checkout -- examples/rmg/rms_constant_V/
 
 # when running this image, open an interactive bash terminal inside the rmg_env conda environment
-RUN sed -i '/\. \/opt\/conda\/etc\/profile.d\/conda.sh && conda activate base/c\. /opt/conda/etc/profile.d/conda.sh && conda activate rmg_env' ~/.bashrc
+RUN sed -i 's/conda activate base/conda activate rmg_env/' ~/.bashrc
 ENTRYPOINT ["/bin/bash", "--login"]
 


### PR DESCRIPTION
### Motivation or Problem
Current docker image uses `miniconda` which attempts to use the `defaults` channel. We are already avoiding this in the CLI with miniforge.

### Description of Changes
Docker image now builds from `conda-forge/miniforge` which is the same version of ubuntu that we were using but with `miniforge` already installed.

### Testing
I've run this Docker manually and it builds