### PR TITLE
Load spin multiplicity into the Arkane Species Molecule if given explicitly in the main Arkane input file

### DIFF
--- a/arkane/input.py
+++ b/arkane/input.py
@@ -186,6 +186,8 @@ def species(label, *args, **kwargs):
                 raise TypeError('species() got an unexpected keyword argument {0!r}.'.format(key))
 
         if structure:
+            if spin_multiplicity:
+                structure.multiplicity = spin_multiplicity
             spec.molecule = [structure]
         spec.conformer = Conformer(E0=E0, modes=modes, spin_multiplicity=spin_multiplicity,
                                    optical_isomers=optical_isomers)


### PR DESCRIPTION
### Motivation or Problem
Running thermo in the same ARC/Arkane job for [CH2]CCO[CH2] singlet and [CH2]CCO[CH2] triplet failed with:

```
rmgpy.exceptions.DatabaseError: Adjacency list and multiplicity of [CH2]CCO[CH2][T] matches that of existing molecule [CH2]CCO[CH2][S] in thermo library thermo. Please correct your library.
```

despite defining the multiplicity correctly in the respective Arkane main ouput and in the species .py files.

For example, this input file results in the above error:

```
modelChemistry = LevelOfTheory(method='ccsd(t)f12',basis='ccpvtzf12',software='molpro')

frequencyScaleFactor = 0.988
useHinderedRotors = True
useAtomCorrections = True
useBondCorrections = True
bondCorrectionType = 'p'

species('[CH2]CCO[CH2][S]', '[CH2]CCO[CH2][S].py', structure=SMILES('[CH2]CCO[CH2]'), spinMultiplicity=1)
species('[CH2]CCO[CH2][T]', '[CH2]CCO[CH2][T].py', structure=SMILES('[CH2]CCO[CH2]'), spinMultiplicity=3)

thermo('[CH2]CCO[CH2][S]', 'NASA')
thermo('[CH2]CCO[CH2][T]', 'NASA')
```


### Description of Changes
We now load the reserved keyword `spinMultiplicity` in the Arkane input file into the created molecule object.


### Testing
Run the following ARC job before and after this implementaiton:

``` yaml
project: test_arkane_s_t

level_of_theory: CCSD(T)-F12/cc-pVTZ-F12//wb97xd/def2tzvp

species:
  - label: '[CH2]CCO[CH2](S)'
    smiles: '[CH2]CCO[CH2]'
    multiplicity: 1
    number_of_radicals: 2
  - label: '[CH2]CCO[CH2](T)'
    smiles: '[CH2]CCO[CH2]'
    multiplicity: 3
    number_of_radicals: 2
    
```
