### PR TITLE
Trying to diagnose and fix conda build (on intel mac)

### DIFF
--- a/.conda/conda_build_config.yaml
+++ b/.conda/conda_build_config.yaml
@@ -1,0 +1,14 @@
+# Restrict conda-build's variant matrix so the solver does not enumerate
+# python/numpy combinations from internal_defaults. The CI workflow's
+# CONDA_PY env var narrows to one of these python versions per matrix cell.
+#
+# Without this file, conda-build considers every (python, numpy) pair from
+# its internal defaults during the "Getting pinned dependencies" phase,
+# which substantially enlarges the search space the libmamba solver has
+# to traverse.
+python:
+  - 3.9
+  - 3.10
+  - 3.11
+numpy:
+  - 1.26

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -72,14 +72,8 @@ requirements:
     - blas=*=openblas
   run: *runtime_requirements
 test:
-  # Test environment automatically inherits the run requirements; only
-  # list test-only extras here so they don't constrain the build/host solve.
-  requires:
-    - conda-forge::pytest
-    - conda-forge::pytest-cov
-    - conda-forge::pytest-check
-    - conda-forge::coverage
-    - conda-forge::jupyter
+  # Keep this minimal: test commands below run import checks plus two example
+  # command-line runs, and do not invoke the pytest suite.
   source_files:
     - 'examples/rmg/superminimal'
     - 'examples/arkane/networks/n-butanol_msc'

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -4,6 +4,9 @@
 # RMG-Py into binaries which can then be uploaded for access via the conda package manager
 # to use this file, you can follow the procedure shown in .github/workflows/conda_build.yml
 #
+# Variant axes (python, numpy) are pinned in .conda/conda_build_config.yaml so that
+# conda-build does not enumerate every combination from its internal defaults.
+#
 package:
   name: rmg
   version: 4.0.0.rc1
@@ -39,23 +42,21 @@ requirements:
     - conda-forge::cclib >=1.6.3,<1.9
     - conda-forge::openbabel >=3
     - conda-forge::rdkit >=2022.09.1
+    # python intentionally left loose so the CI matrix (via CONDA_PY)
+    # can pin it without a contradictory-deps error. The real variant pin
+    # lives in .conda/conda_build_config.yaml.
     - conda-forge::python >=3.9,<3.12
-    - conda-forge::setuptools <80
-    - conda-forge::coverage
-    - conda-forge::cython >=0.25.2,<3.1
+    - conda-forge::setuptools >=70,<80
+    - conda-forge::cython >=3.0,<3.1
     - conda-forge::scikit-learn
-    - conda-forge::scipy >=1.9
-    - conda-forge::numpy >=1.10.0,<2
+    - conda-forge::scipy >=1.13
+    - conda-forge::numpy >=1.24,<2
     - conda-forge::pydot
     - conda-forge::jinja2
-    - conda-forge::jupyter
     - conda-forge::pymongo
     - conda-forge::pyparsing
     - conda-forge::pyyaml
     - conda-forge::networkx
-    - conda-forge::pytest
-    - conda-forge::pytest-cov
-    - conda-forge::pytest-check
     - conda-forge::pyutilib
     - conda-forge::matplotlib >=1.5
     - conda-forge::mpmath
@@ -71,7 +72,14 @@ requirements:
     - blas=*=openblas
   run: *runtime_requirements
 test:
-  requires: *runtime_requirements
+  # Test environment automatically inherits the run requirements; only
+  # list test-only extras here so they don't constrain the build/host solve.
+  requires:
+    - conda-forge::pytest
+    - conda-forge::pytest-cov
+    - conda-forge::pytest-check
+    - conda-forge::coverage
+    - conda-forge::jupyter
   source_files:
     - 'examples/rmg/superminimal'
     - 'examples/arkane/networks/n-butanol_msc'

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - conda-forge::psutil
     - conda-forge::ncurses
     - conda-forge::suitesparse
