### PR TITLE
Change orthonormalization when projecting out rotors in Arkane

### DIFF
--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1092,39 +1092,33 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
             d[3 * i + 2, 5] = (p[i, 0] * inertia_xyz[2, 1] - p[i, 1] * inertia_xyz[2, 0]) * amass[i]
 
     # Make sure projection matrix is orthonormal
-    identity = np.identity(n_atoms * 3, float)
-    p = np.zeros((n_atoms * 3, 3 * n_atoms + external), float)
-    p[:, 0:external] = d[:, 0:external]
-    p[:, external:external + 3 * n_atoms] = identity[:, 0:3 * n_atoms]
+    p = np.hstack((d, np.identity(n_atoms * 3, float)))
 
-    # modified Gram–Schmidt orthonormalization
-    for i in range(3 * n_atoms + external):
-        norm = 0.0
-        for j in range(3 * n_atoms):
-            norm += p[j, i] * p[j, i]
-        for j in range(3 * n_atoms):
-            if norm > 1E-15:
-                p[j, i] /= np.sqrt(norm)
-            else:
-                p[j, i] = 0.0  # zeroing out vectors that are nearly zero or dependent, could lose a basis
-        for j in range(i + 1, 3 * n_atoms + external):
-            proj = 0.0
-            for k in range(3 * n_atoms):
-                proj += p[k, i] * p[k, j]
-            for k in range(3 * n_atoms):
-                p[k, j] -= proj * p[k, i]
+    # Compute the QR decomposition in reduced mode
+    Q, R = np.linalg.qr(p, mode='reduced')
 
-    # Order p, since there will be vectors that are 0.0
-    i = 0
-    is_zero_column = (p*p).sum(axis=0) < 0.5
-    # put the columns that are zeros at the end
-    temporary = np.hstack((p[:, ~is_zero_column], p[:, is_zero_column]))
-    p[:, :] = temporary
+    # Verify that Q has orthonormal columns:
+    if np.isclose(np.dot(Q.T, Q), np.eye(Q.shape[1])).all():
+        logging.debug("Q has orthonormal columns")
+    else:
+        logging.warning("Q does not have orthonormal columns")
+    # Verify the reconstruction
+    reconstructed_p = Q @ R
+    if np.isclose(p, reconstructed_p).all():
+        logging.debug("Reconstruction of projection matrix is correct")
+    else:
+        logging.warning("Reconstruction of projection matrix is incorrect")
+
+    # Check for nearly zero columns in the QR decomposition
+    for i, rkk in enumerate(R.diagonal()):
+        if abs(rkk) < 1E-15:
+            logging.warning(f'Column {i} of the QR decomposition is nearly zero, could lose a basis')
+
 
     # T is the transformation vector from cartesian to internal coordinates
     T = np.zeros((n_atoms * 3, 3 * n_atoms - external), float)
 
-    T[:, 0:3 * n_atoms - external] = p[:, external:3 * n_atoms]
+    T[:, :] = Q[:, external:3 * n_atoms]
 
     # Generate mass-weighted force constant matrix
     # This converts the axes to mass-weighted Cartesian axes

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1092,13 +1092,10 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
             d[3 * i + 2, 5] = (p[i, 0] * inertia_xyz[2, 1] - p[i, 1] * inertia_xyz[2, 0]) * amass[i]
 
     # Make sure projection matrix is orthonormal
-
-    inertia = np.identity(n_atoms * 3, float)
-
+    identity = np.identity(n_atoms * 3, float)
     p = np.zeros((n_atoms * 3, 3 * n_atoms + external), float)
-
     p[:, 0:external] = d[:, 0:external]
-    p[:, external:external + 3 * n_atoms] = inertia[:, 0:3 * n_atoms]
+    p[:, external:external + 3 * n_atoms] = identity[:, 0:3 * n_atoms]
 
     for i in range(3 * n_atoms + external):
         norm = 0.0
@@ -1248,8 +1245,8 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
     # Do the projection
     d_int_proj = np.dot(vmw.T, d_int)
     proj = np.dot(d_int, d_int.T)
-    inertia = np.identity(n_atoms * 3, float)
-    proj = inertia - proj
+    identity = np.identity(n_atoms * 3, float)
+    proj = identity - proj
     fm = np.dot(proj, np.dot(fm, proj))
     # Get eigenvalues of mass-weighted force constant matrix
     eig, v = np.linalg.eigh(fm)

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1115,14 +1115,10 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
 
     # Order p, there will be vectors that are 0.0
     i = 0
-    while i < 3 * n_atoms:
-        norm = 0.0
-        for j in range(3 * n_atoms):
-            norm += p[j, i] * p[j, i]
-        if norm < 0.5:
-            p[:, i:3 * n_atoms + external - 1] = p[:, i + 1:3 * n_atoms + external]
-        else:
-            i += 1
+    is_zero_column = (p*p).sum(axis=0) < 0.5
+    # put the columns that are zeros at the end
+    temporary = np.hstack((p[:, ~is_zero_column], p[:, is_zero_column]))
+    p[:, :] = temporary
 
     # T is the transformation vector from cartesian to internal coordinates
     T = np.zeros((n_atoms * 3, 3 * n_atoms - external), float)

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1097,6 +1097,7 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
     p[:, 0:external] = d[:, 0:external]
     p[:, external:external + 3 * n_atoms] = identity[:, 0:3 * n_atoms]
 
