### PR TITLE
Fix covdep

### DIFF
--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -155,7 +155,5 @@ cdef class Reaction:
 
     cpdef get_mean_sigma_and_epsilon(self, bint reverse=?)
 
-    cpdef Reaction get_reverse_reaction(self)
-
 cpdef bint same_species_lists(list list1, list list2, bint check_identical=?, bint only_check_label=?,
                               bint generate_initial_map=?, bint strict=?, bint save_order=?) except -2

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -155,7 +155,7 @@ cdef class Reaction:
 
     cpdef get_mean_sigma_and_epsilon(self, bint reverse=?)
 
-    cpdef get_reverse_reaction(self)
+    cpdef Reaction get_reverse_reaction(self)
 
 cpdef bint same_species_lists(list list1, list list2, bint check_identical=?, bint only_check_label=?,
                               bint generate_initial_map=?, bint strict=?, bint save_order=?) except -2

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -143,7 +143,7 @@ cdef class Reaction:
 
     cpdef generate_pairs(self)
 
-    cpdef copy(self)
+    cpdef Reaction copy(self)
 
     cpdef ensure_species(self, bint reactant_resonance=?, bint product_resonance=?, bint save_order=?)
 

--- a/rmgpy/reaction.pxd
+++ b/rmgpy/reaction.pxd
@@ -155,5 +155,7 @@ cdef class Reaction:
 
     cpdef get_mean_sigma_and_epsilon(self, bint reverse=?)
 
+    cpdef get_reverse_reaction(self)
+
 cpdef bint same_species_lists(list list1, list list2, bint check_identical=?, bint only_check_label=?,
                               bint generate_initial_map=?, bint strict=?, bint save_order=?) except -2

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1842,10 +1842,19 @@ class Reaction:
         raise NotImplementedError("generate_high_p_limit_kinetics is not implemented for all Reaction subclasses.")
 
     def get_reverse_reaction(self):
+        """
+        Return a new :class:`Reaction` with the reactants and products swapped and
+        the kinetics re-parameterized in the reverse direction (via
+        :meth:`generate_reverse_rate_coefficient`). The original reaction is left
+        unmodified.
 
+        Raises :class:`ReactionError` if the reaction has no kinetics, since the
+        reverse rate coefficient cannot otherwise be derived.
+        """
         cython.declare(rev_reaction=Reaction)
 
-        assert self.kinetics is not None
+        if self.kinetics is None:
+            raise ReactionError("Cannot generate the reverse of reaction {0!r}: no kinetics defined.".format(self))
         rev_reaction = self.copy()
         rev_reaction.reactants = self.products[:]
         rev_reaction.products = self.reactants[:]

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1841,6 +1841,15 @@ class Reaction:
         """
         raise NotImplementedError("generate_high_p_limit_kinetics is not implemented for all Reaction subclasses.")
 
+    def get_reverse_reaction(self):
+        assert self.kinetics is not None
+        rev_reaction = deepcopy(self)
+        tmp_reactants = rev_reaction.reactants
+        rev_reaction.reactants = rev_reaction.products
+        rev_reaction.products = tmp_reactants
+        rev_reaction.kinetics = self.generate_reverse_rate_coefficient()
+        return rev_reaction
+
 def _same_object(object1, object2, _check_identical=False, _only_check_label=False,
              _generate_initial_map=False, _strict=True, _save_order=False):
     if _only_check_label:

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1844,21 +1844,17 @@ class Reaction:
     def get_reverse_reaction(self):
         """
         Return a new :class:`Reaction` with the reactants and products swapped and
