### PR TITLE
fix reactionLibraries path

### DIFF
--- a/examples/rmg/catalysis/methane_steam/input.py
+++ b/examples/rmg/catalysis/methane_steam/input.py
@@ -1,7 +1,7 @@
 # Data sources
 database(
     thermoLibraries=['surfaceThermoNi111', 'surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC'], 
-    reactionLibraries = [('Surface/Deutschmann_Ni', True)], # when Pt is used change the library to Surface/CPOX_Pt/Deutschmann2006
+    reactionLibraries = [('Surface/Methane/Deutschmann_Ni', True)], # when Pt is used change the library to Surface/CPOX_Pt/Deutschmann2006
     seedMechanisms = [],
     kineticsDepositories = ['training'],
     kineticsFamilies = ['surface','default'],


### PR DESCRIPTION
### Motivation or Problem
The reactionLibraries path in the catalysis/methane_steam example was broken 

`reactionLibraries = [('Surface/Deutschmann_Ni', True)]`

and I fixed it to point to the correct reaction library

`reactionLibraries = [('Surface/Methane/Deutschmann_Ni', True)]
`

### Testing
This is an easy fix. Try to run the example.  