### PR TITLE
fix(arkane): make PDep sensitivity meaningful for ILT-based path reactions

### DIFF
--- a/arkane/sensitivity.py
+++ b/arkane/sensitivity.py
@@ -47,13 +47,6 @@ from rmgpy.exceptions import InvalidMicrocanonicalRateError, ModifiedStrongColli
 
 ################################################################################
 
-# Tolerance (in J/mol) used when checking whether a TransitionState's E0 was synthesized as
-# E0(TS) = sum(E0(reactants)) + Ea (as RMG and Arkane's own ILT path do), as opposed to being an
-# independent, hand-authored value. 1 kJ/mol is comfortably below the floating-point noise floor
-# introduced by unit conversions and energy corrections along that construction path, while still
-# being small enough to catch a genuinely independent E0.
-SYNTHETIC_TS_E0_TOLERANCE = 1000.0  # J/mol (~1 kJ/mol)
-
 
 class KineticsSensitivity(object):
     """
@@ -224,14 +217,14 @@ class KineticsSensitivity(object):
             ax[i][0].set_yticks(y_pos)
             ax[i][0].set_yticklabels(labels)
             ax[i][0].invert_yaxis()  # labels read top-to-bottom
-            ax[i][0].set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
+            ax[i][0].set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{mol}{J}$)')
             ax[i][0].set_title('Forward, {0}'.format(condition))
             ax[i][0].set_xlim([min_sa, max_sa])
             ax[i][1].barh(y_pos, r_values, align='center', color='blue')
             ax[i][1].set_yticks(y_pos)
             ax[i][1].set_yticklabels(labels)
             ax[i][1].invert_yaxis()  # labels read top-to-bottom
-            ax[i][1].set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
+            ax[i][1].set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{mol}{J}$)')
             ax[i][1].set_title('Reverse, {0}'.format(condition))
             ax[i][1].set_xlim([min_sa, max_sa])
             plt.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
@@ -246,39 +239,6 @@ class KineticsSensitivity(object):
         path = os.path.join(self.sensitivity_path, filename)
         plt.savefig(path)
         plt.close()
-
-
-def _ts_e0_is_synthetic(rxn, ts_e0_si, ea_si):
-    """
-    Determine whether a TransitionState's E0 was synthesized from the owning path reaction's
-    Arrhenius activation energy as ``E0(TS) = sum(E0(reactants)) + Ea`` (the convention used by
-    both RMG, see rmgpy/rmg/pdep.py, and Arkane itself when a TS's E0 is missing, see
-    arkane/pdep.py), as opposed to being an independent, physically meaningful value supplied by
-    a hand-authored Arkane input (a modeless TS with its own E0).
-
-    `ts_e0_si` and `ea_si` must be the TS's E0 and the reaction's Arrhenius Ea, both in SI units
-    (J/mol), taken at the SAME point in a perturb/unperturb pair (i.e. both read before that call's
-    own shift is applied to them). Because both quantities are shifted by the identical amount on
-    a perturb call and shifted back by the identical amount on the matching unperturb call, their
-    difference (ts_e0_si - ea_si) is invariant across the pair, and so is this function's verdict --
-    this is essential, since silently disagreeing between the perturb and unperturb calls would
-    leave Ea perturbed with no corresponding unperturb (or vice versa), corrupting later iterations.
-
-    A path reaction may be stored in either direction relative to which side the TS sits on, so
-    both the reactants-side and the products-side sums are tried before concluding the relation
-    does not hold.
-    """
-    for species_list in (rxn.reactants, rxn.products):
-        try:
-            e0_sum = sum(spc.conformer.E0.value_si for spc in species_list)
-        except AttributeError:
-            # A species on this side lacks a conformer/E0 (e.g. a placeholder species without
-            # statmech data); treat this side as not matching rather than raising, and fall
-            # through to try the other side.
-            continue
-        if abs((ts_e0_si - ea_si) - e0_sum) <= SYNTHETIC_TS_E0_TOLERANCE:
-            return True
-    return False
 
 
 class PDepSensitivity(object):
@@ -297,11 +257,10 @@ class PDepSensitivity(object):
     `sa_rates`          A dictionary with string representations of net_reactions as keys. Values are dictionaries with
                         Wells or TransitionStates as keys and each value is a list of forward rates from `job` at the
                         respective `conditions` after perturbing the corresponding well's E0, or, for a TS, its E0
-                        and (if the owning path reaction is ILT-based rather than RRKM-based, and the TS's E0 was
-                        synthesized from that reaction's Arrhenius Ea in the first place) the Ea of the Arrhenius
-                        kinetics used to derive its microcanonical rate, both by the same amount. For such TS rows
-                        the reported coefficient is therefore NOT a plain dln(r)/dE0(TS): it is a derivative along
-                        the coordinate that raises the synthetic barrier (TS E0 and Ea together)
+                        and (if the owning path reaction is ILT-based rather than RRKM-based) the Ea of the
+                        Arrhenius kinetics used to derive its microcanonical rate, both by the same amount. For
+                        such TS rows the reported coefficient is therefore NOT a plain dln(r)/dE0(TS): it is a
+                        derivative along the coordinate that raises the barrier (TS E0 and Ea together)
     `sa_coefficients`   A dictionary with similar structure as `sa_rates`, containing the sensitivity coefficients
                         in the forward direction
     =================== ================================================================================================
@@ -372,6 +331,11 @@ class PDepSensitivity(object):
             wells = []
             transition_states = []
             while c < self.max_iters:
+                # Each attempt works on a fresh deep copy of the base job, so the in-place E0/Ea
+                # shifts that perturb() applies never touch base_job. This is what makes the
+                # perturb/unperturb pair exception-safe: if self.job.execute() below raises, the
+                # corrupted copy is simply discarded on the next iteration -- the invariant does
+                # not rely on unperturb() running on every code path.
                 self.job = deepcopy(base_job)
                 wells = []
                 wells.extend(self.job.network.reactants)
@@ -429,19 +393,28 @@ class PDepSensitivity(object):
 
         For a :class:TransitionState belonging to one or more path reactions whose microcanonical
         rate is computed via the inverse Laplace transform (ILT) method rather than RRKM theory
-        (i.e. ``not rxn.can_tst()``), perturbing the TS's E0 alone is a structural no-op: the ILT
-        convolution and its high-pressure-limit renormalization are driven by the reaction's
-        Arrhenius activation energy `Ea`, not by the TS conformer's E0. When, by construction,
-        E0(TS) = sum(E0(reactants)) + Ea (see :func:`_ts_e0_is_synthetic`), perturbing `Ea` by the
-        same amount as E0 is the physically consistent perturbation, and is applied here in
-        addition to the E0 perturbation for every ILT-based path reaction that shares this TS
-        object (Arkane input files may point more than one `reaction` block at the same
-        `transitionState` label, so a single TS entry can own several path reactions; since the E0
-        perturbation above already affects all of them -- the object is shared -- the Ea
-        perturbation must match that same blast radius or the two representations of the barrier
-        would desynchronize). Hand-authored, modeless transition states whose E0 is an independent
-        physical value (i.e. the synthetic relation above does not hold) are left with only their
-        E0 perturbed, since moving their Ea as well would not be physically justified. RRKM-based
+        (i.e. ``not rxn.can_tst()``), perturbing the TS's E0 alone is a structural no-op for
+        n >= 0.25 and very nearly one otherwise. In ``apply_inverse_laplace_transform_method``
+        (rmgpy/pdep/reaction.pyx) the TS E0 is never referenced when the Arrhenius temperature
+        exponent n >= 0.25, so E0 is genuinely dead there; for n < 0.25 it enters only as a
+        grain-threshold cutoff, and in every case the resulting k(E) is renormalized
+        (rmgpy/pdep/network.py, ``calculate_microcanonical_rates``) by a single scalar so that its
+        canonical average reproduces ``kf_expected``, the high-pressure-limit Arrhenius k(T), which
+        depends on `Ea` and not on the TS E0. (For n < 0.25 the threshold shift does survive that
+        scalar renormalization into the pressure-dependent rate, so E0 is not strictly a no-op
+        there -- but that is precisely why perturbing E0 alongside Ea is correct rather than a
+        double-count: for an ILT-based reaction the barrier physically lives in `Ea`, with
+        E0(TS) = sum(E0(reactants)) + Ea, so raising the barrier necessarily raises both together.)
+        The `Ea` perturbation is therefore applied here in addition to the E0 perturbation for every
+        ILT-based path reaction with Arrhenius kinetics that shares this TS object (Arkane input
+        files may point more than one `reaction` block at the same `transitionState` label, so a
+        single TS entry can own several path reactions; since the E0 perturbation above already
+        affects all of them -- the object is shared -- the Ea perturbation must match that same
+        blast radius or the two representations of the barrier would desynchronize). This assumes
+        each such path reaction owns its own Arrhenius kinetics object: a single Arrhenius instance
+        shared across a TS's reactions is one barrier and is perturbed only once, while one shared
+        across reactions of *different* transition states is an unsupported input that would
+        cross-contaminate their sensitivities -- a warning is emitted if that is detected. RRKM-based
         (`can_tst()` is `True`) path reactions are unaffected, since RRKM genuinely uses the TS's
         E0 and sum of states, and perturbing both would double-count.
         """
@@ -449,31 +422,52 @@ class PDepSensitivity(object):
         if unperturb:
             perturbation *= -1
         if isinstance(entry, TransitionState):
-            # Read the pre-shift TS E0 (and, below, each reaction's pre-shift Ea) so that the
-            # synthetic-relation check below is invariant across a perturb/unperturb pair: both
-            # E0(TS) and Ea are shifted by the identical `perturbation` here and in the matching
-            # call, so their difference -- and hence the check's verdict -- does not change
-            # between the two calls. See :func:`_ts_e0_is_synthetic` for the full argument.
-            ts_e0_before = entry.conformer.E0.value_si
-            entry.conformer.E0 = quantity.Energy(ts_e0_before + perturbation, 'J/mol')
+            entry.conformer.E0 = quantity.Energy(entry.conformer.E0.value_si + perturbation, 'J/mol')
+            # Shift Ea by the same amount for every ILT-based path reaction owning this TS. The gate
+            # below MUST return the same verdict on a perturb call and its matching unperturb call,
+            # or Ea would be left shifted (or shifted twice) and every later iteration would run on a
+            # corrupted network. It trivially does: it depends only on the presence of statmech modes
+            # on the TS (`can_tst`) and on the type of the kinetics object, neither of which is
+            # affected by the E0/Ea shifts applied here.
+            perturbed_kinetics = set()  # id()s of Arrhenius objects already shifted this call
             for rxn in self.job.network.path_reactions:
                 if rxn.transition_state is not None and rxn.transition_state is entry and not rxn.can_tst():
                     kinetics = rxn.kinetics if rxn.network_kinetics is None else rxn.network_kinetics
                     if isinstance(kinetics, Arrhenius):