-        the kinetics re-parameterized in the reverse direction (via
+        the kinetics (unless None) are re-parameterized in the reverse direction (via
         :meth:`generate_reverse_rate_coefficient`). The original reaction is left
         unmodified.
-
-        Raises :class:`ReactionError` if the reaction has no kinetics, since the
-        reverse rate coefficient cannot otherwise be derived.
         """
         cython.declare(rev_reaction=Reaction)
 
-        if self.kinetics is None:
-            raise ReactionError("Cannot generate the reverse of reaction {0!r}: no kinetics defined.".format(self))
         rev_reaction = self.copy()
         rev_reaction.reactants = self.products[:]
         rev_reaction.products = self.reactants[:]
-        rev_reaction.kinetics = self.generate_reverse_rate_coefficient()
+        if self.kinetics is not None:
+            rev_reaction.kinetics = self.generate_reverse_rate_coefficient()
         return rev_reaction
 
 def _same_object(object1, object2, _check_identical=False, _only_check_label=False,

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1842,11 +1842,13 @@ class Reaction:
         raise NotImplementedError("generate_high_p_limit_kinetics is not implemented for all Reaction subclasses.")
 
     def get_reverse_reaction(self):
+
+        cython.declare(rev_reaction=Reaction)
+
         assert self.kinetics is not None
-        rev_reaction = deepcopy(self)
-        tmp_reactants = rev_reaction.reactants
-        rev_reaction.reactants = rev_reaction.products
-        rev_reaction.products = tmp_reactants
+        rev_reaction = self.copy()
+        rev_reaction.reactants = self.products[:]
+        rev_reaction.products = self.reactants[:]
         rev_reaction.kinetics = self.generate_reverse_rate_coefficient()
         return rev_reaction
 

--- a/rmgpy/reaction.py
+++ b/rmgpy/reaction.py
@@ -1841,22 +1841,6 @@ class Reaction:
         """
         raise NotImplementedError("generate_high_p_limit_kinetics is not implemented for all Reaction subclasses.")
 
-    def get_reverse_reaction(self):
-        """
-        Return a new :class:`Reaction` with the reactants and products swapped and
-        the kinetics (unless None) are re-parameterized in the reverse direction (via
-        :meth:`generate_reverse_rate_coefficient`). The original reaction is left
-        unmodified.
-        """
-        cython.declare(rev_reaction=Reaction)
-
-        rev_reaction = self.copy()
-        rev_reaction.reactants = self.products[:]
-        rev_reaction.products = self.reactants[:]
-        if self.kinetics is not None:
-            rev_reaction.kinetics = self.generate_reverse_rate_coefficient()
-        return rev_reaction
-
 def _same_object(object1, object2, _check_identical=False, _only_check_label=False,
              _generate_initial_map=False, _strict=True, _save_order=False):
     if _only_check_label:

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -50,6 +50,7 @@ from rmgpy.data.vaporLiquidMassTransfer import vapor_liquid_mass_transfer
 from rmgpy.display import display
 from rmgpy.exceptions import ForbiddenStructureException
 from rmgpy.kinetics import Arrhenius, KineticsData
+from rmgpy.kinetics.surface import StickingCoefficient
 from rmgpy.molecule.fragment import Fragment
 from rmgpy.molecule.group import Group
 from rmgpy.quantity import Quantity
@@ -630,6 +631,14 @@ class CoreEdgeReactionModel:
                 # If this is going to be run through pressure dependence code,
                 # we need to make sure the barrier is positive.
                 forward.fix_barrier_height(force_positive=True,solvent="")
+
+            # If any product has thermo_coverage_dependence, flip the reaction
+            # and parameterize in the reverse direction
+            if (any(getattr(spc.thermo, 'thermo_coverage_dependence', None) and spc.thermo.thermo_coverage_dependence for
+                spc in forward.products) and not isinstance(forward.kinetics, StickingCoefficient)):
+                forward = Reaction.get_reverse_reaction(forward)
+                logging.debug("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
+                          forward)
 
         # Since the reaction is new, add it to the list of new reactions
         self.new_reaction_list.append(forward)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -632,17 +632,27 @@ class CoreEdgeReactionModel:
                 # we need to make sure the barrier is positive.
                 forward.fix_barrier_height(force_positive=True,solvent="")
 
-            # If any product has thermo_coverage_dependence, flip the reaction
-            # and parameterize in the reverse direction
-            if (any(getattr(spc.thermo, 'thermo_coverage_dependence', None) and spc.thermo.thermo_coverage_dependence for
-                spc in forward.products) and not isinstance(forward.kinetics, StickingCoefficient)):
-                forward = Reaction.get_reverse_reaction(forward)
-                forward.reactants = [self.make_new_species(reactant, generate_thermo=generate_thermo)[0] for reactant in
-                                     forward.reactants]
-                forward.products = [self.make_new_species(product, generate_thermo=generate_thermo)[0] for product in
-                                    forward.products]
+            # When a product has thermo_coverage_dependence, the reverse rate
+            # constant derived from Keq becomes coverage dependent, which
+            # can make the reverse unrealistically fast. We tend to get better rate estimates
+            # when the coverage dependence is on the reactant side, so flip it.
+            # (unless a reactant is *also* coverage dependent, or it's a sticking coefficient)
+            products_coverage_dependent = any(
+                getattr(spc.thermo, 'thermo_coverage_dependence', None) for spc in forward.products)
+            reactants_coverage_dependent = any(
+                getattr(spc.thermo, 'thermo_coverage_dependence', None) for spc in forward.reactants)
+            if (products_coverage_dependent and not reactants_coverage_dependent
+                    and not isinstance(forward.kinetics, StickingCoefficient)):
+                forward = forward.get_reverse_reaction()
+                # make_new_species returns the model's canonical Species object for each
+                # structure (creating it if new), so the flipped reaction references the
+                # same Species instances the rest of the model uses, not fresh copies.
+                forward.reactants = [self.make_new_species(reactant, generate_thermo=generate_thermo)[0]
+                                     for reactant in forward.reactants]
+                forward.products = [self.make_new_species(product, generate_thermo=generate_thermo)[0]
+                                    for product in forward.products]
                 logging.debug("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
-                          forward)
+                              forward)
 
         # Since the reaction is new, add it to the list of new reactions
         self.new_reaction_list.append(forward)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -652,7 +652,7 @@ class CoreEdgeReactionModel:
                                         if spc.thermo and getattr(spc.thermo, 'thermo_coverage_dependence', None)]
                 forward.kinetics.comment += "\nReaction direction flipped due to thermo_coverage_dependence on species: {0}.".format(
                     ", ".join(coverage_dep_species))
