### PR TITLE
Update `stable` with `main`

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - conda-forge::cantera >=3.0
     - conda-forge::mopac
     - conda-forge::cclib >=1.6.3,<1.9
-    - conda-forge::openbabel >=3
+    # 3.2.1 hangs pytest collection under Python 3.10/3.11, where test/conftest.py imports pybel
+    - conda-forge::openbabel >=3,<3.2
     - conda-forge::rdkit >=2024
     # python intentionally left loose so the CI matrix (via CONDA_PY)
     # can pin it without a contradictory-deps error. The real variant pin

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,7 +119,9 @@ jobs:
         if: matrix.include-rms == 'with RMS'
         uses: julia-actions/install-juliaup@v3
         with:
-          channel: '1.10'
+          # Pinned to a patch version, not the 1.10 channel: juliacall segfaults on
+          # import under Julia 1.10.12, and the channel floats to the newest patch.
+          channel: '1.10.11'
 
       # RMS installation and linking to Julia
       - name: Install and link Julia dependencies
@@ -189,7 +191,9 @@ jobs:
       - name: Setup Juliaup
         uses: julia-actions/install-juliaup@v3
         with:
-          channel: '1.10'
+          # Pinned to a patch version, not the 1.10 channel: juliacall segfaults on
+          # import under Julia 1.10.12, and the channel floats to the newest patch.
+          channel: '1.10.11'
 
       # RMS installation and linking to Julia
       - name: Install and link Julia dependencies

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -72,29 +72,27 @@ jobs:
           uname -a
           sysctl hw.memsize hw.ncpu hw.physicalcpu 2>/dev/null || cat /proc/meminfo 2>/dev/null | head -3 || true
 
-      - name: Configure Auto-upload
-        if: >
-          (github.event_name == 'push' && github.ref == 'refs/heads/stable') ||
-          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/stable')
-        run: |
-          conda config --set anaconda_upload yes
-
       - name: Build Binary
         env:
           CONDA_VERBOSITY: "1"
+          CONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          # set a default value to the conda_token if needed (like from forks)
-          : "${CONDA_TOKEN:=${{ secrets.ANACONDA_TOKEN }}}"
-          : "${CONDA_TOKEN:=default_value}"
-          echo "CONDA_TOKEN=$CONDA_TOKEN" >> $GITHUB_ENV
           conda config --add channels rmg
           conda config --add channels conda-forge
           # --add prepends, so the final channel order is [conda-forge, rmg, ...].
-          # Strict priority makes the solver skip lower-priority channels entirely
-          # for any package the higher-priority channel offers.
           conda config --set channel_priority strict
-          CONDA_NPY=${{ matrix.numpy-version }} CONDA_PY=${{ matrix.python-version }} conda build --token $CONDA_TOKEN --user rmg .
 
