### PR TITLE
Blowers-Masel fitting: changes and refactoring

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4596,13 +4596,16 @@ def _make_rule(rr):
     for i, rxn in enumerate(rxns):
         rxn.rank = ranks[i]
     rxns = np.array(rxns)
-    rs = np.array([r for r in rxns if type(r.kinetics) != KineticsModel])
+    rs = np.array([r for r in rxns if type(r.kinetics) is not KineticsModel]) # KineticsModel is the base class with no data.
     n = len(rs)
-    if n > 0 and isinstance(rs[0].kinetics, Marcus):
+    if n == 0:
+        return None
+
+    if isinstance(rs[0].kinetics, Marcus):
         kin = average_kinetics([r.kinetics for r in rs])
         return kin
     data_mean = np.mean(np.log([r.kinetics.get_rate_coefficient(Tref) for r in rs]))
-    if n > 0:
+    if n > 0: # not needed. at this point n should always be > 0
         if isinstance(rs[0].kinetics, Arrhenius):
             arr = ArrheniusBM
         else:
@@ -4772,7 +4775,7 @@ def average_kinetics(kinetics_list):
             beta=(beta,"1/m"),
             wr=(wr * 0.001, "kJ/mol"),
             wp=(wp * 0.001, "kJ/mol"),
-            comment="Averaged from {} reactions.".format(len(kinetics_list)),
+            comment=f"Averaged from {len(kinetics_list)} rate expressions.",
             )
     elif isinstance(kinetics, SurfaceChargeTransfer):
         averaged_kinetics = SurfaceChargeTransfer(
@@ -4782,6 +4785,7 @@ def average_kinetics(kinetics_list):
             alpha=alpha,
             V0=(V0,'V'),
             Ea=(Ea * 0.001, "kJ/mol"),
+            comment=f"Averaged from {len(kinetics_list)} rate expressions.",
             )
     elif isinstance(kinetics, ArrheniusChargeTransfer):
         averaged_kinetics = ArrheniusChargeTransfer(
@@ -4791,6 +4795,7 @@ def average_kinetics(kinetics_list):
             alpha=alpha,
             V0=(V0,'V'),
             Ea=(Ea * 0.001, "kJ/mol"),
+            comment=f"Averaged from {len(kinetics_list)} rate expressions.",
             )
     else:
         averaged_kinetics = Arrhenius(

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4605,73 +4605,72 @@ def _make_rule(rr):
         kin = average_kinetics([r.kinetics for r in rs])
         return kin
     data_mean = np.mean(np.log([r.kinetics.get_rate_coefficient(Tref) for r in rs]))
-    if n > 0: # not needed. at this point n should always be > 0
-        if isinstance(rs[0].kinetics, Arrhenius):
-            arr = ArrheniusBM
+
+    if isinstance(rs[0].kinetics, Arrhenius):
+        arr = ArrheniusBM
+    else:
+        arr = ArrheniusChargeTransferBM
+    if n > 1:
+        kin = arr().fit_to_reactions(rs, recipe=recipe)
+    if n == 1 or kin.E0.value_si < 0.0:
+        kin = average_kinetics([r.kinetics for r in rs])
+        #kin.comment = "Only one reaction or Arrhenius BM fit bad. Instead averaged from {} reactions.".format(n)
+        if n == 1:
+            kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
         else:
-            arr = ArrheniusChargeTransferBM
-        if n > 1:
-            kin = arr().fit_to_reactions(rs, recipe=recipe)
-        if n == 1 or kin.E0.value_si < 0.0:
-            kin = average_kinetics([r.kinetics for r in rs])
-            #kin.comment = "Only one reaction or Arrhenius BM fit bad. Instead averaged from {} reactions.".format(n)
-            if n == 1:
-                kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
+            dlnks = np.array([
+                np.log(
+                        average_kinetics([r.kinetics for r in rs[list(set(range(len(rs))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
+                    ) for i, rxn in enumerate(rs)
+                ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
+            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
+            # weighted average calculations
+            ws = 1.0 / varis
+            V1 = ws.sum()
+            V2 = (ws ** 2).sum()
+            mu = np.dot(ws, dlnks) / V1
+            s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
+            kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
+    else:
+        if n == 1:
+            kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
+        else:
+            if isinstance(rs[0].kinetics, Arrhenius):
+                dlnks = np.array([
+                    np.log(
+                        arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
+                .to_arrhenius(rxn.get_enthalpy_of_reaction(Tref))
+                .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
+            ) for i, rxn in enumerate(rs)
+        ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
             else:
                 dlnks = np.array([
                     np.log(
-                            average_kinetics([r.kinetics for r in rs[list(set(range(len(rs))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
-                        ) for i, rxn in enumerate(rs)
-                    ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-                varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
-                # weighted average calculations
-                ws = 1.0 / varis
-                V1 = ws.sum()
-                V2 = (ws ** 2).sum()
-                mu = np.dot(ws, dlnks) / V1
-                s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
-                kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
-        else:
-            if n == 1:
-                kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
-            else:
-                if isinstance(rs[0].kinetics, Arrhenius):
-                    dlnks = np.array([
-                        np.log(
-                            arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
-                    .to_arrhenius(rxn.get_enthalpy_of_reaction(Tref))
-                    .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
-                ) for i, rxn in enumerate(rs)
-            ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-                else:
-                    dlnks = np.array([
-                        np.log(
-                            arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
-                            .to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(Tref))
-                            .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
-                        ) for i, rxn in enumerate(rs)
-                    ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-                varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
-                # weighted average calculations
-                ws = 1.0 / varis
-                V1 = ws.sum()
-                V2 = (ws ** 2).sum()
-                mu = np.dot(ws, dlnks) / V1
-                s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
-                kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
-        
-        #site solute parameters
-        site_datas = [get_site_solute_data(rxn) for rxn in rxns]
-        site_datas = [sdata for sdata in site_datas if sdata is not None]
-        if len(site_datas) > 0:
-            site_data = SoluteTSData()
-            for sdata in site_datas:
-                site_data += sdata
-            site_data = site_data * (1.0/len(site_datas))
-            kin.solute = site_data
-        return kin
-    else:
-        return None
+                        arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
+                        .to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(Tref))
+                        .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
+                    ) for i, rxn in enumerate(rs)
+                ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
+            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
+            # weighted average calculations
+            ws = 1.0 / varis
+            V1 = ws.sum()
+            V2 = (ws ** 2).sum()
+            mu = np.dot(ws, dlnks) / V1
+            s = np.sqrt(np.dot(ws, (dlnks - mu) ** 2) / (V1 - V2 / V1))
+            kin.uncertainty = RateUncertainty(mu=mu, var=s ** 2, N=n, Tref=Tref, data_mean=data_mean, correlation=label)
+    
+    #site solute parameters
+    site_datas = [get_site_solute_data(rxn) for rxn in rxns]
+    site_datas = [sdata for sdata in site_datas if sdata is not None]
+    if len(site_datas) > 0:
+        site_data = SoluteTSData()
+        for sdata in site_datas:
+            site_data += sdata
+        site_data = site_data * (1.0/len(site_datas))
+        kin.solute = site_data
+    return kin
+
 
 
 def _spawn_tree_process(family, template_rxn_map, obj, T, nprocs, depth, min_splitable_entry_num, min_rxns_to_spawn, extension_iter_max, extension_iter_item_cap):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4613,18 +4613,23 @@ def _make_rule(rr):
     if n > 1:
         kin = arr().fit_to_reactions(rs, recipe=recipe)
     if n == 1 or kin.E0.value_si < 0.0 or abs(kin.n.value_si) > 5.0:
-        # still run it through the averaging function when n=1 to standardize the units and run checks
-        kin = average_kinetics([r.kinetics for r in rs])
-        #kin.comment = "Only one reaction or Arrhenius BM fit bad. Instead averaged from {} reactions.".format(n)
-        if n == 1:
-            kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
-        else:
+        
+        if n > 1: #we have an ArrheniusBM
             if kin.E0.value_si < 0.0:
                 reason = "E0<0"
             elif abs(kin.n.value_si) > 5.0:
                 reason = "abs(n)>5"
             else:
                 reason = "?"
+        
+        # still run it through the averaging function when n=1 to standardize the units and run checks
+        kin = average_kinetics([r.kinetics for r in rs])
+        
+        if n == 1:
+
+            kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
+        else:
+            
             kin.comment = f"Blowers-Masel fit was bad ({reason}) so instead averaged from {n} reactions."
             dlnks = np.array([
                 np.log(

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4631,7 +4631,7 @@ def _make_rule(rr):
                         average_kinetics([r.kinetics for r in rs[list(set(range(len(rs))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
                     ) for i, rxn in enumerate(rs)
                 ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
+            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * constants.R * Tref)) ** 2
             # weighted average calculations
             ws = 1.0 / varis
             V1 = ws.sum()
@@ -4659,7 +4659,7 @@ def _make_rule(rr):
                         .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
                     ) for i, rxn in enumerate(rs)
                 ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
-            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * 8.314 * Tref)) ** 2
+            varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * constants.R * Tref)) ** 2
             # weighted average calculations
             ws = 1.0 / varis
             V1 = ws.sum()

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4628,7 +4628,7 @@ def _make_rule(rr):
             kin.comment = f"Blowers-Masel fit was bad ({reason}) so instead averaged from {n} reactions."
             dlnks = np.array([
                 np.log(
-                        average_kinetics([r.kinetics for r in rs[list(set(range(len(rs))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
+                        average_kinetics([r.kinetics for r in np.delete(rs, i)]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
                     ) for i, rxn in enumerate(rs)
                 ])  # 1) fit to set of reactions without the current reaction (k)  2) compute log(kfit/kactual) at Tref
             varis = (np.array([rank_accuracy_map[rxn.rank].value_si for rxn in rs]) / (2.0 * constants.R * Tref)) ** 2
@@ -4646,7 +4646,7 @@ def _make_rule(rr):
             if isinstance(rs[0].kinetics, Arrhenius):
                 dlnks = np.array([
                     np.log(
-                        arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
+                        arr().fit_to_reactions(np.delete(rs, i), recipe=recipe)
                 .to_arrhenius(rxn.get_enthalpy_of_reaction(Tref))
                 .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
             ) for i, rxn in enumerate(rs)
@@ -4654,7 +4654,7 @@ def _make_rule(rr):
             else:
                 dlnks = np.array([
                     np.log(
-                        arr().fit_to_reactions(rs[list(set(range(len(rs))) - {i})], recipe=recipe)
+                        arr().fit_to_reactions(np.delete(rs, i), recipe=recipe)
                         .to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(Tref))
                         .get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)
                     ) for i, rxn in enumerate(rs)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -3678,19 +3678,22 @@ class KineticsFamily(Database):
 
                 uncertainties[rxn] = self.rules.entries[entry.label][0].data.uncertainty
 
-
                 L = list(set(template_rxn_map[entry.label]) - set(rxns_test))
 
                 if L != []:
                     if isinstance(L[0].kinetics, Arrhenius):
                         kinetics = ArrheniusBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
-                        if kinetics.E0.value_si < 0.0 or len(L) == 1:
+                        # These conditions (eg. n>5) for rejecting the BM fit should correspond
+                        # to those in _marke_rule, and those just below:
+                        if len(L) == 1 or kinetics.E0.value_si < 0.0 or abs(kinetics.n.value_si) > 5.0:
                             kinetics = average_kinetics([r.kinetics for r in L])
                         else:
                             kinetics = kinetics.to_arrhenius(rxn.get_enthalpy_of_reaction(298.))
                     else:
                         kinetics = ArrheniusChargeTransferBM().fit_to_reactions(L, recipe=self.forward_recipe.actions)
-                        if kinetics.E0.value_si < 0.0 or len(L) == 1:
+                        # These conditions (eg. n>5) for rejecting the BM fit should correspond
+                        # to those in _marke_rule, and those just above:
+                        if len(L) == 1 or kinetics.E0.value_si < 0.0 or abs(kinetics.n.value_si) > 5.0:
                             kinetics = average_kinetics([r.kinetics for r in L])
                         else:
                             kinetics = kinetics.to_arrhenius_charge_transfer(rxn.get_enthalpy_of_reaction(298.))
@@ -4612,8 +4615,9 @@ def _make_rule(rr):
         arr = ArrheniusChargeTransferBM
     if n > 1:
         kin = arr().fit_to_reactions(rs, recipe=recipe)
+
+    # If you update the following conditions, also update the cross_validate function.
     if n == 1 or kin.E0.value_si < 0.0 or abs(kin.n.value_si) > 5.0:
-        
         if n > 1: #we have an ArrheniusBM
             if kin.E0.value_si < 0.0:
                 reason = "E0<0"
@@ -4621,15 +4625,13 @@ def _make_rule(rr):
                 reason = "abs(n)>5"
             else:
                 reason = "?"
-        
+
         # still run it through the averaging function when n=1 to standardize the units and run checks
         kin = average_kinetics([r.kinetics for r in rs])
-        
-        if n == 1:
 
+        if n == 1:
             kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
         else:
-            
             kin.comment = f"Blowers-Masel fit was bad ({reason}) so instead averaged from {n} reactions."
             dlnks = np.array([
                 np.log(

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -4612,12 +4612,20 @@ def _make_rule(rr):
         arr = ArrheniusChargeTransferBM
     if n > 1:
         kin = arr().fit_to_reactions(rs, recipe=recipe)
-    if n == 1 or kin.E0.value_si < 0.0:
+    if n == 1 or kin.E0.value_si < 0.0 or abs(kin.n.value_si) > 5.0:
+        # still run it through the averaging function when n=1 to standardize the units and run checks
         kin = average_kinetics([r.kinetics for r in rs])
         #kin.comment = "Only one reaction or Arrhenius BM fit bad. Instead averaged from {} reactions.".format(n)
         if n == 1:
             kin.uncertainty = RateUncertainty(mu=0.0, var=(np.log(fmax) / 2.0) ** 2, N=1, Tref=Tref, data_mean=data_mean, correlation=label)
         else:
+            if kin.E0.value_si < 0.0:
+                reason = "E0<0"
+            elif abs(kin.n.value_si) > 5.0:
+                reason = "abs(n)>5"
+            else:
+                reason = "?"
+            kin.comment = f"Blowers-Masel fit was bad ({reason}) so instead averaged from {n} reactions."
             dlnks = np.array([
                 np.log(
                         average_kinetics([r.kinetics for r in rs[list(set(range(len(rs))) - {i})]]).get_rate_coefficient(T=Tref) / rxn.get_rate_coefficient(T=Tref)

--- a/rmgpy/display.py
+++ b/rmgpy/display.py
@@ -29,18 +29,18 @@
 
 """
 This module contains only a display() function, which, if you are running in
-the IPython --pylab mode, will render things inline in pretty SVG or PNG graphics.
-If you are NOT running in IPython --pylab mode, it will do nothing.
+a Jupyter notebook or IPython session, will render things inline in pretty SVG or PNG graphics.
+If you are NOT running in such an environment, it will do nothing.
 """
 
 try:
-    from IPython.core.interactiveshell import InteractiveShell
+    from IPython import get_ipython
+    _ipython = get_ipython()
 except ImportError:
+    _ipython = None
+
+if _ipython is not None:
+    from IPython.display import display
+else:
     def display(obj):
         pass
-else:
-    if InteractiveShell.initialized():
-        from IPython.core.display import display
-    else:
-        def display(obj):
-            pass

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -679,6 +679,8 @@ cdef class ArrheniusBM(KineticsModel):
             lnA /= len(rxns)
             n /= len(rxns)
             E0 = min(E0, w0)
+            w0 = max(2 * E0, w0) # Expression only works if w0>2E0, and is insensitive to w0
+            self.w0 = (w0 * 0.001, 'kJ/mol')
             if E0 < 0:
                 E0 = w0 / 100.0
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -1580,16 +1580,22 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
         Return the activation energy in J/mol corresponding to the given
         enthalpy of reaction `dHrxn` in J/mol.
         """
-        cdef double w0, E0
+        cdef double w0, E0, Ea
         E0 = self._E0.value_si
-        if dHrxn < -4 * self._E0.value_si:
-            return 0.0
-        elif dHrxn > 4 * self._E0.value_si:
-            return dHrxn
+        w0 = self._w0.value_si
+        if E0 < 0:
+            if dHrxn > 0:
+                Ea = dHrxn
+            else:
+                Ea = min(0.0, E0)
         else:
-            w0 = self._w0.value_si
             Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-            return (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) ** 2 / (Vp ** 2 - (2 * w0) ** 2 + dHrxn ** 2)
+            Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
+            if (dHrxn < 0.0 and Ea < 0.0) or (dHrxn < -4 * E0):
+                Ea = 0.0
+            elif (dHrxn > 0.0 and Ea < dHrxn) or (dHrxn > 4 * E0):
+                Ea = dHrxn
+        return Ea
 
     cpdef double get_rate_coefficient_from_potential(self, double T, double V, double dHrxn) except -1:
         """

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -652,7 +652,7 @@ cdef class ArrheniusBM(KineticsModel):
                 Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
                 Ea = np.where(dHrxn< -4.0*E0, 0.0, Ea)
                 Ea = np.where(dHrxn > 4.0*E0, dHrxn, Ea)
-                return lnA + np.log(T ** n * np.exp(-Ea / (8.314 * T)))
+                return lnA + np.log(T) * n + (-Ea / (8.314472 * T))
 
             # get (T,dHrxn(T)) -> (Ln(k) mappings
             xdata = []

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -619,11 +619,12 @@ cdef class ArrheniusBM(KineticsModel):
         assert w0 is not None or recipe is not None, 'either w0 or recipe must be specified'
 
         if Ts is None:
-            Ts = [300.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0, 1500.0, 2000.0]
+            Ts = np.array([300.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0, 1500.0, 2000.0])
         if w0 is None:
             #estimate w0
             w0s = get_w0s(recipe, rxns)
             w0 = sum(w0s) / len(w0s)
+        self.w0 = (w0 * 0.001, 'kJ/mol')
 
         if len(rxns) == 1:
             rxn = rxns[0]
@@ -688,10 +689,18 @@ cdef class ArrheniusBM(KineticsModel):
             keep_trying = True
             xtol = 1e-8
             ftol = 1e-8
+            attempts = 0
             while keep_trying:
                 keep_trying = False
                 try:
                     params = curve_fit(kfcn, xdata, ydata, sigma=sigmas, p0=[lnA, n, E0], xtol=xtol, ftol=ftol)
+                    lnA, n, E0 = params[0].tolist()
+                    if abs(E0/self.w0.value_si) > 1 and attempts < 5:
+                        keep_trying = True
+                        if attempts > 0:
+                            self.w0.value_si *= 1.25
+                        attempts += 1
+                        E0 = self.w0.value_si / 10.0
                 except RuntimeError:
                     if xtol < 1.0:
                         keep_trying = True
@@ -700,7 +709,6 @@ cdef class ArrheniusBM(KineticsModel):
                     else:
                         raise ValueError("Could not fit BM arrhenius to reactions with xtol<1.0")
 
-            lnA, n, E0 = params[0].tolist()
             A = np.exp(lnA)
 
             self.Tmin = (np.min(Ts), "K")
@@ -716,8 +724,7 @@ cdef class ArrheniusBM(KineticsModel):
         self.A = (A, A_units[order])
 
         self.n = n
-        self.w0 = (w0, 'J/mol')
-        self.E0 = (E0, 'J/mol')
+        self.E0 = (E0 * 0.001, 'kJ/mol')
 
         return self
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -661,8 +661,9 @@ cdef class ArrheniusBM(KineticsModel):
             for rxn in rxns:
                 # approximately correct the overall uncertainties to std deviations
                 s = rank_accuracy_map[rxn.rank].value_si/2.0
+                dHrxn = rxn.get_enthalpy_of_reaction(298.0)
                 for T in Ts:
-                    xdata.append([T, rxn.get_enthalpy_of_reaction(298.0)])
+                    xdata.append([T, dHrxn])
                     ydata.append(np.log(rxn.get_rate_coefficient(T)))
                     sigmas.append(s / (8.314 * T))
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -580,11 +580,11 @@ cdef class ArrheniusBM(KineticsModel):
             # Negative E0 is unphysical, but could be encountered during optimization.
             Ea = E0 + max(dHrxn, 0.0)
         else:
-            Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-            Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) ** 2 / (Vp ** 2 - (2 * w0) ** 2 + dHrxn ** 2)
-            if (dHrxn < 0.0 and Ea < 0.0) or (dHrxn < -4 * E0):
+            Vp = 2 * w0 * (w0 + E0) / (w0 - E0)
+            Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
+            if (Ea < 0.0) or (dHrxn < -4 * E0):
                 Ea = 0.0
-            elif (dHrxn > 0.0 and Ea < dHrxn) or (dHrxn > 4 * E0):
+            elif (Ea < dHrxn) or (dHrxn > 4 * E0):
                 Ea = dHrxn
         return Ea
 
@@ -632,8 +632,8 @@ cdef class ArrheniusBM(KineticsModel):
             Ea = rxn.kinetics.Ea.value_si
 
             def kfcn(E0):
-                Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-                out = Ea - (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
+                Vp = 2 * w0 * (w0 + E0) / (w0 - E0)
+                out = Ea - (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
                 return out
 
             E0 = fsolve(kfcn, w0 / 10.0)[0]
@@ -647,8 +647,8 @@ cdef class ArrheniusBM(KineticsModel):
             def kfcn(xs, lnA, n, E0):
                 T = xs[:,0]
                 dHrxn = xs[:,1]
-                Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-                Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
+                Vp = 2 * w0 * (w0 + E0) / (w0 - E0)
+                Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
                 Ea = np.where(dHrxn< -4.0*E0, 0.0, Ea)
                 Ea = np.where(dHrxn > 4.0*E0, dHrxn, Ea)
                 return lnA + np.log(T) * n + (-Ea / (8.314472 * T))
@@ -1585,11 +1585,11 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
             # Negative E0 is unphysical, but could be encountered during optimization.
             Ea = E0 + max(dHrxn, 0.0)
         else:
-            Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-            Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
-            if (dHrxn < 0.0 and Ea < 0.0) or (dHrxn < -4 * E0):
+            Vp = 2 * w0 * (w0 + E0) / (w0 - E0)
+            Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
+            if (Ea < 0.0) or (dHrxn < -4 * E0):
                 Ea = 0.0
-            elif (dHrxn > 0.0 and Ea < dHrxn) or (dHrxn > 4 * E0):
+            elif (Ea < dHrxn) or (dHrxn > 4 * E0):
                 Ea = dHrxn
         return Ea
 
@@ -1636,8 +1636,8 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
             Ea = rxn.kinetics.Ea.value_si
 
             def kfcn(E0):
-                Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-                out = Ea - (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
+                Vp = 2 * w0 * (w0 + E0) / (w0 - E0)
+                out = Ea - (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
                 return out
 
             E0 = fsolve(kfcn, w0 / 10.0)[0]
@@ -1650,8 +1650,8 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
             def kfcn(xs, lnA, n, E0):
                 T = xs[:,0]
                 dHrxn = xs[:,1]
-                Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
-                Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
+                Vp = 2 * w0 * (w0 + E0) / (w0 - E0)
+                Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
                 Ea = np.where(dHrxn< -4.0*E0, 0.0, Ea)
                 Ea = np.where(dHrxn > 4.0*E0, dHrxn, Ea)
                 return lnA + np.log(T) * n + (-Ea / (8.314 * T))

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -577,10 +577,8 @@ cdef class ArrheniusBM(KineticsModel):
         E0 = self._E0.value_si
         w0 = self._w0.value_si
         if E0 < 0:
-            if dHrxn > 0:
-                Ea = dHrxn
-            else:
-                Ea = min(0.0, E0)
+            # Negative E0 is unphysical, but could be encountered during optimization.
+            Ea = E0 + max(dHrxn, 0.0)
         else:
             Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
             Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) ** 2 / (Vp ** 2 - (2 * w0) ** 2 + dHrxn ** 2)
@@ -1584,10 +1582,8 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
         E0 = self._E0.value_si
         w0 = self._w0.value_si
         if E0 < 0:
-            if dHrxn > 0:
-                Ea = dHrxn
-            else:
-                Ea = min(0.0, E0)
+            # Negative E0 is unphysical, but could be encountered during optimization.
+            Ea = E0 + max(dHrxn, 0.0)
         else:
             Vp = 2 * w0 * (2 * w0 + 2 * E0) / (2 * w0 - 2 * E0)
             Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -1625,11 +1625,12 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
                 rxn.kinetics.change_v0(0.0)
 
         if Ts is None:
-            Ts = [300.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0, 1500.0]
+            Ts = np.array([300.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0, 1500.0])
         if w0 is None:
             #estimate w0
             w0s = get_w0s(recipe, rxns)
             w0 = sum(w0s) / len(w0s)
+        self.w0 = (w0 * 0.001, 'kJ/mol')
 
         if len(rxns) == 1:
             rxn = rxns[0]
@@ -1657,19 +1658,36 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
                 Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (2 * w0) * (2 * w0) + dHrxn * dHrxn)
                 Ea = np.where(dHrxn< -4.0*E0, 0.0, Ea)
                 Ea = np.where(dHrxn > 4.0*E0, dHrxn, Ea)
-                return lnA + np.log(T ** n * np.exp(-Ea / (8.314 * T)))
+                return lnA + np.log(T) * n + (-Ea / (8.314 * T))
 
             # get (T,dHrxn(T)) -> (Ln(k) mappings
             xdata = []
             ydata = []
             sigmas = []
+            E0 = 0.0
+            lnA = 0.0
+            n = 0.0
             for rxn in rxns:
                 # approximately correct the overall uncertainties to std deviations
                 s = rank_accuracy_map[rxn.rank].value_si/2.0
+                dHrxn = rxn.get_enthalpy_of_reaction(298.0)
                 for T in Ts:
-                    xdata.append([T, rxn.get_enthalpy_of_reaction(298.0)])
+                    xdata.append([T, dHrxn])
                     ydata.append(np.log(rxn.get_rate_coefficient(T)))
                     sigmas.append(s / (8.314 * T))
+                # Use BEP with alpha = 0.25 for initial guess of E0
+                E0 += rxn.kinetics._Ea.value_si - 0.25 * dHrxn
+                lnA += np.log(rxn.kinetics.A.value_si)
+                n += rxn.kinetics.n.value_si
+            # average E0, lnA, n over all reactions
+            E0 /= len(rxns)
+            lnA /= len(rxns)
+            n /= len(rxns)
+            E0 = min(E0, w0)
+            w0 = max(2 * E0, w0) # ensure w0 is at least 2*E0
+            self.w0 = (w0 * 0.001, 'kJ/mol')
+            if E0 < 0:
+                E0 = w0 / 100.0
 
             xdata = np.array(xdata)
             ydata = np.array(ydata)
@@ -1678,10 +1696,18 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
             keep_trying = True
             xtol = 1e-8
             ftol = 1e-8
+            attempts = 0
             while keep_trying:
                 keep_trying = False
                 try:
-                    params = curve_fit(kfcn, xdata, ydata, sigma=sigmas, p0=[1.0, 1.0, w0 / 10.0], xtol=xtol, ftol=ftol)
+                    params = curve_fit(kfcn, xdata, ydata, sigma=sigmas, p0=[lnA, n, E0], xtol=xtol, ftol=ftol)
+                    lnA, n, E0 = params[0].tolist()
+                    if abs(E0/self.w0.value_si) > 1.0 and attempts < 5:
+                        keep_trying = True
+                        if attempts > 0:
+                            self.w0.value_si *= 1.25
+                        attempts += 1
+                        E0 = self.w0.value_si / 10.0
                 except RuntimeError:
                     if xtol < 1.0:
                         keep_trying = True
@@ -1690,7 +1716,6 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
                     else:
                         raise ValueError("Could not fit BM arrhenius to reactions with xtol<1.0")
 
-            lnA, n, E0 = params[0].tolist()
             A = np.exp(lnA)
 
             self.Tmin = (np.min(Ts), "K")
@@ -1705,8 +1730,7 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
         self.A = (A, A_units[order])
 
         self.n = n
-        self.w0 = (w0, 'J/mol')
-        self.E0 = (E0, 'J/mol')
+        self.E0 = (E0 * 0.001, 'kJ/mol')
         self._V0.value_si = 0.0
         self.electrons = rxns[0].electrons
 

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -699,6 +699,7 @@ cdef class ArrheniusBM(KineticsModel):
                         keep_trying = True
                         if attempts > 0:
                             self.w0.value_si *= 1.25
+                            w0 = self.w0.value_si # update local variable for use in kfcn optimization function
                         attempts += 1
                         E0 = self.w0.value_si / 10.0
                 except RuntimeError:
@@ -1702,6 +1703,7 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
                         keep_trying = True
                         if attempts > 0:
                             self.w0.value_si *= 1.25
+                            w0 = self.w0.value_si # update local variable for use in kfcn optimization function
                         attempts += 1
                         E0 = self.w0.value_si / 10.0
                 except RuntimeError:

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -651,7 +651,7 @@ cdef class ArrheniusBM(KineticsModel):
                 Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
                 Ea = np.where(dHrxn< -4.0*E0, 0.0, Ea)
                 Ea = np.where(dHrxn > 4.0*E0, dHrxn, Ea)
-                return lnA + np.log(T) * n + (-Ea / (8.314472 * T))
+                return lnA + np.log(T) * n + (-Ea / (constants.R * T))
 
             # get (T,dHrxn(T)) -> (Ln(k) mappings
             xdata = []
@@ -667,7 +667,7 @@ cdef class ArrheniusBM(KineticsModel):
                 for T in Ts:
                     xdata.append([T, dHrxn])
                     ydata.append(np.log(rxn.get_rate_coefficient(T)))
-                    sigmas.append(s / (8.314 * T))
+                    sigmas.append(s / (constants.R * T))
                 # Use BEP with alpha = 0.25 for inital guess of E0
                 E0 += rxn.kinetics._Ea.value_si - 0.25 * dHrxn
                 lnA += np.log(rxn.kinetics.A.value_si)
@@ -1654,7 +1654,7 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
                 Ea = (w0 + dHrxn / 2.0) * (Vp - 2 * w0 + dHrxn) * (Vp - 2 * w0 + dHrxn) / (Vp * Vp - (4 * w0 * w0) + dHrxn * dHrxn)
                 Ea = np.where(dHrxn< -4.0*E0, 0.0, Ea)
                 Ea = np.where(dHrxn > 4.0*E0, dHrxn, Ea)
-                return lnA + np.log(T) * n + (-Ea / (8.314 * T))
+                return lnA + np.log(T) * n + (-Ea / (constants.R * T))
 
             # get (T,dHrxn(T)) -> (Ln(k) mappings
             xdata = []
@@ -1670,7 +1670,7 @@ cdef class ArrheniusChargeTransferBM(KineticsModel):
                 for T in Ts:
                     xdata.append([T, dHrxn])
                     ydata.append(np.log(rxn.get_rate_coefficient(T)))
-                    sigmas.append(s / (8.314 * T))
+                    sigmas.append(s / (constants.R * T))
                 # Use BEP with alpha = 0.25 for initial guess of E0
                 E0 += rxn.kinetics._Ea.value_si - 0.25 * dHrxn
                 lnA += np.log(rxn.kinetics.A.value_si)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem

In recent years, @Nora-Khalil had been having issues with re-training some kinetics trees with halocarbon data, and @davidfarinajr had made various tweaks before that.  Along the way we collected various changes to the Blowers-Masel fitting code. Some of these changes date back to 2021, but somehow only ever existed on David and Nora's topic branches.

Here they are, collected and rebased, with some extra refactoring along the way.

The Blowers-Masel (BM) fitting in `ArrheniusBM` and `ArrheniusChargeTransferBM` had several issues: the optimizer used poor initial guesses (hard-coded `lnA=1, n=1, E0=w0/10`) that frequently led to non-converging or physically unreasonable fits; negative `E0` values encountered during optimization caused undefined/incorrect behavior; Additionally, fitted BM parameters with `abs(n) > 5` are usually artifacts of reactions that don't follow BM enthalpy-dependence, but these were previously trusted.

### Description of Changes

Behavioral changes:
-   **Reject untrustworthy BM fits** where `abs(n) > 5.0` in `_make_rule` (kinetics family), as these typically indicate reactions that don't exhibit BM enthalpy-dependence.
-   **Negative `E0` handling** in `get_activation_energy`: instead of crashing or producing nonsensical values, returns `E0 + max(dHrxn, 0)` when `E0 < 0` --- a physically continuous and monotonic choice at the `E0=0` boundary.  This is what I chose:
<img  alt="BMsketch" src="https://github.com/user-attachments/assets/a7f33010-9ce2-45fe-8139-e6232afe3117" />


Small behavioral changes:
-   **Better initial guesses** for the `curve_fit` optimizer: `lnA`, `n`, and `E0` are now seeded from the mean Arrhenius parameters of the training reactions (using a BEP relation with `alpha=0.25` for `E0`), rather than fixed values.
-   **Enforced `w0 >= 2*E0`** before optimization, since the BM expression requires this constraint; `w0` is updated adaptively if the _fitted_ `E0` exceeds `w0`.
-   **Unit handling fix**: `w0` and `E0` are now stored internally in kJ/mol.

Performance improvements:
-   **Performance**: replaced `np.log(T**n * np.exp(-Ea/(R*T)))` with `np.log(T)*n - Ea/(R*T)` in the objective function.
-   `dHrxn` is now computed once per reaction rather than redundantly inside the temperature loop. 

Code simplification refactoring:
-   **Minor refactor** of `_make_rule` in `rmgpy/data/kinetics/family.py`: removed an always-true `if True:` block and reduced indentation; no behavioral change.
-   **Simplified `Vp` formula** in `get_activation_energy` and `fit_to_reactions` for both `ArrheniusBM` and `ArrheniusChargeTransferBM`: simplified `2*w0*(2*w0+2*E0)/(2*w0-2*E0)` → `2*w0*(w0+E0)/(w0-E0)` and the denominator `(2*w0)^2` → `4*w0*w0` (algebraically equivalent, avoids redundant factors of 2).

### Testing

So far, not much besides the standard test suites.



### Reviewer Tips

Note there is code duplication between `ArrheniusBM` and `ArrheniusChargeTransferBM` --- changes (should) appear twice throughout.

### Open question

How should we evaluate different ways of doing fitting? 
How do we know what's best?

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