-                logging.debug("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
+                logging.info("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
                               forward)
 
         # Since the reaction is new, add it to the list of new reactions

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -619,12 +619,12 @@ class CoreEdgeReactionModel:
             if isinstance(forward.kinetics, KineticsData):
                 forward.kinetics = forward.kinetics.to_arrhenius()
             #  correct barrier heights of estimated kinetics
-            if isinstance(forward, (TemplateReaction,DepositoryReaction)): # i.e. not LibraryReaction
+            if isinstance(forward, (TemplateReaction, DepositoryReaction)): # i.e. not LibraryReaction
                 forward.fix_barrier_height(solvent=self.solvent_name)  # also converts ArrheniusEP to Arrhenius.
             elif isinstance(forward, LibraryReaction) and forward.is_surface_reaction():
                 # do fix the library reaction barrier if this is scaled from another metal
                 if any(['Binding energy corrected by LSR' in x.thermo.comment for x in forward.reactants + forward.products]):
-                    forward.fix_barrier_height(solvent=self.solvent_name)            
+                    forward.fix_barrier_height(solvent=self.solvent_name)
             elif forward.kinetics.solute:
                 forward.apply_solvent_correction(solvent=self.solvent_name)
             if self.pressure_dependence and forward.is_unimolecular():
@@ -639,21 +639,22 @@ class CoreEdgeReactionModel:
             # (unless a reactant is *also* coverage dependent, or it's a sticking coefficient)
             products_coverage_dependent = any(
                 getattr(spc.thermo, 'thermo_coverage_dependence', None) for spc in forward.products)
-            reactants_coverage_dependent = any(
-                getattr(spc.thermo, 'thermo_coverage_dependence', None) for spc in forward.reactants)
-            if (products_coverage_dependent and not reactants_coverage_dependent
-                    and not isinstance(forward.kinetics, StickingCoefficient)):
-                reverse_kinetics = forward.generate_reverse_rate_coefficient()
-                forward.reactants, forward.products = forward.products, forward.reactants
-                if forward.pairs is not None:
-                    forward.pairs = [(p, r) for r, p in forward.pairs]
-                forward.kinetics = reverse_kinetics
-                coverage_dep_species = [spc.label for spc in forward.reactants
-                                        if spc.thermo and getattr(spc.thermo, 'thermo_coverage_dependence', None)]
-                forward.kinetics.comment += "\nReaction direction flipped due to thermo_coverage_dependence on species: {0}.".format(
-                    ", ".join(coverage_dep_species))
-                logging.info("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
-                              forward)
+            if products_coverage_dependent:
+                reactants_coverage_dependent = any(
+                    getattr(spc.thermo, 'thermo_coverage_dependence', None) for spc in forward.reactants)
+                if (not reactants_coverage_dependent
+                        and not isinstance(forward.kinetics, StickingCoefficient)):
+                    reverse_kinetics = forward.generate_reverse_rate_coefficient()
+                    forward.reactants, forward.products = forward.products, forward.reactants
+                    if forward.pairs is not None:
+                        forward.pairs = [(p, r) for r, p in forward.pairs]
+                    forward.kinetics = reverse_kinetics
+                    coverage_dep_species = [spc.label for spc in forward.reactants
+                                            if spc.thermo and getattr(spc.thermo, 'thermo_coverage_dependence', None)]
+                    forward.kinetics.comment += (f"\nReaction direction reversed due to "
+                        f"coverage-dependent thermo on species {' and '.join(coverage_dep_species)}.")
+                    logging.info("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
+                                forward)
 
         # Since the reaction is new, add it to the list of new reactions
         self.new_reaction_list.append(forward)

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -637,6 +637,10 @@ class CoreEdgeReactionModel:
             if (any(getattr(spc.thermo, 'thermo_coverage_dependence', None) and spc.thermo.thermo_coverage_dependence for
                 spc in forward.products) and not isinstance(forward.kinetics, StickingCoefficient)):
                 forward = Reaction.get_reverse_reaction(forward)
+                forward.reactants = [self.make_new_species(reactant, generate_thermo=generate_thermo)[0] for reactant in
+                                     forward.reactants]
+                forward.products = [self.make_new_species(product, generate_thermo=generate_thermo)[0] for product in
+                                    forward.products]
                 logging.debug("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
                           forward)
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -648,6 +648,10 @@ class CoreEdgeReactionModel:
                 if forward.pairs is not None:
                     forward.pairs = [(p, r) for r, p in forward.pairs]
                 forward.kinetics = reverse_kinetics
+                coverage_dep_species = [spc.label for spc in forward.reactants
+                                        if spc.thermo and getattr(spc.thermo, 'thermo_coverage_dependence', None)]
+                forward.kinetics.comment += "\nReaction direction flipped due to thermo_coverage_dependence on species: {0}.".format(
+                    ", ".join(coverage_dep_species))
                 logging.debug("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
                               forward)
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -643,14 +643,11 @@ class CoreEdgeReactionModel:
                 getattr(spc.thermo, 'thermo_coverage_dependence', None) for spc in forward.reactants)
             if (products_coverage_dependent and not reactants_coverage_dependent
                     and not isinstance(forward.kinetics, StickingCoefficient)):
-                forward = forward.get_reverse_reaction()
-                # make_new_species returns the model's canonical Species object for each
-                # structure (creating it if new), so the flipped reaction references the
-                # same Species instances the rest of the model uses, not fresh copies.
-                forward.reactants = [self.make_new_species(reactant, generate_thermo=generate_thermo)[0]
-                                     for reactant in forward.reactants]
-                forward.products = [self.make_new_species(product, generate_thermo=generate_thermo)[0]
-                                    for product in forward.products]
+                reverse_kinetics = forward.generate_reverse_rate_coefficient()
+                forward.reactants, forward.products = forward.products, forward.reactants
+                if forward.pairs is not None:
+                    forward.pairs = [(p, r) for r, p in forward.pairs]
+                forward.kinetics = reverse_kinetics
                 logging.debug("Flipped reaction to reverse direction due to thermo_coverage_dependence on product: %s",
                               forward)
 

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -431,7 +431,7 @@ cdef class SurfaceReactor(ReactionSystem):
         for i, matrix in enumerate(self.thermo_coeff_matrix):
             free_energy_coverage_corrections[i] = np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
         rxns_free_energy_change = np.matmul(self.stoi_matrix, free_energy_coverage_corrections)