+          if [[ "${GITHUB_REF}" == "refs/heads/stable" ]] && \
+             [[ "${GITHUB_EVENT_NAME}" == "push" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            CONDA_NPY=${{ matrix.numpy-version }} \
+            CONDA_PY=${{ matrix.python-version }} \
+            conda build --token "$CONDA_TOKEN" --user rmg .
+          else
+            CONDA_NPY=${{ matrix.numpy-version }} \
+            CONDA_PY=${{ matrix.python-version }} \
+            conda build --no-anaconda-upload .
+          fi
+  
   result:
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ RUN apt-get update && \
     apt-get clean -y
 
 
-# Install Julia 1.10 using juliaup
-RUN wget -qO- https://install.julialang.org | sh -s -- --yes --default-channel 1.10 && \
-    /root/.juliaup/bin/juliaup add 1.10 && \
-    /root/.juliaup/bin/juliaup default 1.10 && \
+# Install Julia using juliaup. Pinned to a patch version, not the 1.10 channel:
+# juliacall segfaults on import under 1.10.12, and the channel floats to the newest patch.
+RUN wget -qO- https://install.julialang.org | sh -s -- --yes --default-channel 1.10.11 && \
+    /root/.juliaup/bin/juliaup add 1.10.11 && \
+    /root/.juliaup/bin/juliaup default 1.10.11 && \
     /root/.juliaup/bin/juliaup list && \
     rm -rf /root/.juliaup/downloads /root/.juliaup/tmp
 ENV PATH="/root/.juliaup/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN make
 
 # Install and link Julia dependencies for RMS
 # setting this env variable fixes an issue with Julia precompilation on Windows
-ENV JULIA_CPU_TARGET="x86-64,haswell,skylake,broadwell,znver1,znver2,znver3,cascadelake,icelake-client,cooperlake,generic"
+ENV JULIA_CPU_TARGET="generic;x86-64;haswell;skylake;broadwell;znver1;znver2;znver3;cascadelake;icelake-client;cooperlake"
 ENV RMS_BRANCH=${RMS_Branch}
 ENV RMS_INSTALLER=continuous
 # Usually this is set automatically, but we're not actually running

--- a/documentation/source/users/rmg/releaseNotes.rst
+++ b/documentation/source/users/rmg/releaseNotes.rst
@@ -8,7 +8,7 @@ RMG-Py Version 4.0.0
 ====================
 Date: June 10, 2026
 
-The below list is a summary. For a complete list of all changes, see the `Official RMG-Py Release Page <https://github.com/ReactionMechanismGenerator/RMG-Py/compare/3.3.0...4.0.0>`_.
+The below list is a summary. For a complete list of all changes, see the `Official RMG-Py v4.0.0 Release Page <https://github.com/ReactionMechanismGenerator/RMG-Py/releases/tag/4.0.0>`_.
 
 - New Features
     - Introduced an automated database selection feature
@@ -32,7 +32,7 @@ The below list is a summary. For a complete list of all changes, see the `Offici
 
 - Bug Fixes
     - Fixed duplicate reactions from identical templates being erroneously added to mechanisms
-    - Fixed energy correction calculations in pressure-dependent reactions and ensured consistency of transition state $E_0$ values in Arkane output files
+    - Fixed energy correction calculations in pressure-dependent reactions and ensured consistency of transition state :math:`E_0` values in Arkane output files
     - Corrected constant-species index mapping in `SimpleReactor`
     - Improved RDKit `GetSSSR` non-determinism
     - Removed deprecated `imp.load_source` calls and eliminated unreachable code segments
@@ -43,25 +43,25 @@ RMG-Database Version 4.0.0
 ==========================
 Date: June 10, 2026
 
-The below list is a summary. For a complete list of all changes, see the `Official RMG-Database Release Page <https://github.com/ReactionMechanismGenerator/RMG-database/compare/3.3.0...4.0.0>`_.
+The below list is a summary. For a complete list of all changes, see the `Official RMG-Database v4.0.0 Release Page <https://github.com/ReactionMechanismGenerator/RMG-database/releases/tag/4.0.0>`_.
 
 - Features
     - Expanded datasets with a new Formic Acid library and example coverage-dependent thermo libraries
-    - Added data for electrocatalytic $\text{CO}_2$ reduction ($\text{CO}_2\text{RR}$) kinetics and adsorbates
+    - Added data for electrocatalytic :math:`CO_2` reduction (:math:`CO_2\mathrm{RR}`) kinetics and adsorbates
     - Added BEEF uncertainty covariance data support
-    - Implemented new surface nitrogen reaction families, BEP rules, and NOx chemistry for $\text{Pt}(111)$
+    - Implemented new surface nitrogen reaction families, BEP rules, and NOx chemistry for :math:`\mathrm{Pt}(111)`
     - Introduced a `recommended_libraries.yml` configuration file
 
 - Bugfixes
     - Fixed incorrect entry details in the `Glarborg/C2` database
     - Fixed thermodynamic discontinuity issues found in the formic acid dataset
-    - Corrected temperature minimum settings ($T_{min}$) from 300 K to 298 K in NASA polynomials for $\text{CO}_2\text{RR}$ adsorbates on $\text{Ag}(111)$
+    - Corrected temperature minimum settings (:math:`T_{min}`) from 300 K to 298 K in NASA polynomials for :math:`CO_2\mathrm{RR}` adsorbates on :math:`\mathrm{Ag}(111)`
 
 RMG-Py Version 3.3.0
 ====================
 Date: July 10, 2025
 
-The below list is a summary. For a complete list of all changes, see the `Official RMG-Py Release Page <https://github.com/ReactionMechanismGenerator/RMG-Py/releases/tag/3.3.0>`_.
+The below list is a summary. For a complete list of all changes, see the `Official RMG-Py v3.3.0 Release Page <https://github.com/ReactionMechanismGenerator/RMG-Py/releases/tag/3.3.0>`_.
 
 - Software Improvements
     - RMG-Py now uses Python 3.9
@@ -86,7 +86,7 @@ RMG-Database Version 3.3.0
 ==========================
 Date: July 10, 2025
 
-The below list is a summary. For a complete list of all changes, see the `Official RMG-Database Release Page <https://github.com/ReactionMechanismGenerator/RMG-database/releases/tag/3.3.0>`_.
+The below list is a summary. For a complete list of all changes, see the `Official RMG-Database v3.3.0 Release Page <https://github.com/ReactionMechanismGenerator/RMG-database/releases/tag/3.3.0>`_.
 
 - Features
     - Electrochemistry with Lithium

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,8 @@ dependencies:
   - conda-forge::mopac
   # see https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2639#issuecomment-2050292972
   - conda-forge::cclib >=1.6.3,<1.9
-  - conda-forge::openbabel >= 3
+  # 3.2.1 hangs pytest collection under Python 3.10/3.11, where test/conftest.py imports pybel
+  - conda-forge::openbabel >=3,<3.2
   - conda-forge::rdkit >=2024
   - rmg::pysidt-rmg >=1.2
 

--- a/examples/rmg/CO2RR/input.py
+++ b/examples/rmg/CO2RR/input.py
@@ -1,12 +1,21 @@
+# This example demonstrates CO2RR mechanism generation on Ag(111).
+# Ag-specific data are provided through the CO2RR_Adsorbates_Ag111
+# thermochemistry library and CO2RR_DFT_Ag111 reaction library.
+# Species or reactions outside these curated Ag(111) entries are estimated
+# using RMG's existing surface thermochemistry and kinetics workflows,
+# including Pt(111)-based surface estimates with LSR corrections where applicable.
+
 # Data sources
 database(
-    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC','DFT_QCI_thermo', 'electrocatThermo', 
-    # 'CO2RR_Adsorbates_Ag111'
+    thermoLibraries=['surfaceThermoPt111', 'primaryThermoLibrary', 'thermo_DFT_CCSDTF12_BAC','DFT_QCI_thermo', 'electrocatThermo',
+    'CO2RR_Adsorbates_Ag111',
     ],
-    reactionLibraries = [('Surface/CPOX_Pt/Deutschmann2006_adjusted', False)],
+    reactionLibraries = [('Surface/CPOX_Pt/Deutschmann2006_adjusted', False),
+                         'CO2RR_DFT_Ag111',
+                         ],
     seedMechanisms = [],
     kineticsDepositories = ['training'],
-    kineticsFamilies = ['electrochem', 
+    kineticsFamilies = ['electrochem',
                         # 'surface',
                         'Surface_Abstraction',
                         'Surface_Abstraction_vdW',
@@ -106,7 +115,7 @@ species(
     label='OCX',
     reactive=True,
     structure=adjacencyList("""
-1 O u0 p2 c0 {2,D} 
+1 O u0 p2 c0 {2,D}
 2 C u0 p0 c0 {1,D} {3,D}
 3 X u0 p0 c0 {2,D}
 """),
@@ -116,7 +125,7 @@ species(
     label='OX',
     reactive=True,
     structure=adjacencyList("""
-1 O u0 p2 c0 {2,D} 
+1 O u0 p2 c0 {2,D}
 2 X u0 p0 c0 {1,D}
 """),
 )
@@ -252,33 +261,6 @@ liquidSurfaceReactor(
     # constantSpecies=["proton"],
  )
 
-# liquidSurfaceReactor(
-#     temperature=(300,'K'),
-#     liqPotential=(0,'V'),
-#     surfPotential=(-0.5,'V'),
-#     initialConcentrations={
-#         "CO2": (1e-3,'mol/cm^3'),
-#         "proton": (1e-4,'mol/m^3'),
-#     },
-# 	initialSurfaceCoverages={
-#         # "HX": 0.5,
-#         # # "CXO2": 0.0,
-#         "CHO2X": 0.1,
-#         "CO2HX": 0.1,
-#         "vacantX": 0.1,
-#         "CO2X": 0.4,
-#         'OX': 0.1,
-#         'OCX': 0.1,
-#         'CH2O2X': 0.05,
-#         'CHOX': 0.04,
-#         'CH2OX': 0.01
-#     },
-#     surfaceVolumeRatio=(1.0e5, 'm^-1'),
-#     terminationTime=(1.0e3,'sec'),
-#     # terminationConversion={'CO2': 0.90},
-#     # constantSpecies=["proton"],
-#  )
-
 solvation(
 	solvent='water'
 )
@@ -311,7 +293,7 @@ options(
 generatedSpeciesConstraints(
     allowed=['input species','reaction libraries'],
     maximumSurfaceSites=2,
-    maximumCarbonAtoms=3,
+    maximumCarbonAtoms=2,
     maximumOxygenAtoms=2,
     maximumRadicalElectrons=1,
 )

--- a/install_rms.sh
+++ b/install_rms.sh
@@ -114,7 +114,12 @@ export JULIA_PYTHONCALL_EXE="$CONDA_PREFIX/bin/python"
 export PYTHON_JULIAPKG_EXE="$(which julia)"
 export PYTHON_JULIAPKG_PROJECT="$CONDA_PREFIX/julia_env"
 
-conda install -y 'conda-forge::pyjuliacall<0.9.35'
+# Pinned exactly rather than capped, so that pyjuliacall and the Julia-side PythonCall it
+# selects stay on the last combination CI was green with. A ceiling is not enough: the solver
+# takes the highest version below it as soon as conda-forge publishes one, which is how this
+# silently moved from 0.9.28 to 0.9.34. Safe to relax once someone confirms a newer version
+# works against the Julia version pinned in CI.
+conda install -y 'conda-forge::pyjuliacall==0.9.28'
 
 echo "Environment variables referencing JULIA:"
 env | grep JULIA

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -1611,7 +1611,9 @@ class ThermoDatabase(object):
                 assert len(site.bonds) == 1, "Each surface site can only be bonded to 1 atom"
                 bonded_atom = list(site.bonds.keys())[0]
                 bond = site.bonds[bonded_atom]
-                if bond.is_single():
+                if bond.is_van_der_waals():
+                    bond_order = 0.
+                elif bond.is_single():
                     bond_order = 1.
                 elif bond.is_double():
                     bond_order = 2.

--- a/test/rmgpy/data/thermoTest.py
+++ b/test/rmgpy/data/thermoTest.py
@@ -1297,6 +1297,36 @@ multiplicity 2
         groups["NX"].data = _nstardata
         groups["OX"].data = _ostardata
 
+    def test_binding_energy_correction_with_van_der_waals_bond(self):
+        """Binding energy correction must handle van der Waals (order 0) bonds.
+
+        Regression test for issue #2987: a species with a surface site attached
+        by a van der Waals bond (e.g. the Surface_Dissociation_vdWBidentate_Beta
+        product [Pt]~[O]=C[O][Pt]) 
+
+        X..O=CH-O-X
+        """
+        spec = Species(
+            molecule=[
+                Molecule().from_adjacency_list(
+                    """
+1 X u0 p0 c0 {2,vdW}
+2 O u0 p2 c0 {1,vdW} {3,D}
+3 C u0 p0 c0 {2,D} {4,S} {5,S}
+4 O u0 p2 c0 {3,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 X u0 p0 c0 {4,S}
+"""
+                )
+            ]
+        )
+        spec.generate_resonance_structures()
+        thermo = self.database.get_thermo_data(spec)
+        corrected = self.database.correct_binding_energy(
+            thermo, spec, metal_to_scale_from="Pt111", metal_to_scale_to="Ni111"
+        )
+        assert "Binding energy corrected by LSR" in corrected.comment
+
     def test_adsorbate_thermo_generation_bidentate_weird_CO(self):
         """Test thermo generation for a bidentate adsorbate weird resonance of CO
 


### PR DESCRIPTION
Post release of v4 we introduced a number of small fixes that need to be reflected in `stable`

More importantly, I also just fixed a bug that was causing the `rmg` binaries on `conda-forge` to be overwritten. Merging this PR will cause the correct ones to be uploaded 