### PR TITLE
Generate_tree to run on families with own_reverse==True but no defined reverseMap in groups.py

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1335,6 +1335,111 @@ class KineticsFamily(Database):
                           DeprecationWarning)
             return
         self.rules.fill_rules_by_averaging_up(self.get_root_template(), {}, verbose)
+        
+        
+        
+    def make_reverse_map_for_family_with_own_reverse(self):
+        """
+        Separating out the hardcoded relabeling of atoms that in apply_recipe. A reverse_map can now be created
+        for these specific families without calling apply_recipe.
+        """
+        
+        #check to make sure the family doesn't already have a reverse_map: 
+        if self.reverse_map:
+            logging.error('Family already has reverse_map.')
+            return 
+        
+        
+        
+        label = self.label.lower()
+        
+        # If reaction family is its own reverse, relabel atoms
+        # Unfortunately, reaction family info is
+        #  hardcoded, so this must be updated if the database changes.
+        if not self.reverse_template:
+          
+            # key: atom_labeling in forward direction, value: atom label in reverse direction
+            atom_labels = {}
+            
+
+            if label in ('1,2_xy_interchange'):
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*4'
+                atom_labels['*4'] = '*1'
+
+            if label in ('h_abstraction','f_abstraction','cl_abstraction','br_abstraction'):
+                # '*2' is the H that migrates
+                # it moves from '*1' to '*3'
+                atom_labels['*1'] = '*3'
+                atom_labels['*3'] = '*1'
+
+            elif label == 'intra_h_migration':
+                # '*3' is the H that migrates
+                # swap the two ends between which the H moves
+                atom_labels['*1'] = '*2'
+                atom_labels['*2'] = '*1'
+                # reverse all the atoms in the chain between *1 and *2
+                highest = len(atom_labels)
+                if highest > 4:
+                    # swap *4 with *5
+                    atom_labels['*4'] = '*5'
+                    atom_labels['*5'] = '*4'
+                if highest > 6:
+                    # swap *6 with the highest, etc.
+                    for i in range(6, highest + 1):
+                        atom_labels['*{0:d}'.format(i)].label = '*{0:d}'.format(6 + highest - i)
+
+            elif label == 'intra_ene_reaction':
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*2'
+                atom_labels['*2'] = '*1'
+                atom_labels['*3'] = '*5'
+                atom_labels['*5'] = '*3'
+
+            elif label == '6_membered_central_c-c_shift':
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*3'
+                atom_labels['*3'] = '*1'
+                atom_labels['*4'] = '*6'
+                atom_labels['*6'] = '*4'
+
+            elif label == '1,2_shiftc':
+                # Labels for nodes are swapped
+                atom_labels['*2'] = '*3'
+                atom_labels['*3'] = '*2'
+                self.reverse_map = atom_labels
+
+            elif label == 'intra_r_add_exo_scission':
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*3'
+                atom_labels['*3'] = '*1'
+
+            elif label == 'intra_substitutions_isomerization':
+                # Swap *2 and *3
+                atom_labels['*2'] = '*3'
+                atom_labels['*3'] = '*2'
+
+            elif label == 'surface_abstraction':
+                atom_labels['*1'] = '*3'
+                atom_labels['*2'] = '*5'
+                atom_labels['*3'] = '*1'
+                atom_labels['*5'] = '*2'
+
+            elif label == 'surface_abstraction_single_vdw':
+                # *3 migrates from *2-*1 to *4-*5
+                # so swap *1 with *5, swap *2 with *4
+                atom_labels['*1'] = '*5'
+                atom_labels['*5'] = '*1'
+                atom_labels['*2'] = '*4'
+                atom_labels['*4'] = '*2'
+            
+        if atom_labels == {}: #if this wasn't one of the families with hardcoded reverse mapping
+            logging.error('No hardcoded relabeling of atoms in for this family. Cannot generate a reverse map for this family.')
+            return 
+        else: 
+            self.reverse_map=atom_labels
+            return 
+
 
     def apply_recipe(self, reactant_structures, forward=True, unique=True, relabel_atoms=True):
         """
@@ -3286,6 +3391,10 @@ class KineticsFamily(Database):
             stratum_num: Number of strata used in stratified sampling scheme
             max_rxns_to_reopt_node: Nodes with more matching reactions than this will not be pruned
         """
+        
+        if self.own_reverse and not self.reverse_template:
+            self.make_reverse_map_for_family_with_own_reverse()
+        
         if rxns is None:
             rxns = self.get_training_set(thermo_database=thermo_database, remove_degeneracy=True, estimate_thermo=True,
                                          fix_labels=True, get_reverse=True, rxns_with_kinetics_only=True)

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1335,6 +1335,111 @@ class KineticsFamily(Database):
                           DeprecationWarning)
             return
         self.rules.fill_rules_by_averaging_up(self.get_root_template(), {}, verbose)