-        corrected_K_eq = copy.deepcopy(self.Keq)
+        corrected_K_eq = self.Keq.copy()
         corrected_K_eq *= np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))
         return corrected_K_eq
 

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -417,6 +417,24 @@ cdef class SurfaceReactor(ReactionSystem):
                 bimolecular_threshold_rate_constant,
                 trimolecular_threshold_rate_constant)
 
+    def compute_thermo_coverage_corrections(self, coverages):
+        coverages_squared = coverages * coverages
+        temperature_scaled_coverages = -self.T.value_si * coverages
+        thermo_dep_coverage = np.empty((6, coverages.shape[0]), dtype=np.float64)
+        thermo_dep_coverage[0, :] = coverages
+        thermo_dep_coverage[1, :] = coverages_squared
+        thermo_dep_coverage[2, :] = coverages_squared * coverages
+        thermo_dep_coverage[3, :] = temperature_scaled_coverages
+        thermo_dep_coverage[4, :] = temperature_scaled_coverages * coverages
+        thermo_dep_coverage[5, :] = temperature_scaled_coverages * coverages_squared
+        free_energy_coverage_corrections = np.empty(len(self.thermo_coeff_matrix), dtype=np.float64)
+        for i, matrix in enumerate(self.thermo_coeff_matrix):
+            free_energy_coverage_corrections[i] = np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
+        rxns_free_energy_change = np.matmul(self.stoi_matrix, free_energy_coverage_corrections)
+        corrected_K_eq = copy.deepcopy(self.Keq)
+        corrected_K_eq *= np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))
+        return corrected_K_eq
+
     @cython.boundscheck(False)
     def residual(self,
                  double t,
@@ -491,22 +509,7 @@ cdef class SurfaceReactor(ReactionSystem):
 
         # Thermodynamic coverage dependence
         if self.thermo_coverage_dependence:
-            coverages_squared = coverages * coverages
-            temperature_scaled_coverages = -self.T.value_si * coverages
-            thermo_dep_coverage = np.empty((6, coverages.shape[0]), dtype=np.float64)
-            thermo_dep_coverage[0, :] = coverages
-            thermo_dep_coverage[1, :] = coverages_squared
-            thermo_dep_coverage[2, :] = coverages_squared * coverages
-            thermo_dep_coverage[3, :] = temperature_scaled_coverages
-            thermo_dep_coverage[4, :] = temperature_scaled_coverages * coverages
-            thermo_dep_coverage[5, :] = temperature_scaled_coverages * coverages_squared
-            free_energy_coverage_corrections = np.empty(len(self.thermo_coeff_matrix), dtype=np.float64)
-            for i, matrix in enumerate(self.thermo_coeff_matrix):
-                free_energy_coverage_corrections[i] = np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
-            rxns_free_energy_change = np.matmul(self.stoi_matrix,free_energy_coverage_corrections)
-            corrected_K_eq = copy.deepcopy(self.Keq)
-            corrected_K_eq *= np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))
-            kr = kf / corrected_K_eq
+            kr = kf / self.compute_thermo_coverage_corrections(coverages)
 
         # Coverage dependence
         coverage_corrections = np.ones_like(kf, float)

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -719,6 +719,15 @@ cdef class SurfaceReactor(ReactionSystem):
         for j in range(num_core_species):
             C[j] = y[j] * inv_omega[j]
 
+        if self.thermo_coverage_dependence:
+            total_sites = self.surface_site_density.value_si * A
+            coverages = np.where(self.species_on_surface[:num_core_species],
+                                 np.maximum(y[:num_core_species] / total_sites, 0.0),
+                                 0.0)
+            kr = kf / self.compute_thermo_coverage_corrections(coverages)
+        else:
+            kr = self.kb
+
         for j in range(num_core_reactions):
 
             # ------------------------------------------------------------------

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -308,7 +308,10 @@ cdef class SurfaceReactor(ReactionSystem):
                     warned = True
                 self.kf[j] = rxn.get_rate_coefficient(self.T.value_si, P)
             if rxn.reversible:
-                # ToDo: get_equilibrium_constant should be coverage dependent
+                # kb is set here from the uncorrected Keq. For reactions with
+                # thermo_coverage_dependence, kb is not used directly — residual
+                # and jacobian both compute kr = kf / compute_thermo_coverage_corrections()
+                # which applies the coverage-dependent correction to Keq at runtime.
                 self.Keq[j] = rxn.get_equilibrium_constant(self.T.value_si)
                 self.kb[j] = self.kf[j] / self.Keq[j]
 

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -739,14 +739,33 @@ cdef class SurfaceReactor(ReactionSystem):
         for j in range(num_core_species):
             C[j] = y[j] * inv_omega[j]
 