-    - conda-forge::pyopenssl >20
+    - conda-forge::pyopenssl >24
     - conda-forge::coolprop
     - conda-forge::cantera >=3.0
     - conda-forge::mopac

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - conda-forge::ffmpeg >=7
     - conda-forge::xlrd
     - conda-forge::xlwt
-    - conda-forge::h5py
+    - conda-forge::h5py >=3.10
     - conda-forge::graphviz >=12
     - conda-forge::markupsafe
     - conda-forge::psutil
@@ -41,14 +41,14 @@ requirements:
     - conda-forge::mopac
     - conda-forge::cclib >=1.6.3,<1.9
     - conda-forge::openbabel >=3
-    - conda-forge::rdkit >=2022.09.1
+    - conda-forge::rdkit >=2024
     # python intentionally left loose so the CI matrix (via CONDA_PY)
     # can pin it without a contradictory-deps error. The real variant pin
     # lives in .conda/conda_build_config.yaml.
     - conda-forge::python >=3.9,<3.12
     - conda-forge::setuptools >=70,<80
     - conda-forge::cython >=3.0,<3.1
-    - conda-forge::scikit-learn
+    - conda-forge::scikit-learn >=1.3
     - conda-forge::scipy >=1.13
     - conda-forge::numpy >=1.24,<2
     - conda-forge::pydot
@@ -58,9 +58,9 @@ requirements:
     - conda-forge::pyyaml
     - conda-forge::networkx
     - conda-forge::pyutilib
-    - conda-forge::matplotlib >=1.5
+    - conda-forge::matplotlib >=3.5
     - conda-forge::mpmath
-    - conda-forge::pandas
+    - conda-forge::pandas >=2
     - conda-forge::gprof2dot
     - conda-forge::numdifftools
     - conda-forge::quantities !=0.16.0,!=0.16.1

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -27,19 +27,19 @@ jobs:
         # for PRs just run a single build per platform to save time and resources
           - is_pr: true
             os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.9"
           - is_pr: true
             os: ubuntu-latest
             python-version: "3.10"
           - is_pr: true
             os: macos-15-intel
-            python-version: "3.11"
+            python-version: "3.9"
           - is_pr: true
             os: macos-15-intel
             python-version: "3.10"
           - is_pr: true
             os: macos-latest
-            python-version: "3.11"
+            python-version: "3.9"
           - is_pr: true
             os: macos-latest
             python-version: "3.10"

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -12,9 +12,7 @@ on:
       - stable
 jobs:
   build:
-    # Hard cap so a solver hang fails attributably instead of consuming the
-    # default 6-hour runner allotment in silence (as happened on macos-15-intel
-    # before the .conda recipe was tightened in this branch).
+    # Timeout to avoid waisting the default 6-hour runner allotment.
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -44,7 +42,7 @@ jobs:
             os: macos-latest
             python-version: "3.10"
     runs-on: ${{ matrix.os }}
-    name: Build ${{ matrix.os }} Python ${{ matrix.python-version }} Numpy ${{ matrix.numpy-version }}
+    name: Conda Build ${{ matrix.os }} Python ${{ matrix.python-version }} Numpy ${{ matrix.numpy-version }}
     defaults:
       run:
         shell: bash -l {0}
@@ -66,9 +64,7 @@ jobs:
         run: conda install python anaconda-client conda-build
 
       - name: Show solver and runner info
-        # Small diagnostic snapshot — captures conda version, configured
-        # channels, base env contents, and runner CPU/RAM. Cheap to keep
-        # in CI and invaluable when something starts hanging again.
+        # Small diagnostic snapshot.
         run: |
           conda info
           conda config --show-sources
@@ -78,9 +74,6 @@ jobs:
 
       - name: Build Binary
         env:
-          # Light verbosity bump over default. Surfaces libmamba "Solver
-          # attempt: #N" markers and per-package install plans in the log
-          # without dragging in the firehose that --debug produces.
           CONDA_VERBOSITY: "1"
         run: |
           # set a default value to the conda_token if needed (like from forks)
@@ -91,9 +84,7 @@ jobs:
           conda config --add channels conda-forge
           # --add prepends, so the final channel order is [conda-forge, rmg, ...].
           # Strict priority makes the solver skip lower-priority channels entirely
