### PR TITLE
Fix conda env creation hang and clang build failure on macOS; improve install docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,6 +80,14 @@ jobs:
       - name: Checkout RMG-Py
         uses: actions/checkout@v6
 
+      - name: Pin Python version for CI matrix
+        # environment.yml pins python=3.11 for fast user installs; rewrite to the
+        # matrix version here so setup-miniconda can inject the correct pin cleanly.
+        # The -i.bak / rm pattern works on both GNU sed (Linux) and BSD sed (macOS).
+        run: |
+          sed -i.bak "s/conda-forge::python =3\.11/conda-forge::python =${{ matrix.python-version }}/" environment.yml
+          rm -f environment.yml.bak
+
       - name: Setup Miniforge Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v4
         with:
@@ -147,13 +155,13 @@ jobs:
       - name: Checkout RMG-Py
         uses: actions/checkout@v6
 
-      - name: Setup Miniforge Python 3.9
+      - name: Setup Miniforge Python 3.11
         uses: conda-incubator/setup-miniconda@v4
         with:
           environment-file: environment.yml
           miniforge-variant: Miniforge3
           miniforge-version: latest
-          python-version: 3.9
+          python-version: 3.11
           activate-environment: rmg_env
           auto-update-conda: true
           show-channel-urls: true

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,6 +4,35 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
+.. warning::
+
+   **Before you begin — check your build tools are up to date.**
+
+   RMG-Py compiles Cython extensions during installation, so your C compiler and
+   conda installation must be reasonably modern or the build will fail.
+
+   **On macOS:** Ensure your Xcode Command Line Tools are current.  An outdated
+   installation (more than a year or two old) will cause ``make`` to fail with a
+   ``clang: error: invalid version number`` message.  To check::
+
+       clang --version
+
+   If the reported version is older than Apple clang 13, reinstall the tools::
+
+       sudo rm -rf /Library/Developer/CommandLineTools
+       xcode-select --install
+
+   **conda version:** Ensure conda is version 24.0 or newer (run ``conda --version``
+   to check).  Older versions use a slower solver that can hang indefinitely when
+   creating the RMG environment.  To update::
+
+       conda update -n base -c conda-forge conda
+
+   If ``conda update`` does not advance the version, install a specific release
+   explicitly::
+
+       conda install -n base -c conda-forge conda=26.3
+
 #. Install the `conda` package manager via `miniforge`, if you do not already have it (or Anaconda), by following the `Miniforge installation instructions <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_.
 
 #. If your `conda` version is older than 23.10.0, manually switch the solver backend to `libmamba` (or update your conda)::
@@ -40,6 +69,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
       These are a set of packages relevant for software development which have been bundled together by Apple.
       The easiest way to install this is to simply run one of the commands in the terminal, e.g. ``git``.
       The terminal will then prompt you to install the Command Line Tools.
+      See the warning at the top of this page about keeping the tools up to date.
 
 #. Install the latest versions of RMG and RMG-database through cloning the source code via Git. Make sure to start in an
    appropriate local directory where you want both RMG-Py and RMG-database folders to exist.
@@ -51,7 +81,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
    It is still possible to clone the repositories using ``https`` if you are
    unfamiliar with ``ssh``::
-   
+
     git clone https://github.com/ReactionMechanismGenerator/RMG-Py.git
     git clone https://github.com/ReactionMechanismGenerator/RMG-database.git
 
@@ -61,7 +91,10 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     cd RMG-Py
 
-#. Create the conda environment for RMG-Py::
+#. Create the conda environment for RMG-Py.
+
+   The ``environment.yml`` file pins Python 3.11, so the solver only needs to
+   consider packages for a single Python version and the solve completes quickly::
 
     conda env create -f environment.yml
 
@@ -89,10 +122,10 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
        - nodefaults
      channel_priority: strict
      custom_channels:
-       main: null
-       r: null
-       anaconda: null
-       msys2: null
+         main: null
+         r: null
+         anaconda: null
+         msys2: null
 
 #. Activate conda environment ::
 

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -4,41 +4,27 @@
 Installation by Source Using Anaconda Environment for Unix-based Systems: Linux and Mac OSX
 *******************************************************************************************
 
-.. warning::
-
-   **Before you begin — check your build tools are up to date.**
+#. Before you begin — check your build tools are up to date.
 
    RMG-Py compiles Cython extensions during installation, so your C compiler and
    conda installation must be reasonably modern or the build will fail.
 
-   **On macOS:** Ensure your Xcode Command Line Tools are current.  An outdated
-   installation (more than a year or two old) will cause ``make`` to fail with a
-   ``clang: error: invalid version number`` message.  To check::
-
-       clang --version
-
-   If the reported version is older than Apple clang 13, reinstall the tools::
+   **On MacOS:** Ensure your Xcode Command Line Tools are current.  If more than a year or two old, reinstall the tools::
 
        sudo rm -rf /Library/Developer/CommandLineTools
        xcode-select --install
 