-        if self.thermo_coverage_dependence:
+        if self.thermo_coverage_dependence or self.coverage_dependence:
             total_sites = self.surface_site_density.value_si * A
             coverages = np.where(self.species_on_surface[:num_core_species],
                                  np.maximum(y[:num_core_species] / total_sites, 0.0),
                                  0.0)
+
+        # Thermodynamic coverage dependence: the reverse rate constant is derived
+        # from the coverage-corrected equilibrium constant.
+        if self.thermo_coverage_dependence:
             kr = kf / self.compute_thermo_coverage_corrections(coverages)
         else:
             kr = self.kb
+
+        # Kinetic coverage dependence: kf (and hence kr) are scaled by a
+        # coverage-dependent factor.
+        if self.coverage_dependence:
+            coverage_corrections = np.ones_like(kf, float)
+            for i, list_of_coverage_deps in self.coverage_dependencies.items():
+                surface_site_fraction = coverages[i]
+                if surface_site_fraction <= 1e-6:
+                    continue
+                for j, a, m, E in list_of_coverage_deps:
+                    coverage_corrections[j] *= 10. ** (a * surface_site_fraction) *\
+                                                pow(surface_site_fraction, m) *\
+                                                exp(-1 * E * surface_site_fraction / (constants.R * self.T.value_si))
+            kf = kf * coverage_corrections  # corrected copy; leaves self.kf unchanged
+            kr = kr * coverage_corrections
 
         for j in range(num_core_reactions):
 

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -43,7 +43,6 @@ cimport rmgpy.constants as constants
 from rmgpy.quantity import Quantity
 from rmgpy.quantity cimport ScalarQuantity
 from rmgpy.solver.base cimport ReactionSystem
-import copy
 from rmgpy.molecule import Molecule
 
 cdef class SurfaceReactor(ReactionSystem):

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -417,20 +417,40 @@ cdef class SurfaceReactor(ReactionSystem):
                 bimolecular_threshold_rate_constant,
                 trimolecular_threshold_rate_constant)
 
-    def compute_thermo_coverage_corrections(self, coverages):
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef np.ndarray compute_thermo_coverage_corrections(self, np.ndarray[np.float64_t, ndim=1] coverages):
+        """
+        Return the equilibrium constants ``Keq`` corrected for thermodynamic
+        coverage dependence at the given surface ``coverages``.
+
+        For each species the free-energy correction is the sum over the (up to)
+        six polynomial terms ``coverage**k`` and ``-T*coverage**k`` weighted by the
+        per-species coefficients stored in ``thermo_coeff_matrix``. These are
+        mapped to per-reaction free-energy changes via ``stoi_matrix`` and applied
+        to ``Keq``. The corrected ``Keq`` is used to obtain a coverage-dependent
+        reverse rate constant ``kr = kf / Keq_corrected`` in both the residual and
+        the Jacobian.
+        """
+        cdef np.ndarray[np.float64_t, ndim=1] coverages_squared, temperature_scaled_coverages
+        cdef np.ndarray[np.float64_t, ndim=1] free_energy_coverage_corrections, rxns_free_energy_change, corrected_K_eq
+        cdef np.ndarray[np.float64_t, ndim=2] thermo_dep_coverage, matrix
+        cdef int i, n
+
+        n = coverages.shape[0]
         coverages_squared = coverages * coverages
         temperature_scaled_coverages = -self.T.value_si * coverages
-        thermo_dep_coverage = np.empty((6, coverages.shape[0]), dtype=np.float64)
+        thermo_dep_coverage = np.empty((6, n), dtype=np.float64)
         thermo_dep_coverage[0, :] = coverages
         thermo_dep_coverage[1, :] = coverages_squared
         thermo_dep_coverage[2, :] = coverages_squared * coverages
         thermo_dep_coverage[3, :] = temperature_scaled_coverages
         thermo_dep_coverage[4, :] = temperature_scaled_coverages * coverages
         thermo_dep_coverage[5, :] = temperature_scaled_coverages * coverages_squared
-        free_energy_coverage_corrections = np.empty(len(self.thermo_coeff_matrix), dtype=np.float64)
-        n = coverages.shape[0]
-        for i, matrix in enumerate(self.thermo_coeff_matrix):
-            free_energy_coverage_corrections[i] = np.sum(matrix[:n, :].T * thermo_dep_coverage) #np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
+        free_energy_coverage_corrections = np.empty(self.thermo_coeff_matrix.shape[0], dtype=np.float64)
+        for i in range(self.thermo_coeff_matrix.shape[0]):
+            matrix = self.thermo_coeff_matrix[i]
+            free_energy_coverage_corrections[i] = np.sum(matrix[:n, :].T * thermo_dep_coverage)
         rxns_free_energy_change = np.matmul(self.stoi_matrix, free_energy_coverage_corrections)
         corrected_K_eq = self.Keq * np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))
         return corrected_K_eq

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -432,8 +432,7 @@ cdef class SurfaceReactor(ReactionSystem):
         for i, matrix in enumerate(self.thermo_coeff_matrix):
             free_energy_coverage_corrections[i] = np.sum(matrix[:n, :].T * thermo_dep_coverage) #np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
         rxns_free_energy_change = np.matmul(self.stoi_matrix, free_energy_coverage_corrections)
-        corrected_K_eq = self.Keq.copy()
-        corrected_K_eq *= np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))
+        corrected_K_eq = self.Keq * np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))
         return corrected_K_eq
 
     @cython.boundscheck(False)

