### PR TITLE
Use eigh (not eig) for moment-of-inertia diagonalization

### DIFF
--- a/arkane/common.py
+++ b/arkane/common.py
@@ -695,8 +695,8 @@ def get_principal_moments_of_inertia(coords, numbers=None, symbols=None):
         tuple: The corresponding principal axes.
     """
     tensor0 = get_moment_of_inertia_tensor(coords=coords, numbers=numbers, symbols=symbols)
-    # Since tensor0 is real and symmetric, diagonalization is always possible
-    principal_moments_of_inertia, axes = np.linalg.eig(tensor0)
+    # tensor0 is real and symmetric by construction; use eigh so eigenvalues are guaranteed real.
+    principal_moments_of_inertia, axes = np.linalg.eigh(tensor0)
     principal_moments_of_inertia, axes = zip(*sorted(zip(np.ndarray.tolist(principal_moments_of_inertia),
                                                          np.ndarray.tolist(axes)), reverse=True))
     return principal_moments_of_inertia, axes

--- a/rmgpy/statmech/conformer.pyx
+++ b/rmgpy/statmech/conformer.pyx
@@ -326,8 +326,8 @@ cdef class Conformer(RMGObject):
         kg*m^2, while the principal axes have unit length.
         """
         I0 = self.get_moment_of_inertia_tensor()
-        # Since I0 is real and symmetric, diagonalization is always possible
-        I, V = np.linalg.eig(I0)
+        # I0 is real and symmetric by construction; use eigh so eigenvalues are guaranteed real.
+        I, V = np.linalg.eigh(I0)
         return I, V
 
     @cython.boundscheck(False)


### PR DESCRIPTION

### Motivation or Problem
The CI test test_co2_linear_rotor has been failing sporadically with "TypeError: '<' not supported between instances of 'complex' and 'complex'" raised from arkane/common.py:get_principal_moments_of_inertia. CO2 (and any linear molecule) has a doubly-degenerate eigenvalue in its inertia tensor, and np.linalg.eig's generic routine occasionally returns a complex128 array with tiny imaginary noise on degenerate spectra. The downstream sorted() call then chokes on complex comparison. Whether the noise is exactly zero depends on input rounding, which is why the failure is flaky.

### Description of Changes
The inertia tensor is real and symmetric by construction so np.linalg.eigh  is the right routine: it is specialised
for symmetric/Hermitian matrices, guarantees real eigenvalues, and is what arkane/statmech.py already uses for analogous diagonalisations. The fix is applied in two places that had the same latent bug:

  * arkane/common.py:get_principal_moments_of_inertia — directly hits the sort and is the path that triggered the CI failure.
  * rmgpy/statmech/conformer.pyx:Conformer.get_principal_moments_of_inertia — same construction, same risk; would silently return complex-typed moments for linear species and pass them to downstream consumers.
 
  
### Testing
Ran relevant tests locally. All passed.
Hopefully this clears the CI test suite.