-                        ea_before = kinetics.Ea.value_si
-                        if _ts_e0_is_synthetic(rxn, ts_e0_before, ea_before):
-                            kinetics.Ea = quantity.Energy(ea_before + perturbation, 'J/mol')
-                        else:
-                            logging.info(
-                                "Not perturbing Ea for ILT-based path reaction '{0}': its TS E0 does not "
-                                "match sum(E0(reactants)) + Ea (nor the products-side equivalent), so it "
-                                "appears to carry an independent, hand-authored E0. Only E0 was "
-                                "perturbed.".format(rxn))
-                    else:
+                        if id(kinetics) in perturbed_kinetics:
+                            # Several of this TS's path reactions share one Arrhenius object: it is a
+                            # single barrier, already shifted once to match the single E0 shift above,
+                            # so do not shift it again (that would move Ea by 2x the E0 shift).
+                            continue
+                        perturbed_kinetics.add(id(kinetics))
+                        kinetics.Ea = quantity.Energy(kinetics.Ea.value_si + perturbation, 'J/mol')
+                    elif not unperturb:
+                        # Defensive only: a non-Arrhenius ILT path reaction cannot actually reach
+                        # sensitivity analysis, because apply_inverse_laplace_transform_method
+                        # (rmgpy/pdep/reaction.pyx) declares a Cython-typed `Arrhenius kinetics`
+                        # parameter, so the unperturbed base run in __init__ would already raise a
+                        # TypeError before we ever get here. The warning is guarded by `not unperturb`
+                        # so it is logged once per perturbation rather than twice (perturb + unperturb).
                         logging.warning(
                             "Not perturbing Ea for ILT-based path reaction '{0}' with kinetics of type "
                             "'{1}': the resulting TS sensitivity coefficient will be meaningless.".format(
                                 rxn, kinetics.__class__.__name__))
+            if not unperturb:
+                # Aliased-kinetics guard: if an Arrhenius object just shifted for this TS is also the
+                # kinetics of an ILT path reaction owned by a *different* TS, that reaction's rate has
+                # been collaterally perturbed and its sensitivity row is contaminated. This is an
+                # unsupported input (distinct reactions should not share one mutable kinetics object),
+                # so surface it loudly rather than silently reporting a corrupted coefficient.
+                for rxn in self.job.network.path_reactions:
+                    if (rxn.transition_state is not None and rxn.transition_state is not entry
+                            and not rxn.can_tst()):
+                        other_kinetics = rxn.kinetics if rxn.network_kinetics is None else rxn.network_kinetics
+                        if id(other_kinetics) in perturbed_kinetics:
+                            logging.warning(
+                                "Path reaction '{0}' (transition state '{1}') shares its Arrhenius kinetics "
+                                "object with a path reaction of the perturbed transition state '{2}'; its "
+                                "sensitivity coefficients will be contaminated. Give each path reaction its "
+                                "own kinetics object.".format(rxn, rxn.transition_state.label, entry.label))
         elif isinstance(entry, Configuration):
             entry.species[0].conformer.E0 = quantity.Energy(entry.species[0].conformer.E0.value_si + perturbation,
                                                             'J/mol')
@@ -481,6 +475,38 @@ class PDepSensitivity(object):
     def unperturb(self, entry):
         """A helper function for calling self.perturb cleanly when unperturbing"""
         self.perturb(entry, unperturb=True)
+
+    def _classify_ilt_transition_states(self):
+        """
+        Return ``(ilt_labels, contaminated_labels)``, two ordered lists of transition-state labels.
+
+        ``ilt_labels`` are the TSes whose sensitivity row carries the combined-E0+Ea (ILT) semantics
+        rather than a plain dln(r)/dE0(TS): a TS qualifies when at least one of its path reactions is
+        both ILT-based (``not can_tst()``) AND carries Arrhenius kinetics, which is exactly when
+        perturb() shifts Ea alongside E0.
+
+        ``contaminated_labels`` (a subset of ``ilt_labels``) are TSes whose Arrhenius kinetics object
+        is shared with a path reaction of a *different* TS: perturbing one collaterally shifts the
+        other, so their coefficients are contaminated. Such sharing is unsupported input; perturb()
+        also warns about it at run time.
+
+        Both save() and plot() classify rows from this single source so the table, the YAML metadata
+        and the figure never disagree about which rows are ILT-based or contaminated.
+        """
+        ilt_labels = []
+        kinetics_to_ts = {}  # id(Arrhenius) -> set of TS labels among ILT path reactions
+        for rxn in self.job.network.path_reactions:
+            if rxn.transition_state is not None and not rxn.can_tst():
+                kinetics = rxn.kinetics if rxn.network_kinetics is None else rxn.network_kinetics
+                if not isinstance(kinetics, Arrhenius):
+                    continue
+                if rxn.transition_state.label not in ilt_labels:
+                    ilt_labels.append(rxn.transition_state.label)
+                kinetics_to_ts.setdefault(id(kinetics), set()).add(rxn.transition_state.label)
+        contaminated_labels = [label for label in ilt_labels
+                               if any(label in ts_set and len(ts_set) > 1
+                                      for ts_set in kinetics_to_ts.values())]
+        return ilt_labels, contaminated_labels
 
     def save(self, wells, transition_states):
         """Save the SA output as tabulated data as well as in YAML format"""
@@ -492,15 +518,38 @@ class PDepSensitivity(object):
         path = os.path.join(self.output_directory, filename)
         sa_data = dict()
         sa_data['structures'] = dict()
+        # Classify TS rows once (shared with plot()): which carry the combined-E0+Ea (ILT) semantics
+        # rather than a plain dln(r)/dE0(TS), and which are contaminated by an Arrhenius kinetics
+        # object shared across transition states. The '(TS) ' prefix matches the entry keys used below.
+        ilt_raw_labels, contaminated_raw_labels = self._classify_ilt_transition_states()
+        ilt_ts_labels = ['(TS) ' + label for label in ilt_raw_labels]
+        contaminated_ts_labels = ['(TS) ' + label for label in contaminated_raw_labels]
+        # Only emit the top-level `metadata` key when it actually carries something, so an all-RRKM
+        # network's YAML keeps the pre-existing shape (`structures` + reaction strings) byte-for-byte
+        # and consumers that never dealt with ILT markers see no new key.
+        metadata = {}
+        if ilt_ts_labels:
+            metadata['ilt_transition_states'] = ilt_ts_labels
+        if contaminated_ts_labels:
+            metadata['contaminated_transition_states'] = contaminated_ts_labels
+        if metadata:
+            sa_data['metadata'] = metadata
         with open(path, 'w') as sa_f:
             sa_f.write("Sensitivity analysis for network {0}\n\n"
                        "The semi-normalized sensitivity coefficients are calculated as dln(r)/dE0\n"
                        "by perturbing E0 of each well or TS by {1}, and are given in `mol/J` units.\n"
-                       "For a TS owned by an ILT-based path reaction whose E0 was synthesized from\n"
-                       "that reaction's Arrhenius Ea (E0(TS) = sum(E0(reactants)) + Ea), the Ea is\n"
-                       "perturbed by the same amount alongside E0, so that row's coefficient is a\n"
-                       "derivative along the coordinate that raises the synthetic barrier (TS E0\n"
-                       "and Ea together), not a plain dln(r)/dE0(TS).\n\n\n".format(network_str, self.perturbation))
+                       "For a TS owned by an ILT-based path reaction (no statmech modes, so its\n"
+                       "microcanonical rate comes from the high-pressure-limit Arrhenius kinetics),\n"
+                       "the Arrhenius Ea is perturbed by the same amount alongside E0, so that row's\n"
+                       "coefficient is a derivative along the coordinate that raises the barrier\n"
+                       "(TS E0 and Ea together), not a plain dln(r)/dE0(TS).\n\n\n".format(network_str, self.perturbation))
+            if contaminated_ts_labels:
+                sa_f.write("WARNING: rows marked '(!)' belong to a transition state whose Arrhenius\n"
+                           "kinetics object is shared with a path reaction of a DIFFERENT transition\n"
+                           "state. Perturbing one collaterally shifts the other, so these coefficients\n"
+                           "are contaminated and unreliable. Give each path reaction its own kinetics\n"
+                           "object. (The same labels are listed under metadata.contaminated_transition_"
+                           "states in sa_coefficients.yml.)\n\n\n")
             for rxn in self.job.network.net_reactions:
                 for species in rxn.reactants + rxn.products:
                     if species.label not in sa_data['structures']:
@@ -520,7 +569,14 @@ class PDepSensitivity(object):
                         entry_label = '(TS) ' + entry.label
                     elif isinstance(entry, Configuration):
                         entry_label = ' + '.join([species.label for species in entry.species])
