### PR TITLE
Delete unreachable code in _make_rule

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4670,69 +4670,6 @@ def _make_rule(rr):
     else:
         return None
 
-    if isinstance(rs[0].kinetics, Arrhenius):
-        arr = ArrheniusBM
-    else:
-        arr = ArrheniusChargeTransferBM
-    if n > 1:
-        kin = arr().fit_to_reactions(rs, recipe=recipe)
-    if n == 1 or kin.E0.value_si < 0.0:
-        # still run it through the averaging function when n=1 to standardize the units and run checks
-        kin = average_kinetics([r.kinetics for r in rs])
-        if n == 1:
-            kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
-            kin.comment = f"Only one reaction rate: {rs[0]!s}"
-        else:
-            kin.comment = f"Blowers-Masel fit was bad (E0<0) so instead averaged from {n} reactions."
-            dlnks = np.array([
-                np.log(
-                        average_kinetics([r.kinetics for r in rs[list(set(range(len(rs))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
-                    ) for i, rxn in enumerate(rs)
-                ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
-            # weighted average calculations
-            ws = 1.0 / varis
-            V1 = ws.sum()
-            V2 = (ws ** 2).sum()
-            mu = np.dot(ws, dlnks) / V1
-            s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
-            kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
-    else: # Blowers-Masel fit was good
-        if isinstance(rs[0].kinetics, Arrhenius):
-            dlnks = np.array([
-                np.log(
-                    arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
-                    .to_arrhenius(rxn.get_enthalpy_of_reaction(298.))
-                    .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
-                ) for i, rxn in enumerate(rs)
-            ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-        else: # SurfaceChargeTransfer or ArrheniusChargeTransfer
-            dlnks = np.array([
-                np.log(
-                    arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
-                    .to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(298.))
-                    .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
-                ) for i, rxn in enumerate(rs)
-            ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-        varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
-        # weighted average calculations
-        ws = 1.0 / varis
-        V1 = ws.sum()
-        V2 = (ws ** 2).sum()
-        mu = np.dot(ws, dlnks) / V1
-        s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
-        kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
-
-    #site solute parameters
-    site_datas = [get_site_solute_data(rxn) for rxn in rxns]
-    site_datas = [sdata for sdata in site_datas if sdata is not None]
-    if len(site_datas) > 0:
-        site_data = SoluteTSData()
-        for sdata in site_datas:
-            site_data += sdata
-        site_data = site_data * (1.0/len(site_datas))
-        kin.solute = site_data
-    return kin
 
 def _spawn_tree_process(family, template_rxn_map, obj, T, nprocs, depth, min_splitable_entry_num, min_rxns_to_spawn, extension_iter_max, extension_iter_item_cap):
     parent_conn, child_conn = mp.Pipe()


### PR DESCRIPTION
There's some unreachable code in _make_rule that looks like it shouldn't have been included in the first place. Deleting it will help avoid confusion for future developers.

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2892

### Description of Changes
This deletes unreachable code.

### Testing
~~The code is already unreachable, so this PR should have no effect on execution. We can check the CI test to be sure.~~

Scratch that. This is actually one of those cases where I think the CI tests won't necessarily catch a problem. I should try generating a family to make sure it yields the same results as before:

As a test, I regenerated the Birad_recombination family before and after this PR and verified that it gives me identical results (which were different from what's stored in RMG-database because that hasn't been updated in a while), so everything appears to be in working order.