### PR TITLE
Modifications to Arrhenius BM's get_w0() to enable halocarbene_recombination_double retraining

### DIFF
--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -2025,6 +2025,8 @@ def get_w0(actions, rxn):
                         
                         #overwrite bond order for bd1 to reflect the fact that originally there was no bond between these two atoms
                         bd1.order = 0
+                else: 
+                    raise e
 
             if act[2] + bd1.order == 0.5:
                 mol2 = None

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -1979,13 +1979,14 @@ def get_w0(actions, rxn):
             mol = mol.merge(m)
         else:
             mol = m.copy(deep=True)
+                 
     a_dict = mol.get_all_labeled_atoms()
 
     recipe = actions
 
     wb = 0.0
     wf = 0.0
-    for act in recipe:
+    for ind, act in enumerate(recipe):
 
         if act[0] in ['BREAK_BOND','FORM_BOND','CHANGE_BOND']:
 
@@ -2003,7 +2004,27 @@ def get_w0(actions, rxn):
             bd = Bond(atom1, atom2, act[2])
             wf += bd.get_bde()
         elif act[0] == 'CHANGE_BOND':
-            bd1 = mol.get_bond(atom1, atom2)
+            
+            #make sure the bond has been formed before it can be changed (only exception to this is halocarbene_recombination_double)
+            try: 
+                bd1 = mol.get_bond(atom1, atom2)
+            except ValueError as e: 
+                #confirm that this is the error we need to catch
+                if 'The specified vertices are not connected by an edge in this graph.' in str(e): 
+                    if ind!=0: #make sure we are at least one action step in
+                        current_action = act
+                        previous_action = recipe[ind-1]
+                        
+                        #make sure this error occurred because there was FORM_BOND and then CHANGE_BOND performed between the same two atoms. 
+                        assert previous_action[0]=='FORM_BOND' and current_action[1:]==previous_action[1:], f'{e} This is NOT because CHANGE_BOND was performed on a bond that was formed in the action step before.'
+                        
+                        #perform the bond forming of the previous action step
+                        #This is just so that bd1 can still be called without breaking things. 
+                        #but molecule should not actually have bond added to it
+                        bd1 = Bond(atom1, atom2, previous_action[2])
+                        
+                        #overwrite bond order for bd1 to reflect the fact that originally there was no bond between these two atoms
+                        bd1.order = 0
 
             if act[2] + bd1.order == 0.5:
                 mol2 = None
@@ -2029,7 +2050,13 @@ def get_w0(actions, rxn):
                 bd2_bde = 0.0
             else:
                 bd2_bde = bd2.get_bde()
-            bde_diff = bd2_bde - bd1.get_bde()
+            
+            if bd1.order == 0:
+                bd1_bde = 0.0
+            else:
+                bd1_bde = bd1.get_bde()
+                
+            bde_diff = bd2_bde - bd1_bde
             if bde_diff > 0:
                 wf += abs(bde_diff)
             else:

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -2031,6 +2031,8 @@ def get_w0(actions, rxn):
                         
                         #overwrite bond order for bd1 to reflect the fact that originally there was no bond between these two atoms
                         bd1.order = 0
+                else: 
+                    raise e
 
             if act[2] + bd1.order == 0.5:
                 mol2 = None

--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -1985,13 +1985,14 @@ def get_w0(actions, rxn):
             mol = mol.merge(m)
         else:
             mol = m.copy(deep=True)
+                 
     a_dict = mol.get_all_labeled_atoms()
 
     recipe = actions
 
     wb = 0.0
     wf = 0.0
-    for act in recipe:
+    for ind, act in enumerate(recipe):
 
         if act[0] in ['BREAK_BOND','FORM_BOND','CHANGE_BOND']:
 
@@ -2009,7 +2010,27 @@ def get_w0(actions, rxn):
             bd = Bond(atom1, atom2, act[2])
             wf += bd.get_bde()
         elif act[0] == 'CHANGE_BOND':