-                    mod_entry_label = entry_label + ' ' * (max_label - len(entry_label))
+                    # Flag contaminated TS rows in the table with a '(!)' suffix. The marker goes on
+                    # the display label only; the YAML data key (entry_label) stays clean so consumers
+                    # keying on '(TS) <label>' are unaffected -- the marker is carried in the YAML via
+                    # metadata.contaminated_transition_states instead.
+                    display_label = entry_label
+                    if isinstance(entry, TransitionState) and entry_label in contaminated_ts_labels:
+                        display_label = entry_label + ' (!)'
+                    mod_entry_label = display_label + ' ' * max(1, max_label - len(display_label))
                     for i, condition in enumerate(self.conditions):
                         sa_f.write('| {0} | {1:6.1f}          | {2:8.2f}       | {3:+1.2e}               |\n'.format(
                             mod_entry_label, condition[0].value_si, condition[1].value_si * 1e-5,
@@ -545,8 +601,19 @@ class PDepSensitivity(object):
         for rxn in self.job.network.net_reactions:
             plt.rcdefaults()
             ax = plt.subplots(nrows=len(self.conditions), ncols=1, tight_layout=True)[1]
+            # Annotate the TS tick labels so the figure distinguishes the two derivative types it
+            # plots on one axis: a plain dln(k)/dE0 for wells and RRKM-based TSes, versus the
+            # combined-E0+Ea derivative for ILT-based TSes (see save()). Contaminated rows (shared
+            # kinetics across TSes) are flagged too, matching the '(!)' note in the text table.
+            ilt_raw_labels, contaminated_raw_labels = self._classify_ilt_transition_states()
             labels = [str(entry) for entry in wells]
-            labels.extend(ts.label for ts in transition_states)
+            for ts in transition_states:
+                if ts.label in contaminated_raw_labels:
+                    labels.append(ts.label + ' (E0+Ea, contaminated)')
+                elif ts.label in ilt_raw_labels:
+                    labels.append(ts.label + ' (E0+Ea)')
+                else:
+                    labels.append(ts.label)
             max_sa = min_sa = self.sa_coefficients[str(rxn)][wells[0]][0]
             for conformer_sa in self.sa_coefficients[str(rxn)].values():
                 for sa_condition in conformer_sa:
@@ -566,10 +633,11 @@ class PDepSensitivity(object):
                 axis.set_yticks(y_pos)
                 axis.set_yticklabels(labels)
                 axis.invert_yaxis()  # labels read top-to-bottom
-                # Note: for a TS row belonging to an ILT-based path reaction with a synthetic E0
-                # (E0(TS) = sum(E0(reactants)) + Ea), this coefficient is a derivative along the
-                # coordinate that raises E0 and Ea together, not a plain dln(k)/dE0(TS); see save().
-                axis.set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
+                # A generic label: for wells and RRKM-based TS rows this is dln(k)/dE0, but for a
+                # TS row belonging to an ILT-based path reaction it is a derivative along the
+                # coordinate that raises E0 and Ea together, not a plain dln(k)/dE0(TS) (see save()).
+                # The coefficient has units of mol/J (the reciprocal of the perturbed energy).
+                axis.set_xlabel(r'Sensitivity coefficient ($\frac{mol}{J}$)')
                 # axis.ticklabel_format('sci')
                 axis.set_title('{0}, {1}'.format(condition[0], condition[1]))
                 try:

--- a/arkane/sensitivity.py
+++ b/arkane/sensitivity.py
@@ -42,9 +42,17 @@ import numpy as np
 from rmgpy.pdep import Configuration
 import rmgpy.quantity as quantity
 from rmgpy.species import TransitionState
+from rmgpy.kinetics import Arrhenius
 from rmgpy.exceptions import InvalidMicrocanonicalRateError, ModifiedStrongCollisionError, PressureDependenceError
 
 ################################################################################
+
+# Tolerance (in J/mol) used when checking whether a TransitionState's E0 was synthesized as
+# E0(TS) = sum(E0(reactants)) + Ea (as RMG and Arkane's own ILT path do), as opposed to being an
+# independent, hand-authored value. 1 kJ/mol is comfortably below the floating-point noise floor
+# introduced by unit conversions and energy corrections along that construction path, while still
+# being small enough to catch a genuinely independent E0.
+SYNTHETIC_TS_E0_TOLERANCE = 1000.0  # J/mol (~1 kJ/mol)
 
 
 class KineticsSensitivity(object):
@@ -240,6 +248,39 @@ class KineticsSensitivity(object):
         plt.close()
 
 
+def _ts_e0_is_synthetic(rxn, ts_e0_si, ea_si):
+    """
+    Determine whether a TransitionState's E0 was synthesized from the owning path reaction's
+    Arrhenius activation energy as ``E0(TS) = sum(E0(reactants)) + Ea`` (the convention used by
+    both RMG, see rmgpy/rmg/pdep.py, and Arkane itself when a TS's E0 is missing, see
+    arkane/pdep.py), as opposed to being an independent, physically meaningful value supplied by
+    a hand-authored Arkane input (a modeless TS with its own E0).
+
+    `ts_e0_si` and `ea_si` must be the TS's E0 and the reaction's Arrhenius Ea, both in SI units
+    (J/mol), taken at the SAME point in a perturb/unperturb pair (i.e. both read before that call's
+    own shift is applied to them). Because both quantities are shifted by the identical amount on
+    a perturb call and shifted back by the identical amount on the matching unperturb call, their
+    difference (ts_e0_si - ea_si) is invariant across the pair, and so is this function's verdict --
+    this is essential, since silently disagreeing between the perturb and unperturb calls would
+    leave Ea perturbed with no corresponding unperturb (or vice versa), corrupting later iterations.
+
+    A path reaction may be stored in either direction relative to which side the TS sits on, so
+    both the reactants-side and the products-side sums are tried before concluding the relation
+    does not hold.
+    """
+    for species_list in (rxn.reactants, rxn.products):
+        try:
+            e0_sum = sum(spc.conformer.E0.value_si for spc in species_list)
+        except AttributeError:
+            # A species on this side lacks a conformer/E0 (e.g. a placeholder species without
+            # statmech data); treat this side as not matching rather than raising, and fall
+            # through to try the other side.
+            continue
+        if abs((ts_e0_si - ea_si) - e0_sum) <= SYNTHETIC_TS_E0_TOLERANCE:
+            return True
+    return False
+
+
 class PDepSensitivity(object):
     """
     The :class:`Sensitivity` class represents an instance of a sensitivity analysis job
@@ -255,7 +296,12 @@ class PDepSensitivity(object):
                         respective path reaction at the respective `conditions` in the appropriate units
     `sa_rates`          A dictionary with string representations of net_reactions as keys. Values are dictionaries with
                         Wells or TransitionStates as keys and each value is a list of forward rates from `job` at the
-                        respective `conditions` after perturbing the corresponding well or TS's E0
+                        respective `conditions` after perturbing the corresponding well's E0, or, for a TS, its E0
+                        and (if the owning path reaction is ILT-based rather than RRKM-based, and the TS's E0 was
+                        synthesized from that reaction's Arrhenius Ea in the first place) the Ea of the Arrhenius
+                        kinetics used to derive its microcanonical rate, both by the same amount. For such TS rows
+                        the reported coefficient is therefore NOT a plain dln(r)/dE0(TS): it is a derivative along
+                        the coordinate that raises the synthetic barrier (TS E0 and Ea together)
     `sa_coefficients`   A dictionary with similar structure as `sa_rates`, containing the sensitivity coefficients
                         in the forward direction
     =================== ================================================================================================
@@ -380,12 +426,54 @@ class PDepSensitivity(object):
         The perturbation is done by addition of the energy amount in self.perturbation.
         If unperturb is `False`, the perturbation is addition of the energy amount in self.perturbation.
         If unperturb is `False`, this is done by subtracting.
+
+        For a :class:TransitionState belonging to one or more path reactions whose microcanonical
+        rate is computed via the inverse Laplace transform (ILT) method rather than RRKM theory
+        (i.e. ``not rxn.can_tst()``), perturbing the TS's E0 alone is a structural no-op: the ILT
+        convolution and its high-pressure-limit renormalization are driven by the reaction's
+        Arrhenius activation energy `Ea`, not by the TS conformer's E0. When, by construction,
+        E0(TS) = sum(E0(reactants)) + Ea (see :func:`_ts_e0_is_synthetic`), perturbing `Ea` by the
+        same amount as E0 is the physically consistent perturbation, and is applied here in
+        addition to the E0 perturbation for every ILT-based path reaction that shares this TS
+        object (Arkane input files may point more than one `reaction` block at the same
+        `transitionState` label, so a single TS entry can own several path reactions; since the E0
+        perturbation above already affects all of them -- the object is shared -- the Ea
+        perturbation must match that same blast radius or the two representations of the barrier
+        would desynchronize). Hand-authored, modeless transition states whose E0 is an independent
+        physical value (i.e. the synthetic relation above does not hold) are left with only their
+        E0 perturbed, since moving their Ea as well would not be physically justified. RRKM-based
+        (`can_tst()` is `True`) path reactions are unaffected, since RRKM genuinely uses the TS's
+        E0 and sum of states, and perturbing both would double-count.
         """
         perturbation = self.perturbation.value_si
         if unperturb:
             perturbation *= -1
         if isinstance(entry, TransitionState):
-            entry.conformer.E0 = quantity.Energy(entry.conformer.E0.value_si + perturbation, 'J/mol')
+            # Read the pre-shift TS E0 (and, below, each reaction's pre-shift Ea) so that the
+            # synthetic-relation check below is invariant across a perturb/unperturb pair: both
+            # E0(TS) and Ea are shifted by the identical `perturbation` here and in the matching
+            # call, so their difference -- and hence the check's verdict -- does not change
+            # between the two calls. See :func:`_ts_e0_is_synthetic` for the full argument.
+            ts_e0_before = entry.conformer.E0.value_si
+            entry.conformer.E0 = quantity.Energy(ts_e0_before + perturbation, 'J/mol')
+            for rxn in self.job.network.path_reactions:
+                if rxn.transition_state is not None and rxn.transition_state is entry and not rxn.can_tst():
+                    kinetics = rxn.kinetics if rxn.network_kinetics is None else rxn.network_kinetics
+                    if isinstance(kinetics, Arrhenius):
+                        ea_before = kinetics.Ea.value_si
+                        if _ts_e0_is_synthetic(rxn, ts_e0_before, ea_before):
+                            kinetics.Ea = quantity.Energy(ea_before + perturbation, 'J/mol')
+                        else:
+                            logging.info(
+                                "Not perturbing Ea for ILT-based path reaction '{0}': its TS E0 does not "
+                                "match sum(E0(reactants)) + Ea (nor the products-side equivalent), so it "
+                                "appears to carry an independent, hand-authored E0. Only E0 was "
+                                "perturbed.".format(rxn))
+                    else:
+                        logging.warning(
+                            "Not perturbing Ea for ILT-based path reaction '{0}' with kinetics of type "
+                            "'{1}': the resulting TS sensitivity coefficient will be meaningless.".format(
+                                rxn, kinetics.__class__.__name__))
         elif isinstance(entry, Configuration):
             entry.species[0].conformer.E0 = quantity.Energy(entry.species[0].conformer.E0.value_si + perturbation,
                                                             'J/mol')
@@ -407,8 +495,12 @@ class PDepSensitivity(object):
         with open(path, 'w') as sa_f:
             sa_f.write("Sensitivity analysis for network {0}\n\n"
                        "The semi-normalized sensitivity coefficients are calculated as dln(r)/dE0\n"
-                       "by perturbing E0 of each well or TS by {1},\n and are given in "
-                       "`mol/J` units.\n\n\n".format(network_str, self.perturbation))
+                       "by perturbing E0 of each well or TS by {1}, and are given in `mol/J` units.\n"
+                       "For a TS owned by an ILT-based path reaction whose E0 was synthesized from\n"
+                       "that reaction's Arrhenius Ea (E0(TS) = sum(E0(reactants)) + Ea), the Ea is\n"
+                       "perturbed by the same amount alongside E0, so that row's coefficient is a\n"
+                       "derivative along the coordinate that raises the synthetic barrier (TS E0\n"
+                       "and Ea together), not a plain dln(r)/dE0(TS).\n\n\n".format(network_str, self.perturbation))
             for rxn in self.job.network.net_reactions:
                 for species in rxn.reactants + rxn.products:
                     if species.label not in sa_data['structures']:
@@ -474,6 +566,9 @@ class PDepSensitivity(object):
                 axis.set_yticks(y_pos)
                 axis.set_yticklabels(labels)
                 axis.invert_yaxis()  # labels read top-to-bottom
+                # Note: for a TS row belonging to an ILT-based path reaction with a synthetic E0
+                # (E0(TS) = sum(E0(reactants)) + Ea), this coefficient is a derivative along the
+                # coordinate that raises E0 and Ea together, not a plain dln(k)/dE0(TS); see save().
                 axis.set_xlabel(r'Sensitivity: $\frac{\partial\:\ln{k}}{\partial\:E0}$, ($\frac{J}{mol}$)')
                 # axis.ticklabel_format('sci')
                 axis.set_title('{0}, {1}'.format(condition[0], condition[1]))

--- a/test/arkane/arkanePdepTest.py
+++ b/test/arkane/arkanePdepTest.py
@@ -145,13 +145,19 @@ class ArkaneILTSensitivityTest:
     ones, exercising the real perturb-both-E0-and-Ea code path (see arkane/sensitivity.py) rather
     than a synthetic/fabricated one.
 
-    The fixture (test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py) reuses, verbatim,
-    the real species/transitionState/reaction/network thermochemistry from the official
+    The fixture (test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py) reuses the real
+    species/transitionState/reaction/network thermochemistry from the official
     examples/arkane/networks/acetyl+O2_cse example (its 'entrance1' transition state is modeless,
     with real Arrhenius kinetics on the owning reaction; its 'isom1'/'exit1'/'exit2'/'exit3'
-    transition states are RRKM, with full statmech modes). Only the `pressureDependence(...)`
-    block's computational settings (grid density/range, solver method) were narrowed to keep this
-    test fast; no thermochemistry was altered or fabricated.
+    transition states are RRKM, with full statmech modes), with two deliberate deviations: the
+    `pressureDependence(...)` block's computational settings (grid density/range, solver method)
+    were narrowed to keep this test fast, and the 'entrance1' TS E0 was moved to 2.0 kcal/mol so
+    that it does NOT satisfy E0(TS) = sum(E0(reactants)) + Ea. The latter is the regression shape
+    that matters: real RMG-written network files generally break that relation, and an earlier
+    revision of the sensitivity fix gated the Ea perturbation on it -- passing on this fixture
+    (where every energy was 0.0 and the relation held trivially) while producing structurally
+    zero TS coefficients on essentially all real networks (24 of 6,434 resolvable path reactions
+    across 400 real RMG networks satisfied the relation, i.e. 0.4%).
     """
 
     @classmethod
@@ -188,9 +194,20 @@ class ArkaneILTSensitivityTest:
 
         job = arkane.job_list[0]
         path_reactions_by_label = {rxn.label: rxn for rxn in job.network.path_reactions}
-        assert not path_reactions_by_label["entrance1"].can_tst()  # the genuinely ILT-based reaction
+        ilt_rxn = path_reactions_by_label["entrance1"]
+        assert not ilt_rxn.can_tst()  # the genuinely ILT-based reaction
         for rrkm_label in ("isom1", "exit1", "exit2", "exit3"):
             assert path_reactions_by_label[rrkm_label].can_tst()
+
+        # Guard the fixture's regression shape: the ILT TS's E0 must NOT satisfy
+        # E0(TS) = sum(E0) + Ea on either side (real RMG-written networks generally break this
+        # relation; an earlier revision gated the Ea perturbation on it and thus passed on a
+        # relation-satisfying fixture while failing on real networks).
+        ts_e0 = ilt_rxn.transition_state.conformer.E0.value_si
+        ea = ilt_rxn.kinetics.Ea.value_si
+        for side in (ilt_rxn.reactants, ilt_rxn.products):
+            e0_sum = sum(spc.conformer.E0.value_si for spc in side)
+            assert abs((ts_e0 - ea) - e0_sum) > 5000.0  # J/mol
 
         yaml_path = os.path.join(self.directory, "sensitivity", "sa_coefficients.yml")
         assert os.path.isfile(yaml_path)
@@ -199,8 +216,9 @@ class ArkaneILTSensitivityTest:
 
         ilt_ts_values = []
         rrkm_ts_values = []
+        well_values = []
         for reaction_str, conditions in sa_data.items():
-            if reaction_str == "structures":
+            if reaction_str in ("structures", "metadata"):
                 continue
             for condition_data in conditions.values():
                 for entry_label, coefficient in condition_data.items():
@@ -208,10 +226,27 @@ class ArkaneILTSensitivityTest:
                         ilt_ts_values.append(coefficient)
                     elif entry_label.startswith("(TS) "):
                         rrkm_ts_values.append(coefficient)
+                    else:
+                        well_values.append(coefficient)
 
         assert len(ilt_ts_values) > 0
         assert all(math.isfinite(v) for v in ilt_ts_values)
         assert any(v != 0.0 for v in ilt_ts_values)
+
+        # The YAML carries a machine-discoverable marker of which TS rows are ILT-based (combined
+        # E0+Ea perturbation), so a consumer need not re-derive can_tst() per reaction.
+        assert "(TS) entrance1" in sa_data["metadata"]["ilt_transition_states"]
+
+        # The ILT TS coefficients must be genuinely meaningful, not numerical noise: without the
+        # Ea perturbation they sit many orders of magnitude below the well coefficients (the E0
+        # perturbation alone is a structural no-op for an ILT-based reaction), so require the
+        # largest ILT TS coefficient to be within two orders of magnitude of the largest well
+        # coefficient.
+        assert len(well_values) > 0
+        max_well = max(abs(v) for v in well_values)
+        max_ilt_ts = max(abs(v) for v in ilt_ts_values)
+        assert max_well > 0.0
+        assert max_ilt_ts >= 1e-2 * max_well
 
         assert len(rrkm_ts_values) > 0
         assert all(math.isfinite(v) for v in rrkm_ts_values)

--- a/test/arkane/arkanePdepTest.py
+++ b/test/arkane/arkanePdepTest.py
@@ -32,11 +32,12 @@ This module contains unit tests of the :mod:`arkane.pdep` module.
 """
 
 import logging