+        
+        
+        
+    def make_reverse_map_for_family_with_own_reverse(self):
+        """
+        Separating out the hardcoded relabeling of atoms that in apply_recipe. A reverse_map can now be created
+        for these specific families without calling apply_recipe.
+        """
+        
+        #check to make sure the family doesn't already have a reverse_map: 
+        if self.reverse_map:
+            logging.error('Family already has reverse_map.')
+            return 
+        
+        
+        
+        label = self.label.lower()
+        
+        # If reaction family is its own reverse, relabel atoms
+        # Unfortunately, reaction family info is
+        #  hardcoded, so this must be updated if the database changes.
+        if not self.reverse_template:
+          
+            # key: atom_labeling in forward direction, value: atom label in reverse direction
+            atom_labels = {}
+            
+
+            if label in ('1,2_xy_interchange'):
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*4'
+                atom_labels['*4'] = '*1'
+
+            if label in ('h_abstraction','f_abstraction','cl_abstraction','br_abstraction'):
+                # '*2' is the H that migrates
+                # it moves from '*1' to '*3'
+                atom_labels['*1'] = '*3'
+                atom_labels['*3'] = '*1'
+
+            elif label == 'intra_h_migration':
+                # '*3' is the H that migrates
+                # swap the two ends between which the H moves
+                atom_labels['*1'] = '*2'
+                atom_labels['*2'] = '*1'
+                # reverse all the atoms in the chain between *1 and *2
+                highest = len(atom_labels)
+                if highest > 4:
+                    # swap *4 with *5
+                    atom_labels['*4'] = '*5'
+                    atom_labels['*5'] = '*4'
+                if highest > 6:
+                    # swap *6 with the highest, etc.
+                    for i in range(6, highest + 1):
+                        atom_labels['*{0:d}'.format(i)].label = '*{0:d}'.format(6 + highest - i)
+
+            elif label == 'intra_ene_reaction':
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*2'
+                atom_labels['*2'] = '*1'
+                atom_labels['*3'] = '*5'
+                atom_labels['*5'] = '*3'
+
+            elif label == '6_membered_central_c-c_shift':
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*3'
+                atom_labels['*3'] = '*1'
+                atom_labels['*4'] = '*6'
+                atom_labels['*6'] = '*4'
+
+            elif label == '1,2_shiftc':
+                # Labels for nodes are swapped
+                atom_labels['*2'] = '*3'
+                atom_labels['*3'] = '*2'
+                self.reverse_map = atom_labels
+
+            elif label == 'intra_r_add_exo_scission':
+                # Labels for nodes are swapped
+                atom_labels['*1'] = '*3'
+                atom_labels['*3'] = '*1'
+
+            elif label == 'intra_substitutions_isomerization':
+                # Swap *2 and *3
+                atom_labels['*2'] = '*3'
+                atom_labels['*3'] = '*2'
+
+            elif label == 'surface_abstraction':
+                atom_labels['*1'] = '*3'
+                atom_labels['*2'] = '*5'
+                atom_labels['*3'] = '*1'
+                atom_labels['*5'] = '*2'
+
+            elif label == 'surface_abstraction_single_vdw':
+                # *3 migrates from *2-*1 to *4-*5
+                # so swap *1 with *5, swap *2 with *4
+                atom_labels['*1'] = '*5'
+                atom_labels['*5'] = '*1'
+                atom_labels['*2'] = '*4'
+                atom_labels['*4'] = '*2'
+            
+        if atom_labels == {}: #if this wasn't one of the families with hardcoded reverse mapping
+            logging.error('No hardcoded relabeling of atoms in for this family. Cannot generate a reverse map for this family.')
+            return 
+        else: 
+            self.reverse_map=atom_labels
+            return 
+
 
     def apply_recipe(self, reactant_structures, forward=True, unique=True, relabel_atoms=True):
         """
@@ -3291,6 +3396,10 @@ class KineticsFamily(Database):
             stratum_num: Number of strata used in stratified sampling scheme
             max_rxns_to_reopt_node: Nodes with more matching reactions than this will not be pruned
         """
+        
+        if self.own_reverse and not self.reverse_template:
+            self.make_reverse_map_for_family_with_own_reverse()
+        
         if rxns is None:
             rxns = self.get_training_set(thermo_database=thermo_database, remove_degeneracy=True, estimate_thermo=True,
                                          fix_labels=True, get_reverse=True, rxns_with_kinetics_only=True)


### PR DESCRIPTION
### Motivation or Problem
For some reason, some families in the database do not have their reverse map defined in their groups.py even though they are their own reverse (ownReverse=True in the template field of groups.py). 

For some other reason, there is some hardcoded atom relabeling in `apply_recipe` of family.py that generates a mapping of how atom labeling should be remapped when going from products to reactants, basically creating and using the reverse map if it's not explicitly defined in the groups.py of the family. 

If you're trying to retrain one of these trees with ownReverse==True but no reverse map in the groups.py, `generate_tree` will raise the following error: 

```
 File "~/Code/RMG-Py/rmgpy/data/kinetics/family.py", line 3333, in generate_tree
    rxns = self.get_training_set(thermo_database=thermo_database, remove_degeneracy=True, estimate_thermo=True,
  File "~/Code/RMG-Py/rmgpy/data/kinetics/family.py", line 4097, in get_training_set
    rkeys = list(self.reverse_map.keys())
AttributeError: 'NoneType' object has no attribute 'keys'
```

