### PR TITLE
Miscellaneous changes, including a change to how species are named.

### DIFF
--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1447,7 +1447,7 @@ class Reaction:
         from rmgpy.molecule.element import element_list
         from rmgpy.molecule.fragment import CuttingLabel, Fragment
 
-        cython.declare(reactant_elements=dict, product_elements=dict, molecule=Graph, atom=Vertex, element=Element,
+        cython.declare(reactant_elements=dict, product_elements=dict, molecule=Molecule, atom=Atom, element=Element,
                        reactants_net_charge=cython.int, products_net_charge=cython.int)
 
         reactant_elements = {}

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -365,10 +365,11 @@ class CoreEdgeReactionModel:
         spec.molecular_weight = Quantity(spec.molecule[0].get_molecular_weight() * 1000.0, "amu")
 
         if generate_thermo:
-            self.generate_thermo(spec)
+            # Rename from thermo library label only if no user-provided label exists yet.
+            self.generate_thermo(spec, rename=not bool(spec.label))
 
         # If the species still does not have a label, set initial label as the SMILES
-        # This may change later after getting thermo in self.generate_thermo()
+        # (applies when generate_thermo is False, or when no library match was found)
         if not spec.label:
             spec.label = spec.smiles
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Some small, miscellaneous changes, collected from other branches that they're not actually pertinent to.
One of them changes species naming. The others are minor tweaks.

### Description of Changes
This pull request introduces several improvements and fixes across the codebase, focusing on better environment detection, minor type corrections, and improved species labeling logic.

* **Behavior change!** Updated `make_new_species` in `rmgpy/rmg/model.py` to rename a species using the name from a thermo library label, if the user did not already provide a label, but did specify a thermo library that has a label. This was the original intended behavior, but it was accidentally changed a while ago so that it ignored thermo library names. (Because `generate_thermo(spec)` was first called with a default of _not_ renaming, and then when it was later called with the intent to rename things, the thermo already existed so it was skipped).  A down-side of this new approach is that the names in your model might change when you swap in and out thermo libraries. A benefit of this change is that you have some control over the names in your model, and the names in thermo libraries should be better (the ones currently auto-generated from SMILES strings or chemical formulae can be misleading).    Do people have strong views? 
* ~~Bug fix: Updated the logic in `rmgpy/display.py` to more robustly detect if the code is running in a Jupyter or IPython environment. Was using a decades-old deprecated API that recently caused me an error when running `jupyter nbconvert --execute` on something.~~ Got merged in d9ab313c024b9f0a9cde3c2f7d8dbbcb55f1441b on a different PR.
* Optimization: Corrected the Cython type declarations in `rmgpy/reaction.py`  from `Graph`/`Vertex` to `Molecule`/`Atom`, so Cython knows that some of the subclasses methods are available.


### Testing
How I tested? I made the changes because they fixed things.I have been using most of the changes on other branches for a while.  I ran the tests. I relied on CI (which is about to run on this pull request).

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