-   **conda version:** Ensure conda is version 24.0 or newer (run ``conda --version``
-   to check).  Older versions use a slower solver that can hang indefinitely when
-   creating the RMG environment.  To update::
+   **conda version:** Ensure conda is also up to date.  To update::
 
        conda update -n base -c conda-forge conda
 
-   If ``conda update`` does not advance the version, install a specific release
-   explicitly::
+   If ``conda update`` does not advance the version (which can happen), install a specific release explicitly, e.g.::
 
        conda install -n base -c conda-forge conda=26.3
 
-#. Install the `conda` package manager via `miniforge`, if you do not already have it (or Anaconda), by following the `Miniforge installation instructions <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_.
+#. If you do not already have the `conda` package manager (or Anaconda) then install it via `miniforge`, by following the `Miniforge installation instructions <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_.
 
-#. If your `conda` version is older than 23.10.0, manually switch the solver backend to `libmamba` (or update your conda)::
 
-    conda install -n base conda-libmamba-solver
-    conda config --set solver libmamba
 
 #. There are a few system-level dependencies which are required and should not be installed via Conda. These include
    `Git <https://git-scm.com/>`_ for version control, `GNU Make <https://www.gnu.org/software/make/>`_, and the C and C++ compilers from the `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`_ for compiling RMG.
@@ -69,7 +55,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
       These are a set of packages relevant for software development which have been bundled together by Apple.
       The easiest way to install this is to simply run one of the commands in the terminal, e.g. ``git``.
       The terminal will then prompt you to install the Command Line Tools.
-      See the warning at the top of this page about keeping the tools up to date.
+      See the warning in step 1 about keeping the tools up to date.
 
 #. Install the latest versions of RMG and RMG-database through cloning the source code via Git. Make sure to start in an
    appropriate local directory where you want both RMG-Py and RMG-database folders to exist.
@@ -93,8 +79,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
 #. Create the conda environment for RMG-Py.
 
-   The ``environment.yml`` file pins Python 3.11, so the solver only needs to
-   consider packages for a single Python version and the solve completes quickly::
+   To create an environment called ``rmg_env`` containing all that you need for RMG, run::
 
     conda env create -f environment.yml
 
@@ -102,17 +87,13 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     conda env create -f environment.yml -n rmg_env2
 
-   If either of these commands return an error due to being unable to find the ``conda`` command,
-   try to either close and reopen your terminal to refresh your environment variables
-   or type the following command.
+   If you have a recent version of conda (``conda -V`` reports >= 26.3) then the preferred command is without the ``env`` subcommand::
 
-   If on Linux or pre-Catalina MacOS (or if you have a bash shell)::
+    conda create --file environment.yml --name rmg_env
 
-    source ~/.bashrc
-
-   If on MacOS Catalina or later (or if you have a Z shell)::
-
-    source ~/.zshrc
+   If any of these commands return an error due to being unable to find the ``conda`` command,
+   (for example if you only just installed it)
+   then close and reopen your terminal (or log out and log in again) to refresh your environment variables.
 
    NOTE: You may wish to forbid ``conda`` from installing from the Anaconda channels due to licensing restrictions.
    The ``environment.yml`` file already forbids using default channels, but you may further add the file ``.condarc`` to your RMG-Py directory (or modify the ``.condarc`` in your home directory) with the following contents before running the ``conda env create`` command: ::
@@ -152,7 +133,7 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
 
     Installing Julia and ReactionMechanismSimulator.jl (RMS) will enable all the features in RMG that require RMS-based reactors,
     as well as using ``method='ode'`` when solving the Master Equation with Arkane.
-    Note that installing RMS can cause errors when running Cantera simulations; this should not affect normal RMG use, but if you wish to run Cantera simulations you will need to maintain a separate conda environment without RMS in it.
+    Note that installing RMS has sometimes caused errors when running Cantera; this should not affect normal RMG use, but if you wish to run Cantera simulations you might need to use a separate conda environment without RMS in it.
 
     Ensure that you have modified your environment variables as described above, and then run the following: ::
 

--- a/documentation/source/users/rmg/installation/anacondaDeveloper.rst
+++ b/documentation/source/users/rmg/installation/anacondaDeveloper.rst
@@ -9,9 +9,8 @@ Installation by Source Using Anaconda Environment for Unix-based Systems: Linux 
    RMG-Py compiles Cython extensions during installation, so your C compiler and
    conda installation must be reasonably modern or the build will fail.
 
