### PR TITLE
Fix flux diagram naming of species images

### DIFF
--- a/rmgpy/tools/fluxdiagram.py
+++ b/rmgpy/tools/fluxdiagram.py
@@ -208,7 +208,7 @@ def generate_flux_diagram(reaction_model, times, concentrations, reaction_rates,
             continue
         for root, dirs, files in os.walk(species_directory):
             for f in files:
-                if f.endswith(species_index):
+                if f == species_index:
                     image_path = os.path.join(root, f)
                     break
         if os.path.exists(image_path):


### PR DESCRIPTION
There can be multiple species that end the same way, so using endswith is not guaranteed to get you the right images. This change makes sure the flux diagrams will map the correct species image onto the flux diagram.

### Motivation or Problem
The flux diagram tool sometimes grabs the wrong image for a species. See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2904

The problem is that it's relying on the filename ending the same as the species name, instead of matching exactly. In the above example, you get RMG using the image of C4H71-O2 for O2.


### Description of Changes
Instead of searching for a file name by checking that it ends with the right key, it now forces the file name to match exactly.

### Testing
I tested this using the example in [ReactionMechanismGenerator/RMG-Py/issues/2904 ](https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2904)

The bad "before" image is shown in the bug, and the fixed "after" image is shown below. You can see O2 is now displaying properly.
<img width="1200" height="1209" alt="flux_diagram_0001" src="https://github.com/user-attachments/assets/5b61b8f8-d43a-471e-8ab1-15119cd17044" />


~~I will also test this for the case of nested directories. If you put the O2 image inside another folder, does it still work?~~
Yes. I tested and this works fine.