--- a/rmgpy/solver/surface.pyx
+++ b/rmgpy/solver/surface.pyx
@@ -428,8 +428,9 @@ cdef class SurfaceReactor(ReactionSystem):
         thermo_dep_coverage[4, :] = temperature_scaled_coverages * coverages
         thermo_dep_coverage[5, :] = temperature_scaled_coverages * coverages_squared
         free_energy_coverage_corrections = np.empty(len(self.thermo_coeff_matrix), dtype=np.float64)
+        n = coverages.shape[0]
         for i, matrix in enumerate(self.thermo_coeff_matrix):
-            free_energy_coverage_corrections[i] = np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
+            free_energy_coverage_corrections[i] = np.sum(matrix[:n, :].T * thermo_dep_coverage) #np.diag(np.dot(matrix, thermo_dep_coverage)).sum()
         rxns_free_energy_change = np.matmul(self.stoi_matrix, free_energy_coverage_corrections)
         corrected_K_eq = self.Keq.copy()
         corrected_K_eq *= np.exp(-1 * rxns_free_energy_change / (constants.R * self.T.value_si))

--- a/test/rmgpy/solver/solverSurfaceTest.py
+++ b/test/rmgpy/solver/solverSurfaceTest.py
@@ -844,6 +844,10 @@ class SurfaceReactorTest:
 
         # Check that we're computing the species fluxes correctly
         for i in range(t.shape[0]):
+            # At equilibrium the reaction rate can round to exactly 0.0, which makes the
+            # relative-tolerance check below trivially fail (0 < 0); skip those points.
+            if reaction_rates[i, 0] == 0.0:
+                continue
             assert abs(reaction_rates[i, 0] - -species_rates[i, 0]) < abs(
                 1e-6 * reaction_rates[i, 0]
             )
@@ -1510,6 +1514,135 @@ class SurfaceReactorTest:
         # residual uses the same constant kr as the analytical Jacobian, so the two must
         # agree. (We freeze because the analytical Jacobian deliberately omits d(kr)/d(theta).)
         rxn_system.thermo_coverage_dependence = False
+        rxn_system.kb = kr_corrected.copy()
+        rxn_system.sensitivity = False
+
+        f0, _ = rxn_system.residual(0.0, y, dydt)
+
+        eps_machine = np.sqrt(np.finfo(float).eps)
+        n_scale = 1e-10
+        J_fd = np.zeros((n, n))
+        for s in range(n):
+            y_perturbed = y.copy()
+            delta_n_s = eps_machine * max(abs(y[s]), n_scale)
+            y_perturbed[s] += delta_n_s
+            f_perturbed, _ = rxn_system.residual(0.0, y_perturbed, dydt)
+            J_fd[:, s] = (f_perturbed - f0) / delta_n_s
+
+        assert np.allclose(J_analytical, J_fd, rtol=1e-2, atol=1e-6)
+
+    def test_jacobian_with_kinetic_coverage_dependence(self):
+        """
+        Verify the analytical Jacobian applies the kinetic ``coverage_dependence``
+        correction to kf and kr, consistently with the residual.
+
+        Previously the Jacobian used the uncorrected self.kf / self.kb while the
+        residual scaled both by the coverage-dependent factor, leaving the
+        Jacobian inconsistent with the rate expression it differentiates.
+
+        As in :meth:`test_jacobian_with_thermo_coverage_dependence`, we freeze the
+        rate constants at their coverage-corrected values and finite-difference the
+        residual, because the analytical Jacobian deliberately neglects the
+        d(correction)/d(coverage) term. The correction must differ from unity,
+        otherwise the test would pass even with the old (uncorrected) code.
+        """
+        h2 = Species(
+            molecule=[Molecule().from_smiles("[H][H]")],
+            thermo=ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([6.955, 6.955, 6.956, 6.961, 7.003, 7.103, 7.502], "cal/(mol*K)"),
+                H298=(0, "kcal/mol"),
+                S298=(31.129, "cal/(mol*K)"),
+            ),
+        )
+        x = Species(
+            molecule=[Molecule().from_adjacency_list("1 X u0 p0")],
+            thermo=ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "cal/(mol*K)"),
+                H298=(0.0, "kcal/mol"),
+                S298=(0.0, "cal/(mol*K)"),
+            ),
+        )
+        hx = Species(
+            molecule=[Molecule().from_adjacency_list("1 H u0 p0 {2,S} \n 2 X u0 p0 {1,S}")],
+            thermo=ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([1.50, 2.58, 3.40, 4.00, 4.73, 5.13, 5.57], "cal/(mol*K)"),
+                H298=(-11.26, "kcal/mol"),
+                S298=(0.44, "cal/(mol*K)"),
+            ),
+        )
+        # a=1, m=0 gives a coverage correction of 10**(theta_x) which is clearly != 1
+        # at the chosen coverage and avoids the theta**m singularity at m<0.
+        rxn1 = Reaction(
+            reactants=[h2, x, x],
+            products=[hx, hx],
+            kinetics=SurfaceArrhenius(
+                A=(9.05e18, "cm^5/(mol^2*s)"),
+                n=0.5,
+                Ea=(5.0, "kJ/mol"),
+                T0=(1.0, "K"),
+                coverage_dependence={x: {"a": 1.0, "m": 0.0, "E": (0.0, "J/mol")}},
+            ),
+        )
+        core_species = [h2, x, hx]
+        core_reactions = [rxn1]
+
+        T = 600
+        P_initial = 1.0e5
+        rxn_system = SurfaceReactor(
+            T,
+            P_initial,
+            n_sims=1,
+            initial_gas_mole_fractions={h2: 1.0},
+            initial_surface_coverages={x: 1.0},
+            surface_volume_ratio=(1e1, "m^-1"),
+            surface_site_density=(2.72e-9, "mol/cm^2"),
+            coverage_dependence=True,
+            termination=[],
+        )
+        rxn_system.initialize_model(core_species, core_reactions, [], [])
+
+        n = rxn_system.num_core_species
+        total_sites = (rxn_system.surface_site_density.value_si
+                       * rxn_system.V * rxn_system.surface_volume_ratio.value_si)
+
+        # Build a state with non-trivial X coverage so the correction is active.
+        y = np.zeros(n)
+        y[0] = 1.0  # moles of gas-phase H2 (one mole total of gas at start)
+        y[1] = 0.4 * total_sites  # X
+        y[2] = 0.6 * total_sites  # HX
+        dydt = np.zeros(n)
+
+        coverages = np.where(rxn_system.species_on_surface[:n],
+                             np.maximum(y / total_sites, 0.0), 0.0)
+
+        # Replicate the residual's coverage-correction factor using the parameters the
+        # solver actually stored (avoids any unit ambiguity in the input).
+        coverage_corrections = np.ones_like(rxn_system.kf)
+        for i, deps in rxn_system.coverage_dependencies.items():
+            theta = coverages[i]
+            if theta <= 1e-6:
+                continue
+            for j, a, m, E in deps:
+                coverage_corrections[j] *= (10.0 ** (a * theta) * theta ** m
+                                            * np.exp(-E * theta / (constants.R * rxn_system.T.value_si)))
+
+        # The correction must be significant, otherwise the test would pass even with the
+        # old code that ignored coverage_dependence in the Jacobian.
+        assert not np.allclose(coverage_corrections, 1.0, rtol=0.1)
+
+        kf_corrected = rxn_system.kf * coverage_corrections
+        kr_corrected = rxn_system.kb * coverage_corrections
+
+        J_analytical = rxn_system.jacobian(0.0, y, dydt, cj=0.0)
+
+        # Freeze the rate constants at their coverage-corrected values and turn off
+        # coverage_dependence so the residual uses the same constant kf/kr as the
+        # analytical Jacobian (which omits d(correction)/d(coverage)).
+        rxn_system.coverage_dependence = False
+        rxn_system.kf = kf_corrected.copy()
         rxn_system.kb = kr_corrected.copy()
         rxn_system.sensitivity = False
 