-   **On MacOS:** Ensure your Xcode Command Line Tools are current.  If more than a year or two old, reinstall the tools::
+   **On MacOS:** Ensure your Xcode Command Line Tools are current. If they are more than a year or two old, either download the latest Command Line Tools from `Apple Developer Downloads <https://developer.apple.com/download/all/>`_ (free Apple ID required) or manually remove them and reinstall them using::
 
-       sudo rm -rf /Library/Developer/CommandLineTools
        xcode-select --install
 
    **conda version:** Ensure conda is also up to date.  To update::

--- a/environment.yml
+++ b/environment.yml
@@ -28,12 +28,9 @@ dependencies:
   - conda-forge::xlrd
   - conda-forge::xlwt
   - conda-forge::h5py
-  # keep graphviz from conda-forge; see https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2750
   - conda-forge::graphviz >=12
   - conda-forge::markupsafe
   - conda-forge::psutil
-  # conda-forge not default, since default has a version information bug
-  # (see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2421)
   - conda-forge::ncurses
   - conda-forge::suitesparse
   # ThermoCentralDatabaseInterface fails if pyopenssl is too old. 20 is just a guess at the version number. 
@@ -60,6 +57,7 @@ dependencies:
   - conda-forge::pydot
   - conda-forge::jinja2
   - conda-forge::jupyter
+  - conda-forge::pip
   - conda-forge::pymongo
   - conda-forge::pyparsing
   - conda-forge::pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - rmg::pysidt-rmg >=1.2
 
 # Python tools
-  - conda-forge::python >=3.9,<3.12  # leave as GEQ so that GitHub actions can add EQ w/o breaking (contradictory deps)
+  - conda-forge::python =3.11  # pinned to a single version to keep solver fast; CI rewrites this to the matrix version (see CI.yml)
   - conda-forge::setuptools <80
   - conda-forge::coverage
   - conda-forge::cython >=0.25.2,<3.1


### PR DESCRIPTION
### Motivation or Problem

Two separate issues were encountered when doing a fresh source install on macOS (reported while setting up a new conda environment after `pysidt-rmg` was added as a dependency. See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2952):

1. **`conda env create -f environment.yml` hangs or is very slow.** The previous Python constraint `>=3.9,<3.12` causes the conda solver to consider the full package graph for three Python versions simultaneously. This can hang, apparently indefinitely (or at least beyond my patience).

2. **`make` fails with `clang: error: invalid version number in 'MACOSX_DEPLOYMENT_TARGET=11.0'`.** The conda-forge `osx-64` Python package targets `macosx-11.0`, but Apple clang versions older than ~clang 13 (shipped with Xcode Command Line Tools before ~2021) do not recognise any macOS deployment target ≥ 11.0. Users whose Command Line Tools installation was never updated since macOS Big Sur was released hit this immediately.

Neither issue was documented, and the install guide gave no guidance on prerequisite tool versions.

### Description of Changes

**`environment.yml`**
- Tighten the Python pin from `>=3.9,<3.12` to `=3.11`. This collapses the solver search space to a single Python version, making fresh environment creation fast and reliable.

**`.github/workflows/CI.yml`**
- `build-and-test` job: add a "Pin Python version for CI matrix" step immediately after checkout that rewrites `conda-forge::python =3.11` to `conda-forge::python =<matrix-version>` before `setup-miniconda` runs. This is necessary because `setup-miniconda` *adds* an equality pin rather than replacing the existing one, so a pre-existing `=3.11` would conflict with the injected `=3.9` or `=3.10`. The `sed -i.bak / rm` idiom works on both GNU sed (Linux) and BSD sed (macOS).
- `regression-test` job: upgrade the hardcoded Python version from 3.9 to 3.11. 

**`documentation/source/users/rmg/installation/anacondaDeveloper.rst`**
- Promote a new "Before you begin" step to the top of the numbered list covering:
  - macOS: check clang version, and how to reinstall Xcode Command Line Tools if outdated
  - conda: how to check version and force-upgrade when `conda update` fails to advance it
- Remove the now-redundant step about manually switching to the libmamba solver (any conda version that warrants an upgrade will get libmamba automatically).
- Expand the `conda env create` step with the alternative `conda create --file` syntax (preferred on conda ≥ 26.3) and simplify the "conda command not found" recovery advice.

### Testing

- Verified locally on macOS 26.5 (Intel x86_64, `osx-64`) with Apple clang 21.0.0 and conda 26.3.2:
  - `conda env create -f environment.yml` resolves successfully with the `=3.11` pin.
  - `make build` completes without errors after reinstalling Xcode Command Line Tools.
- The CI matrix change (sed rewrite + regression job Python bump) ran ok on the CI

### Reviewer Tips

- `conda_build.yml` is not changed — it builds from `.conda/meta.yaml` and never reads `environment.yml`.
