### PR TITLE
Explicitly Forbid Default `conda` Channels

### DIFF
--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -82,7 +82,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
     source ~/.zshrc
 
    NOTE: You may wish to forbid ``conda`` from installing from the Anaconda channels due to licensing restrictions.
-   The ``environment.yml`` file already forbids using default channels, but you may further add the file ``.condarc`` to your RMG-Py directory (or modify the ``.condarc`` in your home directory) with the following contents before running the ``conda env create`` command:
+   The ``environment.yml`` file already forbids using default channels, but you may further add the file ``.condarc`` to your RMG-Py directory (or modify the ``.condarc`` in your home directory) with the following contents before running the ``conda env create`` command: ::
 
      channels:
        - conda-forge

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -81,6 +81,19 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     source ~/.zshrc
 
+   NOTE: You may wish to forbid ``conda`` from installing from the Anaconda channels due to licensing restrictions.
+   The ``environment.yml`` file already forbids using default channels, but you may further add the file ``.condarc`` to your RMG-Py directory (or modify the ``.condarc`` in your home directory) with the following contents before running the ``conda env create`` command:
+
+     channels:
+       - conda-forge
+       - nodefaults
+     channel_priority: strict
+     custom_channels:
+       main: null
+       r: null
+       anaconda: null
+       msys2: null
+
 #. Activate conda environment ::
 
     conda activate rmg_env

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ name: rmg_env
 channels:
   - conda-forge
   - rmg
+  - nodefaults
 dependencies:
 # System-level dependencies - we could install these at the OS level
 # but by installing them in the conda environment we get better control


### PR DESCRIPTION
### Motivation or Problem

It is still possible to install conda package from the license-restricted official channels, even though we don't explicitly allow them.

This issue is related to and resolves #2843

### Description of Changes

Explicitly forbid default channels in environment and add developer instructions for further restrictions.

### Testing

Just need to ensure the CI runs.

### Reviewer Tips

Please see if the news docs make sense.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
