### PR TITLE
modify max_heavy_atoms constraint

### DIFF
--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -113,7 +113,7 @@ def fails_species_constraints(species):
 
     max_heavy_atoms = species_constraints.get('maximumHeavyAtoms', -1)
     if max_heavy_atoms != -1:
-        heavy_atoms = struct.get_num_atoms() - struct.get_num_atoms('H')
+        heavy_atoms = struct.get_num_atoms() - struct.get_num_atoms('H') - struct.get_num_atoms('X')
         if heavy_atoms > max_heavy_atoms:
             return f"Exceeded maximumHeavyAtoms: {heavy_atoms} > {max_heavy_atoms}"
 


### PR DESCRIPTION
### Motivation or Problem
Applying the `maximumHeavyAtoms` constraint for adsorbates currently includes the number of surface sites. For example, setting `maximumHeavyAtoms=4` would lead to cases where a bidentate species with 3 carbon atoms (e.g., XCH2XCHCH3) is excluded while the a monodentate species with 3 carbon atoms is included (e.g., XCH2CH2CH3). Therefore, I think we should not count the number of surface sites as heavy atoms. We have the constraint `maximumSurfaceSites` to adjust the maximum denticity for an adsorbate. 

### Description of Changes
This was a very quick fix and I just modified the 'max_heavy_atoms' function in `constraints.py`

### Testing & Review
I generating a mechanism with this constraint to confirm that it works as intended. Reviewing should be quick. I suggest to test this in one of your existing input files to confirm that it works. 