### PR TITLE
Specify initial core species using external dictionary

### DIFF
--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -322,6 +322,14 @@ The following is an example of a typical species item, based on methane using SM
 			"""
 	)
 
+For long lists of initial core species, you can specify a coreSpeciesList, shown below::
+
+    coreSpeciesList(
+        species_dictionary_file="path/to/your/species_dictionary.txt"
+    )
+
+This specifies the path for an RMG-formatted :ref:`species dictionary <the_chemkin_folder>` from which additional species will be loaded. Note that RMG will complain if any species in the input file is duplicated in the species dictionary.
+
 .. _forbidden_structures:
 
 Forbidden Structures

--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -328,7 +328,7 @@ For long lists of initial core species, you can specify a coreSpeciesList, shown
         species_dictionary_file="path/to/your/species_dictionary.txt"
     )
 
-This specifies the path for an RMG-formatted :ref:`species dictionary <the_chemkin_folder>` from which additional species will be loaded. Note that RMG will complain if any species in the input file is duplicated in the species dictionary.
+This specifies the path for an RMG-formatted :ref:`species dictionary <the_chemkin_folder>` from which additional species will be loaded. Note that RMG will complain if any species in the input file is duplicated in the species dictionary. All species are assumed to be reactive.
 
 .. _forbidden_structures:
 

--- a/documentation/source/users/rmg/output.rst
+++ b/documentation/source/users/rmg/output.rst
@@ -17,6 +17,9 @@ You will see that a sucessfully executed RMG job will create multiple output fil
 ``/species``
 ``RMG.log``
 
+
+.. _the_chemkin_folder:
+
 ------------------
 The Chemkin Folder
 ------------------ 

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -40,6 +40,7 @@ from rmgpy.data.surface import MetalDatabase
 from rmgpy.data.vaporLiquidMassTransfer import (
     liquidVolumetricMassTransferCoefficientPowerLaw,
 )
+from rmgpy.chemkin import load_species_dictionary
 from rmgpy.exceptions import DatabaseError, InputError
 from rmgpy.molecule import Molecule
 from rmgpy.molecule.fragment import Fragment
@@ -232,6 +233,15 @@ def convert_binding_energies(binding_energies):
             logging.error('Element {} missing from binding energies dictionary'.format(element))
             raise
     return new_dict
+
+
+def core_species_file(species_dictionary_file):
+    # all species here are assumed to be reactive
+    new_species_dict = load_species_dictionary(species_dictionary_file)
+    for key in new_species_dict:
+        label = new_species_dict[key].label
+        structure = new_species_dict[key].molecule[0]
+        species(label, structure, reactive=True, cut=False, size_threshold=None)
 
 
 def species(label, structure, reactive=True, cut=False, size_threshold=None):
@@ -1670,6 +1680,7 @@ def read_input_file(path, rmg0):
         'False': False,
         'database': database,
         'catalystProperties': catalyst_properties,
+        'coreSpeciesFile': core_species_file,
         'species': species,
         'forbidden': forbidden,
         'SMARTS': smarts,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Sometimes you want to start RMG with a list of core species that's too long to easily fit inside an input file. This PR allows you to specify an external species dictionary from which to load all your starting core species.

### Description of Changes
This adds the `coreSpeciesFile` option to input files, where you can specify an external species dictionary from which to read more species.

Then the block you'd put in the input file looks something like this:
```
coreSpeciesFile(
    species_dictionary_file="species_dictionary.txt"
)
```

### Testing
I ran this with a small species dictionary and the superminimal input file and it added in the additional species.
[input.txt](https://github.com/user-attachments/files/25722553/input.txt)
[species_dictionary.txt](https://github.com/user-attachments/files/25722554/species_dictionary.txt)

Then I commented out the coreSpeciesFile option and it didn't add the species in species_dictionary.txt

I built the new documentation on my local computer and it looks okay.

### Reviewer Tips
¯\_(ツ)_/¯

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