+import math
 import os
 import shutil
 
-
 import pytest
+import yaml
 
 from rmgpy import settings
 from rmgpy.chemkin import read_reactions_block
@@ -134,3 +135,98 @@ class ArkaneTest:
         for f in files:
             if "pdep_sa" not in f:
                 os.remove(os.path.join(settings["test_data.directory"], "arkane", "tst1", f))
+
+
+@pytest.mark.functional
+class ArkaneILTSensitivityTest:
+    """
+    Integration test for `arkane.sensitivity.PDepSensitivity` on a network that genuinely
+    contains an ILT-based ("modeless", ``not rxn.can_tst()``) path reaction alongside RRKM-based
+    ones, exercising the real perturb-both-E0-and-Ea code path (see arkane/sensitivity.py) rather
+    than a synthetic/fabricated one.
+
+    The fixture (test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py) reuses, verbatim,
+    the real species/transitionState/reaction/network thermochemistry from the official
+    examples/arkane/networks/acetyl+O2_cse example (its 'entrance1' transition state is modeless,
+    with real Arrhenius kinetics on the owning reaction; its 'isom1'/'exit1'/'exit2'/'exit3'
+    transition states are RRKM, with full statmech modes). Only the `pressureDependence(...)`
+    block's computational settings (grid density/range, solver method) were narrowed to keep this
+    test fast; no thermochemistry was altered or fabricated.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        """A function that is run ONCE before all unit tests in this class."""
+        cls.directory = os.path.join(settings["test_data.directory"], "arkane", "tst_ilt_mixed", "")
+        cls.input_file = os.path.join(cls.directory, "pdep_sa_ilt_mixed.py")
+
+        # clear the working folder from any previous test output
+        dirs = [d for d in os.listdir(cls.directory) if not os.path.isfile(os.path.join(cls.directory, d))]
+        for d in dirs:
+            shutil.rmtree(os.path.join(cls.directory, d, ""))
+        files = [f for f in os.listdir(cls.directory) if os.path.isfile(os.path.join(cls.directory, f))]
+        for f in files:
+            if "pdep_sa_ilt_mixed" not in f:
+                os.remove(os.path.join(cls.directory, f))
+
+    def test_ilt_and_rrkm_path_reactions_produce_finite_sensitivity_coefficients(self):
+        """
+        Test that a real PDep sensitivity analysis job, run on a network with both an ILT-based
+        and several RRKM-based path reactions, produces finite, non-all-zero TS sensitivity
+        coefficients for the ILT-based transition state (whose Ea is perturbed alongside its E0),
+        while leaving the RRKM-based transition states' coefficients well-defined too (they are
+        unaffected by the Ea-perturbation logic, since it only applies when `not rxn.can_tst()`).
+        """
+        arkane = Arkane()
+        arkane.input_file = self.input_file
+        arkane.output_directory = self.directory
+        arkane.verbose = logging.WARN
+        arkane.plot = False
+        arkane.job_list = []
+        arkane.job_list = arkane.load_input_file(self.input_file)
+        arkane.execute()
+
+        job = arkane.job_list[0]
+        path_reactions_by_label = {rxn.label: rxn for rxn in job.network.path_reactions}
+        assert not path_reactions_by_label["entrance1"].can_tst()  # the genuinely ILT-based reaction
+        for rrkm_label in ("isom1", "exit1", "exit2", "exit3"):
+            assert path_reactions_by_label[rrkm_label].can_tst()
+
+        yaml_path = os.path.join(self.directory, "sensitivity", "sa_coefficients.yml")
+        assert os.path.isfile(yaml_path)
+        with open(yaml_path, "r") as f:
+            sa_data = yaml.unsafe_load(f)
+
+        ilt_ts_values = []
+        rrkm_ts_values = []
+        for reaction_str, conditions in sa_data.items():
+            if reaction_str == "structures":
+                continue
+            for condition_data in conditions.values():
+                for entry_label, coefficient in condition_data.items():
+                    if entry_label == "(TS) entrance1":
+                        ilt_ts_values.append(coefficient)
+                    elif entry_label.startswith("(TS) "):
+                        rrkm_ts_values.append(coefficient)
+
+        assert len(ilt_ts_values) > 0
+        assert all(math.isfinite(v) for v in ilt_ts_values)
+        assert any(v != 0.0 for v in ilt_ts_values)
+
+        assert len(rrkm_ts_values) > 0
+        assert all(math.isfinite(v) for v in rrkm_ts_values)
+        assert any(v != 0.0 for v in rrkm_ts_values)
+
+    @classmethod
+    def teardown_class(cls):
+        """A function that is run ONCE after all unit tests in this class."""
+        cls.directory = os.path.join(settings["test_data.directory"], "arkane", "tst_ilt_mixed", "")
+
+        # clean working folder from all previous test output
+        dirs = [d for d in os.listdir(cls.directory) if not os.path.isfile(os.path.join(cls.directory, d))]
+        for d in dirs:
+            shutil.rmtree(os.path.join(cls.directory, d, ""))
+        files = [f for f in os.listdir(cls.directory) if os.path.isfile(os.path.join(cls.directory, f))]
+        for f in files:
+            if "pdep_sa_ilt_mixed" not in f:
+                os.remove(os.path.join(cls.directory, f))

--- a/test/arkane/sensitivityTest.py
+++ b/test/arkane/sensitivityTest.py
@@ -46,7 +46,7 @@ from rmgpy.reaction import Reaction
 from rmgpy.species import Species, TransitionState
 from rmgpy.statmech import Conformer, IdealGasTranslation, NonlinearRotor, HarmonicOscillator
 
-from arkane.sensitivity import PDepSensitivity, SYNTHETIC_TS_E0_TOLERANCE, _ts_e0_is_synthetic
+from arkane.sensitivity import PDepSensitivity
 
 
 class _Network(object):
@@ -85,7 +85,7 @@ def _make_full_ts(e0_value_si):
 
 
 def _make_species_with_e0(label, e0_value_si):
-    """A Species with only a conformer E0 set (as `_ts_e0_is_synthetic` needs)."""
+    """A Species with only a conformer E0 set."""
     return Species(label=label, conformer=Conformer(E0=(e0_value_si, 'J/mol'), modes=[]))
 
 
@@ -104,8 +104,7 @@ class TestPDepSensitivityPerturb:
         e0_0 = 10000.0  # J/mol
         ea_0 = 20000.0  # J/mol
         ts = _make_modeless_ts(e0_0)
-        # E0(TS) = sum(E0(reactants)) + Ea, so the synthetic relation holds and Ea is perturbed too.
-        reactant = _make_species_with_e0('A', e0_0 - ea_0)
+        reactant = _make_species_with_e0('A', 5000.0)
         kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
         rxn = Reaction(reactants=[reactant], products=[Species(label='B')],
                         transition_state=ts, kinetics=kinetics)
@@ -149,8 +148,7 @@ class TestPDepSensitivityPerturb:
         ea_0 = 20000.0  # J/mol
         network_ea_0 = 30000.0  # J/mol
         ts = _make_modeless_ts(e0_0)
-        # Chosen so E0(TS) = sum(E0(reactants)) + network_ea_0 (the kinetics actually used for k(E)).
-        reactant = _make_species_with_e0('A', e0_0 - network_ea_0)
+        reactant = _make_species_with_e0('A', 5000.0)
         kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
         network_kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(network_ea_0, 'J/mol'))
         rxn = Reaction(reactants=[reactant], products=[Species(label='B')], transition_state=ts,
@@ -235,69 +233,47 @@ class TestPDepSensitivityPerturb:
         assert kinetics_1.Ea.value_si == pytest.approx(ea_0_1, abs=1e-9)
         assert kinetics_2.Ea.value_si == pytest.approx(ea_0_2, abs=1e-9)
 
-    def test_modeless_ts_with_independent_e0_is_not_perturbed_for_ea(self, caplog):
+    def test_ilt_reaction_with_unrelated_ts_e0_still_perturbs_ea(self):
         """
