### PR TITLE
Replace deprecated imp.load_source call

### DIFF
--- a/rmgpy/data/kinetics/database.py
+++ b/rmgpy/data/kinetics/database.py
@@ -142,6 +142,7 @@ class KineticsDatabase(object):
 
         # Load the recommended.py file as a module
         try:
+            # https://docs.python.org/3/whatsnew/3.12.html#imp
             loader = importlib.machinery.SourceFileLoader('rec', filepath)
             spec = importlib.util.spec_from_file_location('rec', filepath, loader=loader)
             rec = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
imp is deprecated and is getting removed in Python 3.12. documentation here shows the official suggestion for replacing imp.load_source calls: https://docs.python.org/3/whatsnew/3.12.html#imp

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Tiny PR to replace deprecated call to imp.load_source

### Description of Changes
Changes adopted from official documentation:

https://docs.python.org/3/whatsnew/3.12.html#imp
```
import importlib.util
import importlib.machinery

def load_source(modname, filename):
    loader = importlib.machinery.SourceFileLoader(modname, filename)
    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
    module = importlib.util.module_from_spec(spec)
    # The module is always executed and not cached in sys.modules.
    # Uncomment the following line to cache the module.
    # sys.modules[module.__name__] = module
    loader.exec_module(module)
    return module
```

### Testing
Should be good to go as long as the CI tests pass. All the code is responsible for is loading the recommended families.