### PR TITLE
Handle van der Waals bonds in binding energy correction

### DIFF
--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1611,7 +1611,9 @@ class ThermoDatabase(object):
                 assert len(site.bonds) == 1, "Each surface site can only be bonded to 1 atom"
                 bonded_atom = list(site.bonds.keys())[0]
                 bond = site.bonds[bonded_atom]
-                if bond.is_single():
+                if bond.is_van_der_waals():
+                    bond_order = 0.
+                elif bond.is_single():
                     bond_order = 1.
                 elif bond.is_double():
                     bond_order = 2.

--- a/test/rmgpy/data/thermoTest.py
+++ b/test/rmgpy/data/thermoTest.py
@@ -1297,6 +1297,36 @@ multiplicity 2
         groups["NX"].data = _nstardata
         groups["OX"].data = _ostardata
 
+    def test_binding_energy_correction_with_van_der_waals_bond(self):
+        """Binding energy correction must handle van der Waals (order 0) bonds.
+
+        Regression test for issue #2987: a species with a surface site attached
+        by a van der Waals bond (e.g. the Surface_Dissociation_vdWBidentate_Beta
+        product [Pt]~[O]=C[O][Pt]) 
+
+        X..O=CH-O-X
+        """
+        spec = Species(
+            molecule=[
+                Molecule().from_adjacency_list(
+                    """
+1 X u0 p0 c0 {2,vdW}
+2 O u0 p2 c0 {1,vdW} {3,D}
+3 C u0 p0 c0 {2,D} {4,S} {5,S}
+4 O u0 p2 c0 {3,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 X u0 p0 c0 {4,S}
+"""
+                )
+            ]
+        )
+        spec.generate_resonance_structures()
+        thermo = self.database.get_thermo_data(spec)
+        corrected = self.database.correct_binding_energy(
+            thermo, spec, metal_to_scale_from="Pt111", metal_to_scale_to="Ni111"
+        )
+        assert "Binding energy corrected by LSR" in corrected.comment
+
     def test_adsorbate_thermo_generation_bidentate_weird_CO(self):
         """Test thermo generation for a bidentate adsorbate weird resonance of CO
 


### PR DESCRIPTION
### Motivation or Problem

Fixes #2987. 
RMG crashes with `NotImplementedError: Unsupported bond order 0.0 for binding energy correction` whenever a reaction family produces a partially-physisorbed (van der Waals) bidentate adsorbate on a metal whose binding energies differ from the Pt111 group-additivity reference. This was observed with the `Surface_Dissociation_vdWBidentate_Beta` family generating species such as `[Pt]~[O]=C[O][Pt]`, scaled to Nickel.

When applying the linear scaling relationship (in `ThermoDatabase.correct_binding_energy`), it walks each surface site and classifies its bond as single/double/triple/quadruple. A van der Waals bond matched none of those cases and raised `NotImplementedError`. Previously vdW adsorbates had *zero* bonds — but with the new bidentate families, you can now have an explicit vdW-bonded site with a bond of order 0.

### Description of Changes

- Added an explicit `bond.is_van_der_waals()` case in `correct_binding_energy`. A van der Waals bond contributes a bond order of `0` and therefore nothing to the LSR correction. This mirrors the existing vdW handling in `Molecule.desorb_molecule`.
- Added a regression test, `test_binding_energy_correction_with_van_der_waals_bond`, covering the exact species from the issue (`X~O=CH-O-X`).

### Testing already performed

- Reproduced the crash on a minimal vdW-adsorbed species and on the exact issue species; both raised `NotImplementedError: Unsupported bond order 0.0` before the change.
- After the fix, both process cleanly: the covalently-bonded O receives the correction while the vdW-bonded O correctly contributes nothing.
- The new regression test fails without the fix and passes with it; all 13 adsorbate/binding thermo tests in `thermoTest.py` pass.
- Confirmed the original #2987 input file now runs to completion without error.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
