### PR TITLE
Tweaking install_rms for Github Actions

### DIFF
--- a/install_rms.sh
+++ b/install_rms.sh
@@ -62,7 +62,7 @@ env | grep JULIA
 RMS_BRANCH=${RMS_BRANCH:-for_rmg}
 echo "Installing ReactionMechanismSimulator from branch: $RMS_BRANCH"
 
-julia -e "using Pkg; Pkg.add(Pkg.PackageSpec(name=\"ReactionMechanismSimulator\", url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl.git\", rev=\"$RMS_BRANCH\")); using ReactionMechanismSimulator; Pkg.instantiate()" || echo "RMS install error - continuing anyway ¯\_(ツ)_/¯"
+julia -e "using Pkg; Pkg.add(Pkg.PackageSpec(name=\"ReactionMechanismSimulator\", url=\"https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl.git\", rev=\"$RMS_BRANCH\")); using ReactionMechanismSimulator; println(read(joinpath(dirname(pathof(ReactionMechanismSimulator)), \"..\", \"Project.toml\"), String)); Pkg.instantiate()" || echo "RMS install error - continuing anyway."
 
 echo "Checking if ReactionMechanismSimulator is installed in the current conda environment for Python usage..."
 python -c "from juliacall import Main; import sys; sys.exit(0 if Main.seval('Base.identify_package(\"ReactionMechanismSimulator\") !== nothing') and print('ReactionMechanismSimulator is installed in $current_env') is None else 1)"


### PR DESCRIPTION
### Motivation or Problem
As descripbed in https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2861
We need to restrict PythonCall to 0.9.28
https://github.com/JuliaPy/PythonCall.jl/releases

### Description of Changes
I updated the Project.toml on the `for_rmg` branch of RMS
https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/commit/7b4fc4ff1d0f15f20186d8d62be870efef24c08a

This PR on RMG-Py is partly to test that fix.

But it also fixes another problem that crept into `install_rms` due to how conda now lists environments.

### Testing
The whole point is to get the CI to work.
But I did run the new install_rms.sh locally, and it _seemed_ to work.

### Reviewer Tips
Check the CI logs