-        A hand-authored, modeless TS whose E0 is an independent physical value (i.e. it does NOT
-        satisfy E0(TS) = sum(E0(reactants)) + Ea, nor the products-side equivalent) must have only
-        its E0 perturbed; moving Ea as well would not be physically justified for such a TS.
+        Regression test built from a real RMG-written network (T3 PDep network13_2,
+        CH2CNH <=> CH3CN): the written network file carries a TS E0 that does NOT satisfy
+        E0(TS) = sum(E0(reactants)) + Ea on either side (the relation misses by 137 and
+        23 kJ/mol respectively -- RMG mutates Ea via `fix_barrier_height` after synthesizing
+        the TS E0, and Arkane strips `energy_correction` when writing the network file, so
+        the relation is generally unrecoverable from the file). An earlier revision gated the
+        Ea perturbation on that arithmetic relation, which only 24 of 6,434 resolvable path
+        reactions across 400 real RMG networks satisfied (0.4%); real networks therefore got a
+        structurally zero TS sensitivity coefficient. The Ea perturbation must apply whenever
+        the reaction is ILT-based with Arrhenius kinetics, regardless of any relation between
+        the TS E0 and the species energies.
         """
-        e0_0 = 10000.0  # J/mol
-        ea_0 = 20000.0  # J/mol
-        ts = _make_modeless_ts(e0_0)
-        # Reactant/product E0s chosen so neither side comes anywhere near satisfying the relation.
-        reactant = _make_species_with_e0('A', 500000.0)
-        product = _make_species_with_e0('B', 600000.0)
-        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        e0_ts = 331959.0  # J/mol, from the real network file
+        ea_0 = 294135.2  # J/mol
+        ts = _make_modeless_ts(e0_ts)
+        reactant = _make_species_with_e0('CH2CNH', 174694.0)
+        product = _make_species_with_e0('CH3CN', 61223.1)
+        kinetics = Arrhenius(A=(2.5e13, 's^-1'), n=0.0, Ea=(ea_0, 'J/mol'), T0=(1, 'K'))
         rxn = Reaction(reactants=[reactant], products=[product], transition_state=ts, kinetics=kinetics)
         assert not rxn.can_tst()
-        assert not _ts_e0_is_synthetic(rxn, ts.conformer.E0.value_si, kinetics.Ea.value_si)
+        # The defining property of this regression case: the old synthetic-E0 relation fails
+        # on both sides, by far more than any plausible tolerance.
+        for side in (rxn.reactants, rxn.products):
+            e0_sum = sum(spc.conformer.E0.value_si for spc in side)
+            assert abs((e0_ts - ea_0) - e0_sum) > 20000.0
 
         stub = _StubPDepSensitivity([rxn], self.perturbation)
-        with caplog.at_level(logging.INFO):
-            PDepSensitivity.perturb(stub, ts)
+        PDepSensitivity.perturb(stub, ts)
 
-        assert any('independent' in record.message for record in caplog.records)
         p = self.perturbation.value_si
-        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + p)
-        assert kinetics.Ea.value_si == pytest.approx(ea_0)  # untouched
+        assert ts.conformer.E0.value_si == pytest.approx(e0_ts + p)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0 + p)  # perturbed despite the broken relation
 
-        # Round-trip: unperturb must restore E0 exactly, and Ea must remain untouched throughout,
-        # bit-for-bit (the same verdict -- "not synthetic" -- must be reached on both calls).
+        # Round-trip: unperturb must restore both exactly (the condition gating the Ea
+        # perturbation is structural -- can_tst() and the kinetics type -- so it is invariant
+        # across the perturb/unperturb pair by construction).
         PDepSensitivity.perturb(stub, ts, unperturb=True)
-        assert ts.conformer.E0.value_si == e0_0
-        assert kinetics.Ea.value_si == ea_0
-
-    def test_ts_e0_is_synthetic_tries_products_side_when_reactants_side_fails(self):
-        """
-        A path reaction may be stored in either direction relative to which side the TS sits on;
-        `_ts_e0_is_synthetic` must try the products-side sum when the reactants-side sum does not
-        satisfy the relation.
-        """
-        e0_0 = 10000.0  # J/mol
-        ea_0 = 20000.0  # J/mol
-        ts = _make_modeless_ts(e0_0)
-        reactant = _make_species_with_e0('A', 999999.0)  # reactants-side check fails
-        product = _make_species_with_e0('B', e0_0 - ea_0)  # products-side check matches
-        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
-        rxn = Reaction(reactants=[reactant], products=[product], transition_state=ts, kinetics=kinetics)
-
-        assert _ts_e0_is_synthetic(rxn, ts.conformer.E0.value_si, kinetics.Ea.value_si)
-
-    def test_ts_e0_is_synthetic_tolerance_boundary(self):
-        """Sanity-check the module-level tolerance constant is applied as documented."""
-        e0_0 = 10000.0  # J/mol
-        ea_0 = 20000.0  # J/mol
-        ts = _make_modeless_ts(e0_0)
-        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
-        just_inside = _make_species_with_e0('A', e0_0 - ea_0 + 0.9 * SYNTHETIC_TS_E0_TOLERANCE)
-        just_outside = _make_species_with_e0('A', e0_0 - ea_0 + 1.1 * SYNTHETIC_TS_E0_TOLERANCE)
-        rxn_inside = Reaction(reactants=[just_inside], products=[Species(label='B')],
-                               transition_state=ts, kinetics=kinetics)
-        rxn_outside = Reaction(reactants=[just_outside], products=[Species(label='B')],
-                                transition_state=ts, kinetics=kinetics)
-
-        assert _ts_e0_is_synthetic(rxn_inside, ts.conformer.E0.value_si, kinetics.Ea.value_si)
-        assert not _ts_e0_is_synthetic(rxn_outside, ts.conformer.E0.value_si, kinetics.Ea.value_si)
+        assert ts.conformer.E0.value_si == pytest.approx(e0_ts, abs=1e-9)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0, abs=1e-9)
 
     def test_unsupported_kinetics_type_logs_warning(self, caplog):
         """An ILT-based reaction with an unsupported kinetics type should log a warning, not fail silently."""
@@ -315,3 +291,178 @@ class TestPDepSensitivityPerturb:
         assert any('Chebyshev' in record.message for record in caplog.records)
         # E0 is still perturbed even though Ea perturbation was skipped
         assert ts.conformer.E0.value_si == pytest.approx(e0_0 + self.perturbation.value_si)
+
+    def test_perturbing_one_ts_does_not_perturb_other_ts_reactions(self):
+        """
+        A network with two DISTINCT transition states, each owning its own ILT-based reaction:
+        perturbing TS A must move only TS A's reaction Ea, leaving TS B's reaction Ea and E0 fully
+        untouched. This pins the `rxn.transition_state is entry` scoping in the Ea loop -- without
+        it, perturbing one TS would shift Ea for every ILT reaction anywhere in the network and
+        silently corrupt every other TS's sensitivity coefficient computed in the same job.
+        """
+        e0_a, e0_b = 10000.0, 12000.0  # J/mol
+        ea_a, ea_b = 20000.0, 30000.0  # J/mol
+        ts_a = _make_modeless_ts(e0_a)
+        ts_b = _make_modeless_ts(e0_b)
+        kinetics_a = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_a, 'J/mol'))
+        kinetics_b = Arrhenius(A=(1e12, 's^-1'), n=1.2, Ea=(ea_b, 'J/mol'))
+        rxn_a = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                          transition_state=ts_a, kinetics=kinetics_a)
+        rxn_b = Reaction(reactants=[Species(label='C')], products=[Species(label='D')],
+                          transition_state=ts_b, kinetics=kinetics_b)
+        assert ts_a is not ts_b
+        assert not rxn_a.can_tst() and not rxn_b.can_tst()
+
+        stub = _StubPDepSensitivity([rxn_a, rxn_b], self.perturbation)
+        PDepSensitivity.perturb(stub, ts_a)
+
+        p = self.perturbation.value_si
+        assert ts_a.conformer.E0.value_si == pytest.approx(e0_a + p)
+        assert kinetics_a.Ea.value_si == pytest.approx(ea_a + p)
+        # TS B's reaction is entirely untouched.
+        assert ts_b.conformer.E0.value_si == pytest.approx(e0_b)
+        assert kinetics_b.Ea.value_si == pytest.approx(ea_b)
+
+    def test_shared_kinetics_object_is_perturbed_only_once(self):
+        """
+        If two path reactions of the same TS share a single Arrhenius object, it represents one
+        barrier: the E0 shift already touches it once, so its Ea must move by exactly the
+        perturbation, not by twice it (once per owning reaction). The Ea loop keys on kinetics-object
+        identity to guard this.
+        """
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        rxn_1 = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                          transition_state=ts, kinetics=kinetics)
+        rxn_2 = Reaction(reactants=[Species(label='C')], products=[Species(label='D')],
+                          transition_state=ts, kinetics=kinetics)
+        assert rxn_1.kinetics is rxn_2.kinetics is kinetics
+        assert not rxn_1.can_tst() and not rxn_2.can_tst()
+
+        stub = _StubPDepSensitivity([rxn_1, rxn_2], self.perturbation)
+        PDepSensitivity.perturb(stub, ts)
+
+        p = self.perturbation.value_si
+        assert kinetics.Ea.value_si == pytest.approx(ea_0 + p)  # shifted once, not 2*p
+
+        PDepSensitivity.perturb(stub, ts, unperturb=True)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0, abs=1e-9)
+
+    def test_kinetics_shared_across_transition_states_warns(self, caplog):
+        """
+        Two ILT reactions with DIFFERENT transition states that share one Arrhenius object is an
+        unsupported input: perturbing TS A shifts the shared Ea, collaterally perturbing TS B's
+        reaction rate and contaminating its sensitivity row. perturb() cannot undo the aliasing, but
+        it must surface it loudly rather than report a silently corrupted coefficient.
+        """
+        ts_a = _make_modeless_ts(10000.0)
+        ts_b = _make_modeless_ts(12000.0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(20000.0, 'J/mol'))
+        rxn_a = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                          transition_state=ts_a, kinetics=kinetics)
+        rxn_b = Reaction(reactants=[Species(label='C')], products=[Species(label='D')],
+                          transition_state=ts_b, kinetics=kinetics)
+        assert rxn_a.kinetics is rxn_b.kinetics is kinetics
+        assert ts_a is not ts_b
+
+        stub = _StubPDepSensitivity([rxn_a, rxn_b], self.perturbation)
+        with caplog.at_level(logging.WARNING):
+            PDepSensitivity.perturb(stub, ts_a)
+
+        assert any('shares its Arrhenius kinetics object' in record.message for record in caplog.records)
+
+    def test_unsupported_kinetics_warning_not_duplicated_on_unperturb(self, caplog):
+        """
+        The unsupported-kinetics warning must fire once per perturbation, not once on the perturb
+        call and again on the matching unperturb call (which re-runs the same loop). It is guarded by
+        `not unperturb` for exactly this reason.
+        """
+        ts = _make_modeless_ts(10000.0)
+        kinetics = Chebyshev()
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        assert not rxn.can_tst()
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        with caplog.at_level(logging.WARNING):
+            PDepSensitivity.perturb(stub, ts)
+            PDepSensitivity.perturb(stub, ts, unperturb=True)
+
+        n_warnings = sum('Not perturbing Ea' in record.message for record in caplog.records)
+        assert n_warnings == 1
+
+
+class TestClassifyIltTransitionStates:
+    """
+    Unit tests for :meth:`PDepSensitivity._classify_ilt_transition_states`, the single source that
+    save() and plot() use to decide which TS rows carry the combined-E0+Ea (ILT) semantics and which
+    are contaminated by an Arrhenius kinetics object shared across transition states.
+    """
+
+    def setup_method(self):
+        self.perturbation = quantity.Quantity(1, 'kcal/mol')
+
+    def test_arrhenius_ilt_ts_is_classified_ilt_not_contaminated(self):
+        ts = _make_modeless_ts(10000.0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(20000.0, 'J/mol'))
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        ilt, contaminated = PDepSensitivity._classify_ilt_transition_states(stub)
+        assert ilt == ['TS']
+        assert contaminated == []
+
+    def test_rrkm_ts_is_not_classified_ilt(self):
+        ts = _make_full_ts(10000.0)  # has statmech modes -> can_tst() is True
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(20000.0, 'J/mol'))
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        ilt, contaminated = PDepSensitivity._classify_ilt_transition_states(stub)
+        assert ilt == []
+        assert contaminated == []
+
+    def test_non_arrhenius_ilt_ts_is_not_classified_ilt(self):
+        """
+        The classification gate must match perturb()'s Ea shift: a non-Arrhenius ILT reaction has
+        its Ea left untouched, so its row is a plain E0-only derivative and must NOT be marked ILT --
+        otherwise the YAML/header/plot would over-promise the combined-E0+Ea semantics for a row that
+        never got the Ea perturbation.
+        """
+        ts = _make_modeless_ts(10000.0)
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=Chebyshev())
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        ilt, contaminated = PDepSensitivity._classify_ilt_transition_states(stub)
+        assert ilt == []
+        assert contaminated == []
+
+    def test_kinetics_shared_across_distinct_ts_is_contaminated(self):
+        """One Arrhenius object shared across two DIFFERENT transition states contaminates both."""
+        ts_a = _make_modeless_ts(10000.0)
+        ts_b = _make_modeless_ts(12000.0)
+        ts_a.label, ts_b.label = 'TS_A', 'TS_B'
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(20000.0, 'J/mol'))
+        rxn_a = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                          transition_state=ts_a, kinetics=kinetics)
+        rxn_b = Reaction(reactants=[Species(label='C')], products=[Species(label='D')],
+                          transition_state=ts_b, kinetics=kinetics)
+        stub = _StubPDepSensitivity([rxn_a, rxn_b], self.perturbation)
+        ilt, contaminated = PDepSensitivity._classify_ilt_transition_states(stub)
+        assert sorted(ilt) == ['TS_A', 'TS_B']
+        assert sorted(contaminated) == ['TS_A', 'TS_B']
+
+    def test_kinetics_shared_within_one_ts_is_not_contaminated(self):
+        """An Arrhenius object shared across reactions of the SAME TS is one barrier, not contamination."""
+        ts = _make_modeless_ts(10000.0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(20000.0, 'J/mol'))
+        rxn_1 = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                          transition_state=ts, kinetics=kinetics)
+        rxn_2 = Reaction(reactants=[Species(label='C')], products=[Species(label='D')],
+                          transition_state=ts, kinetics=kinetics)
+        stub = _StubPDepSensitivity([rxn_1, rxn_2], self.perturbation)
+        ilt, contaminated = PDepSensitivity._classify_ilt_transition_states(stub)
+        assert ilt == ['TS']
+        assert contaminated == []

--- a/test/arkane/sensitivityTest.py
+++ b/test/arkane/sensitivityTest.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2026 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This module contains unit tests of the :mod:`arkane.sensitivity` module.
+
+`PDepSensitivity` normally requires a fully executed :class:`PressureDependenceJob`
+to instantiate, so these tests exercise its `perturb` method as an unbound method
+against a lightweight stub object that only exposes the attributes `perturb` reads:
+`self.job.network.path_reactions` and `self.perturbation`.
+"""
+
+import logging
+
+import pytest
+
+import rmgpy.quantity as quantity
+from rmgpy.kinetics import Arrhenius, MultiArrhenius, Chebyshev
+from rmgpy.reaction import Reaction
+from rmgpy.species import Species, TransitionState
+from rmgpy.statmech import Conformer, IdealGasTranslation, NonlinearRotor, HarmonicOscillator
+
+from arkane.sensitivity import PDepSensitivity, SYNTHETIC_TS_E0_TOLERANCE, _ts_e0_is_synthetic
+
+
+class _Network(object):
+    def __init__(self, path_reactions):
+        self.path_reactions = path_reactions
+
+
+class _Job(object):
+    def __init__(self, path_reactions):
+        self.network = _Network(path_reactions)
+
+
+class _StubPDepSensitivity(object):
+    """A minimal stand-in exposing only what `PDepSensitivity.perturb` reads."""
+
+    def __init__(self, path_reactions, perturbation):
+        self.job = _Job(path_reactions)
+        self.perturbation = perturbation
+
+
+def _make_modeless_ts(e0_value_si):
+    """A TS with E0 only, and no statmech modes -- i.e. `can_tst()` is False."""
+    conformer = Conformer(E0=(e0_value_si, 'J/mol'), modes=[])
+    return TransitionState(label='TS', conformer=conformer)
+
+
+def _make_full_ts(e0_value_si):
+    """A TS with real statmech modes -- i.e. `can_tst()` is True."""
+    modes = [
+        IdealGasTranslation(mass=(28.0, 'amu')),
+        NonlinearRotor(inertia=([1.0, 2.0, 3.0], 'amu*angstrom^2'), symmetry=1),
+        HarmonicOscillator(frequencies=([500.0, 1000.0], 'cm^-1')),
+    ]
+    conformer = Conformer(E0=(e0_value_si, 'J/mol'), modes=modes)
+    return TransitionState(label='TS', conformer=conformer)
+
+
+def _make_species_with_e0(label, e0_value_si):
+    """A Species with only a conformer E0 set (as `_ts_e0_is_synthetic` needs)."""
+    return Species(label=label, conformer=Conformer(E0=(e0_value_si, 'J/mol'), modes=[]))
+
+
+class TestPDepSensitivityPerturb:
+    """
+    Unit tests for :meth:`PDepSensitivity.perturb`, focused on the ILT-based path
+    reaction case where perturbing the TS's E0 alone is a structural no-op for the
+    resulting microcanonical rate, and the reaction's Arrhenius `Ea` must also move.
+    """
+
+    def setup_method(self):
+        self.perturbation = quantity.Quantity(1, 'kcal/mol')
+
+    def test_ilt_reaction_perturbs_e0_and_ea(self):
+        """For an ILT-based path reaction (no TS modes, n >= 0.25), both E0 and Ea should move."""
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        # E0(TS) = sum(E0(reactants)) + Ea, so the synthetic relation holds and Ea is perturbed too.
+        reactant = _make_species_with_e0('A', e0_0 - ea_0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        rxn = Reaction(reactants=[reactant], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        assert not rxn.can_tst()
+        assert kinetics.n.value_si >= 0.25
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        PDepSensitivity.perturb(stub, ts)
+
+        p = self.perturbation.value_si
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + p)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0 + p)
+
+        PDepSensitivity.perturb(stub, ts, unperturb=True)
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0)
+
+    def test_rrkm_reaction_does_not_perturb_ea(self):
+        """For an RRKM-based path reaction (TS has modes), Ea must not be touched, only E0."""
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        ts = _make_full_ts(e0_0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        assert rxn.can_tst()
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        PDepSensitivity.perturb(stub, ts)
+
+        p = self.perturbation.value_si
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + p)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0)  # unchanged
+
+        PDepSensitivity.perturb(stub, ts, unperturb=True)
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0)
+
+    def test_network_kinetics_is_perturbed_when_present(self):
+        """When `network_kinetics` is set, it (not `kinetics`) must be the one perturbed."""
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        network_ea_0 = 30000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        # Chosen so E0(TS) = sum(E0(reactants)) + network_ea_0 (the kinetics actually used for k(E)).
+        reactant = _make_species_with_e0('A', e0_0 - network_ea_0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        network_kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(network_ea_0, 'J/mol'))
+        rxn = Reaction(reactants=[reactant], products=[Species(label='B')], transition_state=ts,
+                        kinetics=kinetics, network_kinetics=network_kinetics)
+        assert not rxn.can_tst()
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        PDepSensitivity.perturb(stub, ts)
+
+        p = self.perturbation.value_si
+        assert network_kinetics.Ea.value_si == pytest.approx(network_ea_0 + p)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0)  # the non-selected kinetics is untouched
+
+    def test_multi_arrhenius_falls_through_to_unsupported_kinetics_warning(self, caplog):
+        """
+        `MultiArrhenius`-kinetics path reactions cannot genuinely reach the ILT sensitivity path:
+        `apply_inverse_laplace_transform_method` (rmgpy/pdep/reaction.pyx) takes a Cython-typed
+        `Arrhenius kinetics` argument, and `MultiArrhenius` is a distinct `KineticsModel` subclass
+        (not an `Arrhenius` subclass), so passing a `MultiArrhenius` reaction's kinetics into it
+        raises a `TypeError` before Arkane's sensitivity code is ever reached (verified directly
+        against the compiled extension). Since a real `MultiArrhenius` ILT path reaction can never
+        reach `perturb`, it is intentionally NOT given a dedicated perturbation branch here (that
+        would have been an unverified vector-perturbation claim); it must fall through to the
+        same unsupported-kinetics warning as any other unhandled kinetics type, with only E0
+        perturbed.
+        """
+        e0_0 = 10000.0  # J/mol
+        ea_0a, ea_0b = 15000.0, 25000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        arrh_a = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0a, 'J/mol'))
+        arrh_b = Arrhenius(A=(1e10, 's^-1'), n=2.0, Ea=(ea_0b, 'J/mol'))
+        kinetics = MultiArrhenius(arrhenius=[arrh_a, arrh_b])
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        assert not rxn.can_tst()
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        with caplog.at_level(logging.WARNING):
+            PDepSensitivity.perturb(stub, ts)
+
+        assert any('MultiArrhenius' in record.message for record in caplog.records)
+        p = self.perturbation.value_si
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + p)
+        assert arrh_a.Ea.value_si == pytest.approx(ea_0a)  # untouched
+        assert arrh_b.Ea.value_si == pytest.approx(ea_0b)  # untouched
+
+    def test_shared_transition_state_perturbs_ea_for_every_owning_reaction(self):
+        """
+        Arkane input files may point more than one `reaction` block at the same `transitionState`
+        label, so two path reactions can share a single `TransitionState` object. The E0
+        perturbation above already reaches every reaction using that shared object, so the Ea
+        perturbation must match that same blast radius: previously a `break` after the first
+        matching reaction meant only one of two owning reactions' Ea moved, desynchronizing it
+        from the (already shared) E0 perturbation.
+        """
+        e0_0 = 10000.0  # J/mol
+        ea_0_1 = 20000.0  # J/mol
+        ea_0_2 = 5000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        reactant_1 = _make_species_with_e0('A', e0_0 - ea_0_1)
+        reactant_2 = _make_species_with_e0('C', e0_0 - ea_0_2)
+        kinetics_1 = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0_1, 'J/mol'))
+        kinetics_2 = Arrhenius(A=(1e12, 's^-1'), n=1.2, Ea=(ea_0_2, 'J/mol'))
+        rxn_1 = Reaction(reactants=[reactant_1], products=[Species(label='B')],
+                          transition_state=ts, kinetics=kinetics_1)
+        rxn_2 = Reaction(reactants=[reactant_2], products=[Species(label='D')],
+                          transition_state=ts, kinetics=kinetics_2)
+        assert not rxn_1.can_tst() and not rxn_2.can_tst()
+        assert rxn_1.transition_state is rxn_2.transition_state is ts
+
+        stub = _StubPDepSensitivity([rxn_1, rxn_2], self.perturbation)
+        PDepSensitivity.perturb(stub, ts)
+
+        p = self.perturbation.value_si
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + p)
+        assert kinetics_1.Ea.value_si == pytest.approx(ea_0_1 + p)
+        assert kinetics_2.Ea.value_si == pytest.approx(ea_0_2 + p)
+
+        # Round-trip: unperturb must restore both Ea values (and E0) exactly.
+        PDepSensitivity.perturb(stub, ts, unperturb=True)
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0, abs=1e-9)
+        assert kinetics_1.Ea.value_si == pytest.approx(ea_0_1, abs=1e-9)
+        assert kinetics_2.Ea.value_si == pytest.approx(ea_0_2, abs=1e-9)
+
+    def test_modeless_ts_with_independent_e0_is_not_perturbed_for_ea(self, caplog):
+        """
+        A hand-authored, modeless TS whose E0 is an independent physical value (i.e. it does NOT
+        satisfy E0(TS) = sum(E0(reactants)) + Ea, nor the products-side equivalent) must have only
+        its E0 perturbed; moving Ea as well would not be physically justified for such a TS.
+        """
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        # Reactant/product E0s chosen so neither side comes anywhere near satisfying the relation.
+        reactant = _make_species_with_e0('A', 500000.0)
+        product = _make_species_with_e0('B', 600000.0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        rxn = Reaction(reactants=[reactant], products=[product], transition_state=ts, kinetics=kinetics)
+        assert not rxn.can_tst()
+        assert not _ts_e0_is_synthetic(rxn, ts.conformer.E0.value_si, kinetics.Ea.value_si)
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        with caplog.at_level(logging.INFO):
+            PDepSensitivity.perturb(stub, ts)
+
+        assert any('independent' in record.message for record in caplog.records)
+        p = self.perturbation.value_si
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + p)
+        assert kinetics.Ea.value_si == pytest.approx(ea_0)  # untouched
+
+        # Round-trip: unperturb must restore E0 exactly, and Ea must remain untouched throughout,
+        # bit-for-bit (the same verdict -- "not synthetic" -- must be reached on both calls).
+        PDepSensitivity.perturb(stub, ts, unperturb=True)
+        assert ts.conformer.E0.value_si == e0_0
+        assert kinetics.Ea.value_si == ea_0
+
+    def test_ts_e0_is_synthetic_tries_products_side_when_reactants_side_fails(self):
+        """
+        A path reaction may be stored in either direction relative to which side the TS sits on;
+        `_ts_e0_is_synthetic` must try the products-side sum when the reactants-side sum does not
+        satisfy the relation.
+        """
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        reactant = _make_species_with_e0('A', 999999.0)  # reactants-side check fails
+        product = _make_species_with_e0('B', e0_0 - ea_0)  # products-side check matches
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        rxn = Reaction(reactants=[reactant], products=[product], transition_state=ts, kinetics=kinetics)
+
+        assert _ts_e0_is_synthetic(rxn, ts.conformer.E0.value_si, kinetics.Ea.value_si)
+
+    def test_ts_e0_is_synthetic_tolerance_boundary(self):
+        """Sanity-check the module-level tolerance constant is applied as documented."""
+        e0_0 = 10000.0  # J/mol
+        ea_0 = 20000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        kinetics = Arrhenius(A=(1e13, 's^-1'), n=1.5, Ea=(ea_0, 'J/mol'))
+        just_inside = _make_species_with_e0('A', e0_0 - ea_0 + 0.9 * SYNTHETIC_TS_E0_TOLERANCE)
+        just_outside = _make_species_with_e0('A', e0_0 - ea_0 + 1.1 * SYNTHETIC_TS_E0_TOLERANCE)
+        rxn_inside = Reaction(reactants=[just_inside], products=[Species(label='B')],
+                               transition_state=ts, kinetics=kinetics)
+        rxn_outside = Reaction(reactants=[just_outside], products=[Species(label='B')],
+                                transition_state=ts, kinetics=kinetics)
+
+        assert _ts_e0_is_synthetic(rxn_inside, ts.conformer.E0.value_si, kinetics.Ea.value_si)
+        assert not _ts_e0_is_synthetic(rxn_outside, ts.conformer.E0.value_si, kinetics.Ea.value_si)
+
+    def test_unsupported_kinetics_type_logs_warning(self, caplog):
+        """An ILT-based reaction with an unsupported kinetics type should log a warning, not fail silently."""
+        e0_0 = 10000.0  # J/mol
+        ts = _make_modeless_ts(e0_0)
+        kinetics = Chebyshev()
+        rxn = Reaction(reactants=[Species(label='A')], products=[Species(label='B')],
+                        transition_state=ts, kinetics=kinetics)
+        assert not rxn.can_tst()
+
+        stub = _StubPDepSensitivity([rxn], self.perturbation)
+        with caplog.at_level(logging.WARNING):
+            PDepSensitivity.perturb(stub, ts)
+
+        assert any('Chebyshev' in record.message for record in caplog.records)
+        # E0 is still perturbed even though Ea perturbation was skipped
+        assert ts.conformer.E0.value_si == pytest.approx(e0_0 + self.perturbation.value_si)

