### PR TITLE
RDKit `GetSSSR` Non-determinism Fix

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2681,31 +2681,21 @@ class Molecule(Graph):
                                       return_mapping=False,
                                       save_order=True,
                                       ignore_bond_orders=True)
-
+        rdkit_mol.UpdatePropertyCache(strict=False)
+        ranks = list(Chem.CanonicalRankAtoms(rdkit_mol, breakTies=True))
+        rank_to_idx = {rank: idx for idx, rank in enumerate(ranks)}
+        new_order = [rank_to_idx[i] for i in range(rdkit_mol.GetNumAtoms())]
+        canonical_mol = Chem.RenumberAtoms(rdkit_mol, new_order)
         if symmetrized:
-            ring_info = Chem.GetSymmSSSR(rdkit_mol)
+            ring_info = Chem.GetSymmSSSR(canonical_mol)
         else:
-            # Force deterministic SSSR by canonicalizing the atom numbering first.
-            # This prevents RDKit's arbitrary graph traversal from selecting 
-            # different sets of equivalent rings across different runs/platforms.
-            ranks = list(Chem.CanonicalRankAtoms(rdkit_mol, breakTies=True))
-            rank_to_idx = {rank: idx for idx, rank in enumerate(ranks)}
-            
-            # new_order maps the new atom index to the original atom index
-            new_order = [rank_to_idx[i] for i in range(rdkit_mol.GetNumAtoms())]
-            
-            canonical_mol = Chem.RenumberAtoms(rdkit_mol, new_order)
-            canonical_mol.UpdatePropertyCache(strict=False)
-            canonical_rings = Chem.GetSSSR(canonical_mol)
-            
-            # Map the resulting ring indices back to the original rdkit_mol numbering
-            ring_info = []
-            for ring in canonical_rings:
-                orig_ring = tuple([new_order[idx] for idx in ring])
-                ring_info.append(orig_ring)
+            ring_info = Chem.GetSSSR(canonical_mol)
 
         for ring in ring_info:
-            atom_ring = [self.atoms[idx] for idx in ring]
+            # Map the new canonical indices back to the original RMG atom indices
+            original_idx_ring = [new_order[idx] for idx in ring]
+            atom_ring = [self.atoms[idx] for idx in original_idx_ring]
+            
             sorted_ring = self.sort_cyclic_vertices(atom_ring)
             sssr.append(sorted_ring)
         if symmetrized:

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2685,7 +2685,24 @@ class Molecule(Graph):
         if symmetrized:
             ring_info = Chem.GetSymmSSSR(rdkit_mol)
         else:
-            ring_info = Chem.GetSSSR(rdkit_mol)
+            # Force deterministic SSSR by canonicalizing the atom numbering first.
+            # This prevents RDKit's arbitrary graph traversal from selecting 
+            # different sets of equivalent rings across different runs/platforms.
+            ranks = list(Chem.CanonicalRankAtoms(rdkit_mol, breakTies=True))
+            rank_to_idx = {rank: idx for idx, rank in enumerate(ranks)}
+            
+            # new_order maps the new atom index to the original atom index
+            new_order = [rank_to_idx[i] for i in range(rdkit_mol.GetNumAtoms())]
+            
+            canonical_mol = Chem.RenumberAtoms(rdkit_mol, new_order)
+            canonical_rings = Chem.GetSSSR(canonical_mol)
+            
+            # Map the resulting ring indices back to the original rdkit_mol numbering
+            ring_info = []
+            for ring in canonical_rings:
+                orig_ring = tuple([new_order[idx] for idx in ring])
+                ring_info.append(orig_ring)
+
         for ring in ring_info:
             atom_ring = [self.atoms[idx] for idx in ring]
             sorted_ring = self.sort_cyclic_vertices(atom_ring)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -2695,6 +2695,7 @@ class Molecule(Graph):
             new_order = [rank_to_idx[i] for i in range(rdkit_mol.GetNumAtoms())]
             
             canonical_mol = Chem.RenumberAtoms(rdkit_mol, new_order)
+            canonical_mol.UpdatePropertyCache(strict=False)
             canonical_rings = Chem.GetSSSR(canonical_mol)
             
             # Map the resulting ring indices back to the original rdkit_mol numbering

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -3172,8 +3172,8 @@ multiplicity 2
         """)
         polycyclic_vertices = mol.get_all_polycyclic_vertices()
         assert len(polycyclic_vertices) == 2
-        assert mol.atoms[0] is mol.get_all_polycyclic_vertices()[0]
-        assert mol.atoms[1] is mol.get_all_polycyclic_vertices()[1]
+        assert mol.atoms[0] is mol.get_all_polycyclic_vertices()[1]
+        assert mol.atoms[1] is mol.get_all_polycyclic_vertices()[0]
         
         # Spirocyclic molecule
         mol = Molecule().from_adjacency_list("""


### PR DESCRIPTION
Goal of this PR is to resolve: https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2912

The RDKit `GetSSSR` algorithm _is_ deterministic for the same input (unlike the previous RMG version) __but__ the process of converting the RMG molecule into RDKit does _not_ guarantee the same ordering of atoms, which results in non-determinism. This PR forces the RDKit molecule to have a consistent ordering, and should (hopefully) give the same results each time.

Easiest way to test this: just need to run the regression tests multiple times on the same reference results (so, on the same day, without any changes to `main`). The results should be different from the `main` results, but in the same way.
