### PR TITLE
Update CI to use new macOS runner images

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,10 +64,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
-        os: [macos-13, macos-latest, ubuntu-latest]
+        os: [macos-15-intel, macos-latest, ubuntu-latest]
         include-rms: ["", "with RMS"]
         exclude:
-          - os: macos-13  # GitHub's runners just aren't up to the task of installing Julia
+          - os: macos-15-intel  # GitHub's runners just aren't up to the task of installing Julia
             include-rms: 'with RMS'
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} ${{ matrix.os }} Build and Test ${{ matrix.include-rms }}

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
         numpy-version: ["1.26"]
         python-version: ["3.9"]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
As of December, the macOS 13 runner image is deprecated (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) 

This PR just switches `macos-13` with `macos-15-intel` so that we still have a test for the Intel architecture.