### PR TITLE
Try echem branch of RMS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ env:
   # main with the name of the branch
   RMG_DATABASE_BRANCH: main
   # RMS branch to use for ReactionMechanismSimulator installation
-  RMS_BRANCH: for_rmg
+  RMS_BRANCH: echem
   # julia parallel pre-compilation leads to race conditions and hangs, so we limit it to run in serial
   JULIA_NUM_PRECOMPILE_TASKS: 1
 


### PR DESCRIPTION
An incompatibility with the current `for_rmg` branch of RMS is causing RMG regression tests to fail.
See https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/issues/275

This is a test to see if the echem branch works.
(though it currently fails to pass the RMS CI tests)

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.

### Motivation or Problem
A clear and concise description of what what you're trying to fix or improve. Please reference any issues that this addresses.

### Description of Changes
A clear and concise description of what what you've changed or added.

### Testing
A clear and concise description of testing that you've done or plan to do.

### Reviewer Tips
Suggestions for verifying that this PR works or other notes for the reviewer.
-->

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