-          # for any package the higher-priority channel offers, which means it
-          # won't even load old rmg/osx-64 builds of cantera/numpy/rdkit/etc.
-          # as candidates (they're shadowed by conda-forge's modern builds).
+          # for any package the higher-priority channel offers.
           conda config --set channel_priority strict
           conda config --set anaconda_upload no
           CONDA_NPY=${{ matrix.numpy-version }} CONDA_PY=${{ matrix.python-version }} conda build .
@@ -108,7 +99,7 @@ jobs:
   result:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Final Results
+    name: Conda Build Results
     needs: [build]
     steps:
       - run: exit 1

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -12,6 +12,10 @@ on:
       - stable
 jobs:
   build:
+    # Hard cap so a solver hang fails attributably instead of consuming the
+    # default 6-hour runner allotment in silence (as happened on macos-15-intel
+    # before the .conda recipe was tightened in this branch).
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +65,23 @@ jobs:
       - name: Install Build Tools
         run: conda install python anaconda-client conda-build
 
+      - name: Show solver and runner info
+        # Small diagnostic snapshot — captures conda version, configured
+        # channels, base env contents, and runner CPU/RAM. Cheap to keep
+        # in CI and invaluable when something starts hanging again.
+        run: |
+          conda info
+          conda config --show-sources
+          conda list -n base | head -40
+          uname -a
+          sysctl hw.memsize hw.ncpu hw.physicalcpu 2>/dev/null || cat /proc/meminfo 2>/dev/null | head -3 || true
+
       - name: Build Binary
+        env:
+          # Light verbosity bump over default. Surfaces libmamba "Solver
+          # attempt: #N" markers and per-package install plans in the log
+          # without dragging in the firehose that --debug produces.
+          CONDA_VERBOSITY: "1"
         run: |
           # set a default value to the conda_token if needed (like from forks)
           : "${CONDA_TOKEN:=${{ secrets.ANACONDA_TOKEN }}}"

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -89,6 +89,12 @@ jobs:
           echo "CONDA_TOKEN=$CONDA_TOKEN" >> $GITHUB_ENV
           conda config --add channels rmg
           conda config --add channels conda-forge
+          # --add prepends, so the final channel order is [conda-forge, rmg, ...].
+          # Strict priority makes the solver skip lower-priority channels entirely
+          # for any package the higher-priority channel offers, which means it
+          # won't even load old rmg/osx-64 builds of cantera/numpy/rdkit/etc.
+          # as candidates (they're shadowed by conda-forge's modern builds).
+          conda config --set channel_priority strict
           conda config --set anaconda_upload no
           CONDA_NPY=${{ matrix.numpy-version }} CONDA_PY=${{ matrix.python-version }} conda build .
 

--- a/environment.yml
+++ b/environment.yml
@@ -33,8 +33,8 @@ dependencies:
   - conda-forge::psutil
   - conda-forge::ncurses
   - conda-forge::suitesparse
-  # ThermoCentralDatabaseInterface fails if pyopenssl is too old. 20 is just a guess at the version number. 
-  - conda-forge::pyopenssl >20
+  # ThermoCentralDatabaseInterface fails if pyopenssl is too old.
+  - conda-forge::pyopenssl >24
 
 # external software tools for chemistry
   - conda-forge::coolprop

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - conda-forge::ffmpeg >= 7
   - conda-forge::xlrd
   - conda-forge::xlwt
-  - conda-forge::h5py
+  - conda-forge::h5py >=3.10
   - conda-forge::graphviz >=12
   - conda-forge::markupsafe
   - conda-forge::psutil
@@ -43,17 +43,17 @@ dependencies:
   # see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2639#issuecomment-2050292972
   - conda-forge::cclib >=1.6.3,<1.9
   - conda-forge::openbabel >= 3
-  - conda-forge::rdkit >=2022.09.1
+  - conda-forge::rdkit >=2024
   - rmg::pysidt-rmg >=1.2
 
 # Python tools
   - conda-forge::python =3.11  # pinned to a single version to keep solver fast; CI rewrites this to the matrix version (see CI.yml)
