### PR TITLE
Improvements to constraints handling.

### DIFF
--- a/rmgpy/constraints.py
+++ b/rmgpy/constraints.py
@@ -113,9 +113,8 @@ def fails_species_constraints(species):
 
     max_heavy_atoms = species_constraints.get('maximumHeavyAtoms', -1)
     if max_heavy_atoms != -1:
-        heavy_atoms = struct.get_num_atoms() - struct.get_num_atoms('H') - struct.get_num_atoms('X')
-        if heavy_atoms > max_heavy_atoms:
-            return f"Exceeded maximumHeavyAtoms: {heavy_atoms} > {max_heavy_atoms}"
+        if struct.get_num_heavy_atoms() > max_heavy_atoms:
+            return f"Exceeded maximumHeavyAtoms: {struct.get_num_heavy_atoms()} > {max_heavy_atoms}"
 
     max_surface_sites = species_constraints.get('maximumSurfaceSites', -1)
     if max_surface_sites != -1:

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1655,8 +1655,8 @@ class KineticsFamily(Database):
         for struct in product_structures:
             if self.is_molecule_forbidden(struct):
                 raise ForbiddenStructureException()
-            if fails_species_constraints(struct):
-                reason = fails_species_constraints(struct)
+            reason = fails_species_constraints(struct)
+            if reason:
                 raise ForbiddenStructureException(
                     "Species constraints forbids product species {0}. Please "
                     "reformulate constraints, or explicitly "

--- a/rmgpy/molecule/fragment.py
+++ b/rmgpy/molecule/fragment.py
@@ -761,6 +761,20 @@ class Fragment(Molecule):
                         num_atoms += 1
         return num_atoms
 
+    def get_num_heavy_atoms(self):
+        """
+        Return the number of heavy atoms in the fragment, i.e. the number of
+        atoms that are not Hydrogen ('H') nor a surface site ('X'). Cutting
+        labels are not counted.
+        """
+        num_atoms = 0
+        for vertex in self.vertices:
+            if isinstance(vertex, CuttingLabel):
+                continue
+            if vertex.element.symbol != 'H' and vertex.element.symbol != 'X':
+                num_atoms += 1
+        return num_atoms
+
     # extension methods
     def from_rdkit_mol(self, rdkitmol, atom_replace_dict=None):
         """

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -230,6 +230,8 @@ cdef class Molecule(Graph):
 
     cpdef int get_num_atoms(self, str element=?)
 
+    cpdef int get_num_heavy_atoms(self)
+
     cpdef Graph copy(self, bint deep=?)
 
     cpdef Molecule to_single_bonds(self, bint raise_atomtype_exception=?)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1408,6 +1408,18 @@ class Molecule(Graph):
                     num_atoms += 1
             return num_atoms
 
+    def get_num_heavy_atoms(self):
+        """
+        Return the number of heavy atoms in the molecule, i.e. the number of
+        atoms that are not Hydrogen ('H') nor a surface site ('X').
+        """
+        cython.declare(num_atoms=cython.int, atom=Atom)
+        num_atoms = 0
+        for atom in self.vertices:
+            if atom.element.symbol != 'H' and atom.element.symbol != 'X':
+                num_atoms += 1
+        return num_atoms
+
     def copy(self, deep=False):
         """
         Create a copy of the current graph. If `deep` is ``True``, a deep copy

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -734,11 +734,11 @@ class RMG(util.Subject):
                         "Input species {0} is globally forbidden. You may explicitly "
                         "allow it by adding 'input species' to the `generatedSpeciesConstraints` `allowed` list.".format(spec.label)
                     )
-            if fails_species_constraints(spec):
+            reason = fails_species_constraints(spec)
+            if reason:
                 if "allowed" in self.species_constraints and "input species" in self.species_constraints["allowed"]:
                     self.species_constraints["explicitlyAllowedMolecules"].append(spec.molecule[0])
                 else:
-                    reason = fails_species_constraints(spec)
                     raise ForbiddenStructureException(
                         "Species constraints forbids input species {0}. Please "
                         "reformulate constraints, remove the species, or explicitly "

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -1739,11 +1739,11 @@ class CoreEdgeReactionModel:
                         "found in a seed mechanism or reaction "
                         "library.".format(spec.label, seed_mechanism.label)
                     )
-            if fails_species_constraints(spec):
+            reason = fails_species_constraints(spec)
+            if reason:
                 if "allowed" in rmg.species_constraints and "seed mechanisms" in rmg.species_constraints["allowed"]:
                     rmg.species_constraints["explicitlyAllowedMolecules"].extend(spec.molecule)
                 else:
-                    reason = fails_species_constraints(spec)
                     raise ForbiddenStructureException(
                         "Species constraints forbids species {0} from seed mechanism {1}."
                         " Please reformulate constraints, remove the species, or"
@@ -1867,11 +1867,11 @@ class CoreEdgeReactionModel:
                             "inert unless found in a seed mechanism or reaction "
                             "library.".format(spec.label, reaction_library.label)
                         )
-            if fails_species_constraints(spec):
+            reason = fails_species_constraints(spec)
+            if reason:
                 if "allowed" in rmg.species_constraints and "reaction libraries" in rmg.species_constraints["allowed"]:
                     rmg.species_constraints["explicitlyAllowedMolecules"].extend(spec.molecule)
                 else:
