### PR TITLE
Edit save_training_reactions in family.py to allow use for R_Recombination family

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -846,16 +846,48 @@ class KineticsFamily(Database):
                         if spcs_labels != ex_spcs_labels:
                             # the species have different labels, therefore not a match
                             continue
-                        initial_map = {}
+                            
+                        multiple_mappings_to_test=False
+                    
+                        #first, check if we have a family that will have multiple atoms labeled with the same atom label i.e. R_Recombination family will have two atoms labeled as '*' on a single side of the reaction
+                        if any(isinstance(labeled_atoms, list) for labeled_atoms in spec_labeled_atoms.values()): 
+                            assert self.label=='R_Recombination' #this should only be happening for the R_Recomb family, I believe
+                            initial_map_a = {} #will have to test two variations, only one of which will pass the isomorphism test
+                            initial_map_b = {} 
+                            multiple_mappings_to_test = True
+                        else:
+                            initial_map = {}
                         try:
+                            
                             for atomLabel in spec_labeled_atoms:
-                                initial_map[spec_labeled_atoms[atomLabel]] = ex_spec_labeled_atoms[atomLabel]
-                        except KeyError:
+                                if multiple_mappings_to_test:
+                                    starred = spec_labeled_atoms[atomLabel]
+                                    
+                                    if isinstance(starred,list): #we are at an atomLabel with multiple atoms defined
+                                        initial_map_a[starred[0]] = ex_spec_labeled_atoms[atomLabel][0]
+                                        initial_map_a[starred[1]] = ex_spec_labeled_atoms[atomLabel][1]
+                                        
+                                        initial_map_b[starred[1]] = ex_spec_labeled_atoms[atomLabel][0]
+                                        initial_map_b[starred[0]] = ex_spec_labeled_atoms[atomLabel][1]
+                                    else: 
+                                        initial_map_a[starred] = ex_spec_labeled_atoms[atomLabel]
+                                        initial_map_b[starred] = ex_spec_labeled_atoms[atomLabel]
+                                else: 
+                                    initial_map[spec_labeled_atoms[atomLabel]] = ex_spec_labeled_atoms[atomLabel]
+                        except KeyError :
                             # Atom labels did not match, therefore not a match
                             continue
-                        if spec.molecule[0].is_isomorphic(ex_spec.molecule[0], initial_map):
-                            spec.label = ex_spec.label
-                            break
+                                           
+                        if multiple_mappings_to_test:
+                            for initial_map in [initial_map_a, initial_map_b]:
+                                if spec.molecule[0].is_isomorphic(ex_spec.molecule[0], initial_map):
+                                    spec.label = ex_spec.label
+                                    break
+                                           
+                        if not multiple_mappings_to_test:                
+                            if spec.molecule[0].is_isomorphic(ex_spec.molecule[0], initial_map):
+                                spec.label = ex_spec.label
+                                break
                 else:  # No isomorphic existing species found
                     spec_formula = spec.molecule[0].get_formula()
                     if spec_formula not in species_dict:


### PR DESCRIPTION
In `save_training_reactions` in family.py, this commit allows for training reactions to be added to families that have multiple atoms with the same atom label. Only implemented for R_Recombination as of right now, where two atoms in the product are both labeled as '*' since it is the simple recombination of two radicals and we don't need them individually numbered. I'm not sure if there are other families that do this too. If so, the assert statement in the new code introduced here would just have to be edited. 


### Motivation or Problem
It's easy to use the `ipython/kinetics_library_to_training.ipynb` script to add new training reactions to a pre-existing kinetic family. However, if the family has a top-level group definition/recipe that labels multiple atoms in a reactant or product with the same label (i.e. R_Recombination), an error is encountered when we run `family.save_training_reactions() ` to save new training reactions to this family's existing depository. 

To see if a new training reaction involves a species that already exists in the training dictionary.txt, the `save_training_data` function will 1) see if the formula of the species in the new reaction matches any already in the dictionary and 2) if it finds a match, then retrieves the atom labeling for both the matched existing species and the species in the new reaction. However, in the python dict() that is returned from get_all_labeled_atoms, we will get something like this : {'\*', [Atom F, Atom C]} in the case of the R_Recomb family (if we're getting the labeling of the product generated from the recombination). For the function to work properly, it's instead expecting something like this {'*': Atom F} or {'*1': Atom H}, so we get an error when the value of the dict() is a list.

### Description of Changes

- If the function encounters a value in the atom labeling dict() that is a list, set a flag to True and propose two different mappings (one of which should pass the isomorphism check performed later if the species does indeed already exist in the dictionary). 
- Run the isomorphism check on all the mappings if we have multiple, or proceed as normal if not. 

### Testing
To test, I added  my new training reactions to R_Recombination via the ipython/kinetics_library_to_training.ipynb notebook (which successfully ran with out errors after these changes were introduced). 

To confirm that everything looked good, I loaded the database in a separate script and ran something like: 

```
training_depo_for_R_recomb = database.kinetics.families['R_Recombination'].get_training_depository()
species_in_depo = database.kinetics.families['R_Recombination'].get_species(<path to R_Recomb training dictionary.txt>)

for tr in training_depo_for_R_recomb.entries.values(): 
    if <str unique to my new training reactions> in tr.long_desc:
        display(tr.item)
        print(tr.label)
        
        edited_label_line = tr.label.replace(' <=>', '').replace(' +', '').replace('\n','')
        
        species_involved = edited_label_line.split(' ')

        for spec in species_involved: 
            print(species_in_depo[spec].to_adjacency_list())
```
To get a bunch of outputs like this: 
<img width="396" height="471" alt="Screenshot 2026-04-10 at 2 04 14 PM" src="https://github.com/user-attachments/assets/497982d2-ac6e-47b8-85c6-f5f2a7b28c8c" />
 
I then visually confirmed that the atom labeling of the species involved in the new training reactions looks how it should. 



### Reviewer Tips
just do your best
