### PR TITLE
Pin Julia and openbabel to unbreak CI

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - conda-forge::cantera >=3.0
     - conda-forge::mopac
     - conda-forge::cclib >=1.6.3,<1.9
-    - conda-forge::openbabel >=3
+    # 3.2.1 hangs pytest collection under Python 3.10/3.11, where test/conftest.py imports pybel
+    - conda-forge::openbabel >=3,<3.2
     - conda-forge::rdkit >=2024
     # python intentionally left loose so the CI matrix (via CONDA_PY)
     # can pin it without a contradictory-deps error. The real variant pin

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,7 +119,9 @@ jobs:
         if: matrix.include-rms == 'with RMS'
         uses: julia-actions/install-juliaup@v3
         with:
-          channel: '1.10'
+          # Pinned to a patch version, not the 1.10 channel: juliacall segfaults on
+          # import under Julia 1.10.12, and the channel floats to the newest patch.
+          channel: '1.10.11'
 
       # RMS installation and linking to Julia
       - name: Install and link Julia dependencies
@@ -189,7 +191,9 @@ jobs:
       - name: Setup Juliaup
         uses: julia-actions/install-juliaup@v3
         with:
-          channel: '1.10'
+          # Pinned to a patch version, not the 1.10 channel: juliacall segfaults on
+          # import under Julia 1.10.12, and the channel floats to the newest patch.
+          channel: '1.10.11'
 
       # RMS installation and linking to Julia
       - name: Install and link Julia dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ RUN apt-get update && \
     apt-get clean -y
 
 
-# Install Julia 1.10 using juliaup
-RUN wget -qO- https://install.julialang.org | sh -s -- --yes --default-channel 1.10 && \
-    /root/.juliaup/bin/juliaup add 1.10 && \
-    /root/.juliaup/bin/juliaup default 1.10 && \
+# Install Julia using juliaup. Pinned to a patch version, not the 1.10 channel:
+# juliacall segfaults on import under 1.10.12, and the channel floats to the newest patch.
+RUN wget -qO- https://install.julialang.org | sh -s -- --yes --default-channel 1.10.11 && \
+    /root/.juliaup/bin/juliaup add 1.10.11 && \
+    /root/.juliaup/bin/juliaup default 1.10.11 && \
     /root/.juliaup/bin/juliaup list && \
     rm -rf /root/.juliaup/downloads /root/.juliaup/tmp
 ENV PATH="/root/.juliaup/bin:$PATH"

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,8 @@ dependencies:
   - conda-forge::mopac
   # see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2639#issuecomment-2050292972
   - conda-forge::cclib >=1.6.3,<1.9
-  - conda-forge::openbabel >= 3
+  # 3.2.1 hangs pytest collection under Python 3.10/3.11, where test/conftest.py imports pybel
+  - conda-forge::openbabel >=3,<3.2
   - conda-forge::rdkit >=2024
   - rmg::pysidt-rmg >=1.2
 

--- a/install_rms.sh
+++ b/install_rms.sh
@@ -114,7 +114,12 @@ export JULIA_PYTHONCALL_EXE="$CONDA_PREFIX/bin/python"
 export PYTHON_JULIAPKG_EXE="$(which julia)"
 export PYTHON_JULIAPKG_PROJECT="$CONDA_PREFIX/julia_env"
 
-conda install -y 'conda-forge::pyjuliacall<0.9.35'
+# Pinned exactly rather than capped, so that pyjuliacall and the Julia-side PythonCall it
+# selects stay on the last combination CI was green with. A ceiling is not enough: the solver
+# takes the highest version below it as soon as conda-forge publishes one, which is how this
+# silently moved from 0.9.28 to 0.9.34. Safe to relax once someone confirms a newer version
+# works against the Julia version pinned in CI.
+conda install -y 'conda-forge::pyjuliacall==0.9.28'
 
 echo "Environment variables referencing JULIA:"
 env | grep JULIA


### PR DESCRIPTION
### Motivation or Problem