--- a/test/rmgpy/solver/solverSurfaceTest.py
+++ b/test/rmgpy/solver/solverSurfaceTest.py
@@ -1396,3 +1396,133 @@ class SurfaceReactorTest:
             J_fd[:, s] = (f_perturbed - f0) / delta_n_s
 
         assert np.allclose(J_analytical, J_fd, rtol=1e-2, atol=1e-6)
+
+    def test_jacobian_with_thermo_coverage_dependence(self):
+        """
+        Verify the analytical Jacobian uses the coverage-corrected reverse rate
+        constant kr (not the uncorrected self.kb) when thermo_coverage_dependence
+        is active.
+
+        This is a regression test for the bug fixed in PR #2975: the Jacobian
+        previously used kr = kf / Keq instead of kr = kf / Keq_corrected(theta),
+        which made the analytical Jacobian inconsistent with the residual and
+        forced the ODE solver to take extremely small time steps.
+
+        The analytical Jacobian deliberately holds kr fixed at the current
+        coverages (it neglects the d(kr)/d(theta) term), so a direct finite
+        difference of the residual with thermo_coverage_dependence still active
+        would not match. Instead we freeze kr at the coverage-corrected value
+        and finite-difference the residual: the analytical Jacobian must agree
+        with that, isolating the mass-action structure and confirming the
+        corrected kr is used. We also assert the corrected kr differs
+        substantially from the uncorrected self.kb, otherwise the test would
+        pass even with the old (buggy) code and would not exercise the fix.
+        """
+        h2 = Species(
+            molecule=[Molecule().from_smiles("[H][H]")],
+            thermo=ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([6.955, 6.955, 6.956, 6.961, 7.003, 7.103, 7.502], "cal/(mol*K)"),
+                H298=(0, "kcal/mol"),
+                S298=(31.129, "cal/(mol*K)"),
+            ),
+        )
+        x = Species(
+            molecule=[Molecule().from_adjacency_list("1 X u0 p0")],
+            thermo=ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "cal/(mol*K)"),
+                H298=(0.0, "kcal/mol"),
+                S298=(0.0, "cal/(mol*K)"),
+            ),
+        )
+        # Large thermo coverage coefficients so the coverage correction to Keq
+        # (and hence kr) is significant; entropy coefficients are zero to keep
+        # the correction purely enthalpic and easy to reason about.
+        hx = Species(
+            molecule=[Molecule().from_adjacency_list("1 H u0 p0 {2,S} \n 2 X u0 p0 {1,S}")],
+            thermo=ThermoData(
+                Tdata=([300, 400, 500, 600, 800, 1000, 1500], "K"),
+                Cpdata=([1.50, 2.58, 3.40, 4.00, 4.73, 5.13, 5.57], "cal/(mol*K)"),
+                H298=(-11.26, "kcal/mol"),
+                S298=(0.44, "cal/(mol*K)"),
+                thermo_coverage_dependence={
+                    "1 H u0 p0 {2,S} \n 2 X u0 p0 {1,S}": {
+                        "model": "polynomial",
+                        "enthalpy-coefficients": [(8000, "J/mol"), (4000, "J/mol"), (2000, "J/mol")],
+                        "entropy-coefficients": [(0, "J/(mol*K)"), (0, "J/(mol*K)"), (0, "J/(mol*K)")],
+                    },
+                },
+            ),
+        )
+        rxn1 = Reaction(
+            reactants=[h2, x, x],
+            products=[hx, hx],
+            kinetics=SurfaceArrhenius(
+                A=(9.05e18, "cm^5/(mol^2*s)"),
+                n=0.5,
+                Ea=(5.0, "kJ/mol"),
+                T0=(1.0, "K"),
+            ),
+        )
+        core_species = [h2, x, hx]
+        core_reactions = [rxn1]
+
+        T = 600
+        P_initial = 1.0e5
+        rxn_system = SurfaceReactor(
+            T,
+            P_initial,
+            n_sims=1,
+            initial_gas_mole_fractions={h2: 1.0},
+            initial_surface_coverages={x: 1.0},
+            surface_volume_ratio=(1e1, "m^-1"),
+            surface_site_density=(2.72e-9, "mol/cm^2"),
+            thermo_coverage_dependence=True,
+            termination=[],
+        )
+        rxn_system.initialize_model(core_species, core_reactions, [], [])
+
+        n = rxn_system.num_core_species
+        total_sites = (rxn_system.surface_site_density.value_si
+                       * rxn_system.V * rxn_system.surface_volume_ratio.value_si)
+
+        # Build a state with non-trivial HX coverage so the coverage correction is active.
+        y = np.zeros(n)
+        y[0] = 1.0  # moles of gas-phase H2 (one mole total of gas at start)
+        y[1] = 0.4 * total_sites  # X
+        y[2] = 0.6 * total_sites  # HX
+        dydt = np.zeros(n)
+
+        coverages = np.where(rxn_system.species_on_surface[:n],
+                             np.maximum(y / total_sites, 0.0), 0.0)
+        corrected_keq = rxn_system.compute_thermo_coverage_corrections(coverages)
+        kr_corrected = rxn_system.kf / corrected_keq
+
+        # The coverage correction must be significant, otherwise the test would pass
+        # even with the old uncorrected kr = self.kb and would not exercise the fix.
+        assert not np.allclose(kr_corrected, rxn_system.kb, rtol=0.5)
+
+        J_analytical = rxn_system.jacobian(0.0, y, dydt, cj=0.0)
+
+        # Freeze kr at the coverage-corrected value and finite-difference the residual.
+        # With thermo_coverage_dependence turned off and kb set to the corrected kr, the
+        # residual uses the same constant kr as the analytical Jacobian, so the two must
+        # agree. (We freeze because the analytical Jacobian deliberately omits d(kr)/d(theta).)
+        rxn_system.thermo_coverage_dependence = False
+        rxn_system.kb = kr_corrected.copy()
+        rxn_system.sensitivity = False
+
+        f0, _ = rxn_system.residual(0.0, y, dydt)
+
+        eps_machine = np.sqrt(np.finfo(float).eps)
+        n_scale = 1e-10
+        J_fd = np.zeros((n, n))
+        for s in range(n):
+            y_perturbed = y.copy()
+            delta_n_s = eps_machine * max(abs(y[s]), n_scale)
+            y_perturbed[s] += delta_n_s
+            f_perturbed, _ = rxn_system.residual(0.0, y_perturbed, dydt)
+            J_fd[:, s] = (f_perturbed - f0) / delta_n_s
+
+        assert np.allclose(J_analytical, J_fd, rtol=1e-2, atol=1e-6)


