### PR TITLE
Fix regression tests attempt 2: Work around failed conda activation in regression test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -276,6 +276,9 @@ jobs:
           REFERENCE: stable_regression_results
         run: |
           conda activate rmg_env_without_rms
+          echo "CONDA_PREFIX: $CONDA_PREFIX"  # see if the conda environment was activated
+          conda run -n rmg_env_without_rms conda install -y pip
+          conda run -n rmg_env_without_rms make install
 
           exec 2> >(tee -a regression.stderr >&2) 1> >(tee -a regression.stdout)
           mkdir -p "test/regression-diff"
@@ -295,7 +298,7 @@ jobs:
 
             echo "<details>"
             # Compare the edge and core
-            if python scripts/checkModels.py \
+            if conda run -n rmg_env_without_rms python scripts/checkModels.py \
                 "$regr_test-core" \
                 $REFERENCE/"$regr_test"/chemkin/chem_annotated.inp \
                 $REFERENCE/"$regr_test"/chemkin/species_dictionary.txt \
@@ -318,7 +321,7 @@ jobs:
               echo "</details>"
             fi
             echo "<details>"
-            if python scripts/checkModels.py \
+            if conda run -n rmg_env_without_rms python scripts/checkModels.py \
                 "$regr_test-edge" \
                 $REFERENCE/"$regr_test"/chemkin/chem_edge_annotated.inp \
                 $REFERENCE/"$regr_test"/chemkin/species_edge_dictionary.txt \
@@ -345,7 +348,7 @@ jobs:
             if [ -f test/regression/"$regr_test"/regression_input.py ];
             then
               echo "<details>"
-              if python rmgpy/tools/regression.py \
+              if conda run -n rmg_env_without_rms python rmgpy/tools/regression.py \
                 test/regression/"$regr_test"/regression_input.py \
                 $REFERENCE/"$regr_test"/chemkin \
                 test/regression/"$regr_test"/chemkin 2> regression.py.err


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The regression tests are still failing, possibly because the rmg_env_without_rms fails to activate silently. 

### Description of Changes
This uses the conda run command to force it to use a particular conda env

TODO: If it turns out the conda activate command is failing, then it probably makes sense to delete it.

### Testing
We'll see if this fixes the tests.