-  - conda-forge::setuptools <80
+  - conda-forge::setuptools >=70,<80
   - conda-forge::coverage
-  - conda-forge::cython >=0.25.2,<3.1
-  - conda-forge::scikit-learn
-  - conda-forge::scipy >=1.9
-  - conda-forge::numpy >=1.10.0,<2
+  - conda-forge::cython >=3.0,<3.1
+  - conda-forge::scikit-learn >=1.3
+  - conda-forge::scipy >=1.13
+  - conda-forge::numpy >=1.24,<2
   - conda-forge::pydot
   - conda-forge::jinja2
   - conda-forge::jupyter
@@ -66,9 +66,9 @@ dependencies:
   - conda-forge::pytest-cov
   - conda-forge::pytest-check
   - conda-forge::pyutilib
-  - conda-forge::matplotlib >=1.5
+  - conda-forge::matplotlib >=3.5
   - conda-forge::mpmath
-  - conda-forge::pandas
+  - conda-forge::pandas >=2
   - conda-forge::gprof2dot
   - conda-forge::numdifftools
   # bug in quantities, see:


### PR DESCRIPTION
##  Summary
The Conda Build workflow has been hanging for 6 hours on the macos-15-intel runner and then getting killed silently by GitHub Actions' default job timeout. Local instrumentation showed the time is spent inside the libmamba solver while conda-build enumerates its internal-defaults variant matrix against the full conda-forge+rmg constraint set; the solve eventually completes on linux-64 and osx-arm64 but on osx-64 it explores enough of the candidate graph to blow past the wall clock. This PR attacks the search space from several directions and adds enough CI instrumentation that the next hang fails attributably.

The changes, in order of impact:

- Variant restriction: new file .conda/conda_build_config.yaml pins python to {3.9, 3.10, 3.11} and numpy to {1.26}. Without this, conda-build considers every python and numpy combination from its embedded internal_defaults during the "Getting pinned dependencies" phase, on top of whatever meta.yaml says.
- Strict channel priority (conda config --set channel_priority strict in the workflow). The --add channels calls already prepend conda-forge ahead of rmg. Under strict priority the solver no longer pulls old rmg/osx-64 builds of cantera/rdkit/numpy/h5py/etc. into its universe just to mark them ineligible.
- Recipe restructure in .conda/meta.yaml:
Vestigial open floors raised based on what rmg_env actually runs: cython >=0.25.2 → >=3.0, numpy >=1.10.0 → >=1.24, scipy >=1.9 → >=1.13, setuptools <80 → >=70,<80, h5py → >=3.10, pandas → >=2, scikit-learn → >=1.3, matplotlib >=1.5 → >=3.5, rdkit >=2022.09.1 → >=2024. Counted against the cached conda-forge/osx-64 repodata these collectively remove ~2900 candidate builds the solver no longer has to traverse.
- Test-only dependencies (pytest, pytest-cov, pytest-check, coverage, jupyter) moved out of host:/run: into test.requires, so they no longer constrain the build/host solve. jupyter is not imported anywhere in rmgpy or arkane.
- CI instrumentation in .github/workflows/conda_build.yml:
timeout-minutes: 180 at the job level. Replaces GitHub Actions' default 6-hour silent kill with a fast, attributable failure.
New "Show solver and runner info" step. One snapshot of conda info, configured channels, base env contents, kernel info, and RAM/CPU per matrix cell. Cheap to keep, invaluable when something starts hanging again.
- CONDA_VERBOSITY=1 on the build step. Surfaces libmamba "Solver attempt: #N" markers and the install plan in the CI log so a future hang narrows itself to a phase. Avoids --debug, which produces thousands of repodata-fetch lines.
- The python spec in meta.yaml is intentionally left as a loose range so the CI matrix's CONDA_PY override does not produce a contradictory-deps error; the actual variant pin lives in conda_build_config.yaml.

## Test plan
This seems to be working better on my intel mac. 
And it passes on Github's runners.