+    # modified Gram–Schmidt orthonormalization
     for i in range(3 * n_atoms + external):
         norm = 0.0
         for j in range(3 * n_atoms):
@@ -1105,7 +1106,7 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
             if norm > 1E-15:
                 p[j, i] /= np.sqrt(norm)
             else:
-                p[j, i] = 0.0
+                p[j, i] = 0.0  # zeroing out vectors that are nearly zero or dependent, could lose a basis
         for j in range(i + 1, 3 * n_atoms + external):
             proj = 0.0
             for k in range(3 * n_atoms):
@@ -1113,7 +1114,7 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
             for k in range(3 * n_atoms):
                 p[k, j] -= proj * p[k, i]
 
-    # Order p, there will be vectors that are 0.0
+    # Order p, since there will be vectors that are 0.0
     i = 0
     is_zero_column = (p*p).sum(axis=0) < 0.5
     # put the columns that are zeros at the end

--- a/arkane/statmech.py
+++ b/arkane/statmech.py
@@ -1212,23 +1212,19 @@ def project_rotors(conformer, hessian, rotors, linear, is_ts, get_projected_out_
                 d_int[j, i] += d_int_proj[k, i] * vmw[j, k]
 
     # Ortho normalize
-    for i in range(n_rotors):
-        norm = 0.0
-        for j in range(3 * n_atoms):
-            norm += d_int[j, i] * d_int[j, i]
-        for j in range(3 * n_atoms):
-            d_int[j, i] /= np.sqrt(norm)
-        for j in range(i + 1, n_rotors):
-            proj = 0.0
-            for k in range(3 * n_atoms):
-                proj += d_int[k, i] * d_int[k, j]
-            for k in range(3 * n_atoms):
-                d_int[k, j] -= proj * d_int[k, i]
+    # Here, Q will have orthonormal columns, and R is the triangular factor.
+    Q, R = np.linalg.qr(d_int, mode='reduced')
+    # replace d_int with its orthonormalized version:
+    d_int = Q
 
     # calculate the frequencies corresponding to the internal rotors
     int_proj = np.dot(fm, d_int)
     kmus = np.array([np.linalg.norm(int_proj[:, i]) for i in range(int_proj.shape[1])])
     int_rotor_freqs = np.sqrt(kmus) / (2.0 * math.pi * constants.c * 100.0)
+
+    logging.debug('Frequencies from internal rotors:')
+    for i in range(n_rotors):
+        logging.debug('  rotor %d: %.6f cm^-1', i, int_rotor_freqs[i])
 
     if get_projected_out_freqs:
         return int_rotor_freqs


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem


When trying to project out rotors, Arkane would sometimes have major numerical issues and give very poor results.
These changes were made while trying to debug that issue - I switched to a more robust method for orthonormalization, and added some diagnostic defensive checks that would detect zero diagonal elements.

See discussion in https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2757 (specifically https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2757#issuecomment-2641982070 and  https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2757#issuecomment-2642015292 )

It turned out to have a different solution (ensuring Gaussian uses the same coordinate system for the Hessian matrix as the geometry, which is checked for in https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2758 ) but the changes here are nevertheless probably improvements.

### Description of Changes
This pull request refactors the `project_rotors` function in `arkane/statmech.py` to modernize and simplify the orthonormalization and projection logic by replacing manual Gram-Schmidt procedures with NumPy's QR decomposition. It also adds extensive logging for debugging matrix orthogonality and projection accuracy. 
The most important changes are:

**Refactoring and Modernization:**

* Replaced manual Gram-Schmidt orthonormalization of projection and internal rotor matrices with NumPy's `np.linalg.qr`, streamlining the code and improving numerical stability. (`arkane/statmech.py` [[1]](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dR1101-R1127) [[2]](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dL1213-R1242)
* Updated the construction of the transformation matrix `T` to use the orthonormalized basis from QR decomposition instead of manually normalized vectors. (`arkane/statmech.py` [arkane/statmech.pyR1101-R1127](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dR1101-R1127))

**Debugging and Logging Enhancements:**

* Added detailed logging to verify that the QR decomposition yields orthonormal columns and that the projection matrix can be accurately reconstructed, including warnings for nearly zero diagonal elements in `R` (potentially indicating loss of basis vectors). (`arkane/statmech.py` [[1]](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dR1067-R1086) [[2]](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dR1101-R1127)
* Added debug output for computed internal rotor frequencies to aid in diagnostics. (`arkane/statmech.py` [arkane/statmech.pyL1213-R1242](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dL1213-R1242))

**Minor Corrections:**

* Fixed a variable name from `inertia` to `identity` for clarity when constructing the identity matrix for projection. (`arkane/statmech.py` [arkane/statmech.pyL1213-R1242](diffhunk://#diff-a0fcdb10553197e41dffa54ffa1a1b78cc8214548f6bdce3dadef1ec797e9a8dL1213-R1242))


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
