### PR TITLE
Reduce "error" logging in regression testing (only WARN and above)

### DIFF
--- a/rmgpy/tools/observablesregression.py
+++ b/rmgpy/tools/observablesregression.py
@@ -291,7 +291,6 @@ class ObservablesTestCase(object):
         conditions_broken = []
         variables_failed = []
 
-        print('{0} Comparison'.format(self))
         # Check the species profile observables
         if 'species' in self.observables:
             if self.old_sim.surface_species_list:
@@ -400,7 +399,6 @@ class ObservablesTestCase(object):
 
             return variables_failed
         else:
-            print('')
             print('✅ All Observables varied by less than {0:.3f} on average between old model and '
                   'new model in all conditions!'.format(tol))
             print('')

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -198,13 +198,16 @@ def parse_command_line_arguments():
     return input_file, benchmark, tested
 
 
-def configure_logging():
+def configure_logging(quiet=False):
     """
-    Configure the root logger so that INFO (and above) goes to stdout, while
-    WARNING and above *also* goes to stderr.
+    Configure the root logger so that INFO (and above) goes to stdout
+    (unless quiet=True),
+    while WARNING and above *also* goes to stderr.
 
-    This means the full log is captured in the normal CI build output (stdout),
+    This means the full log is output (stdout),
     while only genuine warnings/errors land on stderr.
+    In the CI context, run with quiet=True to make 
+    annotations less verbose.
     """
     root = logging.getLogger()
     root.setLevel(logging.INFO)
@@ -215,11 +218,12 @@ def configure_logging():
 
     formatter = logging.Formatter('%(levelname)s: %(message)s')
 
-    # INFO and above -> stdout (captured in the normal CI log).
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setLevel(logging.INFO)
-    stdout_handler.setFormatter(formatter)
-    root.addHandler(stdout_handler)
+    if not quiet:
+        # INFO and above -> stdout (captured in the normal CI log).
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setLevel(logging.INFO)
+        stdout_handler.setFormatter(formatter)
+        root.addHandler(stdout_handler)
 
     # WARNING and above -> stderr (so CI flags/annotates them via regression.py.err).
     stderr_handler = logging.StreamHandler(sys.stderr)
@@ -230,7 +234,7 @@ def configure_logging():
 
 def main():
     "Returns the list of variables that failed the regression."
-    configure_logging()
+    configure_logging(quiet=True)  # set quiet=False if you want more info.
 
     input_file, benchmark, tested = parse_command_line_arguments()
 

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -198,11 +198,39 @@ def parse_command_line_arguments():
     return input_file, benchmark, tested
 
 
+def configure_logging():
+    """
+    Configure the root logger so that INFO (and above) goes to stdout, while
+    WARNING and above *also* goes to stderr.
+
+    This means the full log is captured in the normal CI build output (stdout),
+    while only genuine warnings/errors land on stderr.
+    """
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    # Remove any handlers installed by imported libraries.
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    formatter = logging.Formatter('%(levelname)s: %(message)s')
+
+    # INFO and above -> stdout (captured in the normal CI log).
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.INFO)
+    stdout_handler.setFormatter(formatter)
+    root.addHandler(stdout_handler)
+
+    # WARNING and above -> stderr (so CI flags/annotates them via regression.py.err).
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(formatter)
+    root.addHandler(stderr_handler)
+
+
 def main():
     "Returns the list of variables that failed the regression."
-    # Imported libraries can call logging.basicConfig at import time.
-    # Reset it so that only WARNING and worse are emitted.
-    logging.basicConfig(level=logging.WARNING, force=True)
+    configure_logging()
 
     input_file, benchmark, tested = parse_command_line_arguments()
 

--- a/rmgpy/tools/regression.py
+++ b/rmgpy/tools/regression.py
@@ -200,6 +200,10 @@ def parse_command_line_arguments():
 
 def main():
     "Returns the list of variables that failed the regression."
+    # Imported libraries can call logging.basicConfig at import time.
+    # Reset it so that only WARNING and worse are emitted.
+    logging.basicConfig(level=logging.WARNING, force=True)
+
     input_file, benchmark, tested = parse_command_line_arguments()
 
     args = read_input_file(input_file)  # casetitle, observables, setups, tol


### PR DESCRIPTION
### Motivation or Problem
Previously, pysidt, pulled in transitively via rmgpy.data.thermo, would configure a logger at import time, which put all INFO messages into stderr, which would then end up showing as errors in the pull request annotations.

### Description of Changes
Now, only WARNINGs and ERRORs should be reported, to stderr.
The INFO should, however, still go to stdout.

### Testing
Let's see if it works (await the Regression testing annotation on this PR)

### Other context
I have opened https://github.com/zadorlab/PySIDT/issues/44 on PySIDT