### PR TITLE
Regression test fix option 1: Create fresh and not cloned environment to avoid cache issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Make separate No-RMS conda env
         run: |
-          conda create --name rmg_env_without_rms --clone rmg_env
+          conda create --name rmg_env_without_rms -f environment.yml
 
       - name: Setup Juliaup
         uses: julia-actions/install-juliaup@v2


### PR DESCRIPTION
### Motivation or Problem
Regression tests are broken because the x264 package is messed up in the cache. ffmpeg uses it. This sacrifices a bit of extra time to build a clean environment but is more robust because problematic cached packages are less likely to cause problems in the future.

### Description of Changes
This changes the CI yaml file so that it creates a clean RMG environment for regression tests instead of cloning the existing rmg_env.

### Testing
We'll see if this fixes the regression tests. (or at least gets them to run to completion)


We can compare how much time it adds on versus [option 2](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2943). It seems creating a fresh environment is more robust than cloning, but is also a bit slower. I think we should probably go with this option unless it's about 5+ minutes slower.