### PR TITLE
Add unload_libraries helper function

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -974,6 +974,25 @@ class ThermoDatabase(object):
                     raise DatabaseError('Library {} not found in {}... Please check if your library is '
                                         'correctly placed'.format(libraryName, path))
 
+    def unload_libraries(self, libraries=None):
+        """
+        Unload the libraries where `libraries` is a list of library names to unload.
+        If `libraries` is None, unload all libraries.
+        """
+        if isinstance(libraries, str):
+            libraries = [libraries]
+
+        if libraries is None:  # unload all
+            self.libraries = {}
+            self.library_order = []
+        else:
+            for libraryName in libraries:
+                if libraryName in self.libraries:
+                    self.libraries.pop(libraryName)
+                    self.library_order.remove(libraryName)
+                else:
+                    raise DatabaseError('Library {} not found in the current database... Please check if your library name is correct'.format(libraryName))
+
     def load_surface(self):
         """
         Load the metal database from the given `path` on disk, where `path`

--- a/test/rmgpy/data/thermoTest.py
+++ b/test/rmgpy/data/thermoTest.py
@@ -102,6 +102,33 @@ class TestThermoDatabaseLoading:
         assert list(database.libraries.keys()) == ["copied_thermo_lib"]
         os.remove(thermo_lib_in_test_dir_path)
 
+    def test_load_unload_libraries(self):
+        """This tests loading and unloading thermo libraries"""
+
+        database = ThermoDatabase()
+        database.load_libraries(
+            path=os.path.join(settings["database.directory"], "thermo", "libraries"),
+            libraries=['primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC'],
+        )
+
+        # make sure we are now using primaryThermoLibrary thermo
+        lib_thermo = database.get_thermo_data(Species(smiles="O"))  # H2O is in both libraries, first it finds it in primaryThermoLibrary
+        assert 'primaryThermoLibrary' in lib_thermo.comment
+        assert 'thermo_DFT_CCSDTF12_BAC' not in lib_thermo.comment
+
+        # unload library
+        database.unload_libraries(libraries=['primaryThermoLibrary'])
+        lib_thermo = database.get_thermo_data(Species(smiles="O"))  # now it finds it in thermo_DFT_CCSDTF12_BAC
+        assert 'thermo_DFT_CCSDTF12_BAC' in lib_thermo.comment
+        assert 'primaryThermoLibrary' not in lib_thermo.comment
+
+        # unload the other library
+        database.unload_libraries(libraries='thermo_DFT_CCSDTF12_BAC')  # test unloading with string instead of list
+
+        # because this is an empty database now with no libraries or groups, this should error out
+        with pytest.raises(KeyError):  # KeyError because no groups are loaded
+            database.get_thermo_data(Species(smiles="O"))
+
 
 class TestThermoDatabase:
     """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Sometimes you just want to remove a single library and it's annoying to have to instantiate an entirely new database to get the exact set of libraries you want. This helper function allows you to unload specific libraries without having to worry about resetting internal database properties like library_order.

### Description of Changes
Added an unload_libraries function to RMG-Py/rmgpy/data/thermo.py along with a test in RMG-Py/test/rmgpy/data/thermoTest.py

### Testing
This adds a test to load a library, get thermo for that library, then unload and check that you can't get thermo for that library anymore.

### Reviewer Tips
Try using it to load and unload a thermo library and estimate thermo data.

Here's code for loading a database (kinetics excluded for speed).
```
import rmgpy.data.rmg
database = rmgpy.data.rmg.RMGDatabase()
database.load(
    path = rmgpy.settings['database.directory'],
    thermo_libraries = ['primaryThermoLibrary'],
    transport_libraries = [],
    reaction_libraries = [],
    seed_mechanisms = [],
    kinetics_families = 'none',
    kinetics_depositories = ['training'],
    depository = False,
) 
```

You can then estimate species thermo with something like:
```
CCC = rmgpy.species.Species(smiles="CCC")
CCC.thermo = database.thermo.get_thermo_data(CCC)
print(CCC.thermo.comment)
```