--- a/test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py
+++ b/test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py
@@ -1,0 +1,290 @@
+################################################################################
+#
+#   Arkane input file for acetyl + O2 pressure-dependent reaction network
+#
+################################################################################
+
+title = 'acetyl + oxygen'
+
+description = \
+"""
+The chemically-activated reaction of acetyl with oxygen. This system is of
+interest in atmospheric chemistry as a step in the conversion of acetaldehyde
+to the secondary pollutant peroxyacetylnitrate (PAN); it is also potentially
+important in the ignition chemistry of ethanol.
+"""
+
+species(
+    label = 'acetylperoxy',
+    structure = SMILES('CC(=O)O[O]'),
+    E0 = (-34.6,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([54.2977,104.836,156.05],"amu*angstrom^2"), symmetry=1),
+        HarmonicOscillator(frequencies=([319.695,500.474,536.674,543.894,727.156,973.365,1037.77,1119.72,1181.55,1391.11,1449.53,1454.72,1870.51,3037.12,3096.93,3136.39],"cm^-1")),
+        HinderedRotor(inertia=(7.38359,"amu*angstrom^2"), symmetry=1, fourier=([[-1.95191,-11.8215,0.740041,-0.049118,-0.464522],[0.000227764,0.00410782,-0.000805364,-0.000548218,-0.000266277]],"kJ/mol")),
+        HinderedRotor(inertia=(2.94723,"amu*angstrom^2"), symmetry=3, fourier=([[0.130647,0.0401507,-2.54582,-0.0436065,-0.120982],[-0.000701659,-0.000989654,0.00783349,-0.00140978,-0.00145843]],"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    molecularWeight = (75.04,"g/mol"),
+    collisionModel = TransportData(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
+    energyTransferModel = SingleExponentialDown(
+        alpha0 = (0.5718,'kcal/mol'),
+        T0 = (300,'K'),
+        n = 0.85,
+    ),
+)
+
+species(
+    label = 'hydroperoxylvinoxy',
+    structure = SMILES('[CH2]C(=O)OO'),
+    E0 = (-32.4,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([44.8034,110.225,155.029],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([318.758,420.907,666.223,675.962,752.824,864.66,998.471,1019.54,1236.21,1437.91,1485.74,1687.9,3145.44,3262.88,3434.34],"cm^-1")),
+        HinderedRotor(inertia=(1.68464,"u*angstrom**2"), symmetry=2, fourier=([[0.359649,-16.1155,-0.593311,1.72918,0.256314],[-7.42981e-06,-0.000238057,3.29276e-05,-6.62608e-05,8.8443e-05]],"kJ/mol")),
+        HinderedRotor(inertia=(8.50433,"u*angstrom**2"), symmetry=1, fourier=([[-7.53504,-23.4471,-3.3974,-0.940593,-0.313674],[-4.58248,-2.47177,0.550012,1.03771,0.844226]],"kJ/mol")),
+        HinderedRotor(inertia=(0.803309,"u*angstrom**2"), symmetry=1, fourier=([[-8.65946,-3.97888,-1.13469,-0.402197,-0.145101],[4.41884e-05,4.83249e-05,1.30275e-05,-1.31353e-05,-6.66878e-06]],"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    molecularWeight = (75.04,"g/mol"),
+    collisionModel = TransportData(sigma=(5.09,'angstrom'), epsilon=(473,'K')),
+    energyTransferModel = SingleExponentialDown(
+        alpha0 = (0.5718,'kcal/mol'),
+        T0 = (300,'K'),
+        n = 0.85,
+    ),
+)
+
+species(
+    label = 'acetyl',
+    structure = SMILES('C[C]=O'),
+    E0 = (0.0,'kcal/mol'),  #(-20.5205,"kJ/mol")
+    modes = [
+        IdealGasTranslation(mass=(43.05,"g/mol")),
+        NonlinearRotor(inertia=([5.94518,50.8166,53.6436],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([464.313,845.126,1010.54,1038.43,1343.54,1434.69,1442.25,1906.18,2985.46,3076.57,3079.46],"cm^-1")),
+        HinderedRotor(inertia=(1.61752,"u*angstrom**2"), symmetry=3, barrier=(2.00242,"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+)
+
+species(
+    label = 'oxygen',
+    structure = SMILES('[O][O]'),
+    E0 = (0.0,'kcal/mol'),  #(-5.74557,"kJ/mol")
+    modes = [
+        IdealGasTranslation(mass=(32.00,"g/mol")),
+        LinearRotor(inertia=(11.6056,"u*angstrom**2"), symmetry=2),
+        HarmonicOscillator(frequencies=([1621.54],"cm^-1")),
+    ],
+    spinMultiplicity = 3,
+    opticalIsomers = 1,
+)
+
+species(
+    label = 'ketene',
+    structure = SMILES('C=C=O'),
+    E0 = (-6.6,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(42.0106,"g/mol")),
+        NonlinearRotor(inertia=([1.76922,48.8411,50.6103],"u*angstrom**2"), symmetry=2),
+        HarmonicOscillator(frequencies=([441.622,548.317,592.155,981.379,1159.66,1399.86,2192.1,3150.02,3240.58],"cm^-1")),
+    ],
+    spinMultiplicity = 1,
+    opticalIsomers = 1,
+)
+
+species(
+    label = 'lactone',
+    structure = SMILES('C1OC1(=O)'),
+    E0 = (-30.8,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(58.0055,"g/mol")),
+        NonlinearRotor(inertia=([20.1707,62.4381,79.1616],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([484.387,527.771,705.332,933.372,985.563,1050.26,1107.93,1176.43,1466.54,1985.09,3086.23,3186.46],"cm^-1")),
+    ],
+    spinMultiplicity = 1,
+    opticalIsomers = 1,
+)
+
+
+
+species(
+    label = 'hydroxyl',
+    structure = SMILES('[OH]'),
+    E0 = (0.0,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(17.0027,"g/mol")),
+        LinearRotor(inertia=(0.899988,"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([3676.39],"cm^-1")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+)
+
+species(
+    label = 'hydroperoxyl',
+    structure = SMILES('O[O]'),
+    E0 = (0.0,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(32.9977,"g/mol")),
+        NonlinearRotor(inertia=([0.811564,14.9434,15.755],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([1156.77,1424.28,3571.81],"cm^-1")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+)
+
+species(
+    label = 'nitrogen',
+    structure = SMILES('N#N'),
+    molecularWeight = (28.04,"g/mol"),
+    collisionModel = TransportData(sigma=(3.70,'angstrom'), epsilon=(94.9,'K')),
+    reactive = False
+)
+
+################################################################################
+
+transitionState(
+    label = 'entrance1',
+    E0 = (0.0,'kcal/mol'),
+)
+
+transitionState(
+    label = 'isom1',
+    E0 = (-5.8,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([49.3418,103.697,149.682],"u*angstrom**2"), symmetry=1, quantum=False),
+        HarmonicOscillator(frequencies=([148.551,306.791,484.573,536.709,599.366,675.538,832.594,918.413,1022.28,1031.45,1101.01,1130.05,1401.51,1701.26,1844.17,3078.6,3163.07],"cm^-1"), quantum=True),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    frequency = (-1679.04,'cm^-1'),
+)
+
+transitionState(
+    label = 'exit1',
+    E0 = (0.6,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([55.4256, 136.1886, 188.2442],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([59.9256,204.218,352.811,466.297,479.997,542.345,653.897,886.657,1017.91,1079.17,1250.02,1309.14,1370.36,1678.52,2162.41,3061.53,3135.55],"cm^-1")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    frequency=(-1053.25,'cm^-1'),
+)
+
+transitionState(
+    label = 'exit2',
+    E0 = (-4.6,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.0082,"g/mol"), quantum=False),
+        NonlinearRotor(inertia=([51.7432,119.373,171.117],"u*angstrom**2"), symmetry=1, quantum=False),
+        HarmonicOscillator(frequencies=([250.311,383.83,544.382,578.988,595.324,705.422,964.712,1103.25,1146.91,1415.98,1483.33,1983.79,3128,3143.84,3255.29],"cm^-1")),
+        HinderedRotor(inertia=(9.35921,"u*angstrom**2"), symmetry=1, fourier=([[-11.2387,-12.5928,-3.87844,1.13314,-0.358812],[-1.59863,-8.03329,-5.05235,3.13723,2.45989]],"kJ/mol")),
+        HinderedRotor(inertia=(0.754698,"u*angstrom**2"), symmetry=1, barrier=(47.7645,"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    frequency=(-404.271,'cm^-1'),
+)
+
+transitionState(
+    label = 'exit3',
+    E0 = (-7.2,'kcal/mol'),
+    modes = [
+        IdealGasTranslation(mass=(75.04,"g/mol")),
+        NonlinearRotor(inertia=([53.2821, 120.4050, 170.1570],"u*angstrom**2"), symmetry=1),
+        HarmonicOscillator(frequencies=([152.155,181.909,311.746,348.646,608.487,624.378,805.347,948.875,995.256,996.982,1169.1,1412.6,1834.83,3124.43,3245.2,3634.45],"cm^-1")),
+        HinderedRotor(inertia=(0.813269,"u*angstrom**2"), symmetry=1, fourier=([[-1.15338,-2.18664,-0.669531,-0.11502,-0.0512599],[0.00245222,0.0107485,0.00334564,-0.00165288,-0.0028674]],"kJ/mol")),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    frequency=(-618.234,'cm^-1'),
+)
+
+################################################################################
+
+reaction(
+    label = 'entrance1',
+    reactants = ['acetyl', 'oxygen'],
+    products = ['acetylperoxy'],
+    transitionState = 'entrance1',
+    kinetics = Arrhenius(A=(2.65e6,'m^3/(mol*s)'), n=0.0, Ea=(0.0,'kcal/mol'), T0=(1,"K")),
+)
+
+reaction(
+    label = 'isom1',
+    reactants = ['acetylperoxy'],
+    products = ['hydroperoxylvinoxy'],
+    transitionState = 'isom1',
+    tunneling = 'Eckart',
+)
+
+reaction(
+    label = 'exit1',
+    reactants = ['acetylperoxy'],
+    products = ['ketene', 'hydroperoxyl'],
+    transitionState = 'exit1',
+    tunneling = 'Eckart',
+)
+
+reaction(
+    label = 'exit2',
+    reactants = ['hydroperoxylvinoxy'],
+    products = ['ketene', 'hydroperoxyl'],
+    transitionState = 'exit2',
+    tunneling = 'Eckart',
+)
+
+reaction(
+    label = 'exit3',
+    reactants = ['hydroperoxylvinoxy'],
+    products = ['lactone', 'hydroxyl'],
+    transitionState = 'exit3',
+    tunneling = 'Eckart',
+)
+
+#################################################################################
+
+network(
+    label = 'acetyl + O2',
+    isomers = [
+        'acetylperoxy',
+        'hydroperoxylvinoxy',
+    ],
+    reactants = [
+        ('acetyl', 'oxygen'),
+        ('ketene', 'hydroperoxyl'),
+	('lactone', 'hydroxyl')
+    ],
+    bathGas = {
+        'nitrogen': 1.0,
+    }
+)
+
+#################################################################################
+
+# NOTE: only the computational settings below (grid density/range and solver method) have been
+# changed relative to examples/arkane/networks/acetyl+O2_cse/input.py, to keep this fixture fast
+# enough for unit testing; no species/transitionState/reaction/network thermochemistry above has
+# been altered from that real, published example. `sensitivity_conditions` is added so a
+# PDepSensitivity analysis is actually triggered.
+pressureDependence(
+    'acetyl + O2',
+    Tmin=(900.0,'K'), Tmax=(1100.0,'K'), Tcount=3,
+    Pmin=(0.5,'bar'), Pmax=(2.0,'bar'), Pcount=3,
+    maximumGrainSize = (1.0,'kcal/mol'),
+    minimumGrainCount = 250,
+    method = 'modified strong collision',
+    interpolationModel = ('chebyshev', 2, 2),
+    activeJRotor = True,
+    sensitivity_conditions = [(1000, 'K'), (1, 'bar')],
+)

--- a/test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py
+++ b/test/rmgpy/test_data/arkane/tst_ilt_mixed/pdep_sa_ilt_mixed.py
@@ -152,7 +152,14 @@ species(
 
 transitionState(
     label = 'entrance1',
-    E0 = (0.0,'kcal/mol'),
+    # Deliberately does NOT satisfy E0(TS) = sum(E0(reactants)) + Ea (= 0.0 + 0.0 kcal/mol here):
+    # real RMG-written network files generally break that relation (RMG mutates Ea via
+    # fix_barrier_height after synthesizing the TS E0, and Arkane strips energy_correction when
+    # writing the file), and an earlier revision of the sensitivity fix gated the Ea perturbation
+    # on it -- passing on this fixture (where everything was 0.0, satisfying the relation
+    # trivially) while failing on essentially all real networks. Keeping the relation broken here
+    # ensures this integration test exercises the real-world shape.
+    E0 = (2.0,'kcal/mol'),
 )
 
 transitionState(


### PR DESCRIPTION
Arkane's PDep sensitivity analysis perturbs `conformer.E0`. For path reactions whose k(E) comes from an inverse Laplace transform instead of RRKM, that does nothing at all — the sensitivity coefficients come back as exactly zero.

Since `E0(TS) = Σ E0(reactants) + Ea` by construction, this perturbs `Ea` by the same amount alongside E0, which reaches both the ILT convolution and the renormalization target.

A hand-authored modeless TS with a real E0 keeps the old behavior; applied to every path reaction sharing the TS object, matching the E0 perturbation's reach; and skipped for RRKM reactions, where it would double-count.