-            bd1 = mol.get_bond(atom1, atom2)
+            
+            #make sure the bond has been formed before it can be changed (only exception to this is halocarbene_recombination_double)
+            try: 
+                bd1 = mol.get_bond(atom1, atom2)
+            except ValueError as e: 
+                #confirm that this is the error we need to catch
+                if 'The specified vertices are not connected by an edge in this graph.' in str(e): 
+                    if ind!=0: #make sure we are at least one action step in
+                        current_action = act
+                        previous_action = recipe[ind-1]
+                        
+                        #make sure this error occurred because there was FORM_BOND and then CHANGE_BOND performed between the same two atoms. 
+                        assert previous_action[0]=='FORM_BOND' and current_action[1:]==previous_action[1:], f'{e} This is NOT because CHANGE_BOND was performed on a bond that was formed in the action step before.'
+                        
+                        #perform the bond forming of the previous action step
+                        #This is just so that bd1 can still be called without breaking things. 
+                        #but molecule should not actually have bond added to it
+                        bd1 = Bond(atom1, atom2, previous_action[2])
+                        
+                        #overwrite bond order for bd1 to reflect the fact that originally there was no bond between these two atoms
+                        bd1.order = 0
 
             if act[2] + bd1.order == 0.5:
                 mol2 = None
@@ -2035,7 +2056,13 @@ def get_w0(actions, rxn):
                 bd2_bde = 0.0
             else:
                 bd2_bde = bd2.get_bde()
-            bde_diff = bd2_bde - bd1.get_bde()
+            
+            if bd1.order == 0:
+                bd1_bde = 0.0
+            else:
+                bd1_bde = bd1.get_bde()
+                
+            bde_diff = bd2_bde - bd1_bde
             if bde_diff > 0:
                 wf += abs(bde_diff)
             else:


### PR DESCRIPTION
### Motivation or Problem
The halocarbene_recombination_double family recipe is written as follows: 

```
recipe(actions=[
    ['LOSE_PAIR', '*1', '1'],
    ['LOSE_PAIR', '*2', '1'],
    ['FORM_BOND', '*1', 1, '*2'],
    ['CHANGE_BOND', '*1', 1, '*2']
])
```
where there is no bond between atoms *1 and *2 in the reactants, and a double bond between *1 and *2 in the product. 

This causes an error when using these reactions to fit a ArrheniusBM. When `get_w0()` is called for calculating the w0 for the BM's kinetics, a ValueError is raised: 

`ValueError: The specified vertices are not connected by an edge in this graph`

This is because the current code in get_w0 will attempt to calculate the total bond energy of bonds formed (wf) by first finding the difference between the bond dissociation energy of bond between *1 and *2 in the reactants and the bond between *1 and *2 in the product. The code doesn't seem to expect that there would be no bond between *1 and *2 in the reactants if the reaction recipe has a CHANGE_BOND step. 

I iterated through all families in 'default' looking for recipes that form a bond between two atoms and then change the bond (i.e. going from no bond in reactants to double or higher bond in product). I could only find halocarbene_recombination_double that has this, so I believe this PR fix is only needed for the retraining of this family.


### Description of Changes
Implemented a try/except that catches ValueError, confirms that it is an example of the problem case described above, then creates a Bond object with an order of 0 (so code downstream won't crash) and a bond dissociation energy of 0.0 so the calculation for wf is still accurate. 

Was able to successfully retrain family with this fix. 

### Testing
Here's some simple code for testing...

Before PR, ValueError would be caught in following code snippet. After PR, should pass: 

```
fam_name = 'halocarbene_recombination_double'
training_reactions = [ent.item for ent in database.kinetics.families[fam_name].get_training_depository().entries.values()]
for tr in training_reactions: 
    try:   
        print(tr)
        display(tr)
        get_w0(database.kinetics.families[fam_name].forward_recipe.actions, tr)
        print('passed')
    except ValueError as e: 
        print(e)
        continue
```
Thanks!