### PR TITLE
Avoid Accidental `conda` Uploads

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -56,7 +56,7 @@ jobs:
           (github.event_name == 'push' && github.ref == 'refs/heads/stable') ||
           (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/stable')
         run: |
-          conda --token ${{ secrets.ANACONDA_TOKEN }} upload $(conda build --output)
+          anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload $(conda build --output)
 
   result:
     if: ${{ always() }}


### PR DESCRIPTION
The current `conda_build` action is overwriting the currently uploaded version of RMG 3.3.0 every time it is run (including on pushes to `main`, PRs, etc.) because - for some absolutely STUPID reason - if you pass the `--user` and `--token` arguments to `conda build` it will upload the built binary REGARDLESS of if automatic uploads are enabled.

This slightly shuffles around the logic to avoid this.