This is the full bit of code where it is catching is: 

```
        if self.own_reverse and get_reverse:
            rev_rxns = []
            rkeys = list(self.reverse_map.keys())
            reverse_map = self.reverse_map
```
Looks like a reverse map is expected but is None. 

### Description of Changes
I've introduced another function in family.py called `make_reverse_map_for_family_with_own_reverse` which has all the hardcoded atom relabeling, and sets this relabeling as the reverse map if the family doesn't have a map already but should. 

I call this function as the first step in `generate_tree` to then make sure that families that are expecting reverse maps have them. 

### Testing

1. Loaded database with families that have ownReverse==True (and should therefore have a reverse map, some do and some don't). 
2. Run these families through the new `make_reverse_map_for_family_with_own_reverse()` to make sure a reverse map is produced if needed. 

Testing code:

```
database = RMGDatabase()
database.load(
    path = settings['database.directory'],
    thermo_libraries = thermo_libs,  
    kinetics_families = ['1,2_shiftC',  #families with ownReverse=True
                         '1,2_XY_interchange',
                         'H_Abstraction',
                         'F_Abstraction',
                         'Cl_Abstraction', 
                         'Br_Abstraction',
                         'intra_H_migration',
                         'Intra_ene_reaction',
                         '6_membered_central_C-C_shift',
                         'Intra_R_Add_Exo_scission',
                         'intra_substitutionS_isomerization',
                         'Surface_Abstraction',
                         'Surface_Abstraction_Single_vdW'
                        ],
    reaction_libraries = [],
    kinetics_depositories = ['training'],
)


for fam_name, fam in database.kinetics.families.items():
    print(fam_name)
    
    if fam.reverse_map==None: 
        print('Before PR fix: No reverse map')
    else: 
        print(f'Before PR fix: {fam.reverse_map}')


    fam.make_reverse_map_for_family_with_own_reverse()
    print(f'After PR fix: fam.reverse_map')
    print('---------------------------------------')
```
Testing output: 

```
1,2_XY_interchange
Before PR fix: No reverse map
After PR fix: {'*1': '*4', '*4': '*1'}
---------------------------------------
1,2_shiftC
Before PR fix: No reverse map
After PR fix: {'*2': '*3', '*3': '*2'}
---------------------------------------
6_membered_central_C-C_shift
Before PR fix: No reverse map
After PR fix: {'*1': '*3', '*3': '*1', '*4': '*6', '*6': '*4'}
---------------------------------------
Br_Abstraction
Before PR fix: {'*1': '*3', '*3': '*1'}
After PR fix: {'*1': '*3', '*3': '*1'}
---------------------------------------
Cl_Abstraction
Before PR fix: {'*1': '*3', '*3': '*1'}
After PR fix: {'*1': '*3', '*3': '*1'}
---------------------------------------
F_Abstraction
Before PR fix: {'*1': '*3', '*3': '*1'}
After PR fix: {'*1': '*3', '*3': '*1'}
---------------------------------------
H_Abstraction
Before PR fix: {'*1': '*3', '*3': '*1'}
After PR fix: {'*1': '*3', '*3': '*1'}
---------------------------------------
Intra_R_Add_Exo_scission
Before PR fix: No reverse map
After PR fix: {'*1': '*3', '*3': '*1'}
---------------------------------------
Intra_ene_reaction
Before PR fix: No reverse map
After PR fix: {'*1': '*2', '*2': '*1', '*3': '*5', '*5': '*3'}
---------------------------------------
Surface_Abstraction
Before PR fix: No reverse map
After PR fix: {'*1': '*3', '*2': '*5', '*3': '*1', '*5': '*2'}
---------------------------------------
Surface_Abstraction_Single_vdW
Before PR fix: No reverse map
After PR fix: {'*1': '*5', '*5': '*1', '*2': '*4', '*4': '*2'}
---------------------------------------
intra_H_migration
Before PR fix: No reverse map
After PR fix: {'*1': '*2', '*2': '*1'}
---------------------------------------
intra_substitutionS_isomerization
Before PR fix: No reverse map
After PR fix: {'*2': '*3', '*3': '*2'}
---------------------------------------

```

with expected error messages logged for families that did indeed already have the reverse map defined: 

```
ERROR:root:Family already has reverse_map.
ERROR:root:Family already has reverse_map.
ERROR:root:Family already has reverse_map.
ERROR:root:Family already has reverse_map.
```


### Reviewer Tips
Other possible fixes and why I didn't choose them: 

-  I could have just added the expected reverse maps to the groups.py for each of the families missing them and commit edited groups.py to database. I'll probably do this too. However, if someone hasn't updated their database, they would still run into this issue (and this fix would be helpful). 
- I could have set get_reverse==False in get_training_set() so the code never enters the if statement where the error is encountered. But I think this would affect a lot of the code downstream of this in `generate tree,` since I believe we do need the reactions in the reversed direction for training

A downside of this fix: there are now two locations where the user will have to hardcode atom relabeling, in `apply_recipe` and now also `make_reverse_map_for_family_with_own_reverse.` And they have to be hardcoded slightly differently in each location. 

