### PR TITLE
iter_item_cap passed to make_tree_nodes even if cascade algo isn't used

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -3294,7 +3294,7 @@ class KineticsFamily(Database):
             template_rxn_map = self.get_reaction_matches(rxns=rxns, thermo_database=thermo_database, remove_degeneracy=True,
                                                          fix_labels=True, exact_matches_only=True, get_reverse=True)
             self.make_tree_nodes(template_rxn_map=template_rxn_map, obj=obj, T=T, nprocs=nprocs - 1, depth=0,
-                                 min_splitable_entry_num=min_splitable_entry_num, min_rxns_to_spawn=min_rxns_to_spawn,extension_iter_max=extension_iter_max)
+                                 min_splitable_entry_num=min_splitable_entry_num, min_rxns_to_spawn=min_rxns_to_spawn,extension_iter_max=extension_iter_max, extension_iter_item_cap=extension_iter_item_cap)
         else:
             def rxnkey(rxn):
                 c = 0


### PR DESCRIPTION
### Motivation or Problem
I have added new halocarbon/PFAS training reactions to the R_Recombination kinetic family and am currently retraining. 

I was previously running into a split violation during tree generation (described here in https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2936). I have gotten past this split violation road block via a quick [fix](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/leaf_node_max/rmgpy/data/kinetics/family.py#L3082) that allows for a node to be a leaf node if it cannot be further extended and if the number of training reactions in that node do not exceed a user specified `leaf_node_max` (default set to 2). Now tree generation can proceed rather than stay stuck in the infinite loop that caught the split violation. 

I'm now facing another issue where tree generation is taking forever because `grp.get_extensions` has found bond formation extensions that match all the training reactions in the node and are flagged to be further expanded, which explodes the amount of extensions to be evaluated. I see that this issue was addressed in commit https://github.com/ReactionMechanismGenerator/RMG-Py/commit/b6ae40d0bb5d9de6b5e58342fca4e784de071b95, where an iter_item cap will force it to give up the split if it runs into this issue **but only when the cascade algorithm is used**. 

The R_Recomb family now has 370 training reactions (my new training reactions included), so I wouldn't have thought to decrease max_batch size (usually 800) to force this family retraining through the cascade algorithm. Can we just pass in the `extension_iter_item_cap` parameter even when not using cascade algorithm? 

### Description of Changes
Passing in `extension_iter_item_cap` to `make_tree_nodes` regardless of whether we need to use batches or not in retraining. 

### Testing
Using `generate_tree`, retrained the R_Recombination tree in 85 seconds with this fix (and following the leaf node [fix](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/leaf_node_max/rmgpy/data/kinetics/family.py#L3082)). 


### Reviewer Tips
Something for the reviewer (mostly @mjohnson541 ) to think about: It's possible that maybe this issue only comes up because of the fact that I'm bypassing the split violation with the leaf_node_max fix... so perhaps these two fixes should be paired up? or both discarded if electron pair extensions will be added into RMG soon (and thus no need for the leaf_node_max fix)? 

Thank you!