-                    reason = fails_species_constraints(spec)
                     raise ForbiddenStructureException(
                         "Species constraints forbids species {0} from reaction library "
                         "{1}. Please reformulate constraints, remove the species, or "

--- a/test/rmgpy/constraintsTest.py
+++ b/test/rmgpy/constraintsTest.py
@@ -234,12 +234,35 @@ class TestFailsSpeciesConstraints:
     def test_heavy_constraint(self):
         """
         Test that we can constrain the max number of heavy atoms.
+
+        Hydrogens and surface sites ('X') are not counted as heavy atoms.
         """
         mol1 = Molecule(smiles="CCO")
+        assert mol1.get_num_heavy_atoms() == 3
         assert not fails_species_constraints(mol1)
 
         mol2 = Molecule(smiles="CCN=O")
+        assert mol2.get_num_heavy_atoms() == 4
         assert fails_species_constraints(mol2)
+
+        # An adsorbate: neither the hydrogens nor the surface site 'X' are
+        # heavy atoms, so this ethoxy fragment has only 3 heavy atoms
+        # (2 C + 1 O) and passes the maximumHeavyAtoms=3 constraint.
+        adsorbate = Molecule().from_adjacency_list(
+            """
+1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3 O u0 p2 c0 {2,S} {9,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+9 X u0 p0 c0 {3,S}
+"""
+        )
+        assert adsorbate.get_num_heavy_atoms() == 3
+        assert not fails_species_constraints(adsorbate)
 
     def test_radical_constraint(self):
         """

--- a/test/rmgpy/molecule/fragmentTest.py
+++ b/test/rmgpy/molecule/fragmentTest.py
@@ -605,6 +605,12 @@ class TestFragment:
         assert fragment.get_num_atoms(element="C") == 2
         assert fragment.get_num_atoms(element="H") == 4
 
+    def test_fragment_get_num_heavy_atoms(self):
+        # [CH2]CR has 2 heavy atoms (C), 3 H, and 1 cutting label (R)
+        fragment = rmgpy.molecule.fragment.Fragment().from_smiles_like_string("[CH2]CR")
+
+        assert fragment.get_num_heavy_atoms() == 2
+
     def test_fragment_to_smiles(self):
         adj = """1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
 2 R u0 p0 c0 {1,S}

--- a/test/rmgpy/molecule/moleculeTest.py
+++ b/test/rmgpy/molecule/moleculeTest.py
@@ -2139,6 +2139,48 @@ multiplicity 2
         assert adsorbed.number_of_surface_sites() == 1
         assert bidentate.number_of_surface_sites() == 2
 
+    def test_get_num_heavy_atoms(self):
+        """
+        Test the Molecule.get_num_heavy_atoms() method, which counts atoms
+        that are not Hydrogen ('H') nor a surface site ('X').
+        """
+        # gas-phase molecule: ethane, 2 heavy atoms (C), 6 H
+        ethane = Molecule(smiles="CC")
+        assert ethane.get_num_heavy_atoms() == 2
+
+        # water: 1 heavy atom (O), 2 H
+        water = Molecule(smiles="O")
+        assert water.get_num_heavy_atoms() == 1
+
+        # lone surface site has no heavy atoms
+        surface_site = Molecule().from_adjacency_list(
+            """
+            1 X u0 p0 c0
+            """
+        )
+        assert surface_site.get_num_heavy_atoms() == 0
+
+        # adsorbed H on a surface site: neither H nor X is heavy
+        adsorbed = Molecule().from_adjacency_list(
+            """
+            1 H u0 p0 c0 {2,S}
+            2 X u0 p0 c0 {1,S}
+            """
+        )
+        assert adsorbed.get_num_heavy_atoms() == 0
+
+        # bidentate adsorbate: 2 carbons are heavy, the H and X atoms are not
+        bidentate = Molecule().from_adjacency_list(
+            """
+            1 C u0 p0 c0 {2,D} {3,S} {4,S}
+            2 C u0 p0 c0 {1,D} {5,S} {6,S}
+            3 H u0 p0 c0 {1,S}
+            4 X u0 p0 c0 {1,S}
+            5 H u0 p0 c0 {2,S}
+            6 X u0 p0 c0 {2,S}
+            """)
+        assert bidentate.get_num_heavy_atoms() == 2
+
     def test_is_multidentate(self):
         """
         Test that we can identify a multidentate adsorbate


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem

Recent PR #2972 changed handling of maximumHeavyAtoms constraint (to exclude surface sites). While reviewing it, I made some changes. But I pushed them too late and it's already merged, so here's a new PR. 
Since the species constraints are enforced on every proposed product of every hypothetical reaction, it happens a lot, so I thought some speed tweaks might be worth it. Also added unit tests.

### Description of Changes

- **Add `get_num_heavy_atoms` to `Molecule` and `Fragment`.** Returns the number of atoms that are neither Hydrogen (`'H'`) nor a surface site (`'X'`). The `Molecule` version is cythonized; the `Fragment` override additionally skips `CuttingLabel` vertices.
- **Use `get_num_heavy_atoms` in `fails_species_constraints`.** Replaces the inline `maximumHeavyAtoms` computation with the new method. Behavior is unchanged, but the intent is clearer and the logic is shared with `Fragment`, and it should be faster.
- **Avoid calling `fails_species_constraints` twice on rejection.** Each call site (`family.py`, `main.py`, two in `model.py`) now stores the single return value and branches on it, instead of calling once for the condition and again for the `reason` string. This halves the constraint-checking work on the failing path with no change in behavior.

### Testing

- Added unit tests for `get_num_heavy_atoms` on both `Molecule` and `Fragment` (`moleculeTest.py`, `fragmentTest.py`).
- Extended `test_heavy_constraint` in `constraintsTest.py` to assert heavy-atom counts directly and to cover an adsorbate, confirming that hydrogens and surface sites (`'X'`) are excluded.
- Ran full test suite.

### Reviewer Tips

- The `Molecule.get_num_heavy_atoms` change are cythonized, so the reviewer should rebuild (`make build`) before running tests.


<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
