### PR TITLE
Address a couple of minor deprecations in calls to Cantera

### DIFF
--- a/rmgpy/tools/canteramodel.py
+++ b/rmgpy/tools/canteramodel.py
@@ -329,7 +329,7 @@ class Cantera(object):
 
             self.reaction_map[self.reaction_list.index(rxn)] = indices
 
-        self.model = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
+        self.model = ct.Solution(thermo='ideal-gas', kinetics='gas',
                                  species=ct_species, reactions=ct_reactions)
 
     def refresh_model(self):
@@ -342,7 +342,7 @@ class Cantera(object):
         ct_reactions = self.model.reactions()
         ct_species = self.model.species()
 
-        self.model = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
+        self.model = ct.Solution(thermo='ideal-gas', kinetics='gas',
                                  species=ct_species, reactions=ct_reactions)
 
     def load_chemkin_model(self, chemkin_file, transport_file=None, **kwargs):

--- a/rmgpy/tools/canteramodel.py
+++ b/rmgpy/tools/canteramodel.py
@@ -547,7 +547,7 @@ class Cantera(object):
                 pressure.append(cantera_reactor.thermo.P)
                 
                 if self.surface:
-                    species_data.append(np.concatenate((cantera_reactor.thermo[species_names_list].X, rsurf.kinetics.coverages)))
+                    species_data.append(np.concatenate((cantera_reactor.thermo[species_names_list].X, rsurf.coverages)))
                     N_gas = len(cantera_reactor.thermo[species_names_list].X)
                 else:
                     species_data.append(cantera_reactor.thermo[species_names_list].X)


### PR DESCRIPTION
### Motivation or Problem
We're using some outdated calls to Cantera methods, in the canteramodel used in the regression testing. Some regression warnings show up in the CI logs.

### Description of Changes
use the `rsurf.coverages` instead of `rsurf.kinetics.coverages` and replace `thermo='IdealGas', kinetics='GasKinetics'` with `thermo='ideal-gas', kinetics='gas'`.

### Testing
The CI test suite (this code runs in the regression tests)

### Other context
There are a couple of other deprecations in Cantera 3.2, which will probably be removed in Cantera 4 this summer/fall. But removing them now would break compatibility with Cantera 3.1, so we'd have to bump our minimum version.
I won't make these changes now, but will open a separate issue to track it.