### PR TITLE
Fix regression tests coming back from the dead.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -239,13 +239,14 @@ jobs:
 
       # Retrieve Stable Results for reference
       - name: Find ID of Reference Results
+        if: ${{ env.REFERENCE_JOB == 'false' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # this will search for the last successful execution of CI on main
         run: |
-          run_id=$(gh run list -R ReactionMechanismGenerator/RMG-Py --workflow="Continuous Integration" --branch main --limit 15 --json databaseId,conclusion --jq 'map(select(.conclusion == "success")) | .[0].databaseId')
+          run_id=$(gh run list -R ReactionMechanismGenerator/RMG-Py --workflow="Continuous Integration" --branch main --limit 60 --json databaseId,conclusion --jq 'map(select(.conclusion == "success")) | .[0].databaseId')
           if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
-            echo "::error::No successful reference run found"
+            echo "::error::No successful reference run found in last 60 runs."
             exit 1
           fi
           echo "CI_RUN_ID=$run_id" >> $GITHUB_ENV


### PR DESCRIPTION
### Motivation or Problem
If it had been more than 15 runs (approx 15 days) since the last succesful baseline reference job, then all regression tests would fail. Furthermore, even the baseline reference job, would fail, making it impossible to get started again.

### Description of Changes
Now, it checks the last 60 runs instead of the last 15, and it doesn't bother checking if you're running a reference job - so we should be able to resume even if there are no succesful results in the past.

### Testing
Hopefully the proof is in the pudding.