### PR DESCRIPTION
### Motivation or Problem
This PR addresses issue #2973. RMG was really slow when generating mechanisms that include coverage-dependent thermo.  One problem was that the coverage dependence could cause submerged barriers in the reverse direction, which is discussed in depth in #2973. However, this was not the main reason for the slowness. RMG was extremely slow because it needed a few million time steps to achieve convergence.  

### Description of Changes
I added a functionality that enables changing the direction of a reaction, where a product is coverage dependent. The parameters of this new forward direction are determined from the thermochemistry. 
The main reason why RMG needed a few million time steps to converge was that the Jacobian used the uncorrected reverse rate constant instead of the coverage-dependent kr. Therefore, RMG took many very small time steps. Adjusting the `jacobian` routine did the trick. 

### Testing
I tested this by generating a mechanism for the ethanol steam reforming. 

[input.py](https://github.com/user-attachments/files/28507102/input.py)

Without the changes, the mechanism generation took about 1 hour, but with the updated `jacobian` routine it now takes about 1 minute. 

### Reviewer Tips
I have some more testing and clean-up to do, but I wanted to already share the approach to get some initial feedback. There are further ways to speed things up. Currently, the `compute_thermo_coverage_corrections` is the bottleneck. It can be accelerated by converting it to a `cdef` function and by adjusting the routine. I'll keep working on it. 