### PR TITLE
Imports Species class locally for diffusion_limited_rate function 

### DIFF
--- a/rmgpy/kinetics/diffusionLimited.py
+++ b/rmgpy/kinetics/diffusionLimited.py
@@ -34,7 +34,6 @@ import numpy as np
 
 import rmgpy.constants as constants
 from rmgpy.molecule.fragment import Fragment
-from rmgpy.species import Species
 
 def _to_molecule(obj):
     """Return plain Molecule; accept Molecule or (Molecule, mapping) tuple."""
@@ -113,6 +112,8 @@ class DiffusionLimited(object):
         (ie. forward direction if forward=True [default] or reverse if forward=False)
         Returns the rate coefficient k_diff in m3/mol/s.
         """
+        from rmgpy.species import Species
+
         if forward:
             reacting = reaction.reactants
         else:


### PR DESCRIPTION
Moves the import of the `Species` class to be local to the diffusion_limited_rate` function. This avoids a circular import issue as mentioned here: https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2865

This is a quick fix for the issue when a user attempts to use the sensitivity analysis
