### PR TITLE
Changed syntax seperator in JULIA_CPU_TARGET

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN make
 
 # Install and link Julia dependencies for RMS
 # setting this env variable fixes an issue with Julia precompilation on Windows
-ENV JULIA_CPU_TARGET="x86-64,haswell,skylake,broadwell,znver1,znver2,znver3,cascadelake,icelake-client,cooperlake,generic"
+ENV JULIA_CPU_TARGET="generic;x86-64;haswell;skylake;broadwell;znver1;znver2;znver3;cascadelake;icelake-client;cooperlake"
 ENV RMS_BRANCH=${RMS_Branch}
 ENV RMS_INSTALLER=continuous
 # Usually this is set automatically, but we're not actually running


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
Currently, the compiling of Julia in the Docker build has not been working correctly and has only been compiling for `x86_64` CPUs. Everything following the comma has been intepreted by Julia as features/flags within `x86_64`, thus not compiling for the rest that were written.

Issue can be seen here: https://github.com/ReactionMechanismGenerator/RMG-Py/actions/runs/28938667444/job/85869089871#step:5:9567

So, have changed the separator from `,` to `;` due to the comma being used as flags/features within a target. So, for example you would write:
```
zvner1,clone_all;generic,clone_all
```
In this instance, `clone_all` will compile for variants of that architecture. It overall would be better to compile for all variants but it would increase the time to build and the size of the image. 

Now, since this PR will properly update the compiling of Julia for CPUs, we will see an increase in build time and size of the image. However, it will be working as intended now.\

Here is a discussion on the Julia forum about the separators: https://discourse.julialang.org/t/understanding-julia-cpu-target/116774/5
