### PR TITLE
export RMS_BRANCH so var exists inside Julia

### DIFF
--- a/install_rms.sh
+++ b/install_rms.sh
@@ -21,7 +21,7 @@
 RMS_INSTALLER=${RMS_INSTALLER:-standard}
 
 # RMS branch for standard or continuous installs. Set to "for_rmg" by default.
-RMS_BRANCH=${RMS_BRANCH:-for_rmg}
+export RMS_BRANCH=${RMS_BRANCH:-for_rmg}
 
 # Get local RMS path if in developer mode
 if [ "$RMS_INSTALLER" = "developer" ]; then

--- a/install_rms.sh
+++ b/install_rms.sh
@@ -37,6 +37,7 @@ if [ "$RMS_INSTALLER" = "developer" ]; then
         echo "Please set RMS_PATH to a valid ReactionMechanismSimulator.jl directory."
         return 1
     fi
+    export RMS_PATH
     echo "Using local RMS path: $RMS_PATH"
 fi
 


### PR DESCRIPTION
The environment variable RMS_BRANCH is not get passed into Julia for my "standard" installer, and so the Pkg.Add line for RMS fails with a KeyError because it's looking for a variable that wasn't exported into the new environment. This exports the variable so when you start Julia you still have it.

<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Running `source install_rms.sh` fails because the `RMS_BRANCH` isn't properly exported. See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2915

### Description of Changes
This exports the RMS_BRANCH variable

### Testing
Before this commit, the installer failed due to the Key Error. After this commit, I was able to install RMS using `source install_rms.sh`

~~I'll feel more comfortable merging this when I (or someone else) can answer the question of why this failed using the "standard" installer on my machine but works okay for "continuous" installation in Github Actions.~~

Aha! Github Actions sets the environment variable before running `source install_rms.sh`. That's what's different from the "standard" installer on my machine

https://github.com/ReactionMechanismGenerator/RMG-Py/blob/a35dd78317f75380de286ff25217885a247155df/.github/workflows/CI.yml#L37-L46