### PR TITLE
added full path to hessian search in orca adapter.

### DIFF
--- a/arkane/ess/orca.py
+++ b/arkane/ess/orca.py
@@ -116,7 +116,7 @@ class OrcaLog(ESSAdapter):
         for (_, _, files) in os.walk(os.path.dirname(self.path)):
             for file_ in files:
                 if file_.endswith('.hess'):
-                    hess_files.append(file_)
+                    hess_files.append(os.path.join(os.path.dirname(self.path), file_))
             break
         if len(hess_files) == 1:
             hess_file = hess_files[0]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Before the variable `hess_file` had only the name of the hessian file, without the full path.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
