### PR TITLE
Fix coverage dependent kinetics read/write for chemkin.

### DIFF
--- a/rmgpy/chemkin.pyx
+++ b/rmgpy/chemkin.pyx
@@ -501,7 +501,7 @@ def _read_kinetics_line(line, reaction, species_dict, Eunits, kunits, klow_units
         tokens = case_preserved_tokens[1].split()
         cov_dep_species = species_dict[tokens[0].strip()]
         Ea = Quantity(float(tokens[3]), Eunits)
-        k.coverage_dependence[cov_dep_species] = {'a':float(tokens[1]), 'm':float(tokens[2]), 'E':Ea}
+        k.coverage_dependence[cov_dep_species] = {'a': Quantity(float(tokens[1])), 'm': Quantity(float(tokens[2])), 'E': Ea}
 
     elif 'LOW' in line:
         # Low-pressure-limit Arrhenius parameters
@@ -1867,7 +1867,7 @@ def write_kinetics_entry(reaction, species_list, verbose=True, java_library=Fals
         for species, cov_params in kinetics.coverage_dependence.items():
             label = get_species_identifier(species)
             string += f'    COV / {label:<41} '
-            string += f"{cov_params['a']:<9.3g} {cov_params['m']:<9.3g} {cov_params['E'].value_si/4184.:<9.3f} /\n"
+            string += f"{cov_params['a'].value_si:<9.3g} {cov_params['m'].value_si:<9.3g} {cov_params['E'].value_si/4184.:<9.3f} /\n"
 
     if isinstance(kinetics, (_kinetics.ThirdBody, _kinetics.Lindemann, _kinetics.Troe)):
         # Write collider efficiencies

--- a/test/rmgpy/chemkinTest.py
+++ b/test/rmgpy/chemkinTest.py
@@ -44,6 +44,7 @@ from rmgpy.chemkin import (
     save_chemkin_surface_file,
     save_species_dictionary,
     save_transport_file,
+    write_kinetics_entry,
     write_thermo_entry,
 )
 from rmgpy.chemkin import _remove_line_breaks, _process_duplicate_reactions
@@ -664,6 +665,33 @@ class ChemkinTest:
         # clean up
         os.remove(chemkin_save_path)
         os.remove(dictionary_save_path)
+
+    def test_write_kinetics_entry_with_coverage_dependence(self):
+        """Test that write_kinetics_entry correctly writes COV lines for surface reactions
+        with coverage-dependent kinetics."""
+        s_ox = Species().from_smiles("O=[*]")
+        s_ox.label = "OX"
+
+        kinetics = SurfaceArrhenius(
+            A=(7.39e19, "cm^2/(mol*s)"),
+            n=0.0,
+            Ea=(18.475, "kcal/mol"),
+            T0=(1, "K"),
+            coverage_dependence={s_ox: {"a": 0.0, "m": 0.0, "E": (-17.5, "kcal/mol")}},
+        )
+
+        rxn = Reaction(
+            reactants=[s_ox],
+            products=[s_ox],
+            kinetics=kinetics,
+        )
+
+        result = write_kinetics_entry(rxn, species_list=[s_ox])
+
+        assert "COV" in result
+        cov_line = [line for line in result.splitlines() if "COV" in line][0]
+        assert "OX" in cov_line
+        assert "-17.500" in cov_line
 
 
 class TestThermoReadWrite:


### PR DESCRIPTION

### Motivation or Problem
Running a job with (irrelevant parts removed)
```
database(
    reactionLibraries = [('Surface/CPOX_Pt/Deutschmann2006_adjusted', False)], 
)

catalystProperties(
    metal = 'Pt111',
    coverageDependence=True,
)
```
would cause

```
Exception has occurred: TypeError       (note: full exception trace is shown but execution is paused at: <module>)
unsupported format string passed to rmgpy.quantity.ScalarQuantity.__format__
  File "/Users/rwest/Code/RMG-Py/rmgpy/chemkin.pyx", line 1870, in rmgpy.chemkin.write_kinetics_entry
    string += f"{cov_params['a']:<9.3g} {cov_params['m']:<9.3g} {cov_params['E'].value_si/4184.:<9.3f} /\n"
  File "/Users/rwest/Code/RMG-Py/rmgpy/chemkin.pyx", line 2207, in rmgpy.chemkin.save_chemkin_surface_file
    f.write(write_kinetics_entry(rxn, species_list=species, verbose=verbose))
  File "/Users/rwest/Code/RMG-Py/rmgpy/chemkin.pyx", line 2257, in rmgpy.chemkin.save_chemkin
    save_chemkin_surface_file(surface_path, surface_species_list, surface_rxn_list, verbose=False,
  File "/Users/rwest/Code/RMG-Py/rmgpy/chemkin.pyx", line 2321, in rmgpy.chemkin.save_chemkin_files
    save_chemkin(rmg.reaction_model, this_chemkin_path, latest_chemkin_verbose_path, latest_dictionary_path,
  File "/Users/rwest/Code/RMG-Py/rmgpy/chemkin.pyx", line 2394, in rmgpy.chemkin.ChemkinWriter.update
    save_chemkin_files(rmg)
  File "/Users/rwest/Code/RMG-Py/rmgpy/util.py", line 113, in notify
    observer.update(self)
  File "/Users/rwest/Code/RMG-Py/rmgpy/rmg/main.py", line 2129, in save_everything
    self.notify()
  File "/Users/rwest/Code/RMG-Py/rmgpy/rmg/main.py", line 903, in execute
    self.save_everything()
  File "/Users/rwest/Code/RMG-Py/rmgpy/__main__.py", line 102, in main
    rmg.execute(**kwargs)
  File "/Users/rwest/Code/RMG-Py/rmg.py", line 4, in <module> (Current frame)
    __main__.main()
TypeError: unsupported format string passed to rmgpy.quantity.ScalarQuantity.__format__
```

### Description of Changes
Fix the problem (reading and writing should expect the `m` and `a` parameters to be Quantity objects) and add unit test.

### Testing
Got existing unit tests to pass, and added a new one, and re-ran the troublesome input file which now works.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
