### PR TITLE
Regression test fix option 2: Avoid package version that's breaking the regression test build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - conda-forge::cairo
   - conda-forge::cairocffi
   - conda-forge::ffmpeg >= 7
-  - conda-forge::x264 !=1!164.3095  # avoid broken package cache build
+  - conda-forge::x264 ==1!157.20191217  # pin to old version to avoid broken package cache build
   - conda-forge::xlrd
   - conda-forge::xlwt
   - conda-forge::h5py

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - conda-forge::cairo
   - conda-forge::cairocffi
   - conda-forge::ffmpeg >= 7
+  - conda-forge::x264 !=1!164.3095  # avoid broken package cache build
   - conda-forge::xlrd
   - conda-forge::xlwt
   - conda-forge::h5py


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Regression tests are broken because the x264 package is messed up in the cache. ffmpeg uses it.

### Description of Changes
This fix explicitly forbids the offending package in the environment yaml. It's probably more of a bandaid than option 1: https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2942 but allows us to keep cloning the rmg_env, and may be faster.

### Testing
We'll see if this fixes the regression tests. (or at least gets them to run to completion)

### Reviewer Tips
We'll see how much faster this is than option 1. My personal opinion is that if the speedup is more than about 5 minutes, we go with this fix. Otherwise, we should go with option 1.

Yeah, my first attempt at this failed because there are probably a ton of versions of x264 that don't work and we'll make things less flexible by pinning a specific version of x264. I don't think we should merge this, but I'll see if I can get a working version just for the time comparison.