Two unpinned dependencies moved and took CI down. Both are fixed here because neither can be
verified on its own — the Julia fix cannot go green while openbabel hangs the test step, and an
openbabel fix branched off `main` cannot go green while Julia segfaults.

**Julia.** All the RMS jobs and the regression test were failing at `install_rms.sh`, before
RMG-Py is built or any test runs:

```
install_rms.sh: line 138:  4606 Segmentation fault      (core dumped) python <<EOF
    from juliacall import Main
```

My first guess was the Python/Julia bridge, which had drifted from pyjuliacall 0.9.28 to 0.9.34
because `install_rms.sh` capped it rather than pinning it. Pinning it back restored PythonCall
v0.9.28 and it still crashed — which was the useful part. With that pinned, the Julia package set
at the point of the import is identical to the last green run, all 22 packages. The only thing
left is Julia itself: 1.10.11 on 16 Aug, 1.10.12 on 17 Aug. Both the workflow and the Dockerfile
asked juliaup for channel `1.10`, which floats to the newest patch — the docker job hit the same
segfault inside `install_rms.sh`.

**openbabel.** With Julia fixed, the Python 3.10 and 3.11 jobs got as far as `make test-all` and
then hung, killed at the 6 hour limit on four consecutive attempts, with and without RMS. They
stop here:

```
11:59:56  test session starts
11:59:56  platform linux -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
11:59:56  plugins: anyio-4.14.2, check-2.9.1, cov-7.1.0
17:53:09  ##[error]The operation was canceled.
```

After pytest prints its plugin list and before a single test is collected — which is where
`test/conftest.py` imports pybel. Comparing a green run from 10 Aug against a hanging one,
openbabel is the only package that differs in the whole environment:

| job | openbabel | outcome |
|---|---|---|
| main, 10 Aug, py3.11 | 3.1.1 | passes, 40.9 min |
| this branch, py3.11 | 3.2.1 | hangs, killed at 360 min |
| this branch, py3.10 | 3.2.1 | hangs, killed at 360 min |
| this branch, py3.9 | 3.1.1 | passes, 46.5 min |

Everything else is identical — cantera 3.2.0, cython 3.0.12, numpy 1.26.4, libgcc 16.1.0,
libstdcxx-ng 16.1.0, pytest 9.1.1 and all three plugins. Python 3.9 escapes only because
conda-forge has no py39 build of 3.2.1, so it still resolves to 3.1.1; the split looks
version-specific but isn't.

Both jobs are Linux only. The macOS RMS jobs stayed green throughout.

### Description of Changes

- `.github/workflows/CI.yml` and `Dockerfile`: ask juliaup for 1.10.11 rather than the floating
  `1.10` channel, everywhere it appears.
- `install_rms.sh`: pin pyjuliacall exactly rather than capping it. A ceiling only delays drift
  until conda-forge publishes the next release below it, which is what happened here.
- `environment.yml` and `.conda/meta.yaml`: cap openbabel below 3.2.

### Testing

CI is the test. I cannot reproduce either failure locally without the full Julia toolchain and a
fresh solve of the environment, and have not tried.

The Julia half is already confirmed on this branch: with the pin in place, `Install and link
Julia dependencies` passes, the Regression Test is green, and Python 3.9 with RMS passes end to
end. The openbabel half is the remaining unknown.

### Reviewer Tips

- Evidence this was never caused by a PR: `main` fails the same jobs. Its last CI run was 10 Aug,
  before either dependency moved, so nobody has seen `main` in this state.
- I have not identified what in Julia 1.10.12 breaks the embedding, nor what in openbabel 3.2.1
  hangs on import — only that pinning each restores a known-good configuration. Both are worth
  reporting upstream if someone has the appetite.
- `install_rms.sh`'s help text still tells developers to `juliaup add 1.10`, so a local install
  will pick up 1.10.12 and hit the same crash. That text is only printed when juliaup is missing,
  so it does not affect CI; worth a follow-up to align it with the pin.
- The `Conda Build ubuntu` job failed on an unrelated runner shutdown ("The runner has received a
  shutdown signal"), not on the dependency solve — it resolved openbabel 3.1.1 correctly. A re-run
  should clear it.
